### PR TITLE
Fix various github URLs here and there

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -50,13 +50,13 @@ install:
     - tar xJf autoconf-archive-2017.09.28.tar.xz && pushd autoconf-archive-2017.09.28
     - ./configure --prefix=/usr && make -j$(nproc) && sudo make install
     - popd
-    - git clone https://github.com/intel/tpm2-tss.git
+    - git clone https://github.com/tpm2-software/tpm2-tss.git
     - pushd tpm2-tss
     - ./bootstrap && ./configure && make -j$(nproc)
     - sudo ../.ci/travis-tss-install.sh
     - popd
     - sudo ldconfig /usr/local/lib
-    - git clone https://github.com/intel/tpm2-abrmd.git
+    - git clone https://github.com/tpm2-software/tpm2-abrmd.git
     - pushd tpm2-abrmd
     - git am ../.ci/patches/abrmd/* || true
     - ./bootstrap && ./configure --with-dbuspolicydir=/etc/dbus-1/system.d && make -j$(nproc) && sudo make install && popd

--- a/man/common/footer.md
+++ b/man/common/footer.md
@@ -1,6 +1,6 @@
 # BUGS
 
-[Github Issues](https://github.com/intel/tpm2-tools/issues)
+[Github Issues](https://github.com/tpm2-software/tpm2-tools/issues)
 
 # HELP
 

--- a/test/system/tests/tcti/abrmd/extended-sessions.sh
+++ b/test/system/tests/tcti/abrmd/extended-sessions.sh
@@ -75,8 +75,8 @@ tpm2_clear
 
 #
 # Test an extended policy session beyond client connections. This is ONLY supported by abrmd
-# since version: https://github.com/intel/tpm2-abrmd/releases/tag/1.2.0
-# However, bug: https://github.com/intel/tpm2-abrmd/issues/285 applies
+# since version: https://github.com/tpm2-software/tpm2-abrmd/releases/tag/1.2.0
+# However, bug: https://github.com/tpm2-software/tpm2-abrmd/issues/285 applies
 #
 # The test works by:
 # Step 1: Creating a trial session and updating it with a policyPCR event to generate


### PR DESCRIPTION
Hello, 

Here is a small PR whose goal is only to update the various github URLs that changes when the tpm2 projects went from the intel 'organization' to the tpm2-software 'organization'.

These are quite trivial changes (at least for the 'man' and the 'tests' commit as they have no impact on anything but printed text or comments ; the 'travis' one may need at least a check) that can be, if needed, squashed into a single commit. 

BR, 

-- Emmanuel Deloget