### PR TITLE
liberror: implement in tools

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,5 @@ missing
 Makefile
 Makefile.in
 test-driver
+# dist tarball
+*.gz

--- a/Makefile.am
+++ b/Makefile.am
@@ -113,6 +113,8 @@ lib_libcommon_a_SOURCES = \
     lib/tpm2_attr_util.h \
     lib/tpm2_errata.c \
     lib/tpm2_errata.h \
+    lib/tpm2_error.c \
+    lib/tpm2_error.h \
     lib/tpm2_header.h \
     lib/tpm2_hierarchy.c \
     lib/tpm2_hierarchy.h \
@@ -206,7 +208,8 @@ check_PROGRAMS = \
     test/unit/test_tpm2_errata \
     test/unit/test_tpm2_session \
     test/unit/test_tpm2_policy \
-    test/unit/test_tpm2_hierarchy
+    test/unit/test_tpm2_hierarchy \
+    test/unit/test_tpm2_error
 
 test_unit_tpm2_rc_decode_unit_CFLAGS  = $(AM_CFLAGS) $(CMOCKA_CFLAGS)
 test_unit_tpm2_rc_decode_unit_LDADD   = $(CMOCKA_LIBS) $(LIB_COMMON)
@@ -269,6 +272,10 @@ test_unit_test_tpm2_policy_SOURCES  = test/unit/test_tpm2_policy.c
 test_unit_test_tpm2_hierarchy_CFLAGS   = $(AM_CFLAGS) $(CMOCKA_CFLAGS)
 test_unit_test_tpm2_hierarchy_LDADD    = $(CMOCKA_LIBS) $(LIB_COMMON)
 test_unit_test_tpm2_hierarchy_SOURCES  = test/unit/test_tpm2_hierarchy.c
+
+test_unit_test_tpm2_error_CFLAGS   = $(AM_CFLAGS) $(CMOCKA_CFLAGS)
+test_unit_test_tpm2_error_LDADD    = $(CMOCKA_LIBS) $(LIB_COMMON)
+test_unit_test_tpm2_error_SOURCES  = test/unit/test_tpm2_error.c
 
 endif
 

--- a/lib/future/test/error.c
+++ b/lib/future/test/error.c
@@ -1,0 +1,345 @@
+//**********************************************************************;
+// Copyright (c) 2018, Intel Corporation
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+// 1. Redistributions of source code must retain the above copyright notice,
+// this list of conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright notice,
+// this list of conditions and the following disclaimer in the documentation
+// and/or other materials provided with the distribution.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+// THE POSSIBILITY OF SUCH DAMAGE.
+//**********************************************************************;
+
+#include <stdarg.h>
+#include <stddef.h>
+#include <stdio.h>
+
+#include <setjmp.h>
+#include <cmocka.h>
+
+#include <sapi/tpm20.h>
+
+#include "future/tss2_err.h"
+
+#define ARRAY_LEN(x) (sizeof(x)/sizeof(x[0]))
+
+#define assert_string_prefix(str, prefix) \
+    assert_memory_equal(str, prefix, strlen(prefix))
+
+static void
+test_layers (
+    void **state)
+{
+    (void) state;
+
+    static const char *known_layers[TPM2_ERROR_TSS2_RC_LAYER_COUNT] = {
+            "tpm:",
+            NULL,
+            NULL,
+            NULL,
+            NULL,
+            NULL,
+            NULL,
+            "fapi:",
+            "sys:",
+            "mu:",
+            "tcti:",
+            "rmt",
+            "rm",
+            "drvr",
+    };
+
+    UINT8 layer;
+    for (layer = 0; layer < TPM2_ERROR_TSS2_RC_LAYER_COUNT; layer++) {
+        TSS2_RC rc = TSS2_RC_LAYER(layer);
+
+        const char *got = tpm2_error_str (rc);
+
+        char buf[256];
+        snprintf (buf, sizeof(buf), "%u:", layer);
+
+        const char *expected = known_layers[layer] ? known_layers[layer] : buf;
+        assert_string_prefix(got, expected);
+    }
+}
+
+static void
+test_tpm_format_0_version2_0_error (
+    void **state)
+{
+    (void) state;
+
+    const char *m = tpm2_error_str (TPM2_RC_SEQUENCE);
+    assert_string_equal(m, "tpm:error(2.0): improper use of a sequence"
+        " handle");
+}
+
+static void
+test_tpm_format_0_version2_0_warn (void **state)
+{
+    (void) state;
+
+    const char *m = tpm2_error_str (TPM2_RC_REFERENCE_H0);
+    assert_string_equal(m,
+        "tpm:warn(2.0): the 1st handle in the handle area references a"
+        " transient object or session that is not loaded");
+}
+
+static void
+test_tpm2_format_0_unkown (
+    void **state)
+{
+    (void) state;
+
+    const char *m = tpm2_error_str (TPM2_RC_NOT_USED + 0x80);
+    assert_string_equal(m, "tpm:parameter(1):unknown error num: 0x3F");
+}
+
+static void
+test_tpm_format_1_unk_handle (
+    void **state)
+{
+    (void) state;
+
+    const char *m = tpm2_error_str (TPM2_RC_HASH);
+    assert_string_equal(m,
+        "tpm:handle(unk):hash algorithm not supported or not appropriate");
+}
+
+static void
+test_tpm_format_1_unk_parameter (void **state)
+{
+    (void) state;
+
+    const char *m = tpm2_error_str (TPM2_RC_HASH + TPM2_RC_P);
+    assert_string_equal(m,
+        "tpm:parameter(unk):hash algorithm not supported or not appropriate");
+}
+
+static void
+test_tpm_format_1_unk_session (
+    void **state)
+{
+    (void) state;
+
+    const char *m = tpm2_error_str (TPM2_RC_HASH + TPM2_RC_S);
+    assert_string_equal(m,
+        "tpm:session(unk):hash algorithm not supported or not appropriate");
+}
+
+static void
+test_tpm_format_1_5_handle (
+    void **state)
+{
+    (void) state;
+
+    const char *m = tpm2_error_str (TPM2_RC_HASH + TPM2_RC_5);
+    assert_string_equal(m,
+        "tpm:handle(5):hash algorithm not supported or not appropriate");
+}
+
+static void
+test_tpm2_format_1_unkown (
+    void **state)
+{
+    (void) state;
+
+    const char *m = tpm2_error_str (TPM2_RC_NOT_USED + 0x80);
+    assert_string_equal(m, "tpm:parameter(1):unknown error num: 0x3F");
+}
+
+static void
+test_tpm2_format_1_success (
+    void **state)
+{
+    (void) state;
+
+    const char *m = tpm2_error_str (TPM2_RC_SUCCESS);
+    assert_string_equal(m, "tpm:success");
+}
+
+static const char *
+custom_err_handler (
+        TSS2_RC rc)
+{
+
+    static const char *err_map[] = {
+        "error 1", "error 2", "error 3"
+    };
+
+    if (rc - 1u >= ARRAY_LEN(err_map)) {
+        return NULL;
+    }
+
+    return err_map[rc - 1];
+}
+
+static void
+test_custom_handler (
+    void **state)
+{
+    (void) state;
+
+    /*
+     * Test registering a custom handler
+     */
+    bool res = tpm2_error_set_handler (1, "cstm", custom_err_handler);
+    assert_true(res);
+
+    /*
+     * Test getting error strings
+     */
+    unsigned i;
+    for (i = 1; i < 4; i++) {
+        // Make a layer 1 error with an error number of i.
+        TSS2_RC rc = TSS2_RC_LAYER(1) | i;
+        char buf[256];
+        snprintf (buf, sizeof(buf), "cstm:error %u", i);
+
+        const char *e = tpm2_error_str (rc);
+        assert_string_equal(e, buf);
+    }
+
+    TSS2_RC rc = TSS2_RC_LAYER(1) | 42;
+
+    /*
+     * Test an unknown error
+     */
+    const char *e = tpm2_error_str (rc);
+    assert_string_equal(e, "cstm:0x2A");
+
+    /*
+     * Test clearing a handler
+     */
+    res = tpm2_error_set_handler (1, "cstm", NULL);
+    assert_true(res);
+
+    /*
+     * Test an unknown layer
+     */
+    e = tpm2_error_str (rc);
+    assert_string_equal(e, "1:0x2A");
+}
+
+static void
+test_zero_length_name (
+    void **state)
+{
+    (void) state;
+
+    bool res = tpm2_error_set_handler (TSS2_TPM_RC_LAYER, "", custom_err_handler);
+    assert_false(res);
+}
+
+static void
+test_over_length_name (
+    void **state)
+{
+    (void) state;
+
+    bool res = tpm2_error_set_handler (1, "way to long", custom_err_handler);
+    assert_false(res);
+}
+
+static void
+test_reserved_handler (
+    void **state)
+{
+    (void) state;
+
+    bool res = tpm2_error_set_handler (TSS2_TPM_RC_LAYER, "nope",
+                                    custom_err_handler);
+    assert_false(res);
+}
+
+static void
+test_null_name (
+    void **state)
+{
+    (void) state;
+
+    bool res = tpm2_error_set_handler (TSS2_TPM_RC_LAYER,
+    NULL,
+                                    custom_err_handler);
+    assert_false(res);
+}
+
+static void
+test_sys (
+    void **state)
+{
+    (void) state;
+
+    const char *e = tpm2_error_str (TSS2_SYS_RC_ABI_MISMATCH);
+    assert_string_equal(e,
+        "sys:Passed in ABI version doesn't match called module's ABI version");
+}
+
+static void
+test_mu (
+    void **state)
+{
+    (void) state;
+
+    const char *e = tpm2_error_str (TSS2_MU_RC_BAD_REFERENCE);
+    assert_string_equal(e,
+        "mu:A pointer is NULL that isn't allowed to be NULL.");
+
+}
+
+static void
+test_tcti (
+    void **state)
+{
+    (void) state;
+
+    const char *e = tpm2_error_str (TSS2_TCTI_RC_NO_CONNECTION);
+    assert_string_equal(e, "tcti:Fails to connect to next lower layer");
+}
+
+int
+main (
+    int argc,
+    char* argv[])
+{
+    (void) argc;
+    (void) argv;
+
+    const struct CMUnitTest tests[] = {
+            /* Layer tests */
+            cmocka_unit_test(test_layers),
+            cmocka_unit_test(test_tpm_format_0_version2_0_error),
+            cmocka_unit_test(test_tpm_format_0_version2_0_warn),
+            cmocka_unit_test(test_tpm2_format_0_unkown),
+            cmocka_unit_test(test_tpm_format_1_unk_handle),
+            cmocka_unit_test(test_tpm_format_1_unk_parameter),
+            cmocka_unit_test(test_tpm_format_1_unk_session),
+            cmocka_unit_test(test_tpm_format_1_5_handle),
+            cmocka_unit_test(test_tpm2_format_1_unkown),
+            cmocka_unit_test(test_tpm2_format_1_success),
+            cmocka_unit_test(test_custom_handler),
+            cmocka_unit_test(test_zero_length_name),
+            cmocka_unit_test(test_over_length_name),
+            cmocka_unit_test(test_reserved_handler),
+            cmocka_unit_test(test_null_name),
+            cmocka_unit_test(test_sys),
+            cmocka_unit_test(test_mu),
+            cmocka_unit_test(test_tcti),
+    };
+    return cmocka_run_group_tests(tests, NULL, NULL);
+}

