### PR TITLE
travis: use a custom docker container

### DIFF
--- a/.ci/docker.env
+++ b/.ci/docker.env
@@ -1,0 +1,4 @@
+CC
+COVERITY_SCAN_TOKEN
+
+TRAVIS_BUILD_DIR=/workspace/tpm2-tools

--- a/.ci/docker.run
+++ b/.ci/docker.run
@@ -1,3 +1,4 @@
+#!/usr/bin/env bash
 #;**********************************************************************;
 #
 # Copyright (c) 2017, Intel Corporation
@@ -29,10 +30,51 @@
 # ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
 # THE POSSIBILITY OF SUCH DAMAGE.
 #;**********************************************************************;
-#!/usr/bin/env bash
 
 # all command failures are fatal
 set -e
+
+WORKSPACE=`dirname $TRAVIS_BUILD_DIR`
+
+echo "Workspace: $WORKSPACE"
+
+source $TRAVIS_BUILD_DIR/.ci/download-deps.sh
+
+get_deps "$WORKSPACE"
+
+export LD_LIBRARY_PATH=/usr/local/lib/
+
+echo "echo changing to $TRAVIS_BUILD_DIR"
+# Change to the the travis build dir
+cd $TRAVIS_BUILD_DIR
+
+echo "starting dbus"
+mkdir -p /var/run/dbus
+if [ -e /var/run/dbus/pid ]; then
+  rm /var/run/dbus/pid
+fi
+
+# start dbus
+dbus-daemon --fork --system
+echo "dbus started"
+
+# let dbus have time to start up
+sleep 5
+
+echo "starting tpm server"
+# start the tpm server
+/ibmtpm974/src/tpm_server &
+echo "tpm server started"
+
+# start tpm2-abrmd
+
+# let the tpm simulator have time to start up before abrmd
+# tries to connect.
+sleep 5
+
+echo "starting abrmd server"
+tpm2-abrmd --allow-root --tcti=socket &
+echo "started abrmd server"
 
 if [ -d build ]; then
   rm -rf build
@@ -74,17 +116,6 @@ else #GCC
   echo "Exported ENABLE_COVERAGE=true"
   config_flags="--disable-hardening --enable-code-coverage"
 fi
-
-# Travis is using some EGLIBC version of libc
-# which appears to have some atexit() handling
-# issues when dlclose is used. Just disable it
-# for gcc builds, as clang DOES NOT run the
-# the system tests.
-# I cannot reproduce this on:
-#  OS: Ubuntu 16.04.3 LTS
-#   C: ldd (Ubuntu GLIBC 2.23-0ubuntu10) 2.23
-config_flags="--disable-dlclose $config_flags"
-echo "Enabling configure flag --disable-dlclose"
 
 # Bootstrap in the tpm2.0-tss tools directory
 ./bootstrap

--- a/.ci/download-deps.sh
+++ b/.ci/download-deps.sh
@@ -1,5 +1,6 @@
-#!/bin/bash
-
+#!/usr/bin/env bash
+#;**********************************************************************;
+#
 # Copyright (c) 2017, Intel Corporation
 # All rights reserved.
 #
@@ -13,6 +14,10 @@
 # this list of conditions and the following disclaimer in the documentation
 # and/or other materials provided with the distribution.
 #
+# 3. Neither the name of Intel Corporation nor the names of its contributors
+# may be used to endorse or promote products derived from this software without
+# specific prior written permission.
+#
 # THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
 # AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
 # IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
@@ -24,15 +29,33 @@
 # CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
 # ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
 # THE POSSIBILITY OF SUCH DAMAGE.
+#;**********************************************************************;
 
-# This script is a wrapper around the the 'make install' command for the
-# TSS source code. This is a workaround for a travis-ci quirk that causes
-# any command run under 'sudo' to be unable to run clang. This script fixes
-# up the borked PATH, moves to the directory where we built the TSS and then
-# runs 'make install'
-# see: https://github.com/travis-ci/travis-ci/issues/3088
+function get_deps() {
 
-PATH=${PATH}:/usr/local/clang/bin
-(pushd ${TRAVIS_BUILD_DIR}/tpm2-tss && \
- make install && \
- popd)
+	echo "pwd starting: `pwd`"
+	pushd "$1"
+	echo "pwd clone tss: `pwd`"
+	git clone https://github.com/tpm2-software/tpm2-tss.git
+	pushd tpm2-tss
+	echo "pwd build tss: `pwd`"
+	./bootstrap
+	./configure
+	make -j4
+	make install
+	popd
+	echo "pwd done tss: `pwd`"
+
+	echo "pwd clone abrmd: `pwd`"
+	git clone https://github.com/tpm2-software/tpm2-abrmd.git
+	pushd tpm2-abrmd
+	echo "pwd build abrmd: `pwd`"
+	./bootstrap
+	./configure
+	make -j4
+	make install
+	popd
+	echo "pwd done abrmd: `pwd`"
+	popd
+	echo "pwd done: `pwd`"
+}

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,37 @@
-sudo: false
-dist: trusty
+sudo: required
 
 language: c
