### PR TITLE
Friendly Options for Hierarchy Specification

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -114,6 +114,8 @@ lib_libcommon_a_SOURCES = \
     lib/tpm2_errata.c \
     lib/tpm2_errata.h \
     lib/tpm2_header.h \
+    lib/tpm2_hierarchy.c \
+    lib/tpm2_hierarchy.h \
     lib/tpm2_nv_util.h \
     lib/tpm2_openssl.c \
     lib/tpm2_openssl.h \
@@ -203,7 +205,8 @@ check_PROGRAMS = \
     test/unit/test_tpm2_password_util \
     test/unit/test_tpm2_errata \
     test/unit/test_tpm2_session \
-    test/unit/test_tpm2_policy
+    test/unit/test_tpm2_policy \
+    test/unit/test_tpm2_hierarchy
 
 test_unit_tpm2_rc_decode_unit_CFLAGS  = $(AM_CFLAGS) $(CMOCKA_CFLAGS)
 test_unit_tpm2_rc_decode_unit_LDADD   = $(CMOCKA_LIBS) $(LIB_COMMON)
@@ -262,6 +265,10 @@ test_unit_test_tpm2_policy_LDFLAGS  = -Wl,--wrap=Tss2_Sys_StartAuthSession \
                                       -Wl,--wrap=Tss2_Sys_PolicyGetDigest
 test_unit_test_tpm2_policy_LDADD    = $(CMOCKA_LIBS) $(LIB_COMMON) $(LDADD)
 test_unit_test_tpm2_policy_SOURCES  = test/unit/test_tpm2_policy.c
+
+test_unit_test_tpm2_hierarchy_CFLAGS   = $(AM_CFLAGS) $(CMOCKA_CFLAGS)
+test_unit_test_tpm2_hierarchy_LDADD    = $(CMOCKA_LIBS) $(LIB_COMMON)
+test_unit_test_tpm2_hierarchy_SOURCES  = test/unit/test_tpm2_hierarchy.c
 
 endif
 

--- a/lib/tpm2_hierarchy.c
+++ b/lib/tpm2_hierarchy.c
@@ -34,10 +34,28 @@
 #include <sapi/tpm20.h>
 
 #include "log.h"
+#include "tpm2_hierarchy.h"
 #include "tpm2_util.h"
 
