### PR TITLE
tpm2_createprimary: add missing newline

### DIFF
--- a/tools/tpm2_createprimary.c
+++ b/tools/tpm2_createprimary.c
@@ -267,7 +267,7 @@ int tpm2_tool_onrun(TSS2_SYS_CONTEXT *sapi_context, tpm2_option_flags flags) {
     }
 
     tpm2_util_tpma_object_to_yaml(ctx.objdata.in.public.publicArea.objectAttributes);
-    tpm2_tool_output("handle: 0x%X", ctx.objdata.out.handle);
+    tpm2_tool_output("handle: 0x%X\n", ctx.objdata.out.handle);
 
     if (!ctx.context_file) {
         return 0;


### PR DESCRIPTION
The handle output was missing a newline, which makes
command line output a bit of a struggle as the shell
cursor is on the same line as the output.

Fix this by adding a newline.

Fixes: #914

Signed-off-by: William Roberts <william.c.roberts@intel.com>