### PR TITLE
Yaml output

### DIFF
--- a/lib/tpm2_alg_util.c
+++ b/lib/tpm2_alg_util.c
@@ -351,7 +351,7 @@ UINT8* tpm2_extract_plain_signature(UINT16 *size, TPMT_SIGNATURE *signature) {
         if (!buffer) {
             goto nomem;
         }
-        memcpy(buffer, &hmac_sig, *size);
+        memcpy(buffer, hmac_sig, *size);
         break;
     }
     case TPM2_ALG_ECDSA: {

--- a/man/tpm2_getcap.1.md
+++ b/man/tpm2_getcap.1.md
@@ -58,16 +58,32 @@ command.
     * handles-saved-session:
       Display handles about saved sessions.
 
+  * **-l**, **--list**:
+    List known supported capability names. These names can be
+    supplied as the argument to the **-c** option. Output is in a
+    YAML compliant list to stdout.
+
+    For example:
+```
+    - algorithms
+    - commands
+    - properties-fixed
+    ...
+```
+
 [common options](common/options.md)
 
 [common tcti options](common/tcti.md)
 
 # EXAMPLES
 
-```
-tpm2_getcap --capability="properties-fixed"
+To list the fixed properties of the TPM:
 
-```
+```tpm2_getcap --capability="properties-fixed"```
+
+To list the supported capability arguments to **-c**:
+
+```tpm2_getcap -l```
 
 # RETURNS
 

--- a/test/system/helpers.sh
+++ b/test/system/helpers.sh
@@ -99,3 +99,53 @@ hash_alg_supported() {
         fi
     done
 }
+
+#
+# Verifies that the contexts of a file path provided
+# as the first argument loads as a YAML file.
+#
+function yaml_verify() {
+python << pyscript
+from __future__ import print_function
+
+import sys
+import yaml
+
+with open("$1") as f:
+	try:
+		y = yaml.load(f)
+	except yaml.YAMLError as exc:
+		sys.exit(exc)
+pyscript
+}
+
+#
+# Given a file as argument 1, prints the value of the key
+# provided as argument 2 and optionally argument 3 (for nested maps).
+# Note that if key is a string, pass the quotes. This allows lookups
+# on string or numerical keys.
+#
+function yaml_get_kv() {
+
+third_arg=\"\"
+if [ $# -eq 3 ]; then
+  third_arg=$3
+fi
+
+python << pyscript
+from __future__ import print_function
+
+import sys
+import yaml
+
+with open("$1") as f:
+	try:
+		y = yaml.load(f)
+		if $# == 3:
+			print(y[$2][$third_arg])
+		else:
+			print(y[$2])
+	except yaml.YAMLError as exc:
+		sys.exit(exc)
+pyscript
+}

--- a/test/system/tests/create.sh
+++ b/test/system/tests/create.sh
@@ -49,27 +49,6 @@ cleanup() {
 }
 trap cleanup EXIT
 
-function yaml_get() {
-
-python << pyscript
-from __future__ import print_function
-
-import sys
-import yaml
-
-with open("$2") as f:
-	try:
-		y = yaml.load(f)
-		found = "$1" in y
-		if (not found):
-			sys.stderr.write('Could not find index 0x%X\n' % ("$1"))
-		print(y["$1"])
-		sys.exit(not found)
-	except yaml.YAMLError as exc:
-		sys.exit(exc)
-pyscript
-}
-
 cleanup
 
 tpm2_createprimary -Q -H o -g sha1 -G rsa -C context.out
@@ -91,7 +70,7 @@ echo "$policy_orig" | xxd -r -p > policy.bin
 tpm2_create -c context.out -g sha256 -G 0x1 -L policy.bin -u key.pub -r key.priv \
   -A 'sign|fixedtpm|fixedparent|sensitivedataorigin' > out.pub
 
-policy_new=$(yaml_get "authorization policy" out.pub)
+policy_new=$(yaml_get_kv out.pub \"authorization\ policy\")
 
 test "$policy_orig" == "$policy_new"
 

--- a/test/system/tests/createprimary.sh
+++ b/test/system/tests/createprimary.sh
@@ -63,27 +63,6 @@ for gAlg in `populate_hash_algs mixed`; do
     done
 done
 
-function yaml_get() {
-
-python << pyscript
-from __future__ import print_function
-
-import sys
-import yaml
-
-with open("$2") as f:
-	try:
-		y = yaml.load(f)
-		found = "$1" in y
-		if (not found):
-			sys.stderr.write('Could not find index 0x%X\n' % ("$1"))
-		print(y["$1"])
-		sys.exit(not found)
-	except yaml.YAMLError as exc:
-		sys.exit(exc)
-pyscript
-}
-
 policy_orig="f28230c080bbe417141199e36d18978228d8948fc10a6a24921b9eba6bb1d988"
 
 #test for createprimary objects with policy authorization structures
@@ -94,7 +73,7 @@ tpm2_createprimary -Q -H o -G rsa -g sha256 -C context.out -L policy.bin \
 
 tpm2_readpublic -c context.out > pub.out
 
-policy_new=$(yaml_get "authorization policy" pub.out)
+policy_new=$(yaml_get_kv pub.out \"authorization\ policy\")
 
 test "$policy_orig" == "$policy_new"
 

--- a/test/system/tests/dictionarylockout.sh
+++ b/test/system/tests/dictionarylockout.sh
@@ -32,6 +32,15 @@
 #;**********************************************************************;
 ###this script use for test the implementation tpm2_dictionarylockout 
 
+source helpers.sh
+
+out=out.yaml
+
+cleanup() {
+    rm -f $out
+}
+trap cleanup EXIT
+
 onerror() {
     echo "$BASH_COMMAND on line ${BASH_LINENO[0]} failed: $?"
     exit 1
@@ -40,17 +49,23 @@ trap onerror ERR
 
 tpm2_dictionarylockout -s -n 5 -t 6 -l 7
 
-if [ "$(tpm2_getcap -c properties-variable | grep TPM2_PT_MAX_AUTH_FAIL | sed -e 's/TPM2_PT_MAX_AUTH_FAIL: \+//')" != "0x00000005" ];then
- echo "Failure: setting up the number of allowed tries in the lockout parameters"
- exit 1
+tpm2_getcap -c properties-variable > $out
+v=$(yaml_get_kv "$out" \"TPM2_PT_MAX_AUTH_FAIL\")
+if [ $v -ne 5 ];then
+  echo "Failure: setting up the number of allowed tries in the lockout parameters"
+  exit 1
 fi
 
-if [ "$(tpm2_getcap -c properties-variable | grep TPM2_PT_LOCKOUT_INTERVAL | sed -e 's/TPM2_PT_LOCKOUT_INTERVAL: \+//')" != "0x00000006" ];then
- echo "Failure: setting up the lockout period in the lockout parameters"
+v=$(yaml_get_kv "$out" \"TPM2_PT_LOCKOUT_INTERVAL\")
+if [ $v -ne 6 ];then
+  echo "Failure: setting up the lockout period in the lockout parameters"
+  exit 1
 fi
 
-if [ "$(tpm2_getcap -c properties-variable | grep TPM2_PT_LOCKOUT_RECOVERY | sed -e 's/TPM2_PT_LOCKOUT_RECOVERY: \+//')" != "0x00000007" ];then
- echo "Failure: setting up the lockout recovery period in the lockout parameters"
+v=$(yaml_get_kv "$out" \"TPM2_PT_LOCKOUT_RECOVERY\")
+if [ $v -ne 7 ];then
+  echo "Failure: setting up the lockout recovery period in the lockout parameters"
+  exit 1
 fi
 
 exit 0

--- a/test/system/tests/getcap.sh
+++ b/test/system/tests/getcap.sh
@@ -45,4 +45,14 @@ tpm2_getcap -Q --capability="algorithms"
 
 tpm2_getcap -Q --capability="commands"
 
+# negative tests
+trap - ERR
+
+# Regression test, ensure that getcap -c never accepts prefix matches
+tpm2_getcap -Q --capability="comma" 2>/dev/null
+if [ $? -eq 0 ]; then
+  echo "Expected \"tpm2_getcap -Q --capability=\"comma\"\" to fail."
+  exit 1
+fi
+
 exit 0

--- a/test/system/tests/getrandom.sh
+++ b/test/system/tests/getrandom.sh
@@ -31,6 +31,8 @@
 # THE POSSIBILITY OF SUCH DAMAGE.
 #;**********************************************************************;
 
+source helpers.sh
+
 onerror() {
     echo "$BASH_COMMAND on line ${BASH_LINENO[0]} failed: $?"
     exit 1
@@ -49,5 +51,7 @@ tpm2_getrandom -o random.out 32
 
 #test stdout
 tpm2_getrandom 4 > random.out
+
+yaml_verify random.out
 
 exit 0

--- a/test/system/tests/listpersistent.sh
+++ b/test/system/tests/listpersistent.sh
@@ -56,7 +56,7 @@ onerror() {
 trap onerror ERR
 
 
-function yaml_get() {
+function yaml_get_len() {
 
 python << pyscript
 from __future__ import print_function
@@ -85,7 +85,7 @@ done
 
 tpm2_listpersistent > out.yaml
 
-handle_cnt=$(yaml_get out.yaml)
+handle_cnt=$(yaml_get_len out.yaml)
 
 if [ "$handle_cnt" -ne "${#keys[@]}" ]; then
     echo "Only $handle_cnt of ${#keys[@]} persistent objects were listed"

--- a/test/system/tests/pcrevent.sh
+++ b/test/system/tests/pcrevent.sh
@@ -50,29 +50,6 @@ cleanup() {
 }
 trap cleanup EXIT
 
-function yaml_get() {
-
-python << pyscript
-from __future__ import print_function
-
-import sys
-import yaml
-
-with open("$1", 'r') as stream:
-
-    try:
-        y = yaml.load(stream)
-        alg = y["$2"]
-        value = alg[$3]
-        print(value)
-    except yaml.YAMLError as exc:
-        sys.exit(exc)
-
-    sys.exit(0)
-pyscript
-}
-cleanup
-
 echo "T0naX0u123abc" > $hash_in_file
 
 # Run FILE and stdin as FILE
@@ -102,14 +79,14 @@ while IFS='' read -r l || [[ -n "$l" ]]; do
 done < $hash_out_file
 
 tpm2_pcrlist -L sha1:9 > $yaml_out_file
-old_pcr_value=`yaml_get $yaml_out_file sha1 9`
+old_pcr_value=`yaml_get_kv $yaml_out_file \"sha1\" 9`
 
 # Verify that extend works, and test large files
 dd if=/dev/urandom of=$hash_in_file count=1 bs=2093 2> /dev/null
 tpm2_pcrevent -Q -i 9 $hash_in_file
 
 tpm2_pcrlist -L sha1:9 > $yaml_out_file
-new_pcr_value=`yaml_get $yaml_out_file sha1 9`
+new_pcr_value=`yaml_get_kv $yaml_out_file \"sha1\" 9`
 
 if [ "$new_pcr_value" == "$old_pcr_value" ]; then
   echo "Expected PCR value to change after pcrevent with index 9."

--- a/test/system/tests/pcrlist.sh
+++ b/test/system/tests/pcrlist.sh
@@ -31,6 +31,8 @@
 # THE POSSIBILITY OF SUCH DAMAGE.
 #;**********************************************************************;
 
+source helpers.sh
+
 onerror() {
     echo "$BASH_COMMAND on line ${BASH_LINENO[0]} failed: $?"
     exit 1
@@ -44,7 +46,8 @@ trap cleanup EXIT
 
 cleanup
 
-tpm2_pcrlist -Q
+tpm2_pcrlist > pcrs.out
+yaml_verify pcrs.out
 
 tpm2_pcrlist -Q -g 0x04
 

--- a/test/system/tests/quote.sh
+++ b/test/system/tests/quote.sh
@@ -90,7 +90,9 @@ tpm2_create -Q -g $alg_create_obj -G $alg_create_key -u $file_quote_key_pub -r $
 
 tpm2_load -Q -c $file_primary_key_ctx  -u $file_quote_key_pub  -r $file_quote_key_priv -n $file_quote_key_name -C $file_quote_key_ctx
 
-tpm2_quote -Q -c $file_quote_key_ctx  -g $alg_quote -l 16,17,18 -q $nonce
+tpm2_quote -c $file_quote_key_ctx  -g $alg_quote -l 16,17,18 -q $nonce > $out
+
+yaml_verify $out
 
 tpm2_quote -Q -c $file_quote_key_ctx  -L $alg_quote:16,17,18+$alg_quote1:16,17,18 -q $nonce
 

--- a/tools/tpm2_createpolicy.c
+++ b/tools/tpm2_createpolicy.c
@@ -123,7 +123,7 @@ static bool parse_policy_type_specific_command(TSS2_SYS_CONTEXT *sapi_context) {
 
     // Display the policy digest during real policy session.
     if (pctx.common_policy_options.policy_session_type == TPM2_SE_POLICY) {
-        tpm2_tool_output("TPM2_SE_POLICY: 0x");
+        tpm2_tool_output("policy-digest: 0x");
         int i;
         for(i = 0; i < pctx.common_policy_options.policy_digest.size; i++) {
             tpm2_tool_output("%02X", pctx.common_policy_options.policy_digest.buffer[i]);

--- a/tools/tpm2_getcap.c
+++ b/tools/tpm2_getcap.c
@@ -159,9 +159,8 @@ int sanity_check_capability_opts (void) {
 
     size_t i;
     for (i = 0; i < CAPABILITY_MAP_COUNT; ++i) {
-        int cmp = strncmp(capability_map [i].capability_string,
-                          options.capability_string,
-                          strlen(capability_map [i].capability_string));
+        int cmp = strcmp(capability_map[i].capability_string,
+                          options.capability_string);
         if (cmp == 0) {
             options.capability = capability_map[i].capability;
             options.property   = capability_map[i].property;

--- a/tools/tpm2_getmanufec.c
+++ b/tools/tpm2_getmanufec.c
@@ -260,11 +260,13 @@ static unsigned char *HashEKPublicKey(void) {
     }
 
     if (ctx.verbose) {
+        tpm2_tool_output("public-key-hash:\n");
+        tpm2_tool_output("  sha256: ");
         unsigned i;
         for (i = 0; i < SHA256_DIGEST_LENGTH; i++) {
-            printf("%02X", hash[i]);
+            tpm2_tool_output("%02X", hash[i]);
         }
-        printf("\n");
+        tpm2_tool_output("\n");
     }
 
     return hash;

--- a/tools/tpm2_getrandom.c
+++ b/tools/tpm2_getrandom.c
@@ -66,9 +66,9 @@ static bool get_random_and_save(TSS2_SYS_CONTEXT *sapi_context) {
     if (!ctx.output_file_specified) {
         UINT16 i;
         for (i = 0; i < random_bytes.size; i++) {
-            printf("%s0x%2.2X", i ? " " : "", random_bytes.buffer[i]);
+            tpm2_tool_output("%s0x%2.2X", i ? " " : "", random_bytes.buffer[i]);
         }
-        printf("\n");
+        tpm2_tool_output("\n");
         return true;
     }
 

--- a/tools/tpm2_hash.c
+++ b/tools/tpm2_hash.c
@@ -102,7 +102,7 @@ static bool hash_and_save(TSS2_SYS_CONTEXT *sapi_context) {
 
     if (outHash.size) {
         UINT16 i;
-        tpm2_tool_output("hash(%s):", tpm2_alg_util_algtostr(ctx.halg));
+        tpm2_tool_output("%s: ", tpm2_alg_util_algtostr(ctx.halg));
         for (i = 0; i < outHash.size; i++) {
             tpm2_tool_output("%02x", outHash.buffer[i]);
         }

--- a/tools/tpm2_load.c
+++ b/tools/tpm2_load.c
@@ -100,7 +100,7 @@ int load (TSS2_SYS_CONTEXT *sapi_context) {
         LOG_PERR(Tss2_Sys_Load, rval);
         return -1;
     }
-    tpm2_tool_output("\nLoad succ.\nLoadedHandle: 0x%08x\n\n",handle2048rsa);
+    tpm2_tool_output("handle: 0x%08x\n", handle2048rsa);
 
     if (ctx.out_file) {
         if(!files_save_bytes_to_file(ctx.out_file, nameExt.name, nameExt.size)) {

--- a/tools/tpm2_pcrevent.c
+++ b/tools/tpm2_pcrevent.c
@@ -216,7 +216,7 @@ static bool do_hmac_and_output(TSS2_SYS_CONTEXT *sapi_context) {
     for (i = 0; i < digests.count; i++) {
         TPMT_HA *d = &digests.digests[i];
 
-        tpm2_tool_output("%s:", tpm2_alg_util_algtostr(d->hashAlg));
+        tpm2_tool_output("%s: ", tpm2_alg_util_algtostr(d->hashAlg));
 
         BYTE *bytes;
         size_t size;

--- a/tools/tpm2_pcrlist.c
+++ b/tools/tpm2_pcrlist.c
@@ -251,7 +251,7 @@ static bool show_pcr_values(void) {
         const char *alg_name = tpm2_alg_util_algtostr(
                 ctx.pcr_selections.pcrSelections[i].hash);
 
-        tpm2_tool_output("%s :\n", alg_name);
+        tpm2_tool_output("%s:\n", alg_name);
 
         UINT8 pcr_id;
         for (pcr_id = 0; pcr_id < ctx.pcr_selections.pcrSelections[i].sizeofSelect * 8; pcr_id++) {
@@ -264,11 +264,11 @@ static bool show_pcr_values(void) {
                 return false;
             }
 
-            tpm2_tool_output("  %-2d : ", pcr_id);
+            tpm2_tool_output("  %-2d: 0x", pcr_id);
 
             int k;
             for (k = 0; k < ctx.pcrs.pcr_values[vi].digests[di].size; k++) {
-                tpm2_tool_output("%02x", ctx.pcrs.pcr_values[vi].digests[di].buffer[k]);
+                tpm2_tool_output("%02X", ctx.pcrs.pcr_values[vi].digests[di].buffer[k]);
             }
             tpm2_tool_output("\n");
 

--- a/tools/tpm2_policypcr.c
+++ b/tools/tpm2_policypcr.c
@@ -139,7 +139,7 @@ int tpm2_tool_onrun(TSS2_SYS_CONTEXT *sapi_context, tpm2_option_flags flags) {
         goto out;
     }
 
-    tpm2_tool_output("policy_digest: 0x");
+    tpm2_tool_output("policy-digest: 0x");
     UINT16 i;
     for(i = 0; i < policy_digest.size; i++) {
         tpm2_tool_output("%02X", policy_digest.buffer[i]);


### PR DESCRIPTION
Audit the tools for printf usages and replace with tpm2_tool_output. Also verify that output is in a YAML compliant format. Add tests that verify that the output can be loaded via the YAML module in python.

Fixes: #634 