### PR TITLE
test: fix compilation

### DIFF
--- a/test/unit/test_tpm2_alg_util.c
+++ b/test/unit/test_tpm2_alg_util.c
@@ -332,7 +332,7 @@ static void test_pcr_parse_digest_list_compound(void **state) {
     assert_int_equal(3, dspec->digests.count);
 
     size_t i;
-    for (i=0; i < dspec->digests.count; i++) {
+    for (i=0; i < dspec->digests.count && i < TPM2_NUM_PCR_BANKS; i++) {
         TPMT_HA *digest = &dspec->digests.digests[i];
 
         switch (i) {
@@ -346,7 +346,7 @@ static void test_pcr_parse_digest_list_compound(void **state) {
             test_digest_sha512(digest);
             break;
         default:
-            fail_msg("Missing algorithm test for: %u", dspec->digests.digests[i].hashAlg);
+            fail_msg("Missing algorithm test for: %u", digest->hashAlg);
         }
     }
 }


### PR DESCRIPTION
With gcc v7.3.1 test_tpm2_alg_util.c fails with:
In file included from test/unit/test_tpm2_alg_util.c:33:0:
test/unit/test_tpm2_alg_util.c: In function ‘test_pcr_parse_digest_list_compound’:
test/unit/test_tpm2_alg_util.c:349:78: error: array subscript is above array bounds [-Werror=array-bounds]
             fail_msg("Missing algorithm test for: %u", dspec->digests.digests[i].hashAlg);
                                                        ~~~~~~~~~~~~~~~~~~~~~~^~~

Fix this by explicitly checking the array bounds.