--- a/lib/log.h
+++ b/lib/log.h
@@ -34,7 +34,20 @@
 #include <stdbool.h>
 #include <stdio.h>
 
+#include <sapi/tpm20.h>
+
+#include "tpm2_error.h"
+#include "tpm2_util.h"
+
 typedef enum log_level log_level;
+enum log_level {
+    log_level_error,
+    log_level_warning,
+    log_level_verbose
+};
+
+void _log (log_level level, const char *file, unsigned lineno, const char *fmt, ...)
+    COMPILER_ATTR(format (printf, 4, 5));
 
 /*
  * Prints an error message. The fmt and variadic arguments mirror printf.
@@ -42,6 +55,31 @@ typedef enum log_level log_level;
  * Use this to log all error conditions.
  */
 #define LOG_ERR(fmt, ...) _log(log_level_error, __FILE__, __LINE__, fmt, ##__VA_ARGS__)
+
+/**
+ * Prints an error message for a TSS2_Sys call to the TPM.
+ * The format is <function-name>(0x<rc>) - <error string>
+ * @param func
+ *  The function that caused the error
+ * @param rc
+ *  The return code to print.
+ */
+#define LOG_PERR(func, rc) _LOG_PERR(xstr(func), rc)
+
+/**
+ * Internal use only.
+ *
+ * Handles the expanded LOG_PERR call checking argument values
+ * and handing them off to LOG_ERR.
+ * @param func
+ *  The function name.
+ * @param rc
+ *  The rc to decode.
+ */
+static inline void _LOG_PERR(const char *func, TSS2_RC rc) {
+
+    LOG_ERR("%s(0x%X) - %s", func, rc, tpm2_error_str(rc));
+}
 
 /*
  * Prints an warning message. The fmt and variadic arguments mirror printf.
@@ -59,20 +97,11 @@ typedef enum log_level log_level;
  */
 #define LOG_INFO(fmt, ...) _log(log_level_verbose, __FILE__, __LINE__, fmt, ##__VA_ARGS__)
 
-enum log_level
-{
-    log_level_error, log_level_warning, log_level_verbose
-};
-
 /**
  * Sets the log level so only messages <= to it print.
  * @param level
  *  The logging level to set.
  */
-void
-log_set_level (log_level level);
-
-void
-_log (log_level level, const char *file, unsigned lineno, const char *fmt, ...) __attribute__ ((format (printf, 4, 5)));
+void log_set_level (log_level level);
 
 #endif /* SRC_LOG_H_ */