+
+services:
+  - docker
+
 compiler:
   - gcc
-  - clang-3.8
+  - clang
+
+env:
+  global:
+   # The next declaration is the encrypted COVERITY_SCAN_TOKEN, created
+   #   via the "travis encrypt" command using the project repo's public key
+   - secure: "XrDhcREuntMn39qhSFBSSKZli9ZduGKCoq5rs/b+6e5zQIDwyDklwZIvgmrx2BJV5Sh7c5HB2Uvh9I7HdUOOOqDveZ9dcvjr2me7wfrhfMChB2miK318xVfyrK+6mkRnSMfuvG1CZiIcKYVStN1tX1uou9n3CnGz1ndmt5e4QwSQHR3K3g/HEXEgNjuei0OvtvE35/UaOpdxCoDlV3oExa3pU8mXLL77eskq35ebzwGsOu2zxD3wFhE1DF0O9yH4skH+fOH9ByxqK4n++uxbxXHW2oh4I/mEqr2wyyead/wuVa5UdxMDM7traUojlXy5O/Nn2Zfeky3ngSRQjzEYhKmiU2GiQ6ZBh78tmijPmKQpNOg2+0Uop7iT0SmefhappYOzc7KSTnYtWeEbZ4BXxeXzQZ98WsJj7Tmh258Y53KE2DDrmZYwk4EJuc6/4dv/HNMDdH8ZDzAdwMBi4lcsLnf8GQG/jfWYsrvCQQECkSfP2ICuRL9k/8pUUAnbp3X/WbCEMtaETy9STz7PNVqiWsSv/m9lBDVaHwZ7K87TdqhyDhYRDmPYP8qtu/M0tlNZ/M0VGo09xUgkb8Q2nNB7ahC7XYtBeHEIoIu6nf18gW8LgknpuhskF75ZHrKhh5VeN1zoPbG/oFYEk7ehNjGZC268d7jep5p5EaJzch5ai14="
+
+before_install:
+- docker pull tpm2software/tpm2-tss
+
+script:
+#
+# Docker starts you in a cloned repo of your project with the PR checkout out.
+# We want those changes IN the docker image, so use the -v option to mount the
+# project repo in the docker image.
+#
+# Also, pass in any env variables required for the build via .ci/docker.env file
+#
+# Execute the build and test procedure by running .ci/docker.run
+#
+- >
+  docker run --env-file .ci/docker.env \
+    -v `pwd`:/workspace/tpm2-tools tpm2software/tpm2-tss \
+    /bin/bash -c '/workspace/tpm2-tools/.ci/docker.run'
 
 addons:
   coverity_scan:
@@ -15,68 +42,3 @@ addons:
     build_command_prepend: "./bootstrap && ./configure && make clean"
     build_command:   "make -j4"
     branch_pattern: coverity_scan
