### PR TITLE
Fix build with LibreSSL

### DIFF
--- a/lib/conversion.c
+++ b/lib/conversion.c
@@ -132,7 +132,7 @@ static bool tpm2_convert_pubkey_ssl(TPMT_PUBLIC *public, pubkey_format format, c
         goto error;
     }
 
-#if OPENSSL_VERSION_NUMBER < 0x1010000fL /* OpenSSL 1.1.0 */
+#if OPENSSL_VERSION_NUMBER < 0x1010000fL || defined(LIBRESSL_VERSION_NUMBER) /* OpenSSL 1.1.0 */
     ssl_rsa_key->e = e;
     ssl_rsa_key->n = n;
 #else

--- a/lib/tpm2_openssl.c
+++ b/lib/tpm2_openssl.c
@@ -108,7 +108,7 @@ out:
 
 HMAC_CTX *tpm2_openssl_hmac_new() {
     HMAC_CTX *ctx;
-#if OPENSSL_VERSION_NUMBER < 0x1010000fL /* OpenSSL 1.1.0 */
+#if OPENSSL_VERSION_NUMBER < 0x1010000fL || defined(LIBRESSL_VERSION_NUMBER) /* OpenSSL 1.1.0 */
     ctx = malloc(sizeof(*ctx));
 #else
     ctx = HMAC_CTX_new();
@@ -116,7 +116,7 @@ HMAC_CTX *tpm2_openssl_hmac_new() {
     if (!ctx)
         return NULL;
 
-#if OPENSSL_VERSION_NUMBER < 0x1010000fL
+#if OPENSSL_VERSION_NUMBER < 0x1010000fL || defined(LIBRESSL_VERSION_NUMBER)
     HMAC_CTX_init(ctx);
 #endif
 
@@ -124,7 +124,7 @@ HMAC_CTX *tpm2_openssl_hmac_new() {
 }
 
 void tpm2_openssl_hmac_free(HMAC_CTX *ctx) {
-#if OPENSSL_VERSION_NUMBER < 0x1010000fL
+#if OPENSSL_VERSION_NUMBER < 0x1010000fL || defined(LIBRESSL_VERSION_NUMBER)
     HMAC_CTX_cleanup(ctx);
     free(ctx);
 #else

--- a/tools/tpm2_import.c
+++ b/tools/tpm2_import.c
@@ -97,7 +97,7 @@ static tpm_import_ctx ctx = {
     .import_key_private = TPM2B_EMPTY_INIT,
 };
 
-#if OPENSSL_VERSION_NUMBER < 0x1010000fL /* OpenSSL 1.1.0 */
+#if OPENSSL_VERSION_NUMBER < 0x1010000fL || defined(LIBRESSL_VERSION_NUMBER) /* OpenSSL 1.1.0 */
 static int RSA_set0_key(RSA *r, BIGNUM *n, BIGNUM *e, BIGNUM *d) {
 
     if ((r->n == NULL && n == NULL) || (r->e == NULL && e == NULL)) {


### PR DESCRIPTION
OPENSSL_VERSION_NUMBER is used to test the version of OpenSSL but this
test alone breaks the build with LibreSSL due to implicit declarations
of functions 'RSA_set0_key' and 'HMAC_CTX_free'.

Test if OpenSSL < 1.1.0 or LIBRESSL_VERSION_NUMBER is defined, instead.

Signed-off-by: Carlos Santos <casantos@datacom.ind.br>