### PR TITLE
bootstrap: Remove Spurious Warning about Missing m4 Directory

### DIFF
--- a/bootstrap
+++ b/bootstrap
@@ -2,4 +2,5 @@
 
 AUTORECONF=${AUTORECONF:-autoreconf}
 
+mkdir -p m4
 ${AUTORECONF} --install --sym


### PR DESCRIPTION
A ```mkdir -p m4``` will remove the warning, which is not needed
and only causes confusion.

Fixes #926.

Signed-off-by: Dan Anderson <daniel.anderson@intel.com>