+/**
+ * Parses a hierarchy value from an option argument.
+ * @param value
+ *  The string to parse, which can be a numerical string as
+ *  understood by strtoul() with a base of 0, or an:
+ *    - o - Owner hierarchy
+ *    - p - Platform hierarchy
+ *    - e - Endorsement hierarchy
+ *    - n - Null hierarchy
+ * @param hierarchy
+ *  The parsed hierarchy as output.
+ * @param flags
+ *  What hierarchies should be supported by
+ *  the parsing.
+ * @return
+ *  True on success, False otherwise.
+ */
 bool tpm2_hierarchy_from_optarg(const char *value,
-        TPMI_RH_PROVISION *hierarchy) {
+        TPMI_RH_PROVISION *hierarchy, tpm2_hierarchy_flags flags) {
 
     if (!value) {
         return false;
@@ -45,24 +63,40 @@ bool tpm2_hierarchy_from_optarg(const char *value,
 
     bool is_o = !strcmp(value, "o");
     if (is_o) {
+        if (!(flags & TPM2_HIERARCHY_FLAGS_O)) {
+            LOG_ERR("Owner hierarchy not supported by this command.");
+            return false;
+        }
         *hierarchy = TPM2_RH_OWNER;
         return true;
     }
 
     bool is_p = !strcmp(value, "p");
     if (is_p) {
+        if (!(flags & TPM2_HIERARCHY_FLAGS_P)) {
+            LOG_ERR("Platform hierarchy not supported by this command.");
+            return false;
+        }
         *hierarchy = TPM2_RH_PLATFORM;
         return true;
     }
 
     bool is_e = !strcmp(value, "e");
     if (is_e) {
+        if (!(flags & TPM2_HIERARCHY_FLAGS_E)) {
+            LOG_ERR("Endorsement hierarchy not supported by this command.");
+            return false;
+        }
         *hierarchy = TPM2_RH_ENDORSEMENT;
         return true;
     }
 
     bool is_n = !strcmp(value, "n");
     if (is_n) {
+        if (!(flags & TPM2_HIERARCHY_FLAGS_N)) {
+            LOG_ERR("NULL hierarchy not supported by this command.");
+            return false;
+        }
         *hierarchy = TPM2_RH_NULL;
         return true;
     }

--- a/lib/tpm2_hierarchy.c
+++ b/lib/tpm2_hierarchy.c
@@ -1,0 +1,78 @@
+//**********************************************************************;
+// Copyright (c) 2018, Intel Corporation
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+// 1. Redistributions of source code must retain the above copyright notice,
+// this list of conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright notice,
+// this list of conditions and the following disclaimer in the documentation
+// and/or other materials provided with the distribution.
+//
+// 3. Neither the name of Intel Corporation nor the names of its contributors
+// may be used to endorse or promote products derived from this software without
+// specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+// THE POSSIBILITY OF SUCH DAMAGE.
+//**********************************************************************;
+
+#include <stdbool.h>
+
+#include <sapi/tpm20.h>
+
+#include "log.h"
+#include "tpm2_util.h"
+
+bool tpm2_hierarchy_from_optarg(const char *value,
+        TPMI_RH_PROVISION *hierarchy) {
+
+    if (!value) {
+        return false;
+    }
+
+    bool is_o = !strcmp(value, "o");
+    if (is_o) {
+        *hierarchy = TPM2_RH_OWNER;
+        return true;
+    }
+
+    bool is_p = !strcmp(value, "p");
+    if (is_p) {
+        *hierarchy = TPM2_RH_PLATFORM;
+        return true;
+    }
+
+    bool is_e = !strcmp(value, "e");
+    if (is_e) {
+        *hierarchy = TPM2_RH_ENDORSEMENT;
+        return true;
+    }
+
+    bool is_n = !strcmp(value, "n");
+    if (is_n) {
+        *hierarchy = TPM2_RH_NULL;
+        return true;
+    }
+
+    bool result = tpm2_util_string_to_uint32(value, hierarchy);
+    if (!result) {
+        LOG_ERR("Incorrect hierarchy value, got: \"%s\", expected [o|p|e|n]"
+                "or a number",
+            value);
+    }
+
+    return result;
+}

--- a/lib/tpm2_hierarchy.h
+++ b/lib/tpm2_hierarchy.h
@@ -36,7 +36,18 @@
 
 #include <sapi/tpm20.h>
 
+typedef enum tpm2_hierarchy_flags tpm2_hierarchy_flags;
+
+enum tpm2_hierarchy_flags {
+    TPM2_HIERARCHY_FLAGS_NONE = 0,
+    TPM2_HIERARCHY_FLAGS_O    = 1 << 0,
+    TPM2_HIERARCHY_FLAGS_P    = 1 << 1,
+    TPM2_HIERARCHY_FLAGS_E    = 1 << 2,
+    TPM2_HIERARCHY_FLAGS_N    = 1 << 3,
+    TPM2_HIERARCHY_FLAGS_ALL  = 0x0F
+};
+
 bool tpm2_hierarchy_from_optarg(const char *value,
-        TPMI_RH_PROVISION *hierarchy);
+        TPMI_RH_PROVISION *hierarchy, tpm2_hierarchy_flags flags);
 
 #endif /* TOOLS_TPM2_HIERARCHY_H_ */

--- a/lib/tpm2_hierarchy.h
+++ b/lib/tpm2_hierarchy.h
@@ -1,0 +1,42 @@
+//**********************************************************************;
+// Copyright (c) 2018, Intel Corporation
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+// 1. Redistributions of source code must retain the above copyright notice,
+// this list of conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright notice,
+// this list of conditions and the following disclaimer in the documentation
+// and/or other materials provided with the distribution.
+//
+// 3. Neither the name of Intel Corporation nor the names of its contributors
+// may be used to endorse or promote products derived from this software without
+// specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+// THE POSSIBILITY OF SUCH DAMAGE.
+//**********************************************************************;
+
+#ifndef TOOLS_TPM2_HIERARCHY_H_
+#define TOOLS_TPM2_HIERARCHY_H_
+
+#include <stdbool.h>
+
+#include <sapi/tpm20.h>
+
+bool tpm2_hierarchy_from_optarg(const char *value,
+        TPMI_RH_PROVISION *hierarchy);
+
+#endif /* TOOLS_TPM2_HIERARCHY_H_ */

--- a/man/tpm2_createprimary.1.md
+++ b/man/tpm2_createprimary.1.md
@@ -27,6 +27,7 @@ will create and load a Primary Object. The sensitive area is not returned.
       * **p** for **TPM_RH_PLATFORM**
       * **e** for **TPM_RH_ENDORSEMENT**
       * **n** for **TPM_RH_NULL**
+      * **`<num>`** where a raw number can be used.
 
   * **-P**, **--pwdp**=_PARENT\_KEY\_PASSWORD_:
     Optional authorization string if authorization is required to create object under the specified hierarchy.

--- a/man/tpm2_evictcontrol.1.md
+++ b/man/tpm2_evictcontrol.1.md
@@ -18,9 +18,11 @@ be evicted.
 # OPTIONS
 
   * **-A**, **--auth**=_AUTH_:
-    The authorization used to authorize the commands. Valid choices are:
-    *  **o** for **TPM_RH_OWNER**
-    *  **p** for **TPM_RH_PLATFORM**
+    The authorization used to authorize the commands.
+    Supported options are:
+      * **o** for **TPM_RH_OWNER**
+      * **p** for **TPM_RH_PLATFORM**
+      * **`<num>`** where a raw number can be used.
 
   * **-H**, **--handle**=_HANDLE_:
     The handle of a loaded transient or a persistent object.

--- a/man/tpm2_nvdefine.1.md
+++ b/man/tpm2_nvdefine.1.md
@@ -19,10 +19,12 @@
   * **-x**, **--index**=_NV\_INDEX_:
     Specifies the index to define the space at.
 
-  * **-a**, **--auth-handle**=_SECRET\_DATA\_FILE_:
-    specifies the handle used to authorize:
-    * **0x40000001** for **TPM_RH_OWNER**
-    * **0x4000000C** for **TPM_RH_PLATFORM**
+  * **-a**, **--auth-handle**=_AUTH_:
+    specifies the handle used to authorize.
+    Supported options are:
+      * **o** for **TPM_RH_OWNER**
+      * **p** for **TPM_RH_PLATFORM**
+      * **`<num>`** where a raw number can be used.
 
   * **-s**, **--size**=_SIZE_:
     specifies the size of data area in bytes. Defaults to MAX_NV_INDEX_SIZE

--- a/man/tpm2_nvread.1.md
+++ b/man/tpm2_nvread.1.md
@@ -19,10 +19,12 @@
   * **-x**, **--index**=_NV\_INDEX_:
     Specifies the index to define the space at.
 
-  * **-a**, **--auth-handle**=_SECRET\_DATA\_FILE_:
-    specifies the handle used to authorize:
-    * **0x40000001** for **TPM_RH_OWNER**
-    * **0x4000000C** for **TPM_RH_PLATFORM**
+  * **-a**, **--auth-handle**=_AUTH_:
+    specifies the handle used to authorize.
+    Supported options are:
+      * **o** for **TPM_RH_OWNER**
+      * **p** for **TPM_RH_PLATFORM**
+      * **`<num>`** where a raw number can be used.
 
   * **-f**, **--out-file**=_FILE_:
     file to write data

--- a/man/tpm2_nvrelease.1.md
+++ b/man/tpm2_nvrelease.1.md
@@ -20,10 +20,12 @@ defined with tpm2_nvdefine(1).
   * **-x**, **--index**=_NV\_INDEX_:
     Specifies the index to release.
 
-  * **-a**, **--auth-handle**=_SECRET\_DATA\_FILE_:
-    specifies the handle used to authorize:
-    * **0x40000001** for **TPM_RH_OWNER**
-    * **0x4000000C** for **TPM_RH_PLATFORM**
+  * **-a**, **--auth-handle**=_AUTH_:
+    specifies the handle used to authorize.
+    Supported options are:
+      * **o** for **TPM_RH_OWNER**
+      * **p** for **TPM_RH_PLATFORM**
+      * **`<num>`** where a raw number can be used.
 
   * **-s**, **--size**=_SIZE_:
     specifies the size of data area in bytes.

--- a/man/tpm2_nvwrite.1.md
+++ b/man/tpm2_nvwrite.1.md
@@ -23,10 +23,12 @@ If _FILE_ is not specified, it defaults to stdin.
   * **-o**, **--offset**=_OFFSET_:
     The offset within the NV index to start writing at.
 
-  * **-a**, **--auth-handle**=_SECRET\_DATA\_FILE_:
-    specifies the handle used to authorize:
-    * **0x40000001** for **TPM_RH_OWNER**
-    * **0x4000000C** for **TPM_RH_PLATFORM**
+  * **-a**, **--auth-handle**=_AUTH_:
+    specifies the handle used to authorize.
+    Supported options are:
+      * **o** for **TPM_RH_OWNER**
+      * **p** for **TPM_RH_PLATFORM**
+      * **`<num>`** where a raw number can be used.
 
   * **-P**, **--handle-passwd**=_HANDLE\_PASSWORD_:
     specifies the password of authHandle. Passwords should follow the

--- a/test/system/tests/nv.sh
+++ b/test/system/tests/nv.sh
@@ -32,7 +32,6 @@
 #;**********************************************************************;
 
 nv_test_index=0x1500018
-nv_auth_handle=0x40000001
 
 large_file_name="nv.test_large_w"
 large_file_read_name="nv.test_large_r"
@@ -43,7 +42,7 @@ file_pcr_value=pcr.bin
 file_policy=policy.data
 
 cleanup() {
-  tpm2_nvrelease -Q -x $nv_test_index -a $nv_auth_handle 2>/dev/null || true
+  tpm2_nvrelease -Q -x $nv_test_index -a o 2>/dev/null || true
   tpm2_nvrelease -Q -x 0x1500016 -a 0x40000001 2>/dev/null || true
   tpm2_nvrelease -Q -x 0x1500015 -a 0x40000001 -P owner 2>/dev/null || true
 
@@ -83,13 +82,13 @@ cleanup
 
 tpm2_clear
 
-tpm2_nvdefine -Q -x $nv_test_index -a $nv_auth_handle -s 32 -t "ownerread|policywrite|ownerwrite"
+tpm2_nvdefine -Q -x $nv_test_index -a o -s 32 -t "ownerread|policywrite|ownerwrite"
 
 echo "please123abc" > nv.test_w
 
-tpm2_nvwrite -Q -x $nv_test_index -a $nv_auth_handle nv.test_w
+tpm2_nvwrite -Q -x $nv_test_index -a o nv.test_w
 
-tpm2_nvread -Q -x $nv_test_index -a $nv_auth_handle -s 32 -o 0
+tpm2_nvread -Q -x $nv_test_index -a o -s 32 -o 0
 
 tpm2_nvlist > nv.out
 yaml_get $nv_test_index nv.out
@@ -106,9 +105,9 @@ echo -n "foo" > foo.dat
 dd if=foo.dat of=nv.test_w bs=1 seek=4 conv=notrunc 2>/dev/null
 
 # Test a pipe input
-cat foo.dat | tpm2_nvwrite -Q -x $nv_test_index -a $nv_auth_handle -o 4
+cat foo.dat | tpm2_nvwrite -Q -x $nv_test_index -a o -o 4
 
-tpm2_nvread -x $nv_test_index -a $nv_auth_handle -s 13 > cmp.dat
+tpm2_nvread -x $nv_test_index -a o -s 13 > cmp.dat
 
 cmp nv.test_w cmp.dat
 
@@ -117,18 +116,18 @@ cmp nv.test_w cmp.dat
 
 trap - ERR
 
-tpm2_nvwrite -Q -x $nv_test_index -a $nv_auth_handle -o 30 foo.dat 2>/dev/null
+tpm2_nvwrite -Q -x $nv_test_index -a o -o 30 foo.dat 2>/dev/null
 if [ $? -eq 0 ]; then
   echo "Writing past the public size shouldn't work!"
   exit 1
 fi
 trap onerror ERR
 
-tpm2_nvread -x $nv_test_index -a $nv_auth_handle -s 13 > cmp.dat
+tpm2_nvread -x $nv_test_index -a o -s 13 > cmp.dat
 
 cmp nv.test_w cmp.dat
 
-tpm2_nvrelease -x $nv_test_index -a $nv_auth_handle  
+tpm2_nvrelease -x $nv_test_index -a o
 
 tpm2_pcrlist -Q -L ${alg_pcr_policy}:${pcr_ids} -o $file_pcr_value
 
@@ -157,39 +156,39 @@ large_file_size=$(tpm2_getcap -c properties-fixed | grep TPM2_PT_NV_INDEX_MAX | 
 nv_test_index=0x1000000
 
 # Create an nv space with attributes 1010 = TPMA_NV_PPWRITE and TPMA_NV_AUTHWRITE
-tpm2_nvdefine -Q -x $nv_test_index -a $nv_auth_handle -s $large_file_size -t 0x2000A
+tpm2_nvdefine -Q -x $nv_test_index -a o -s $large_file_size -t 0x2000A
 
 base64 /dev/urandom | head -c $(($large_file_size)) > $large_file_name
 
 # Test file input redirection
-tpm2_nvwrite -Q -x $nv_test_index -a $nv_auth_handle < $large_file_name
+tpm2_nvwrite -Q -x $nv_test_index -a o < $large_file_name
 
-tpm2_nvread -x $nv_test_index -a $nv_auth_handle > $large_file_read_name
+tpm2_nvread -x $nv_test_index -a o > $large_file_read_name
 
 cmp -s $large_file_read_name $large_file_name
 
 tpm2_nvlist > nv.out
 yaml_get $nv_test_index nv.out
 
-tpm2_nvrelease -Q -x $nv_test_index -a $nv_auth_handle
+tpm2_nvrelease -Q -x $nv_test_index -a o
 
 #
 # Test NV access locked
 #
-tpm2_nvdefine -Q -x $nv_test_index -a $nv_auth_handle -s 32 -t "ownerread|policywrite|ownerwrite|read_stclear"
+tpm2_nvdefine -Q -x $nv_test_index -a o -s 32 -t "ownerread|policywrite|ownerwrite|read_stclear"
 
 echo "foobar" > nv.readlock
 
-tpm2_nvwrite -Q -x $nv_test_index -a $nv_auth_handle nv.readlock
+tpm2_nvwrite -Q -x $nv_test_index -a o nv.readlock
 
-tpm2_nvread -Q -x $nv_test_index -a $nv_auth_handle -s 6 -o 0
+tpm2_nvread -Q -x $nv_test_index -a o -s 6 -o 0
 
-tpm2_nvreadlock -Q -x $nv_test_index -a $nv_auth_handle
+tpm2_nvreadlock -Q -x $nv_test_index -a o
 
 # Reset ERR signal handler to test for expected nvread error
 trap - ERR
 
-tpm2_nvread -Q -x $nv_test_index -a $nv_auth_handle -s 6 -o 0 2> /dev/null
+tpm2_nvread -Q -x $nv_test_index -a o -s 6 -o 0 2> /dev/null
 if [ $? != 1 ];then
  echo "nvread didn't fail!"
  exit 1

--- a/test/unit/test_tpm2_hierarchy.c
+++ b/test/unit/test_tpm2_hierarchy.c
@@ -39,7 +39,8 @@ static void test_tpm2_hierarchy_from_optarg_NULL(void **state) {
     UNUSED(state);
 
     TPMI_RH_PROVISION h;
-    bool result = tpm2_hierarchy_from_optarg(NULL, &h);
+    bool result = tpm2_hierarchy_from_optarg(NULL, &h,
+            TPM2_HIERARCHY_FLAGS_ALL);
     assert_false(result);
 }
 
@@ -47,7 +48,8 @@ static void test_tpm2_hierarchy_from_optarg_empty(void **state) {
     UNUSED(state);
 
     TPMI_RH_PROVISION h;
-    bool result = tpm2_hierarchy_from_optarg("", &h);
+    bool result = tpm2_hierarchy_from_optarg("", &h,
+            TPM2_HIERARCHY_FLAGS_ALL);
     assert_false(result);
 }
 
@@ -55,7 +57,8 @@ static void test_tpm2_hierarchy_from_optarg_invalid_id(void **state) {
     UNUSED(state);
 
     TPMI_RH_PROVISION h;
-    bool result = tpm2_hierarchy_from_optarg("q", &h);
+    bool result = tpm2_hierarchy_from_optarg("q", &h,
+            TPM2_HIERARCHY_FLAGS_ALL);
     assert_false(result);
 }
 
@@ -63,7 +66,8 @@ static void test_tpm2_hierarchy_from_optarg_invalid_str(void **state) {
     UNUSED(state);
 
     TPMI_RH_PROVISION h;
-    bool result = tpm2_hierarchy_from_optarg("nope", &h);
+    bool result = tpm2_hierarchy_from_optarg("nope", &h,
+            TPM2_HIERARCHY_FLAGS_ALL);
     assert_false(result);
 }
 
@@ -71,23 +75,84 @@ static void test_tpm2_hierarchy_from_optarg_valid_ids(void **state) {
     UNUSED(state);
 
     TPMI_RH_PROVISION h;
-    bool result = tpm2_hierarchy_from_optarg("o", &h);
+    bool result = tpm2_hierarchy_from_optarg("o", &h,
+            TPM2_HIERARCHY_FLAGS_ALL);
     assert_true(result);
     assert_int_equal(h, TPM2_RH_OWNER);
 
-    result = tpm2_hierarchy_from_optarg("p", &h);
+    result = tpm2_hierarchy_from_optarg("p", &h,
+            TPM2_HIERARCHY_FLAGS_ALL);
     assert_true(result);
     assert_int_equal(h, TPM2_RH_PLATFORM);
 
-    result = tpm2_hierarchy_from_optarg("e", &h);
+    result = tpm2_hierarchy_from_optarg("e", &h,
+            TPM2_HIERARCHY_FLAGS_ALL);
     assert_true(result);
     assert_int_equal(h, TPM2_RH_ENDORSEMENT);
 
-    result = tpm2_hierarchy_from_optarg("n", &h);
+    result = tpm2_hierarchy_from_optarg("n", &h,
+            TPM2_HIERARCHY_FLAGS_ALL);
     assert_true(result);
     assert_int_equal(h, TPM2_RH_NULL);
 
-    result = tpm2_hierarchy_from_optarg("0xBADC0DE", &h);
+    result = tpm2_hierarchy_from_optarg("0xBADC0DE", &h,
+            TPM2_HIERARCHY_FLAGS_ALL);
+    assert_true(result);
+    assert_int_equal(h, 0xBADC0DE);
+}
+
+static void test_tpm2_hierarchy_from_optarg_valid_ids_disabled(void **state) {
+    UNUSED(state);
+
+    TPMI_RH_PROVISION h;
+    bool result = tpm2_hierarchy_from_optarg("o", &h,
+            TPM2_HIERARCHY_FLAGS_N);
+    assert_false(result);
+
+    result = tpm2_hierarchy_from_optarg("p", &h,
+            TPM2_HIERARCHY_FLAGS_O);
+    assert_false(result);
+
+    result = tpm2_hierarchy_from_optarg("e", &h,
+            TPM2_HIERARCHY_FLAGS_P);
+    assert_false(result);
+
+    result = tpm2_hierarchy_from_optarg("n", &h,
+            TPM2_HIERARCHY_FLAGS_E);
+    assert_false(result);
+
+    result = tpm2_hierarchy_from_optarg("0xBADC0DE", &h,
+            TPM2_HIERARCHY_FLAGS_NONE);
+    assert_true(result);
+    assert_int_equal(h, 0xBADC0DE);
+}
+
+static void test_tpm2_hierarchy_from_optarg_valid_ids_enabled(void **state) {
+    UNUSED(state);
+
+    TPMI_RH_PROVISION h;
+    bool result = tpm2_hierarchy_from_optarg("o", &h,
+            TPM2_HIERARCHY_FLAGS_O);
+    assert_true(result);
+    assert_int_equal(h, TPM2_RH_OWNER);
+
+    result = tpm2_hierarchy_from_optarg("p", &h,
+            TPM2_HIERARCHY_FLAGS_P);
+    assert_true(result);
+    assert_int_equal(h, TPM2_RH_PLATFORM);
+
+    result = tpm2_hierarchy_from_optarg("e", &h,
+            TPM2_HIERARCHY_FLAGS_E);
+    assert_true(result);
+    assert_int_equal(h, TPM2_RH_ENDORSEMENT);
+
+    result = tpm2_hierarchy_from_optarg("n", &h,
+            TPM2_HIERARCHY_FLAGS_N);
+    assert_true(result);
+    assert_int_equal(h, TPM2_RH_NULL);
+
+    result = tpm2_hierarchy_from_optarg("0xBADC0DE", &h,
+            TPM2_HIERARCHY_FLAGS_ALL);
     assert_true(result);
     assert_int_equal(h, 0xBADC0DE);
 }
@@ -102,6 +167,8 @@ int main(int argc, char* argv[]) {
         cmocka_unit_test(test_tpm2_hierarchy_from_optarg_invalid_id),
         cmocka_unit_test(test_tpm2_hierarchy_from_optarg_invalid_str),
         cmocka_unit_test(test_tpm2_hierarchy_from_optarg_valid_ids),
+        cmocka_unit_test(test_tpm2_hierarchy_from_optarg_valid_ids_disabled),
+        cmocka_unit_test(test_tpm2_hierarchy_from_optarg_valid_ids_enabled),
     };
 
     return cmocka_run_group_tests(tests, NULL, NULL);

--- a/test/unit/test_tpm2_hierarchy.c
+++ b/test/unit/test_tpm2_hierarchy.c
@@ -1,0 +1,108 @@
+//**********************************************************************;
+// Copyright (c) 2018, Intel Corporation
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+// 1. Redistributions of source code must retain the above copyright notice,
+// this list of conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright notice,
+// this list of conditions and the following disclaimer in the documentation
+// and/or other materials provided with the distribution.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+// THE POSSIBILITY OF SUCH DAMAGE.
+//**********************************************************************;
+#include <stdarg.h>
+#include <stdio.h>
+#include <stddef.h>
+#include <setjmp.h>
+
+#include <cmocka.h>
+#include <sapi/tpm20.h>
+
+#include "tpm2_hierarchy.h"
+#include "tpm2_util.h"
+
+static void test_tpm2_hierarchy_from_optarg_NULL(void **state) {
+    UNUSED(state);
+
+    TPMI_RH_PROVISION h;
+    bool result = tpm2_hierarchy_from_optarg(NULL, &h);
+    assert_false(result);
+}
+
+static void test_tpm2_hierarchy_from_optarg_empty(void **state) {
+    UNUSED(state);
+
+    TPMI_RH_PROVISION h;
+    bool result = tpm2_hierarchy_from_optarg("", &h);
+    assert_false(result);
+}
+
+static void test_tpm2_hierarchy_from_optarg_invalid_id(void **state) {
+    UNUSED(state);
+
+    TPMI_RH_PROVISION h;
+    bool result = tpm2_hierarchy_from_optarg("q", &h);
+    assert_false(result);
+}
+
+static void test_tpm2_hierarchy_from_optarg_invalid_str(void **state) {
+    UNUSED(state);
+
+    TPMI_RH_PROVISION h;
+    bool result = tpm2_hierarchy_from_optarg("nope", &h);
+    assert_false(result);
+}
+
+static void test_tpm2_hierarchy_from_optarg_valid_ids(void **state) {
+    UNUSED(state);
+
+    TPMI_RH_PROVISION h;
+    bool result = tpm2_hierarchy_from_optarg("o", &h);
+    assert_true(result);
+    assert_int_equal(h, TPM2_RH_OWNER);
+
+    result = tpm2_hierarchy_from_optarg("p", &h);
+    assert_true(result);
+    assert_int_equal(h, TPM2_RH_PLATFORM);
+
+    result = tpm2_hierarchy_from_optarg("e", &h);
+    assert_true(result);
+    assert_int_equal(h, TPM2_RH_ENDORSEMENT);
+
+    result = tpm2_hierarchy_from_optarg("n", &h);
+    assert_true(result);
+    assert_int_equal(h, TPM2_RH_NULL);
+
+    result = tpm2_hierarchy_from_optarg("0xBADC0DE", &h);
+    assert_true(result);
+    assert_int_equal(h, 0xBADC0DE);
+}
+
+int main(int argc, char* argv[]) {
+    (void)argc;
+    (void)argv;
+
+    const struct CMUnitTest tests[] = {
+        cmocka_unit_test(test_tpm2_hierarchy_from_optarg_NULL),
+        cmocka_unit_test(test_tpm2_hierarchy_from_optarg_empty),
+        cmocka_unit_test(test_tpm2_hierarchy_from_optarg_invalid_id),
+        cmocka_unit_test(test_tpm2_hierarchy_from_optarg_invalid_str),
+        cmocka_unit_test(test_tpm2_hierarchy_from_optarg_valid_ids),
+    };
+
+    return cmocka_run_group_tests(tests, NULL, NULL);
+}

--- a/tools/tpm2_createprimary.c
+++ b/tools/tpm2_createprimary.c
@@ -43,6 +43,7 @@
 
 #include "files.h"
 #include "log.h"
+#include "tpm2_hierarchy.h"
 #include "tpm2_alg_util.h"
 #include "tpm2_attr_util.h"
 #include "tpm2_options.h"
@@ -189,42 +190,14 @@ int create_primary(TSS2_SYS_CONTEXT *sapi_context) {
     return 0;
 }
 
-static bool hierarchy_value_from_string(const char *value, TPMI_RH_HIERARCHY *hierarchy) {
-
-    switch (value[0]) {
-    case 'e':
-        *hierarchy = TPM2_RH_ENDORSEMENT;
-        break;
-    case 'n':
-        *hierarchy = TPM2_RH_NULL;
-        break;
-    case 'o':
-        *hierarchy = TPM2_RH_OWNER;
-        break;
-    case 'p':
-        *hierarchy = TPM2_RH_PLATFORM;
-        break;
-    default:
-        return false;
-    }
-
-    bool result = value[1] == '\0';
-
-    if (!result) {
-        LOG_ERR("Incorrect hierarchy value, got: \"%s\", expected o|p|e|n",
-            value);
-    }
-
-    return result;
-}
-
 static bool on_option(char key, char *value) {
 
     bool res;
 
     switch(key) {
     case 'H':
-        res = hierarchy_value_from_string(value, &ctx.hierarchy);
+        res = tpm2_hierarchy_from_optarg(value, &ctx.hierarchy,
+                TPM2_HIERARCHY_FLAGS_ALL);
         if (!res) {
             return false;
         }

--- a/tools/tpm2_evictcontrol.c
+++ b/tools/tpm2_evictcontrol.c
@@ -42,6 +42,7 @@
 
 #include "files.h"
 #include "log.h"
+#include "tpm2_hierarchy.h"
 #include "tpm2_options.h"
 #include "tpm2_password_util.h"
 #include "tpm2_tool.h"
@@ -87,36 +88,14 @@ static int evict_control(TSS2_SYS_CONTEXT *sapi_context) {
     return true;
 }
 
-static bool auth_value_from_string(const char *value, TPMI_RH_PROVISION *auth) {
-
-    switch (value[0]) {
-    case 'o':
-        *auth = TPM2_RH_OWNER;
-        break;
-    case 'p':
-        *auth = TPM2_RH_PLATFORM;
-        break;
-    default:
-        return false;
-    }
-
-    bool result = value[1] == '\0';
-
-    if (!result) {
-        LOG_ERR("Incorrect auth value, got: \"%s\", expected o|p",
-            value);
-    }
-
-    return result;
-}
-
 static bool on_option(char key, char *value) {
 
     bool result;
 
     switch (key) {
     case 'A':
-        result = auth_value_from_string(value, &ctx.auth);
+        result = tpm2_hierarchy_from_optarg(value, &ctx.auth,
+                TPM2_HIERARCHY_FLAGS_O|TPM2_HIERARCHY_FLAGS_P);
         if (!result) {
             return false;
         }

--- a/tools/tpm2_nvread.c
+++ b/tools/tpm2_nvread.c
@@ -39,6 +39,7 @@
 #include "files.h"
 #include "log.h"
 #include "pcr.h"
+#include "tpm2_hierarchy.h"
 #include "tpm2_nv_util.h"
 #include "tpm2_options.h"
 #include "tpm2_password_util.h"
@@ -50,7 +51,7 @@
 typedef struct tpm_nvread_ctx tpm_nvread_ctx;
 struct tpm_nvread_ctx {
     UINT32 nv_index;
-    UINT32 auth_handle;
+    TPMI_RH_PROVISION auth_handle;
     UINT32 size_to_read;
     UINT32 offset;
     TPMS_AUTH_COMMAND session_data;
@@ -183,15 +184,9 @@ static bool on_option(char key, char *value) {
         }
         break;
     case 'a':
-        result = tpm2_util_string_to_uint32(value, &ctx.auth_handle);
+        result = tpm2_hierarchy_from_optarg(value, &ctx.auth_handle,
+                TPM2_HIERARCHY_FLAGS_O|TPM2_HIERARCHY_FLAGS_P);
         if (!result) {
-            LOG_ERR("Could not convert auth handle to number, got: \"%s\"",
-                    value);
-            return false;
-        }
-
-        if (ctx.auth_handle == 0) {
-            LOG_ERR("Auth handle cannot be 0");
             return false;
         }
         break;

--- a/tools/tpm2_nvreadlock.c
+++ b/tools/tpm2_nvreadlock.c
@@ -39,6 +39,7 @@
 #include <sapi/tpm20.h>
 
 #include "log.h"
+#include "tpm2_hierarchy.h"
 #include "tpm2_options.h"
 #include "tpm2_password_util.h"
 #include "tpm2_session.h"
@@ -48,7 +49,7 @@
 typedef struct tpm_nvreadlock_ctx tpm_nvreadlock_ctx;
 struct tpm_nvreadlock_ctx {
     UINT32 nv_index;
-    UINT32 auth_handle;
+    TPMI_RH_PROVISION auth_handle;
     UINT32 size_to_read;
     UINT32 offset;
     TPMS_AUTH_COMMAND session_data;
@@ -95,15 +96,9 @@ static bool on_option(char key, char *value) {
         }
         break;
     case 'a':
-        result = tpm2_util_string_to_uint32(value, &ctx.auth_handle);
+        result = tpm2_hierarchy_from_optarg(value, &ctx.auth_handle,
+                TPM2_HIERARCHY_FLAGS_O|TPM2_HIERARCHY_FLAGS_P);
         if (!result) {
-            LOG_ERR("Could not convert auth handle to number, got: \"%s\"",
-                    value);
-            return false;
-        }
-
-        if (ctx.auth_handle == 0) {
-            LOG_ERR("Auth handle cannot be 0");
             return false;
         }
         break;

--- a/tools/tpm2_nvrelease.c
+++ b/tools/tpm2_nvrelease.c
@@ -37,6 +37,7 @@
 #include <sapi/tpm20.h>
 
 #include "log.h"
+#include "tpm2_hierarchy.h"
 #include "tpm2_options.h"
 #include "tpm2_password_util.h"
 #include "tpm2_session.h"
@@ -46,7 +47,7 @@
 typedef struct tpm_nvrelease_ctx tpm_nvrelease_ctx;
 struct tpm_nvrelease_ctx {
     UINT32 nv_index;
-    UINT32 auth_handle;
+    TPMI_RH_PROVISION auth_handle;
     TPMS_AUTH_COMMAND session_data;
 };
 
@@ -91,17 +92,12 @@ static bool on_option(char key, char *value) {
         }
         break;
     case 'a':
-        result = tpm2_util_string_to_uint32(value, &ctx.auth_handle);
+        result = tpm2_hierarchy_from_optarg(value, &ctx.auth_handle,
+                TPM2_HIERARCHY_FLAGS_O|TPM2_HIERARCHY_FLAGS_P);
         if (!result) {
-            LOG_ERR("Could not convert auth handle to number, got: \"%s\"",
-                    value);
             return false;
         }
 
-        if (ctx.auth_handle == 0) {
-            LOG_ERR("Auth handle cannot be 0");
-            return false;
-        }
         break;
     case 'S': {
         tpm2_session *s = tpm2_session_restore(value);

--- a/tools/tpm2_nvwrite.c
+++ b/tools/tpm2_nvwrite.c
@@ -42,6 +42,7 @@
 #include "files.h"
 #include "log.h"
 #include "pcr.h"
+#include "tpm2_hierarchy.h"
 #include "tpm2_nv_util.h"
 #include "tpm2_password_util.h"
 #include "tpm2_policy.h"
@@ -52,7 +53,7 @@
 typedef struct tpm_nvwrite_ctx tpm_nvwrite_ctx;
 struct tpm_nvwrite_ctx {
     UINT32 nv_index;
-    UINT32 auth_handle;
+    TPMI_RH_PROVISION auth_handle;
     UINT16 data_size;
     UINT8 nv_buffer[TPM2_MAX_NV_BUFFER_SIZE];
     TPMS_AUTH_COMMAND session_data;
@@ -160,15 +161,9 @@ static bool on_option(char key, char *value) {
         }
         break;
     case 'a':
-        result = tpm2_util_string_to_uint32(value, &ctx.auth_handle);
+        result = tpm2_hierarchy_from_optarg(value, &ctx.auth_handle,
+                TPM2_HIERARCHY_FLAGS_O|TPM2_HIERARCHY_FLAGS_P);
         if (!result) {
-            LOG_ERR("Could not convert auth handle to number, got: \"%s\"",
-                    value);
-            return false;
-        }
-
-        if (ctx.auth_handle == 0) {
-            LOG_ERR("Auth handle cannot be 0");
             return false;
         }
         break;


### PR DESCRIPTION
Correct the handling of hierarchies in the NV related tools to use friendly names like "o" for the owner platform rather than the raw numerical format.

This also moves the parsing logic to a common routine, with unit tests.

Fixes: #512 
