### PR TITLE
tools: Fix typos in tpm2_send and tpm2_tool

### DIFF
--- a/tools/tpm2_send.c
+++ b/tools/tpm2_send.c
@@ -194,7 +194,7 @@ int tpm2_tool_onrun(TSS2_SYS_CONTEXT *sapi_context, tpm2_option_flags flags) {
         goto out;
     }
 
-    rval = tss2_tcti_transmit(tcti_context, size, command->bytes);
+    rval = Tss2_Tcti_Transmit(tcti_context, size, command->bytes);
     if (rval != TPM2_RC_SUCCESS) {
         LOG_ERR("tss2_tcti_transmit failed: 0x%x", rval);
         goto out;
@@ -202,7 +202,7 @@ int tpm2_tool_onrun(TSS2_SYS_CONTEXT *sapi_context, tpm2_option_flags flags) {
 
     size_t rsize = TPM2_MAX_SIZE;
     UINT8 rbuf[TPM2_MAX_SIZE];
-    rval = tss2_tcti_receive(tcti_context, &rsize, rbuf, TSS2_TCTI_TIMEOUT_BLOCK);
+    rval = Tss2_Tcti_Receive(tcti_context, &rsize, rbuf, TSS2_TCTI_TIMEOUT_BLOCK);
     if (rval != TPM2_RC_SUCCESS) {
         LOG_ERR("tss2_tcti_receive failed: 0x%x", rval);
         goto out;

--- a/tools/tpm2_tool.c
+++ b/tools/tpm2_tool.c
@@ -43,7 +43,7 @@ bool output_enabled = true;
 
 static void tcti_teardown (TSS2_TCTI_CONTEXT *tcti_context) {
 
-    tss2_tcti_finalize (tcti_context);
+    Tss2_Tcti_Finalize (tcti_context);
     free (tcti_context);
 }
 


### PR DESCRIPTION
Without this patch build fails with 'implicit declaration of function'.

* tools/tpm2_send.c (tpm2_tool_onrun): Replace tss2_tcti_transmit with
  Tss2_Tcti_Transmit.  Replace tss2_tcti_receive with Tss2_Tcti_Receive.
* tools/tpm2_tool.c (tcti_teardown): Replace tss2_tcti_finalize with
  Tss2_Tcti_Finalize.

Signed-off-by: Manolis Ragkousis <manolis837@gmail.com>