### PR TITLE
tcti: handle option string better

### DIFF
--- a/lib/tpm2_tcti_ldr.c
+++ b/lib/tpm2_tcti_ldr.c
@@ -52,9 +52,7 @@ const TSS2_TCTI_INFO *tpm2_tcti_ldr_getinfo(void) {
     return info;
 }
 
-TSS2_TCTI_CONTEXT *tpm2_tcti_ldr_load(const char *path, char *opts) {
-
-    static const char tabrmd[7] = { 't', 'a', 'b', 'r', 'm', 'd', '\0' };
+TSS2_TCTI_CONTEXT *tpm2_tcti_ldr_load(const char *path, const char *opts) {
 
     TSS2_TCTI_CONTEXT *tcti_ctx = NULL;
 
@@ -69,9 +67,6 @@ TSS2_TCTI_CONTEXT *tpm2_tcti_ldr_load(const char *path, char *opts) {
      */
     handle = dlopen (path, RTLD_LAZY);
     if (!handle) {
-
-        //fixup users of abrmd as the tcti specifier
-        path = !strcmp(path, "abrmd") ? tabrmd : path;
 
         char buf[PATH_MAX];
         size_t size = snprintf(buf, sizeof(buf), "libtcti-%s.so", path);
@@ -102,7 +97,8 @@ TSS2_TCTI_CONTEXT *tpm2_tcti_ldr_load(const char *path, char *opts) {
     size_t size;
     TSS2_RC rc = init(NULL, &size, opts);
     if (rc != TPM2_RC_SUCCESS) {
-        LOG_ERR("tcti init routine for getting size failed for library: \"%s\"", path);
+        LOG_ERR("tcti init setup routine failed for library: \"%s\""
+                " options: \"%s\"", path, opts);
         goto err;
     }
 
@@ -114,8 +110,8 @@ TSS2_TCTI_CONTEXT *tpm2_tcti_ldr_load(const char *path, char *opts) {
 
     rc = init(tcti_ctx, &size, opts);
     if (rc != TPM2_RC_SUCCESS) {
-        LOG_ERR("tcti init routine for final initialization failed for library:"
-                " \"%s\" with option: \"%s\"", path, opts);
+        LOG_ERR("tcti init allocation routine failed for library: \"%s\""
+                " options: \"%s\"", path, opts);
         goto err;
     }
 

--- a/lib/tpm2_tcti_ldr.h
+++ b/lib/tpm2_tcti_ldr.h
@@ -43,7 +43,7 @@
  * @return
  *  A tcti context on success or NULL on failure.
  */
-TSS2_TCTI_CONTEXT *tpm2_tcti_ldr_load(const char *path, char *opts);
+TSS2_TCTI_CONTEXT *tpm2_tcti_ldr_load(const char *path, const char *opts);
 
 /**
  * Returns the loaded TCTIs information structure,

--- a/man/common/tcti.md
+++ b/man/common/tcti.md
@@ -10,28 +10,32 @@ The variables respected depend on how the software was configured.
 
   * _TPM2TOOLS\_TCTI\_NAME_:
 	Select the TCTI used for communication with the next component down the TSS
-	stack. In most configurations this will be the Resource Manager called tabrms,
+	stack. In most configurations this will be the Resource Manager called tabrmd,
 	but it could be a TPM simulator or TPM device itself.
 
   The current known TCTIs are:
 
 	* tabrmd - The new resource manager, called
 	           [tabrmd](https://github.com/01org/tpm2-abrmd).
-	* socket - Typically used with the old resource manager, or talking directly to
-	           a simulator.
+	           Note that tabrmd and abrmd as a tcti name are synonymous.
+	* socket - Typically used with the old resource manager, or for communicating to
+	           the TPM software simulator.
 	* device - Used when talking directly to a TPM device file.
 
 One can pass TCTI specific options to a TCTI via the _TPM2TOOLS\_TCTI\_NAME_ environment
-variable by appending the options after the name with a : (colon) seperator. These TCTI
+variable by appending the option string after the name with a : (colon) separator. These TCTI
 option config strings are TCTI specific. Specifying **-h** on the tool command line will
 show help output for the TCTIs. The section **TCTI OPTIONS** has examples for known TCTIs.
 
 Formally, the format is:
-```<tcti-name>:<tcti-options>```
+```<tcti-name>:<tcti-option-config>```
+
+Specifying an empty string for either the ```<tcti-name>``` or ```<tcti-option-config>```
+results in the default being used for that portion respectively.
 
 # TCTI OPTIONS
 
-This collection of options are used to configure the varous TCTI modules
+This collection of options are used to configure the various TCTI modules
 available. They override any environment variables.
 
   * **-T**, **--tcti**=_TCTI\_NAME_**[**:_TCTI\_OPTIONS_**]**:
@@ -57,9 +61,22 @@ available. They override any environment variables.
       2. 'bus_type' : The type of the dbus instance (a string) limited to
          'session' and 'system'.
 
-      * Examples:
-      ```
-        -T"abrmd:bus_name=com.example.FooBar"
-        -T"abrmd:bus_type=session"
-        -T"abrmd:bus_type=system,bus_name=com.example.BarFoo".
-      ```
+## TCTI Option Examples:
+Specify the tabrmd tcti name and a config string of ```bus_name=com.example.FooBar```:
+```
+--tcti=tabrmd:bus_name=com.example.FooBar
+```
+
+Specify the default (abrmd) tcti and a config string of ```bus_type=session```:
+```
+--tcti:bus_type=session
+```
+
+Specify the device tcti and use the default config:
+```
+--tcti=device
+```
+or
+```
+--tcti=device:
+```


### PR DESCRIPTION
Currently, the tcti option supported 3
formats:

--tcti=<name>
--tcti=<name>:
--tcti=<name>:<option(s)>

Add support for:
--tcti=:<option(s)>

This recitifes the tpm2-abrmd dynamic tcti handling with the
tools.

Fixes: #902

Signed-off-by: William Roberts <william.c.roberts@intel.com>