### PR TITLE
tests/encryptdecrypt: fix errors that cause passing

### DIFF
--- a/test/system/tests/encryptdecrypt.sh
+++ b/test/system/tests/encryptdecrypt.sh
@@ -40,14 +40,22 @@ onerror() {
 
 cleanup() {
   rm -f primary.ctx decrypt.ctx key.pub key.priv key.name decrypt.out \
-        encrypt.out secret.dat &>/dev/null
+        encrypt.out secret.dat commands.cap
 }
 trap cleanup EXIT
 
 cleanup
 
+# set the error handler for checking tpm2_getcap call
+trap onerror ERR
+
 # Check for encryptdecrypt command code 0x164
-tpm2_getcap -c commands | grep -q 0x164
+tpm2_getcap -c commands > commands.cap
+
+# clear the handler for the grep check
+trap - ERR
+
+grep -q 0x164 commands.cap
 if [ $? != 0 ];then
     echo "WARN: Command EncryptDecrypt is not supported by your device, skipping..."
     exit 0


### PR DESCRIPTION
The error trap was cleared when using tpm2_getcap
to verify if command encryptdecrypt was supported.

If it wasn't supported, by checking the grep return
code via $?, then a warning is printed and the test
is skipped.

When tpm2_getcap fails, $? is 1 and the test is reported
as passing, which is incorrect.

Signed-off-by: William Roberts <william.c.roberts@intel.com>