### PR TITLE
Revert ".ci: Work around bug selecting default config string for mssi…

### DIFF
--- a/.ci/docker.run
+++ b/.ci/docker.run
@@ -74,7 +74,7 @@ echo "tpm server started"
 sleep 5
 
 echo "starting abrmd server"
-tpm2-abrmd --allow-root --tcti="mssim:tcp://127.0.0.1:2321/" &
+tpm2-abrmd --allow-root --tcti=mssim &
 echo "started abrmd server"
 
 if [ -d build ]; then


### PR DESCRIPTION
…m TCTI."

Fixed upstream in tpm2-tss commit bba44338.

This reverts commit 14c204d652cdba1e44ce7e017eaee36072573aaa.