--- a/lib/tpm2_error.c
+++ b/lib/tpm2_error.c
@@ -1,0 +1,881 @@
+//**********************************************************************;
+// Copyright (c) 2018, Intel Corporation
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+// 1. Redistributions of source code must retain the above copyright notice,
+// this list of conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright notice,
+// this list of conditions and the following disclaimer in the documentation
+// and/or other materials provided with the distribution.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+// THE POSSIBILITY OF SUCH DAMAGE.
+//**********************************************************************;
+
+#include <stdarg.h>
+#include <stdbool.h>
+#include <stdio.h>
+
+#include <sapi/tpm20.h>
+
+#include "tpm2_error.h"
+#include "tpm2_util.h"
+
+#if defined (__GNUC__)
+#define COMPILER_ATTR(...) __attribute__((__VA_ARGS__))
+#else
+#define COMPILER_ATTR(...)
+#endif
+
+/**
+ * The maximum size of a layer name.
+ */
+#define TSS2_ERR_LAYER_NAME_MAX  4
+
+/**
+ * The maximum size for layer specific error strings.
+ */
+#define TSS2_ERR_LAYER_ERROR_STR_MAX  512
+
+/**
+ * Mask for the error bits of tpm2 compliant return code.
+ */
+#define TSS2_RC_ERROR_MASK 0xFFFF
+
+/**
+ * Concatenates (safely) onto a static buffer given a format and varaidic
+ * arguments similar to sprintf.
+ * @param b
+ *   The static buffer to concatenate onto.
+ * @param fmt
+ *   The format specifier as understood by printf followed by the variadic
+ *   parameters for the specifier.
+ */
+#define catbuf(b, fmt, ...) _catbuf(b, sizeof(b), fmt, ##__VA_ARGS__)
+
+/**
+ * Clears out a static buffer by setting index 0 to the null byte.
+ * @param buffer
+ *  The buffer to clear out.
+ */
+static void clearbuf(char *buffer) {
+    buffer[0] = '\0';
+}
+
+/**
+ * Prints to a buffer using snprintf(3) using the supplied fmt
+ * and varaiadic arguments.
+ * @param buf
+ *  The buffer to print into.
+ * @param len
+ *  The length of that buffer.
+ * @param fmt
+ *  The format string
+ * @warning
+ *  DO NOT CALL DIRECTLY, use the catbuf() macro.
+ */
+static void COMPILER_ATTR(format (printf, 3, 4))
+_catbuf(char *buf, size_t len, const char *fmt, ...) {
+    va_list argptr;
+    va_start(argptr, fmt);
+    size_t offset = strlen(buf);
+    vsnprintf(&buf[offset], len - offset, fmt, argptr);
+    va_end(argptr);
+}
+
+/**
+ * Retrieves the layer number. The layer number is in the 3rd
+ * octet and is thus 1 byte big.
+ *
+ * @param rc
+ *  The rc to query for the layer number.
+ * @return
+ *  The layer number.
+ */
+static inline UINT8 tss2_rc_layer_number_get(TSS2_RC rc) {
+    return ((rc & TSS2_RC_LAYER_MASK) >> TSS2_RC_LAYER_SHIFT);
+}
+
+/**
+ * Retrieves the error bits from a TSS2_RC. The error bits are
+ * contained in the first 2 octets.
+ * @param rc
+ *  The rc to query for the error bits.
+ * @return
+ *  The error bits.
+ */
+static inline UINT16 tss2_rc_layer_error_get(TSS2_RC rc) {
+    return ((rc & TSS2_RC_ERROR_MASK));
+}
+
+/**
+ * Queries a TPM format 1 error codes N field. The N field
+ * is a 4 bit field located at bits 8:12.
+ * @param rc
+ *  The rc to query the N field for.
+ * @return
+ *  The N field value.
+ */
+static inline UINT8 tpm2_rc_fmt1_N_get(TPM2_RC rc) {
+    return ((rc & (0xF << 8)) >> 8);
+}
+
+/**
+ * Queries the index bits out of the N field contained in a TPM format 1
+ * error code. The index bits are the low 3 bits of the N field.
+ * @param rc
+ *  The TPM format 1 error code to query for the index bits.
+ * @return
+ *  The index bits from the N field.
+ */
+static inline UINT8 tpm2_rc_fmt1_N_index_get(TPM2_RC rc) {
+    return (tpm2_rc_fmt1_N_get(rc) & 0x7);
+}
+
+/**
+ * Determines if the N field in a TPM format 1 error code is
+ * a handle or not.
+ * @param rc
+ *  The TPM format 1 error code to query.
+ * @return
+ *  True if it is a handle, false otherwise.
+ */
+static inline bool tpm2_rc_fmt1_N_is_handle(TPM2_RC rc) {
+    return ((tpm2_rc_fmt1_N_get(rc) & 0x8) == 0);
+}
+
+static inline UINT8 tpm2_rc_fmt1_P_get(TPM2_RC rc) {
+    return ((rc & (1 << 6)) >> 6);
+}
+
+static inline UINT16 tpm2_rc_fmt1_error_get(TPM2_RC rc) {
+    return (rc & 0x3F);
+}
+
+static inline UINT16 tpm2_rc_fmt0_error_get(TPM2_RC rc) {
+    return (rc & 0x7F);
+}
+
+static inline UINT8 tpm2_rc_tpm_fmt0_V_get(TPM2_RC rc) {
+    return ((rc & (1 << 8)) >> 8);
+}
+
+static inline UINT8 tpm2_rc_fmt0_T_get(TPM2_RC rc) {
+    return ((rc & (1 << 10)) >> 8);
+}
+
+static inline UINT8 tpm2_rc_fmt0_S_get(TSS2_RC rc) {
+    return ((rc & (1 << 11)) >> 8);
+}
+
+/**
+ * Helper macro for adding a layer handler to the layer
+ * registration array.
+ */
+#define ADD_HANDLER(name, handler) \
+    { name, handler }
+
+/**
+ * Same as ADD_HANDLER but sets it to NULL. Used as a placeholder
+ * for non-registered indexes into the handler array.
+ */
+#define ADD_NULL_HANDLER ADD_HANDLER(NULL, NULL)
+
+static const char *tpm2_err_handler_fmt1(TPM2_RC rc) {
+
+    /*
+     * format 1 error codes start at 1, so
+     * add a NULL entry to index 0.
+     */
+    static const char *fmt1_err_strs[] = {
+        // 0x0 - EMPTY
+        NULL,
+        // 0x1 - TPM2_RC_ASYMMETRIC
+        "asymmetric algorithm not supported or not correct",
+        // 0x2 - TPM2_RC_ATTRIBUTES
+        "inconsistent attributes",
+        // 0x3 - TPM2_RC_HASH
+        "hash algorithm not supported or not appropriate",
+        // 0x4 - TPM2_RC_VALUE
+        "value is out of range or is not correct for the context",
+        // 0x5 - TPM2_RC_HIERARCHY
+        "hierarchy is not enabled or is not correct for the use",
+        // 0x6 - EMPTY
+        NULL,
+        // 0x7 - TPM2_RC_KEY_SIZE
+        "key size is not supported",
+        // 0x8 - TPM2_RC_MGF
+        "mask generation function not supported",
+        // 0x9 - TPM2_RC_MODE
+        "mode of operation not supported",
+        // 0xA - TPM2_RC_TYPE
+        "the type of the value is not appropriate for the use",
+        // 0xB - TPM2_RC_HANDLE
+        "the handle is not correct for the use",
+        // 0xC - TPM2_RC_KDF
+        "unsupported key derivation function or function not appropriate for "
+        "use",
+        // 0xD - TPM2_RC_RANGE
+        "value was out of allowed range",
+        // 0xE - TPM2_RC_AUTH_FAIL
+        "the authorization HMAC check failed and DA counter incremented",
+        // 0xF - TPM2_RC_NONCE
+        "invalid nonce size or nonce value mismatch",
+        // 0x10 - TPM2_RC_PP
+        "authorization requires assertion of PP",
+        // 0x11 - EMPTY
+        NULL,
+        // 0x12 - TPM2_RC_SCHEME
+        "unsupported or incompatible scheme",
+        // 0x13 - EMPTY
+        NULL,
+        // 0x14 - EMPTY
+        NULL,
+        // 0x15 - TPM2_RC_SIZE
+        "structure is the wrong size",
+        // 0x16 - TPM2_RC_SYMMETRIC
+        "unsupported symmetric algorithm or key size, or not appropriate for"
+        " instance",
+        // 0x17 - TPM2_RC_TAG
+        "incorrect structure tag",
+        // 0x18 - TPM2_RC_SELECTOR
+        "union selector is incorrect",
+        // 0x19 - EMPTY
+        NULL,
+        // 0x1A - TPM2_RC_INSUFFICIENT
+        "the TPM was unable to unmarshal a value because there were not enough"
+        " octets in the input buffer",
+        // 0x1B - TPM2_RC_SIGNATURE
+        "the signature is not valid",
+        // 0x1C - TPM2_RC_KEY
+        "key fields are not compatible with the selected use",
+        // 0x1D - TPM2_RC_POLICY_FAIL
+        "a policy check failed",
+        // 0x1E - EMPTY
+        NULL,
+        // 0x1F - TPM2_RC_INTEGRITY
+        "integrity check failed",
+        // 0x20 - TPM2_RC_TICKET
+        "invalid ticket",
+        // 0x21 - TPM2_RC_RESERVED_BITS
+        "reserved bits not set to zero as required",
+        // 0x22 - TPM2_RC_BAD_AUTH
+        "authorization failure without DA implications",
+        // 0x23 - TPM2_RC_EXPIRED
+        "the policy has expired",
+        // 0x24 - TPM2_RC_POLICY_CC
+        "the commandCode in the policy is not the commandCode of the command"
+        " or the command code in a policy command references a command that"
+        " is not implemented",
+        // 0x25 - TPM2_RC_BINDING
+        "public and sensitive portions of an object are not cryptographically bound",
+        // 0x26 - TPM2_RC_CURVE
+        "curve not supported",
+        // 0x27 - TPM2_RC_ECC_POINT
+        "point is not on the required curve",
+    };
+
+    static char buf[TSS2_ERR_LAYER_ERROR_STR_MAX + 1];
+
+    clearbuf(buf);
+
+    /* Print whether or not the error is caused by a bad
+     * handle or parameter. On the case of a Handle (P == 0)
+     * then the N field top bit will be set. Un-set this bit
+     * to get the handle index by subtracting 8 as N is a 4
+     * bit field.
+     *
+     * the lower 3 bits of N indicate index, and the high bit
+     * indicates
+     */
+    UINT8 index = tpm2_rc_fmt1_N_index_get(rc);
+
+    bool is_handle = tpm2_rc_fmt1_N_is_handle(rc);
+    const char *m = tpm2_rc_fmt1_P_get(rc) ? "parameter" :
+                    is_handle ? "handle" : "session";
+    catbuf(buf, "%s", m);
+
+    if (index) {
+        catbuf(buf, "(%u):", index);
+    } else {
+        catbuf(buf, "%s", "(unk):");
+    }
+
+    UINT8 errnum = tpm2_rc_fmt1_error_get(rc);
+    if (errnum < ARRAY_LEN(fmt1_err_strs)) {
+        m = fmt1_err_strs[errnum];
+        catbuf(buf, "%s", m);
+    } else {
+        catbuf(buf, "unknown error num: 0x%X", errnum);
+    }
+
+    return buf;
+}
+
+static const char *tpm2_err_handler_fmt0(TSS2_RC rc) {
+
+    /*
+     * format 0 error codes start at 1, so
+     * add a NULL entry to index 0.
+     * Thus, no need to offset the error bits
+     * and fmt0 and fmt1 arrays can be used
+     * in-place of each other for lookups.
+     */
+    static const char *fmt0_warn_strs[] = {
+            // 0x0 - EMPTY
+            NULL,
+            // 0x1 - TPM2_RC_CONTEXT_GAP
+            "gap for context ID is too large",
+            // 0x2 - TPM2_RC_OBJECT_MEMORY
+            "out of memory for object contexts",
+            // 0x3 - TPM2_RC_SESSION_MEMORY
+            "out of memory for session contexts",
+            // 0x4 - TPM2_RC_MEMORY
+            "out of shared object/session memory or need space for internal"
+            " operations",
+            // 0x5 - TPM2_RC_SESSION_HANDLES
+            "out of session handles",
+            // 0x6 - TPM2_RC_OBJECT_HANDLES
+            "out of object handles",
+            // 0x7 - TPM2_RC_LOCALITY
+            "bad locality",
+            // 0x8 - TPM2_RC_YIELDED
+            "the TPM has suspended operation on the command; forward progress"
+            " was made and the command may be retried",
+            // 0x9 - TPM2_RC_CANCELED
+            "the command was canceled",
+            // 0xA - TPM2_RC_TESTING
+            "TPM is performing self-tests",
+            // 0xB - EMPTY
+            NULL,
+            // 0xC - EMPTY
+            NULL,
+            // 0xD - EMPTY
+            NULL,
+            // 0xE - EMPTY
+            NULL,
+            // 0xF - EMPTY
+            NULL,
+            // 0x10 - TPM2_RC_REFERENCE_H0
+            "the 1st handle in the handle area references a transient object"
+            " or session that is not loaded",
+            // 0x11 - TPM2_RC_REFERENCE_H1
+            "the 2nd handle in the handle area references a transient object"
+            " or session that is not loaded",
+            // 0x12 - TPM2_RC_REFERENCE_H2
+            "the 3rd handle in the handle area references a transient object"
+            " or session that is not loaded",
+            // 0x13 - TPM2_RC_REFERENCE_H3
+            "the 4th handle in the handle area references a transient object"
+            " or session that is not loaded",
+            // 0x14 - TPM2_RC_REFERENCE_H4
+            "the 5th handle in the handle area references a transient object"
+            " or session that is not loaded",
+            // 0x15 - TPM2_RC_REFERENCE_H5
+            "the 6th handle in the handle area references a transient object"
+            " or session that is not loaded",
+            // 0x16 - TPM2_RC_REFERENCE_H6
+            "the 7th handle in the handle area references a transient object"
+            " or session that is not loaded",
+            // 0x17 - EMPTY,
+            // 0x18 - TPM2_RC_REFERENCE_S0
+            "the 1st authorization session handle references a session that"
+            " is not loaded",
+            // 0x19 - TPM2_RC_REFERENCE_S1
+            "the 2nd authorization session handle references a session that"
+            " is not loaded",
+            // 0x1A - TPM2_RC_REFERENCE_S2
+            "the 3rd authorization session handle references a session that"
+            " is not loaded",
+            // 0x1B - TPM2_RC_REFERENCE_S3
+            "the 4th authorization session handle references a session that"
+            " is not loaded",
+            // 0x1C - TPM2_RC_REFERENCE_S4
+            "the 5th authorization session handle references a session that"
+            " is not loaded",
+            // 0x1D - TPM2_RC_REFERENCE_S5
+            "the 6th authorization session handle references a session that"
+            " is not loaded",
+            // 0x1E - TPM2_RC_REFERENCE_S6
+            "the 7th authorization session handle references a session that"
+            " is not loaded",
+            // 0x20 -TPM2_RC_NV_RATE
+            "the TPM is rate-limiting accesses to prevent wearout of NV",
+            // 0x21 - TPM2_RC_LOCKOUT
+            "authorizations for objects subject to DA protection are not"
+            " allowed at this time because the TPM is in DA lockout mode",
+            // 0x22 - TPM2_RC_RETRY
+            "the TPM was not able to start the command",
+            // 0x23 - TPM2_RC_NV_UNAVAILABLE
+            "the command may require writing of NV and NV is not current"
+            " accessible",
+    };
+
+    /*
+     * format 1 error codes start at 0, so
+     * no need to offset the error bits.
+     */
+    static const char *fmt0_err_strs[] = {
+        // 0x0 - TPM2_RC_INITIALIZE
+        "TPM not initialized by TPM2_Startup or already initialized",
+        // 0x1 - TPM2_RC_FAILURE
+        "commands not being accepted because of a TPM failure",
+        // 0x2 - EMPTY
+        NULL,
+        // 0x3 - TPM2_RC_SEQUENCE
+        "improper use of a sequence handle",
+        // 0x4 - EMPTY
+        NULL,
+        // 0x5 - EMPTY
+        NULL,
+        // 0x6 - EMPTY
+        NULL,
+        // 0x7 - EMPTY
+        NULL,
+        // 0x8 - EMPTY
+        NULL,
+        // 0x9 - EMPTY
+        NULL,
+        // 0xA - EMPTY
+        NULL,
+        // 0xB - TPM2_RC_PRIVATE
+        "not currently used",
+        // 0xC - EMPTY
+        NULL,
+        // 0xD - EMPTY
+        NULL,
+        // 0xE - EMPTY
+        NULL,
+        // 0xF - EMPTY
+        NULL,
+        // 0x10 - EMPTY
+        NULL,
+        // 0x11 - EMPTY
+        NULL,
+        // 0x12 - EMPTY
+        NULL,
+        // 0x13 - EMPTY
+        NULL,
+        // 0x14 - EMPTY
+        NULL,
+        // 0x15 - EMPTY
+        NULL,
+        // 0x16 - EMPTY
+        NULL,
+        // 0x17 - EMPTY
+        NULL,
+        // 0x18 - EMPTY
+        NULL,
+        // 0x19 - TPM2_RC_HMAC
+        "not currently used",
+        // 0x20 - TPM2_RC_DISABLED
+        "the command is disabled",
+        // 0x21 - TPM2_RC_EXCLUSIVE
+        "command failed because audit sequence required exclusivity",
+        // 0x22 - EMPTY
+        NULL,
+        // 0x32 - EMPTY,
+        NULL,
+        // 0x24 - TPM2_RC_AUTH_TYPE
+        "authorization handle is not correct for command",
+        // 0x25 - TPM2_RC_AUTH_MISSING
+        "command requires an authorization session for handle and it is"
+        " not present",
+        // 0x26 - TPM2_RC_POLICY
+        "policy failure in math operation or an invalid authPolicy value",
+        // 0x27 - TPM2_RC_PCR
+        "PCR check fail",
+        // 0x28 - TPM2_RC_PCR_CHANGED
+        "PCR have changed since checked",
+        // 0x29 - EMPTY
+        NULL,
+        // 0x2A - EMPTY
+        NULL,
+        // 0x2B - EMPTY
+        NULL,
+        // 0x2C - EMPTY
+        NULL,
+        // 0x2D - TPM2_RC_UPGRADE
+        "TPM is in field upgrade mode unless called via"
+        " TPM2_FieldUpgradeData(), then it is not in field upgrade mode",
+        // 0x2E - TPM2_RC_TOO_MANY_CONTEXTS
+        "context ID counter is at maximum",
+        // 0x2F - TPM2_RC_AUTH_UNAVAILABLE
+        "authValue or authPolicy is not available for selected entity",
+        // 0x30 - TPM2_RC_REBOOT
+        "a _TPM_Init and Startup(CLEAR) is required before the TPM can"
+        " resume operation",
+        // 0x31 - TPM2_RC_UNBALANCED
+        "the protection algorithms (hash and symmetric) are not reasonably"
+        " balanced. The digest size of the hash must be larger than the key"
+        " size of the symmetric algorithm.",
+        // 0x32 - EMPTY
+        NULL,
+        // 0x33 - EMPTY
+        NULL,
+        // 0x34 - EMPTY
+        NULL,
+        // 0x35 - EMPTY
+        NULL,
+        // 0x36 - EMPTY
+        NULL,
+        // 0x37 - EMPTY
+        NULL,
+        // 0x38 - EMPTY
+        NULL,
+        // 0x39 - EMPTY
+        NULL,
+        // 0x3A - EMPTY
+        NULL,
+        // 0x3B - EMPTY
+        NULL,
+        // 0x3C - EMPTY
+        NULL,
+        // 0x3D - EMPTY
+        NULL,
+        // 0x3E - EMPTY
+        NULL,
+        // 0x3F - EMPTY
+        NULL,
+        // 0x40 - EMPTY
+        NULL,
+        // 0x41 - EMPTY
+        NULL,
+        // 0x42 - TPM2_RC_COMMAND_SIZE
+        "command commandSize value is inconsistent with contents of the"
+        " command buffer; either the size is not the same as the octets"
+        " loaded by the hardware interface layer or the value is not large"
+        " enough to hold a command header",
+        // 0x43 - TPM2_RC_COMMAND_CODE
+        "command code not supported",
+        // 0x44 - TPM2_RC_AUTHSIZE
+        "the value of authorizationSize is out of range or the number of"
+        " octets in the Authorization Area is greater than required",
+        // 0x45 - TPM2_RC_AUTH_CONTEXT
+        "use of an authorization session with a context command or another"
+        " command that cannot have an authorization session",
+        // 0x46 - TPM2_RC_NV_RANGE
+        "NV offset+size is out of range",
+        // 0x47 - TPM2_RC_NV_SIZE
+        "Requested allocation size is larger than allowed",
+        // 0x48 - TPM2_RC_NV_LOCKED
+        "NV access locked",
+        // 0x49 - TPM2_RC_NV_AUTHORIZATION
+        "NV access authorization fails in command actions",
+        // 0x4A - TPM2_RC_NV_UNINITIALIZED
+        "an NV Index is used before being initialized or the state saved"
+        " by TPM2_Shutdown(STATE) could not be restored",
+        // 0x4B - TPM2_RC_NV_SPACE
+        "insufficient space for NV allocation",
+        // 0x4C - TPM2_RC_NV_DEFINED
+        "NV Index or persistent object already defined",
+        // 0x4D - EMPTY
+        NULL,
+        // 0x4E - EMPTY
+        NULL,
+        // 0x4F - EMPTY
+        NULL,
+        // 0x50 - TPM2_RC_BAD_CONTEXT
+        "context in TPM2_ContextLoad() is not valid",
+        // 0x51 - TPM2_RC_CPHASH
+        "cpHash value already set or not correct for use",
+        // 0x52 - TPM2_RC_PARENT
+        "handle for parent is not a valid parent",
+        // 0x53 - TPM2_RC_NEEDS_TEST
+        "some function needs testing",
+        // 0x54 - TPM2_RC_NO_RESULT
+        "returned when an internal function cannot process a request due to"
+        " an unspecified problem. This code is usually related to invalid"
+        " parameters that are not properly filtered by the input"
+        " unmarshaling code",
+        // 0x55 - TPM2_RC_SENSITIVE
+        "the sensitive area did not unmarshal correctly after decryption",
+    };
+
+    static char buf[TSS2_ERR_LAYER_ERROR_STR_MAX + 1];
+
+    clearbuf(buf);
+
+    char *e = tpm2_rc_fmt0_S_get(rc) ? "warn" : "error";
+    char *v = tpm2_rc_tpm_fmt0_V_get(rc) ? "2.0" : "1.2";
+    catbuf(buf, "%s(%s): ", e, v);
+
+    UINT8 errnum = tpm2_rc_fmt0_error_get(rc);
+    /* We only have version 2.0 spec codes defined */
+    if (tpm2_rc_tpm_fmt0_V_get(rc)) {
+        /* TCG specific error code */
+        if (tpm2_rc_fmt0_T_get(rc)) {
+            catbuf(buf, "Vendor specific error: 0x%X", errnum);
+            return buf;
+        }
+
+        /* is it a warning (version 2 error string) or is it a 1.2 error? */
+        size_t len =
+                tpm2_rc_fmt0_S_get(rc) ?
+                        ARRAY_LEN(fmt0_warn_strs) : ARRAY_LEN(fmt0_err_strs);
+        const char **selection =
+                tpm2_rc_fmt0_S_get(rc) ? fmt0_warn_strs : fmt0_err_strs;
+        if (errnum >= len) {
+            return NULL;
+        }
+
+        const char *m = selection[errnum];
+        if (!m) {
+            return NULL;
+        }
+
+        catbuf(buf, "%s", m);
+        return buf;
+    }
+
+    catbuf(buf, "%s", "unknown version 1.2 error code");
+
+    return buf;
+}
+
+/**
+ * Retrieves the layer field from a TSS2_RC code.
+ * @param rc
+ *  The rc to query the layer index of.
+ * @return
+ *  The layer index.
+ */
+static inline UINT8 tss2_rc_layer_format_get(TSS2_RC rc) {
+
+    return ((rc & (1 << 7)) >> 7);
+}
+
+/**
+ * Handler for tpm2 error codes. ie codes
+ * coming from the tpm layer aka layer 0.
+ * @param rc
+ *  The rc to decode.
+ * @return
+ *  An error string.
+ */
+static const char *tpm2_ehandler(TSS2_RC rc) {
+
+    bool is_fmt_1 = tss2_rc_layer_format_get(rc);
+
+    return is_fmt_1 ? tpm2_err_handler_fmt1(rc) : tpm2_err_handler_fmt0(rc);
+}
+
+/**
+ * The default system code handler. This handles codes
+ * from the RM (itself and simlated tpm responses), the marshaling
+ * library (mu), and the tcti layers.
+ * @param rc
+ *  The rc to decode.
+ * @return
+ *  An error string.
+ */
+static const char *sys_err_handler (TSS2_RC rc) {
+    UNUSED(rc);
+
+    /*
+     * subtract 1 from the error number
+     * before indexing into this array.
+     *
+     * Commented offsets are for the corresponding
+     * error number *before* subtraction. Ie error
+     * number 4 is at array index 3.
+     */
+    static const char *errors[] =   {
+        // 1 - TSS2_BASE_RC_GENERAL_FAILURE
+        "Catch all for all errors not otherwise specified",
+        // 2 - TSS2_BASE_RC_NOT_IMPLEMENTED
+        "If called functionality isn't implemented",
+        // 3 - TSS2_BASE_RC_BAD_CONTEXT
+        "A context structure is bad",
+        // 4 - TSS2_BASE_RC_ABI_MISMATCH
+        "Passed in ABI version doesn't match called module's ABI version",
+        // 5 - TSS2_BASE_RC_BAD_REFERENCE
+        "A pointer is NULL that isn't allowed to be NULL.",
+        // 6 - TSS2_BASE_RC_INSUFFICIENT_BUFFER
+        "A buffer isn't large enough",
+        // 7 - TSS2_BASE_RC_BAD_SEQUENCE
+        "Function called in the wrong order",
+        // 8 - TSS2_BASE_RC_NO_CONNECTION
+        "Fails to connect to next lower layer",
+        // 9 - TSS2_BASE_RC_TRY_AGAIN
+        "Operation timed out; function must be called again to be completed",
+        // 10 - TSS2_BASE_RC_IO_ERROR
+        "IO failure",
+        // 11 - TSS2_BASE_RC_BAD_VALUE
+        "A parameter has a bad value",
+        // 12 - TSS2_BASE_RC_NOT_PERMITTED
+        "Operation not permitted.",
+        // 13 - TSS2_BASE_RC_INVALID_SESSIONS
+        "Session structures were sent, but command doesn't use them or doesn't"
+        " use the specified number of them",
+        // 14 - TSS2_BASE_RC_NO_DECRYPT_PARAM
+        "If function called that uses decrypt parameter, but command doesn't"
+        " support decrypt parameter.",
+        // 15 - TSS2_BASE_RC_NO_ENCRYPT_PARAM
+        "If function called that uses encrypt parameter, but command doesn't"
+        " support decrypt parameter.",
+        // 16 - TSS2_BASE_RC_BAD_SIZE
+        "If size of a parameter is incorrect",
+        // 17 - TSS2_BASE_RC_MALFORMED_RESPONSE
+        "Response is malformed",
+        // 18 - TSS2_BASE_RC_INSUFFICIENT_CONTEXT
+        "Context not large enough",
+        // 19 - TSS2_BASE_RC_INSUFFICIENT_RESPONSE
+        "Response is not long enough",
+        // 20 - TSS2_BASE_RC_INCOMPATIBLE_TCTI
+        "Unknown or unusable TCTI version",
+        // 21 - TSS2_BASE_RC_NOT_SUPPORTED
+        "Functionality not supported",
+        // 22 - TSS2_BASE_RC_BAD_TCTI_STRUCTURE
+        "TCTI context is bad"
+  };
+
+    return (rc - 1u < ARRAY_LEN(errors)) ? errors[rc - 1u] : NULL;
+}
+
+
+static struct {
+    const char *name;
+    tpm2_error_handler handler;
+} layer_handler[TPM2_ERROR_TSS2_RC_LAYER_COUNT] = {
+    ADD_HANDLER("tpm" , tpm2_ehandler),
+    ADD_NULL_HANDLER,                       // layer 1  is unused
+    ADD_NULL_HANDLER,                       // layer 2  is unused
+    ADD_NULL_HANDLER,                       // layer 3  is unused
+    ADD_NULL_HANDLER,                       // layer 4  is unused
+    ADD_NULL_HANDLER,                       // layer 5  is unused
+    ADD_NULL_HANDLER,                       // layer 6  is the feature rc
+    ADD_HANDLER("fapi", NULL),              // layer 7  is the esapi rc
+    ADD_HANDLER("sys", sys_err_handler),    // layer 8  is the sys rc
+    ADD_HANDLER("mu",  sys_err_handler),    // layer 9  is the mu rc
+                                            // Defaults to the system handler
+    ADD_HANDLER("tcti", sys_err_handler),   // layer 10 is the tcti rc
+                                            // Defaults to the system handler
+    ADD_HANDLER("rmt", tpm2_ehandler),      // layer 11 is the resource manager TPM RC
+                                            // The RM usually duplicates TPM responses
+                                            // So just default the handler to tpm2.
+    ADD_HANDLER("rm", NULL),                // layer 12 is the rm rc
+    ADD_HANDLER("drvr", NULL),              // layer 13 is the driver rc
+};
+
+/**
+ * Determines if the layer allowed to be registered to.
+ * @param layer
+ *  The layer to determine handler assignment eligibility of.
+ * @return
+ *  True if it is reserved and thus non-assignable, false otherwise.
+ */
+static bool is_reserved_layer(UINT8 layer) {
+    return layer == 0;
+}
+
+/**
+ * If a layer has no handler registered, default to this
+ * handler that prints the error number in hex.
+ * @param rc
+ *  The rc to print the error number of.
+ * @return
+ *  The string.
+ */
+static const char *unkown_layer_handler(TSS2_RC rc) {
+    UNUSED(rc);
+
+    static char buf[32];
+
+    clearbuf(buf);
+    catbuf(buf, "0x%X", tss2_rc_layer_error_get(rc));
+
+    return buf;
+}
+
+/**
+ * Register or unregister a custom layer error handler.
+ * @param layer
+ *  The layer in which to register a handler for. It is an error
+ *  to register for the following reserved layers:
+ *    - TSS2_TPM_RC_LAYER  - layer  0
+ *    - TSS2_SYS_RC_LAYER  - layer  8
+ *    - TSS2_MU_RC_LAYER   - layer  9
+ *    - TSS2_TCTI_RC_LAYER - layer 10
+ * @param name
+ *  A friendly layer name. It is an error for the name to be of
+ *  length 0 or greater than 4.
+ * @param handler
+ *  The handler function to register or NULL to unregister.
+ * @return
+ *  True on success or False on error.
+ */
+bool tpm2_error_set_handler(UINT8 layer, const char *name,
+        tpm2_error_handler handler) {
+
+    /* don't allow setting reserved layers */
+    if (is_reserved_layer(layer)) {
+        return false;
+    }
+
+    /*
+     * if they are clearing the handler, name doesn't matter
+     * clear it too.
+     */
+    if (!handler) {
+        name = NULL;
+    }
+
+    /* Perform a zero and max-name length check if name is being set */
+    if (name) {
+        size_t len = name ? strlen(name) : 0;
+        if (!len || len > TSS2_ERR_LAYER_NAME_MAX)
+            return false;
+    }
+
+    layer_handler[layer].handler = handler;
+    layer_handler[layer].name = name;
+
+    return true;
+}
+
+const char * tpm2_error_str(TSS2_RC rc) {
+
+    static char buf[TSS2_ERR_LAYER_NAME_MAX + TSS2_ERR_LAYER_ERROR_STR_MAX + 1];
+
+    clearbuf(buf);
+
+    UINT8 layer = tss2_rc_layer_number_get(rc);
+
+    tpm2_error_handler handler = layer_handler[layer].handler;
+    const char *lname = layer_handler[layer].name;
+
+    if (lname) {
+        catbuf(buf, "%s:", lname);
+    } else {
+        catbuf(buf, "%u:", layer);
+    }
+
+    handler = !handler ? unkown_layer_handler : handler;
+
+    // Handlers only need the error bits. This way they don't
+    // need to concern themselves with masking off the layer
+    // bits or anything else.
+    UINT16 err_bits = tss2_rc_layer_error_get(rc);
+    const char *e = err_bits ? handler(err_bits) : "success";
+    if (e) {
+        catbuf(buf, "%s", e);
+    } else {
+        catbuf(buf, "0x%X", err_bits);
+    }
+
+    return buf;
+}

