### PR TITLE
tools: remove incorrect 's' option from tpm2_startup optstring

### DIFF
--- a/tools/tpm2_startup.c
+++ b/tools/tpm2_startup.c
@@ -70,7 +70,7 @@ bool tpm2_tool_onstart(tpm2_options **opts) {
         { "clear", no_argument, NULL, 'c' },
     };
 
-    *opts = tpm2_options_new("cs", ARRAY_LEN(topts), topts,
+    *opts = tpm2_options_new("c", ARRAY_LEN(topts), topts,
                              on_option, NULL, 0);
 
     return *opts != NULL;


### PR DESCRIPTION
The tool doesn't have this short option, so the opstring isn't correct.

Signed-off-by: Javier Martinez Canillas <javierm@redhat.com>