### PR TITLE
fix travis badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![Build Status](https://travis-ci.org/intel/tpm2-tools.svg?branch=3.X)](https://travis-ci.org/intel/tpm2-tools)
+[![Build Status](https://travis-ci.org/tpm2-software/tpm2-tools.svg?branch=3.X)](https://travis-ci.org/intel/tpm2-tools)
 <a href="https://scan.coverity.com/projects/01org-tpm2-0-tools">
   <img alt="Coverity Scan Build Status"
        src="https://scan.coverity.com/projects/13105/badge.svg"/>


### PR DESCRIPTION
The badge stopped working as the link changed when we moved from
intel to tpm2-software