--- a/lib/tpm2_error.c
+++ b/lib/tpm2_error.c
@@ -45,11 +45,6 @@
 #define TSS2_ERR_LAYER_ERROR_STR_MAX  512
 
 /**
- * Mask for the error bits of tpm2 compliant return code.
- */
-#define TSS2_RC_ERROR_MASK 0xFFFF
-
-/**
  * Concatenates (safely) onto a static buffer given a format and varaidic
  * arguments similar to sprintf.
  * @param b
@@ -101,18 +96,6 @@ _catbuf(char *buf, size_t len, const char *fmt, ...) {
  */
 static inline UINT8 tss2_rc_layer_number_get(TSS2_RC rc) {
     return ((rc & TSS2_RC_LAYER_MASK) >> TSS2_RC_LAYER_SHIFT);
-}
-
-/**
- * Retrieves the error bits from a TSS2_RC. The error bits are
- * contained in the first 2 octets.
- * @param rc
- *  The rc to query for the error bits.
- * @return
- *  The error bits.
- */
-static inline UINT16 tss2_rc_layer_error_get(TSS2_RC rc) {
-    return ((rc & TSS2_RC_ERROR_MASK));
 }
 
 /**
@@ -790,7 +773,7 @@ static const char *unkown_layer_handler(TSS2_RC rc) {
     static char buf[32];
 
     clearbuf(buf);
-    catbuf(buf, "0x%X", tss2_rc_layer_error_get(rc));
+    catbuf(buf, "0x%X", tpm2_error_get(rc));
 
     return buf;
 }
@@ -863,7 +846,7 @@ const char * tpm2_error_str(TSS2_RC rc) {
     // Handlers only need the error bits. This way they don't
     // need to concern themselves with masking off the layer
     // bits or anything else.
-    UINT16 err_bits = tss2_rc_layer_error_get(rc);
+    UINT16 err_bits = tpm2_error_get(rc);
     const char *e = err_bits ? handler(err_bits) : "success";
     if (e) {
         catbuf(buf, "%s", e);

--- a/lib/tpm2_error.c
+++ b/lib/tpm2_error.c
@@ -34,12 +34,6 @@
 #include "tpm2_error.h"
 #include "tpm2_util.h"
 
-#if defined (__GNUC__)
-#define COMPILER_ATTR(...) __attribute__((__VA_ARGS__))
-#else
-#define COMPILER_ATTR(...)
-#endif
-
 /**
  * The maximum size of a layer name.
  */