-  apt:
-    packages:
-    - autoconf-archive
-    - libcurl4-openssl-dev
-    - libdbus-1-dev
-    - libglib2.0-dev
-    - clang-3.8
-    - pandoc
-    - lcov
-    - liburiparser-dev
-
-env:
-  global:
-   # The next declaration is the encrypted COVERITY_SCAN_TOKEN, created
-   #   via the "travis encrypt" command using the project repo's public key
-   - secure: "XrDhcREuntMn39qhSFBSSKZli9ZduGKCoq5rs/b+6e5zQIDwyDklwZIvgmrx2BJV5Sh7c5HB2Uvh9I7HdUOOOqDveZ9dcvjr2me7wfrhfMChB2miK318xVfyrK+6mkRnSMfuvG1CZiIcKYVStN1tX1uou9n3CnGz1ndmt5e4QwSQHR3K3g/HEXEgNjuei0OvtvE35/UaOpdxCoDlV3oExa3pU8mXLL77eskq35ebzwGsOu2zxD3wFhE1DF0O9yH4skH+fOH9ByxqK4n++uxbxXHW2oh4I/mEqr2wyyead/wuVa5UdxMDM7traUojlXy5O/Nn2Zfeky3ngSRQjzEYhKmiU2GiQ6ZBh78tmijPmKQpNOg2+0Uop7iT0SmefhappYOzc7KSTnYtWeEbZ4BXxeXzQZ98WsJj7Tmh258Y53KE2DDrmZYwk4EJuc6/4dv/HNMDdH8ZDzAdwMBi4lcsLnf8GQG/jfWYsrvCQQECkSfP2ICuRL9k/8pUUAnbp3X/WbCEMtaETy9STz7PNVqiWsSv/m9lBDVaHwZ7K87TdqhyDhYRDmPYP8qtu/M0tlNZ/M0VGo09xUgkb8Q2nNB7ahC7XYtBeHEIoIu6nf18gW8LgknpuhskF75ZHrKhh5VeN1zoPbG/oFYEk7ehNjGZC268d7jep5p5EaJzch5ai14="
-
-before_install:
-    - echo -n | openssl s_client -connect scan.coverity.com:443 | sed -ne '/-BEGIN CERTIFICATE-/,/-END CERTIFICATE-/p' | sudo tee -a /etc/ssl/certs/ca-
-    - pip install --user cpp-coveralls pyyaml
-
-install: 
-    - wget https://downloads.sourceforge.net/project/ibmswtpm2/ibmtpm974.tar.gz
-    - sha256sum ibmtpm974.tar.gz | grep -q 8e45d86129a0adb95fee4cee51f4b1e5b2d81ed3e55af875df53f98f39eb7ad7
-    - mkdir ibmtpm974 && pushd ibmtpm974 && tar axf ../ibmtpm974.tar.gz && pushd ./src && make
-    - ./tpm_server &
-    - popd && popd
-    - wget http://ftpmirror.gnu.org/autoconf-archive/autoconf-archive-2017.09.28.tar.xz
-    - sha256sum autoconf-archive-2017.09.28.tar.xz | grep -q 5c9fb5845b38b28982a3ef12836f76b35f46799ef4a2e46b48e2bd3c6182fa01
-    - tar xJf autoconf-archive-2017.09.28.tar.xz && pushd autoconf-archive-2017.09.28
-    - ./configure --prefix=/usr && make -j$(nproc) && sudo make install
-    - popd
-    - git clone https://github.com/tpm2-software/tpm2-tss.git
-    - pushd tpm2-tss
-    - ./bootstrap && ./configure --disable-esapi && make -j$(nproc)
-    - sudo ../.ci/travis-tss-install.sh
-    - popd
-    - sudo ldconfig /usr/local/lib
-    - git clone https://github.com/tpm2-software/tpm2-abrmd.git
-    - pushd tpm2-abrmd
-    - git am ../.ci/patches/abrmd/* || true
-    - ./bootstrap && ./configure --disable-dlclose --with-dbuspolicydir=/etc/dbus-1/system.d && make -j$(nproc) && sudo make install && popd
-    - sudo mkdir -p /var/lib/tpm
-    - sudo groupadd tss && sudo useradd -M -d /var/lib/tpm -s /bin/false -g tss tss
-    - sudo pkill -HUP dbus-daemon
-    - sudo -u tss tpm2-abrmd --tcti=libtcti-socket.so &
-    - wget http://mirrors.kernel.org/ubuntu/pool/universe/c/cmocka/libcmocka-dev_1.0.1-2_amd64.deb
-    - wget http://mirrors.kernel.org/ubuntu/pool/universe/c/cmocka/libcmocka0_1.0.1-2_amd64.deb
-    - sha256sum libcmocka-dev_1.0.1-2_amd64.deb | grep -q edb0dcfa14893b0a03375c4fe3b852043ce8fca8f2397cde340562554f6d50eb
-    - sha256sum libcmocka0_1.0.1-2_amd64.deb | grep -q 797155b45a8288a860c4ed9dd3f161420f09ebf362de30166d9f6b98bfc27dd0
-    - sudo dpkg -i libcmocka0_1.0.1-2_amd64.deb
-    - sudo dpkg -i libcmocka-dev_1.0.1-2_amd64.deb
-    # openssl 1.0.2g
-    - wget http://security.ubuntu.com/ubuntu/pool/main/o/openssl/libssl1.0.0_1.0.2g-1ubuntu4.10_amd64.deb
-    - wget http://security.ubuntu.com/ubuntu/pool/main/o/openssl/libssl-dev_1.0.2g-1ubuntu4.10_amd64.deb
-    - sha256sum libssl1.0.0_1.0.2g-1ubuntu4.10_amd64.deb | grep -q 99f550db61b0054715095fc77901280e81235900435f90b7db34af406f053832
-    - sha256sum libssl-dev_1.0.2g-1ubuntu4.10_amd64.deb | grep -q e44b09b81717a9ae86ff17adae1729682cb00b5285710e991f7b61c8a351c744
-    - sudo dpkg -i libssl1.0.0_1.0.2g-1ubuntu4.10_amd64.deb
-    - sudo dpkg -i libssl-dev_1.0.2g-1ubuntu4.10_amd64.deb
-
-script:
-    - ./.ci/travis-build-and-run-tests.sh
-
-after_failure:
-   - cat build/test-suite.log

--- a/tools/tpm2_clearlock.c
+++ b/tools/tpm2_clearlock.c
@@ -52,7 +52,7 @@ static clearlock_ctx ctx = {
 static bool clearlock(TSS2_SYS_CONTEXT *sapi_context) {
 
     TPMI_RH_CLEAR rh = ctx.platform ? TPM2_RH_PLATFORM : TPM2_RH_LOCKOUT;
-    TPMI_YES_NO disable = ctx.clear ? NO : YES;
+    TPMI_YES_NO disable = ctx.clear ? 0 : 1;
 
     LOG_INFO ("Sending TPM2_ClearControl(%s) command on %s",
             ctx.clear ? "CLEAR" : "SET",

--- a/tools/tpm2_encryptdecrypt.c
+++ b/tools/tpm2_encryptdecrypt.c
@@ -68,7 +68,6 @@ struct tpm_encrypt_decrypt_ctx {
 
 static tpm_encrypt_decrypt_ctx ctx = {
     .session_data = TPMS_AUTH_COMMAND_EMPTY_INIT,
-    .is_decrypt = NO,
     .data = TPM2B_EMPTY_INIT,
 };
 
@@ -139,7 +138,7 @@ static bool on_option(char key, char *value) {
         ctx.flags.P = 1;
         break;
     case 'D':
-        ctx.is_decrypt = YES;
+        ctx.is_decrypt = 1;
         break;
     case 'I':
         ctx.data.size = sizeof(ctx.data.buffer);

--- a/tools/tpm2_flushcontext.c
+++ b/tools/tpm2_flushcontext.c
@@ -74,7 +74,7 @@ get_capability_handles(TSS2_SYS_CONTEXT *sapi_ctx, UINT32 property,
                                 NULL);
     if (rval != TSS2_RC_SUCCESS) {
         LOG_PERR(Tss2_Sys_GetCapability, rval);
-    } else if (more_data == YES) {
+    } else if (more_data) {
         LOG_WARN("More data to be queried: capability: 0x%x, property: "
                  "0x%x", TPM2_CAP_HANDLES, property);
     }

--- a/tools/tpm2_getcap.c
+++ b/tools/tpm2_getcap.c
@@ -877,7 +877,7 @@ get_tpm_capability_all (TSS2_SYS_CONTEXT *sapi_ctx,
         LOG_ERR("Failed to GetCapability: capability: 0x%x, property: 0x%x",
                  options.capability, options.property);
         LOG_PERR(Tss2_Sys_GetCapability, rval);
-    } else if (more_data == YES) {
+    } else if (more_data) {
         LOG_WARN("More data to be queried: capability: 0x%x, property: "
                  "0x%x\n", options.capability, options.property);
     }


### PR DESCRIPTION
Travis uses ancient docker and VM images. Switch to a custom
docker image that has all dependencies for the TSS stack pre-installed.

This has a few benefits:
1. Local testing by just running the docker command in the travis.yml file
2. Less dependency setup code in the travis.yml
3. ESAPI builds work on Travis now (the tools can start switching over)

This has a major draw backs:
1. Back on travis VM based builds, which can have long wait queues.
  A. A workaround to this, is you can run your full CI buildup locally
     so you can just merge outside of travis if need-be.

Fixes: #909 