### PR TITLE
cleanup error handling

### DIFF
--- a/tools/tpm2_tool.c
+++ b/tools/tpm2_tool.c
@@ -157,6 +157,10 @@ int main(int argc, char *argv[], char *envp[]) {
      * 'main'.
      */
     ret = tpm2_tool_onrun(sapi_context, flags) ? 1 : 0;
+    if (ret != 0) {
+        LOG_ERR("Unable to run %s", argv[0]);
+    }
+
     /*
      * Cleanup contexts & memory allocated for the modified argument vector
      * passed to execute_tool.


### PR DESCRIPTION
Add extremely minimal error handling to tpm2_tools so that if onrun() fails, it will at least indicate that it will. Also, modify tpm2_createprimary's onrun() function to return slightly more useful errors (one day maybe someone will use them). refactor onrun() a little bit to make it easier to read and correct inconsistency with flag naming.