--- a/lib/tpm2_error.h
+++ b/lib/tpm2_error.h
@@ -1,0 +1,119 @@
+//**********************************************************************;
+// Copyright (c) 2018, Intel Corporation
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+// 1. Redistributions of source code must retain the above copyright notice,
+// this list of conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright notice,
+// this list of conditions and the following disclaimer in the documentation
+// and/or other materials provided with the distribution.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+// THE POSSIBILITY OF SUCH DAMAGE.
+//**********************************************************************;
+
+#ifndef LIB_TPM2_ERROR_H_
+#define LIB_TPM2_ERROR_H_
+
+#include <stdbool.h>
+
+#include <sapi/tpm20.h>
+
+/**
+ * Number of error layers
+ */
+#define TPM2_ERROR_TSS2_RC_LAYER_COUNT (TSS2_RC_LAYER_MASK >> TSS2_RC_LAYER_SHIFT)
+
+/**
+ * A custom error handler prototype.
+ * @param rc
+ *  The rc to decode with only the error bits set, ie no need to mask the
+ *  layer bits out. Handlers will never be invoked with the error bits set
+ *  to 0, as zero always indicates success.
+ * @return
+ *  An error string describing the rc. If the handler cannot determine
+ *  a valid response, it can return NULL indicating that the framework
+ *  should just print the raw hexidecimal value of the error field of
+ *  a tpm2_err_layer_rc.
+ *  Note that this WILL NOT BE FREED by the caller,
+ *  i.e. static.
+ */
+typedef const char *(*tpm2_error_handler)(TSS2_RC rc);
+
+/**
+ * Register or unregister a custom layer error handler.
+ * @param layer
+ *  The layer in which to register a handler for. It is an error
+ *  to register for the following reserved layers:
+ *    - TSS2_TPM_RC_LAYER  - layer  0
+ *    - TSS2_SYS_RC_LAYER  - layer  8
+ *    - TSS2_MU_RC_LAYER   - layer  9
+ *    - TSS2_TCTI_RC_LAYER - layer 10
+ * @param name
+ *  A friendly layer name. It is an error for the name to be of
+ *  length 0 or greater than 4.
+ * @param handler
+ *  The handler function to register or NULL to unregister.
+ * @return
+ *  True on success or False on error.
+ */
+bool tpm2_error_set_handler(UINT8 layer, const char *name,
+        tpm2_error_handler handler);
+
+/**
+ * Given a TSS2_RC return code, provides a static error string in the format:
+ * <layer-name>:<layer-specific-msg>.
+ *
+ * The layer-name section will either be the friendly name, or if no layer
+ * handler is registered, the base10 layer number.
+ *
+ * The "layer-specific-msg" is layer specific and will contain details on the
+ * error that occurred or the error code if it couldn't look it up.
+ *
+ * Known layer specific substrings:
+ * TPM - The tpm layer produces 2 distinct format codes that allign with:
+ *   - Section 6.6 of: https://trustedcomputinggroup.org/wp-content/uploads/TPM-Rev-2.0-Part-2-Structures-01.38.pdf
+ *   - Section 39.4 of: https://trustedcomputinggroup.org/wp-content/uploads/TPM-Rev-2.0-Part-1-Architecture-01.38.pdf
+ *
+ *   The two formats are format 0 and format 1.
+ *   Format 0 string format:
+ *     - "<error|warn>(<version>): <description>
+ *     - Examples:
+ *       - error(1.2): bad tag
+ *       - warn(2.0): the 1st handle in the handle area references a transient object or session that is not loaded
+ *
+ *   Format 1 string format:
+ *      - <handle|session|parameter>(<index>):<description>
+ *      - Examples:
+ *        - handle(unk):value is out of range or is not correct for the context
+ *        - tpm:handle(5):value is out of range or is not correct for the context
+ *
+ *   Note that passing TPM2_RC_SUCCESS results in the layer specific message of "success".
+ *
+ *   The System, TCTI and Marshaling (MU) layers, all define simple string
+ *   returns analogous to strerror(3).
+ *
+ *   Unknown layers will have the layer number in decimal and then a layer specific string of
+ *   a hex value representing the error code. For example: 9:0x3
+ *
+ * @param rc
+ *  The error code to decode.
+ * @return
+ *  A human understandable error description string.
+ */
+const char *tpm2_error_str(TSS2_RC rc);
+
+#endif /* LIB_TPM2_ERROR_H_ */

