### PR TITLE
dist: include built manpages

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -326,6 +326,15 @@ if HAVE_PANDOC
     man/man1/tpm2_startup.1 \
     man/man1/tpm2_unseal.1 \
     man/man1/tpm2_verifysignature.1
+
+# If pandoc is enabled, we want to generate the manpages for the dist tarball
+EXTRA_DIST += $(man1_MANS)
+else
+# If pandoc is not enabled, we want to complain that you need pandoc for make dist,
+# so hook the target and complain.
+dist-hook:
+	@(>&2 echo "You do not have pandoc, a requirement for the distribution of manpages")
+	@exit 1
 endif
 
 MARKDOWN_COMMON_DEPS = \


### PR DESCRIPTION
Generate the man pages from markdown and distribute in the
dist tarball by making a dependency on the man pages via
the EXTRA_DIST variable.

Also, make "make dist" fail if pandoc is not installed:
$ make -j4 dist > /dev/null
You do not have pandoc, a requirement for the distribution of manpages
make[2]: *** [dist-hook] Error 1
make[1]: *** [distdir] Error 2
make: *** [dist] Error 2

Behavior under clean:
1. On a build tree, make clean removes the manpages
2. On a dist tarball, make clean leaves the manpages

Fixes: #925

Signed-off-by: William Roberts <william.c.roberts@intel.com>