### PR TITLE
tpm2_createak: fix manpage double -g options

### DIFF
--- a/man/tpm2_createak.1.md
+++ b/man/tpm2_createak.1.md
@@ -60,7 +60,7 @@ loaded-key:
     See section "Supported Public Object Algorithms" for a list of supported
     object algorithms.
 
-  * **-g**, **--alg**=_ALGORITHM_:
+  * **-D**, **--digest-alg**=_ALGORITHM_:
     Like -g, but specifies the algorithm of sign.
     See section "Supported Signing Algorithms" for details.
 


### PR DESCRIPTION
There was a double -g option, and one of them should
have been -D. Fix this, by correcting the tpm options.

Fixes: #916

Signed-off-by: William Roberts <william.c.roberts@intel.com>