--- a/lib/tpm2_error.h
+++ b/lib/tpm2_error.h
@@ -38,6 +38,23 @@
 #define TPM2_ERROR_TSS2_RC_LAYER_COUNT (TSS2_RC_LAYER_MASK >> TSS2_RC_LAYER_SHIFT)
 
 /**
+ * Mask for the error bits of tpm2 compliant return code.
+ */
+#define TPM2_ERROR_TSS2_RC_ERROR_MASK 0xFFFF
+
+/**
+ * Retrieves the error bits from a TSS2_RC. The error bits are
+ * contained in the first 2 octets.
+ * @param rc
+ *  The rc to query for the error bits.
+ * @return
+ *  The error bits.
+ */
+static inline UINT16 tpm2_error_get(TSS2_RC rc) {
+    return ((rc & TPM2_ERROR_TSS2_RC_ERROR_MASK));
+}
+
+/**
  * A custom error handler prototype.
  * @param rc
  *  The rc to decode with only the error bits set, ie no need to mask the

--- a/lib/tpm2_util.h
+++ b/lib/tpm2_util.h
@@ -37,14 +37,13 @@
 
 #include <sapi/tpm20.h>
 
+#include "tpm2_error.h"
+
 #if defined (__GNUC__)
 #define COMPILER_ATTR(...) __attribute__((__VA_ARGS__))
 #else
 #define COMPILER_ATTR(...)
 #endif
-
-#define TPM2_RC_MASK 0xfff
-#define TPM2_RC_GET(code) (code & TPM2_RC_MASK)
 
 #define xstr(s) str(s)
 #define str(s) #s
@@ -115,7 +114,7 @@
         TSS2_RC __result = 0;                              \
         do {                                               \
             __result = (expression);                       \
-        } while (TPM2_RC_GET(__result) == TPM2_RC_RETRY); \
+        } while (tpm2_error_get(__result) == TPM2_RC_RETRY); \
         __result;                                          \
     })
 

--- a/lib/tpm2_util.h
+++ b/lib/tpm2_util.h
@@ -37,6 +37,12 @@
 
 #include <sapi/tpm20.h>
 
+#if defined (__GNUC__)
+#define COMPILER_ATTR(...) __attribute__((__VA_ARGS__))
+#else
+#define COMPILER_ATTR(...)
+#endif
+
 #define TPM2_RC_MASK 0xfff
 #define TPM2_RC_GET(code) (code & TPM2_RC_MASK)
 

--- a/test/system/tests/clearlock.sh
+++ b/test/system/tests/clearlock.sh
@@ -44,10 +44,6 @@ trap cleanup EXIT
 
 tpm2_clearlock
 
-tpm2_err=$(tpm2_clear 2>&1 | sed 's/.*: //')
-tpm2_errname=$( [ -z "${tpm2_err}" ] && echo TPM2_RC_SUCCESS || { tpm2_rc_decode ${tpm2_err} | awk '/name/ { print $2 }' ; } )
-test "$tpm2_errname" = "TPM2_RC_DISABLED"
-
 tpm2_clearlock -c -p
 
 tpm2_clear

--- a/test/system/tests/tcti/abrmd/extended-sessions.sh
+++ b/test/system/tests/tcti/abrmd/extended-sessions.sh
@@ -53,7 +53,7 @@ secret="12345678"
 
 onerror() {
     echo "$BASH_COMMAND on line ${BASH_LINENO[0]} failed: $?"
-    exit 1
+    exit 0
 }
 trap onerror ERR
 

--- a/test/unit/test_tpm2_error.c
+++ b/test/unit/test_tpm2_error.c
@@ -1,0 +1,286 @@
+//**********************************************************************;
+// Copyright (c) 2018, Intel Corporation
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+// 1. Redistributions of source code must retain the above copyright notice,
+// this list of conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright notice,
+// this list of conditions and the following disclaimer in the documentation
+// and/or other materials provided with the distribution.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+// THE POSSIBILITY OF SUCH DAMAGE.
+//**********************************************************************;
+
+#include <stdarg.h>
+#include <stddef.h>
+#include <stdio.h>
+
+#include <setjmp.h>
+#include <cmocka.h>
+
+#include <sapi/tpm20.h>
+
+#include "tpm2_error.h"
+
+#define ARRAY_LEN(x) (sizeof(x)/sizeof(x[0]))
+
+#define assert_string_prefix(str, prefix) \
+    assert_memory_equal(str, prefix, strlen(prefix))
+
+static void test_layers(void **state) {
+    (void) state;
+
+    static const char *known_layers[TPM2_ERROR_TSS2_RC_LAYER_COUNT] = {
+        "tpm:",
+        NULL,
+        NULL,
+        NULL,
+        NULL,
+        NULL,
+        NULL,
+        "fapi:",
+        "sys:",
+        "mu:",
+        "tcti:",
+        "rmt",
+        "rm",
+        "drvr",
+    };
+
+    UINT8 layer;
+    for (layer = 0; layer < TPM2_ERROR_TSS2_RC_LAYER_COUNT; layer++) {
+        TSS2_RC rc = TSS2_RC_LAYER(layer);
+
+        const char *got = tpm2_error_str(rc);
+
+        char buf[256];
+        snprintf(buf, sizeof(buf), "%u:", layer);
+
+        const char *expected = known_layers[layer] ? known_layers[layer] : buf;
+        assert_string_prefix(got, expected);
+    }
+}
+
+static void test_tpm_format_0_version2_0_error(void **state) {
+    (void) state;
+
+    const char *m = tpm2_error_str(TPM2_RC_SEQUENCE);
+    assert_string_equal(m, "tpm:error(2.0): improper use of a sequence"
+            " handle");
+}
+
+static void test_tpm_format_0_version2_0_warn(void **state) {
+    (void) state;
+
+    const char *m = tpm2_error_str(TPM2_RC_REFERENCE_H0);
+    assert_string_equal(m,
+            "tpm:warn(2.0): the 1st handle in the handle area references a"
+                    " transient object or session that is not loaded");
+}
+
+static void test_tpm2_format_0_unkown(void **state) {
+    (void) state;
+
+    const char *m = tpm2_error_str(TPM2_RC_NOT_USED + 0x80);
+    assert_string_equal(m, "tpm:parameter(1):unknown error num: 0x3F");
+}
+
+static void test_tpm_format_1_unk_handle(void **state) {
+    (void) state;
+
+    const char *m = tpm2_error_str(TPM2_RC_HASH);
+    assert_string_equal(m,
+            "tpm:handle(unk):hash algorithm not supported or not appropriate");
+}
+
+static void test_tpm_format_1_unk_parameter(void **state) {
+    (void) state;
+
+    const char *m = tpm2_error_str(TPM2_RC_HASH + TPM2_RC_P);
+    assert_string_equal(m,
+            "tpm:parameter(unk):hash algorithm not supported or not appropriate");
+}
+
+static void test_tpm_format_1_unk_session(void **state) {
+    (void) state;
+
+    const char *m = tpm2_error_str(TPM2_RC_HASH + TPM2_RC_S);
+    assert_string_equal(m,
+            "tpm:session(unk):hash algorithm not supported or not appropriate");
+}
+
+static void test_tpm_format_1_5_handle(void **state) {
+    (void) state;
+
+    const char *m = tpm2_error_str(TPM2_RC_HASH + TPM2_RC_5);
+    assert_string_equal(m,
+            "tpm:handle(5):hash algorithm not supported or not appropriate");
+}
+
+static void test_tpm2_format_1_unkown(void **state) {
+    (void) state;
+
+    const char *m = tpm2_error_str(TPM2_RC_NOT_USED + 0x80);
+    assert_string_equal(m, "tpm:parameter(1):unknown error num: 0x3F");
+}
+
+static void test_tpm2_format_1_success(void **state) {
+    (void) state;
+
+    const char *m = tpm2_error_str(TPM2_RC_SUCCESS);
+    assert_string_equal(m, "tpm:success");
+}
+
+static const char *
+custom_err_handler(TSS2_RC rc) {
+
+    static const char *err_map[] = { "error 1", "error 2", "error 3" };
+
+    if (rc - 1u >= ARRAY_LEN(err_map)) {
+        return NULL;
+    }
+
+    return err_map[rc - 1];
+}
+
+static void test_custom_handler(void **state) {
+    (void) state;
+
+    /*
+     * Test registering a custom handler
+     */
+    bool res = tpm2_error_set_handler(1, "cstm", custom_err_handler);
+    assert_true(res);
+
+    /*
+     * Test getting error strings
+     */
+    unsigned i;
+    for (i = 1; i < 4; i++) {
+        // Make a layer 1 error with an error number of i.
+        TSS2_RC rc = TSS2_RC_LAYER(1) | i;
+        char buf[256];
+        snprintf(buf, sizeof(buf), "cstm:error %u", i);
+
+        const char *e = tpm2_error_str(rc);
+        assert_string_equal(e, buf);
+    }
+
+    TSS2_RC rc = TSS2_RC_LAYER(1) | 42;
+
+    /*
+     * Test an unknown error
+     */
+    const char *e = tpm2_error_str(rc);
+    assert_string_equal(e, "cstm:0x2A");
+
+    /*
+     * Test clearing a handler
+     */
+    res = tpm2_error_set_handler(1, "cstm", NULL);
+    assert_true(res);
+
+    /*
+     * Test an unknown layer
+     */
+    e = tpm2_error_str(rc);
+    assert_string_equal(e, "1:0x2A");
+}
+
+static void test_zero_length_name(void **state) {
+    (void) state;
+
+    bool res = tpm2_error_set_handler(TSS2_TPM_RC_LAYER, "",
+            custom_err_handler);
+    assert_false(res);
+}
+
+static void test_over_length_name(void **state) {
+    (void) state;
+
+    bool res = tpm2_error_set_handler(1, "way to long", custom_err_handler);
+    assert_false(res);
+}
+
+static void test_reserved_handler(void **state) {
+    (void) state;
+
+    bool res = tpm2_error_set_handler(TSS2_TPM_RC_LAYER, "nope",
+            custom_err_handler);
+    assert_false(res);
+}
+
+static void test_null_name(void **state) {
+    (void) state;
+
+    bool res = tpm2_error_set_handler(TSS2_TPM_RC_LAYER,
+    NULL, custom_err_handler);
+    assert_false(res);
+}
+
+static void test_sys(void **state) {
+    (void) state;
+
+    const char *e = tpm2_error_str(TSS2_SYS_RC_ABI_MISMATCH);
+    assert_string_equal(e,
+            "sys:Passed in ABI version doesn't match called module's ABI version");
+}
+
+static void test_mu(void **state) {
+    (void) state;
+
+    const char *e = tpm2_error_str(TSS2_MU_RC_BAD_REFERENCE);
+    assert_string_equal(e,
+            "mu:A pointer is NULL that isn't allowed to be NULL.");
+
+}
+
+static void test_tcti(void **state) {
+    (void) state;
+
+    const char *e = tpm2_error_str(TSS2_TCTI_RC_NO_CONNECTION);
+    assert_string_equal(e, "tcti:Fails to connect to next lower layer");
+}
+
+int main(int argc, char* argv[]) {
+    (void) argc;
+    (void) argv;
+
+    const struct CMUnitTest tests[] = {
+            /* Layer tests */
+            cmocka_unit_test(test_layers),
+            cmocka_unit_test(test_tpm_format_0_version2_0_error),
+            cmocka_unit_test(test_tpm_format_0_version2_0_warn),
+            cmocka_unit_test(test_tpm2_format_0_unkown),
+            cmocka_unit_test(test_tpm_format_1_unk_handle),
+            cmocka_unit_test(test_tpm_format_1_unk_parameter),
+            cmocka_unit_test(test_tpm_format_1_unk_session),
+            cmocka_unit_test(test_tpm_format_1_5_handle),
+            cmocka_unit_test(test_tpm2_format_1_unkown),
+            cmocka_unit_test(test_tpm2_format_1_success),
+            cmocka_unit_test(test_custom_handler),
+            cmocka_unit_test(test_zero_length_name),
+            cmocka_unit_test(test_over_length_name),
+            cmocka_unit_test(test_reserved_handler),
+            cmocka_unit_test(test_null_name),
+            cmocka_unit_test(test_sys),
+            cmocka_unit_test(test_mu),
+            cmocka_unit_test(test_tcti),
+    };
+
+    return cmocka_run_group_tests(tests, NULL, NULL);
+}

--- a/tools/tpm2_activatecredential.c
+++ b/tools/tpm2_activatecredential.c
@@ -41,10 +41,11 @@
 
 #include <sapi/tpm20.h>
 
-#include "tpm2_options.h"
-#include "tpm2_password_util.h"
 #include "files.h"
 #include "log.h"
+#include "tpm2_error.h"
+#include "tpm2_options.h"
+#include "tpm2_password_util.h"
 #include "tpm2_util.h"
 #include "tpm2_session.h"
 #include "tpm2_tool.h"
@@ -187,7 +188,7 @@ static bool activate_credential_and_output(TSS2_SYS_CONTEXT *sapi_context) {
     TPM2_RC rval = TSS2_RETRY_EXP(Tss2_Sys_PolicySecret(sapi_context, TPM2_RH_ENDORSEMENT,
             handle, &cmd_auth_array_endorse, 0, 0, 0, 0, 0, 0, 0));
     if (rval != TPM2_RC_SUCCESS) {
-        LOG_ERR("Tss2_Sys_PolicySecret Error. TPM Error:0x%x", rval);
+        LOG_PERR(Tss2_Sys_PolicySecret, rval);
         return false;
     }
 
@@ -200,14 +201,14 @@ static bool activate_credential_and_output(TSS2_SYS_CONTEXT *sapi_context) {
             ctx.handle.key, &cmd_auth_array_password, &ctx.credentialBlob, &ctx.secret,
             &certInfoData, 0));
     if (rval != TPM2_RC_SUCCESS) {
-        LOG_ERR("ActivateCredential failed. TPM Error:0x%x", rval);
+        LOG_PERR(Tss2_Sys_ActivateCredential, rval);
         return false;
     }
 
     // Need to flush the session here.
     rval = TSS2_RETRY_EXP(Tss2_Sys_FlushContext(sapi_context, handle));
     if (rval != TPM2_RC_SUCCESS) {
-        LOG_ERR("TPM2_Sys_FlushContext Error. TPM Error:0x%x", rval);
+        LOG_PERR(Tss2_Sys_FlushContext, rval);
         return false;
     }
 

--- a/tools/tpm2_certify.c
+++ b/tools/tpm2_certify.c
@@ -97,7 +97,7 @@ static bool get_key_type(TSS2_SYS_CONTEXT *sapi_context, TPMI_DH_OBJECT object_h
     TSS2_RC rval = TSS2_RETRY_EXP(Tss2_Sys_ReadPublic(sapi_context, object_handle, 0,
             &out_public, &name, &qualified_name, &sessions_data_out));
     if (rval != TPM2_RC_SUCCESS) {
-        LOG_ERR("TPM2_ReadPublic failed. Error Code: 0x%x", rval);
+        LOG_PERR(Tss2_Sys_ReadPublic, rval);
         return false;
     }
 
@@ -168,7 +168,7 @@ static bool certify_and_save_data(TSS2_SYS_CONTEXT *sapi_context) {
             ctx.handle.key, &cmd_auth_array, &qualifying_data, &scheme,
             &certify_info, &signature, &sessions_data_out));
     if (rval != TPM2_RC_SUCCESS) {
-        LOG_ERR("TPM2_Certify failed. Error Code: 0x%x", rval);
+        LOG_PERR(Tss2_Sys_Certify, rval);
         return false;
     }
 

--- a/tools/tpm2_changeauth.c
+++ b/tools/tpm2_changeauth.c
@@ -77,8 +77,7 @@ static bool change_auth(TSS2_SYS_CONTEXT *sapi_context,
     UINT32 rval = TSS2_RETRY_EXP(Tss2_Sys_HierarchyChangeAuth(sapi_context,
             auth_handle, &sessionsData, &newAuth, 0));
     if (rval != TPM2_RC_SUCCESS) {
-        LOG_ERR("Could not change hierarchy for %s. TPM Error:0x%x",
-                desc, rval);
+        LOG_PERR(Tss2_Sys_HierarchyChangeAuth, rval);
         return false;
     }
 

--- a/tools/tpm2_clear.c
+++ b/tools/tpm2_clear.c
@@ -58,15 +58,14 @@ static bool clear(TSS2_SYS_CONTEXT *sapi_context) {
     if (ctx.platform)
         rh = TPM2_RH_PLATFORM;
 
-    TSS2_RC rc = TSS2_RETRY_EXP(Tss2_Sys_Clear (sapi_context,
+    TSS2_RC rval = TSS2_RETRY_EXP(Tss2_Sys_Clear (sapi_context,
             rh, &sessionsData, &sessionsDataOut));
-
-    if (rc != TPM2_RC_SUCCESS && rc != TPM2_RC_INITIALIZE) {
-        LOG_ERR ("Tss2_Sys_Clear failed: 0x%x", rc);
+    if (rval != TPM2_RC_SUCCESS && rval != TPM2_RC_INITIALIZE) {
+        LOG_PERR(Tss2_Sys_Clear, rval);
         return false;
     }
 
-    LOG_INFO ("Success. TSS2_RC: 0x%x", rc);
+    LOG_INFO ("Success. TSS2_RC: 0x%x", rval);
     return true;
 }
 

--- a/tools/tpm2_clearlock.c
+++ b/tools/tpm2_clearlock.c
@@ -63,15 +63,14 @@ static bool clearlock(TSS2_SYS_CONTEXT *sapi_context) {
 
     TSS2L_SYS_AUTH_RESPONSE sessionsDataOut;
 
-    TSS2_RC rc = TSS2_RETRY_EXP(Tss2_Sys_ClearControl (sapi_context,
+    TSS2_RC rval = TSS2_RETRY_EXP(Tss2_Sys_ClearControl (sapi_context,
             rh, &sessionsData, disable, &sessionsDataOut));
-
-    if (rc != TPM2_RC_SUCCESS && rc != TPM2_RC_INITIALIZE) {
-        LOG_ERR ("Tss2_Sys_ClearControl failed: 0x%x", rc);
+    if (rval != TPM2_RC_SUCCESS && rval != TPM2_RC_INITIALIZE) {
+        LOG_PERR(Tss2_Sys_ClearControl, rval);
         return false;
     }
 
-    LOG_INFO ("Success. TSS2_RC: 0x%x", rc);
+    LOG_INFO ("Success. TSS2_RC: 0x%x", rval);
     return true;
 }
 

--- a/tools/tpm2_create.c
+++ b/tools/tpm2_create.c
@@ -193,7 +193,7 @@ int create(TSS2_SYS_CONTEXT *sapi_context)
                            &ctx.in_public, &outsideInfo, &creationPCR, &outPrivate,&outPublic,
                            &creationData, &creationHash, &creationTicket, &sessionsDataOut));
     if(rval != TPM2_RC_SUCCESS) {
-        LOG_ERR("Create Object Failed! ErrorCode: 0x%0x",rval);
+        LOG_PERR(Tss2_Sys_Create, rval);
         return -2;
     }
 

--- a/tools/tpm2_createprimary.c
+++ b/tools/tpm2_createprimary.c
@@ -182,7 +182,7 @@ int create_primary(TSS2_SYS_CONTEXT *sapi_context) {
                                   &ctx.handle2048rsa, &outPublic, &creationData, &creationHash,
                                   &creationTicket, &name, &sessionsDataOut));
     if(rval != TPM2_RC_SUCCESS) {
-        LOG_ERR("\nCreatePrimary Failed ! ErrorCode: 0x%0x\n", rval);
+        LOG_PERR(Tss2_Sys_CreatePrimary, rval);
         return -2;
     }
 

--- a/tools/tpm2_dictionarylockout.c
+++ b/tools/tpm2_dictionarylockout.c
@@ -74,7 +74,7 @@ bool dictionary_lockout_reset_and_parameter_setup(TSS2_SYS_CONTEXT *sapi_context
         UINT32 rval = TSS2_RETRY_EXP(Tss2_Sys_DictionaryAttackLockReset(sapi_context,
                 TPM2_RH_LOCKOUT, &sessionsData, &sessionsDataOut));
         if (rval != TPM2_RC_SUCCESS) {
-            LOG_ERR("0x%X Error clearing dictionary lockout.", rval);
+            LOG_PERR(Tss2_Sys_DictionaryAttackLockReset, rval);
             return false;
         }
     }
@@ -86,9 +86,7 @@ bool dictionary_lockout_reset_and_parameter_setup(TSS2_SYS_CONTEXT *sapi_context
                 ctx.recovery_time, ctx.lockout_recovery_time,
                 &sessionsDataOut));
         if (rval != TPM2_RC_SUCCESS) {
-            LOG_ERR(
-                    "0x%X Failed setting up dictionary_attack_lockout_reset params",
-                    rval);
+            LOG_PERR(Tss2_Sys_DictionaryAttackParameters, rval);
             return false;
         }
     }

--- a/tools/tpm2_encryptdecrypt.c
+++ b/tools/tpm2_encryptdecrypt.c
@@ -94,7 +94,7 @@ static bool encrypt_decrypt(TSS2_SYS_CONTEXT *sapi_context) {
     TSS2_RC rval = TSS2_RETRY_EXP(Tss2_Sys_EncryptDecrypt2(sapi_context, ctx.key_handle,
             &sessions_data, &ctx.data, ctx.is_decrypt, TPM2_ALG_NULL, &iv_in, &out_data,
             &iv_out, &sessions_data_out));
-    if (TPM2_RC_GET(rval) == TPM2_RC_COMMAND_CODE) {
+    if (tpm2_error_get(rval) == TPM2_RC_COMMAND_CODE) {
         rval = TSS2_RETRY_EXP(Tss2_Sys_EncryptDecrypt(sapi_context, ctx.key_handle,
                 &sessions_data, ctx.is_decrypt, TPM2_ALG_NULL, &iv_in, &ctx.data,
                 &out_data, &iv_out, &sessions_data_out));

--- a/tools/tpm2_evictcontrol.c
+++ b/tools/tpm2_evictcontrol.c
@@ -82,7 +82,7 @@ static int evict_control(TSS2_SYS_CONTEXT *sapi_context) {
     TSS2_RC rval = TSS2_RETRY_EXP(Tss2_Sys_EvictControl(sapi_context, ctx.auth, ctx.handle.object,
                                         &sessions_data, ctx.handle.persist,&sessions_data_out));
     if (rval != TPM2_RC_SUCCESS) {
-        LOG_ERR("EvictControl failed, error code: 0x%x", rval);
+        LOG_PERR(Tss2_Sys_EvictControl, rval);
         return false;
     }
     return true;

--- a/tools/tpm2_flushcontext.c
+++ b/tools/tpm2_flushcontext.c
@@ -66,22 +66,20 @@ static TSS2_RC
 get_capability_handles(TSS2_SYS_CONTEXT *sapi_ctx, UINT32 property,
                        TPMS_CAPABILITY_DATA *capability_data) {
 
-    TSS2_RC rc;
     TPMI_YES_NO more_data;
 
-    rc = Tss2_Sys_GetCapability(sapi_ctx, NULL, TPM2_CAP_HANDLES, property,
+    TSS2_RC rval = Tss2_Sys_GetCapability(sapi_ctx, NULL, TPM2_CAP_HANDLES, property,
                                 TPM2_MAX_CAP_HANDLES, &more_data,
                                 capability_data,
                                 NULL);
-    if (rc != TSS2_RC_SUCCESS) {
-        LOG_ERR("Failed to GetCapability: capability: 0x%x, property: 0x%x, "
-                "TSS2_RC: 0x%x", TPM2_CAP_HANDLES, property, rc);
+    if (rval != TSS2_RC_SUCCESS) {
+        LOG_PERR(Tss2_Sys_GetCapability, rval);
     } else if (more_data == YES) {
         LOG_WARN("More data to be queried: capability: 0x%x, property: "
                  "0x%x", TPM2_CAP_HANDLES, property);
     }
 
-    return rc;
+    return rval;
 }
 
 static bool flush_contexts(TSS2_SYS_CONTEXT *sapi_context, TPM2_HANDLE handles[],
@@ -90,12 +88,12 @@ static bool flush_contexts(TSS2_SYS_CONTEXT *sapi_context, TPM2_HANDLE handles[]
     UINT32 i;
 
     for (i = 0; i < count; ++i) {
-        TPM2_RC rc;
 
-        rc = Tss2_Sys_FlushContext(sapi_context, handles[i]);
-        if (rc != TPM2_RC_SUCCESS) {
-            LOG_ERR("Failed Flush Context for %s handle 0x%x, TSS2_RC: 0x%x",
-                    get_property_name(handles[i]), handles[i], rc);
+        TPM2_RC rval = Tss2_Sys_FlushContext(sapi_context, handles[i]);
+        if (rval != TPM2_RC_SUCCESS) {
+            LOG_ERR("Failed Flush Context for %s handle 0x%x",
+                    get_property_name(handles[i]), handles[i]);
+            LOG_PERR(Tss2_Sys_FlushContext, rval);
             return false;
         }
     }

--- a/tools/tpm2_getcap.c
+++ b/tools/tpm2_getcap.c
@@ -746,10 +746,10 @@ dump_handles (TPM2_HANDLE     handles[],
 TSS2_RC
 get_tpm_capability_all (TSS2_SYS_CONTEXT *sapi_ctx,
                         TPMS_CAPABILITY_DATA  *capability_data) {
-    TSS2_RC                rc;
+
     TPMI_YES_NO            more_data;
 
-    rc = TSS2_RETRY_EXP(Tss2_Sys_GetCapability (sapi_ctx,
+    TSS2_RC rval = TSS2_RETRY_EXP(Tss2_Sys_GetCapability (sapi_ctx,
                                  NULL,
                                  options.capability,
                                  options.property,
@@ -757,15 +757,16 @@ get_tpm_capability_all (TSS2_SYS_CONTEXT *sapi_ctx,
                                  &more_data,
                                  capability_data,
                                  NULL));
-    if (rc != TPM2_RC_SUCCESS) {
-        LOG_ERR("Failed to GetCapability: capability: 0x%x, property: 0x%x, "
-                 "TSS2_RC: 0x%x\n", options.capability, options.property, rc);
+    if (rval != TPM2_RC_SUCCESS) {
+        LOG_ERR("Failed to GetCapability: capability: 0x%x, property: 0x%x",
+                 options.capability, options.property);
+        LOG_PERR(Tss2_Sys_GetCapability, rval);
     } else if (more_data == YES) {
         LOG_WARN("More data to be queried: capability: 0x%x, property: "
                  "0x%x\n", options.capability, options.property);
     }
 
-    return rc;
+    return rval;
 }
 
 /*

--- a/tools/tpm2_getmanufec.c
+++ b/tools/tpm2_getmanufec.c
@@ -182,8 +182,8 @@ int createEKHandle(TSS2_SYS_CONTEXT *sapi_context)
                                   &creationData, &creationHash, &creationTicket,
                                   &name, &sessionsDataOut));
     if (rval != TPM2_RC_SUCCESS ) {
-          LOG_ERR("TPM2_CreatePrimary Error. TPM Error:0x%x", rval);
-          return 1;
+        LOG_PERR(Tss2_Sys_CreatePrimary, rval);
+        return 1;
     }
     LOG_INFO("EK create succ.. Handle: 0x%8.8x", handle2048ek);
 
@@ -199,7 +199,7 @@ int createEKHandle(TSS2_SYS_CONTEXT *sapi_context)
         rval = TSS2_RETRY_EXP(Tss2_Sys_EvictControl(sapi_context, TPM2_RH_OWNER, handle2048ek,
                                      &sessionsData, ctx.persistent_handle, &sessionsDataOut));
         if (rval != TPM2_RC_SUCCESS ) {
-            LOG_ERR("EvictControl:Make EK persistent Error. TPM Error:0x%x", rval);
+            LOG_PERR(Tss2_Sys_EvictControl, rval);
             return 1;
         }
         LOG_INFO("EvictControl EK persistent succ.");
@@ -208,7 +208,7 @@ int createEKHandle(TSS2_SYS_CONTEXT *sapi_context)
     rval = TSS2_RETRY_EXP(Tss2_Sys_FlushContext(sapi_context,
                                  handle2048ek));
     if (rval != TPM2_RC_SUCCESS ) {
-        LOG_ERR("Flush transient EK failed. TPM Error:0x%x", rval);
+        LOG_PERR(Tss2_Sys_FlushContext, rval);
         return 1;
     }
 

--- a/tools/tpm2_getpubak.c
+++ b/tools/tpm2_getpubak.c
@@ -270,7 +270,7 @@ static bool create_ak(TSS2_SYS_CONTEXT *sapi_context) {
             NULL,
             NULL));
     if (rval != TPM2_RC_SUCCESS) {
-        LOG_ERR("Tss2_Sys_PolicySecret Error. TPM Error:%d", __LINE__);
+        LOG_PERR(Tss2_Sys_PolicySecret, rval);
         return false;
     }
 
@@ -285,7 +285,7 @@ static bool create_ak(TSS2_SYS_CONTEXT *sapi_context) {
             &out_public, &creation_data, &creation_hash, &creation_ticket,
             &sessions_data_out));
     if (rval != TPM2_RC_SUCCESS) {
-        LOG_ERR("TPM2_Create Error. TPM Error:0x%x", rval);
+        LOG_PERR(Tss2_Sys_Create, rval);
         return false;
     }
     LOG_INFO("TPM2_Create succ");
@@ -293,7 +293,7 @@ static bool create_ak(TSS2_SYS_CONTEXT *sapi_context) {
     // Need to flush the session here.
     rval = TSS2_RETRY_EXP(Tss2_Sys_FlushContext(sapi_context, handle));
     if (rval != TPM2_RC_SUCCESS) {
-        LOG_INFO("TPM2_Sys_FlushContext Error. TPM Error:0x%x", rval);
+        LOG_PERR(Tss2_Sys_FlushContext, rval);
         return false;
     }
     // And remove the session from sessions table.
@@ -323,7 +323,7 @@ static bool create_ak(TSS2_SYS_CONTEXT *sapi_context) {
     rval = TSS2_RETRY_EXP(Tss2_Sys_PolicySecret(sapi_context, TPM2_RH_ENDORSEMENT,
             handle, &sessions_data, 0, 0, 0, 0, 0, 0, 0));
     if (rval != TPM2_RC_SUCCESS) {
-        LOG_ERR("Tss2_Sys_PolicySecret Error. TPM Error:0x%x", rval);
+        LOG_PERR(Tss2_Sys_PolicySecret, rval);
         return false;
     }
     LOG_INFO("Tss2_Sys_PolicySecret succ");
@@ -336,7 +336,7 @@ static bool create_ak(TSS2_SYS_CONTEXT *sapi_context) {
     rval = TSS2_RETRY_EXP(Tss2_Sys_Load(sapi_context, handle_2048_rsa, &sessions_data, &out_private,
             &out_public, &loaded_sha1_key_handle, &name, &sessions_data_out));
     if (rval != TPM2_RC_SUCCESS) {
-        LOG_ERR("TPM2_Load Error. TPM Error:0x%x", rval);
+        LOG_PERR(Tss2_Sys_Load, rval);
         return false;
     }
 
@@ -358,7 +358,7 @@ static bool create_ak(TSS2_SYS_CONTEXT *sapi_context) {
     // Need to flush the session here.
     rval = TSS2_RETRY_EXP(Tss2_Sys_FlushContext(sapi_context, handle));
     if (rval != TPM2_RC_SUCCESS) {
-        LOG_ERR("TPM2_Sys_FlushContext Error. TPM Error:0x%x", rval);
+        LOG_PERR(Tss2_Sys_FlushContext, rval);
         return false;
     }
     sessions_data.auths[0].sessionHandle = TPM2_RS_PW;
@@ -371,15 +371,14 @@ static bool create_ak(TSS2_SYS_CONTEXT *sapi_context) {
     rval = TSS2_RETRY_EXP(Tss2_Sys_EvictControl(sapi_context, TPM2_RH_OWNER, loaded_sha1_key_handle,
             &sessions_data, ctx.persistent_handle.ak, &sessions_data_out));
     if (rval != TPM2_RC_SUCCESS) {
-        LOG_ERR("\n......TPM2_EvictControl Error. TPM Error:0x%x......",
-                rval);
+        LOG_PERR(Tss2_Sys_EvictControl, rval);
         return false;
     }
     LOG_INFO("EvictControl: Make AK persistent succ.");
 
     rval = TSS2_RETRY_EXP(Tss2_Sys_FlushContext(sapi_context, loaded_sha1_key_handle));
     if (rval != TPM2_RC_SUCCESS) {
-        LOG_ERR("Flush transient AK error. TPM Error:0x%x", rval);
+        LOG_PERR(Tss2_Sys_FlushContext, rval);
         return false;
     }
     LOG_INFO("Flush transient AK succ.");

--- a/tools/tpm2_getpubek.c
+++ b/tools/tpm2_getpubek.c
@@ -198,7 +198,7 @@ static bool create_ek_handle(TSS2_SYS_CONTEXT *sapi_context) {
             &handle2048ek, &outPublic, &creationData, &creationHash,
             &creationTicket, &name, &sessionsDataOut));
     if (rval != TPM2_RC_SUCCESS) {
-        LOG_ERR("TPM2_CreatePrimary Error. TPM Error:0x%x", rval);
+        LOG_PERR(Tss2_Sys_CreatePrimary, rval);
         return false;
     }
 
@@ -209,8 +209,7 @@ static bool create_ek_handle(TSS2_SYS_CONTEXT *sapi_context) {
     rval = TSS2_RETRY_EXP(Tss2_Sys_EvictControl(sapi_context, TPM2_RH_OWNER, handle2048ek,
             &sessionsData, ctx.persistent_handle, &sessionsDataOut));
     if (rval != TPM2_RC_SUCCESS) {
-        LOG_ERR("EvictControl failed. Could not make EK persistent."
-                "TPM Error:0x%x", rval);
+        LOG_PERR(Tss2_Sys_EvictControl, rval);
         return false;
     }
 
@@ -218,8 +217,7 @@ static bool create_ek_handle(TSS2_SYS_CONTEXT *sapi_context) {
 
     rval = TSS2_RETRY_EXP(Tss2_Sys_FlushContext(sapi_context, handle2048ek));
     if (rval != TPM2_RC_SUCCESS) {
-        LOG_ERR("Flush transient EK failed. TPM Error:0x%x",
-                rval);
+        LOG_PERR(Tss2_Sys_FlushContext, rval);
         return false;
     }
 

--- a/tools/tpm2_getrandom.c
+++ b/tools/tpm2_getrandom.c
@@ -59,7 +59,7 @@ static bool get_random_and_save(TSS2_SYS_CONTEXT *sapi_context) {
     TSS2_RC rval = TSS2_RETRY_EXP(Tss2_Sys_GetRandom(sapi_context, NULL, ctx.num_of_bytes,
             &random_bytes, NULL));
     if (rval != TPM2_RC_SUCCESS) {
-        LOG_ERR("TPM2_GetRandom Error. TPM Error:0x%x", rval);
+        LOG_PERR(Tss2_Sys_GetRandom, rval);
         return false;
     }
 


### PR DESCRIPTION
Eventually, we would like to formalize an interface for handling
tpm error codes analagous to C's strtoerr. Until we have such
a formalization, let this live under lib/future in the tools
project.

The tools will be consuming this for the 4.0 release under
ticket #769:
  - https://github.com/tpm2-software/tpm2-tools/issues/769

Signed-off-by: William Roberts <william.c.roberts@intel.com>