### PR TITLE
Minor docs tweaks

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -36,7 +36,7 @@ script:
 addons:
   coverity_scan:
     project:
-      name: "01org/tpm2.0-tools"
+      name: "tpm2-software/tpm2.0-tools"
       description: "Build submitted via Travis CI"
     notification_email: william.c.roberts@intel.com
     build_command_prepend: "./bootstrap && ./configure && make clean"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -85,7 +85,7 @@
 
 ### v2.0 - 2017-03-29
 
-  * Tracked on the milestone: https://github.com/01org/tpm2-tools/milestone/2
+  * Tracked on the milestone: https://github.com/tpm2-software/tpm2-tools/milestone/2
   * Reworked all the tools to support configurable TCTIs, based on build time
     configuration, one can specify the tcti via the --tcti (-T) option to all
     tools.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,7 +2,7 @@
 
 All non security bugs can be filed on the Issues tracker:
 
-<https://github.com/01org/tpm2-tools/issues>
+<https://github.com/tpm2-software/tpm2-tools/issues>
 
 Security sensitive bugs should be emailed to a maintainer or to Intel
 via the guidelines here:

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -5,7 +5,7 @@ Below you will find instructions to build and install the tpm2-tools project.
 ### Download the Source
 To obtain the tpm2-tools sources you must clone them as below:
 ```
-git clone https://github.com/01org/tpm2-tools
+git clone https://github.com/tpm2-software/tpm2-tools
 ```
 
 ### Dependencies
@@ -60,9 +60,9 @@ sudo apt-get install autoconf automake libtool pkg-config gcc libssl-dev \
 The following tpm2 userspace dependencies can be satisfied by getting the
 source, building and installing them. They can be located here:
 
-  * SAPI - The low level system API: <https://github.com/01org/tpm2-tss>
+  * SAPI - The low level system API: <https://github.com/tpm2-software/tpm2-tss>
   * ABRMD (**recommended but optional**) - Which is the userspace resource
-    manager: <https://github.com/01org/tpm2-abrmd>
+    manager: <https://github.com/tpm2-software/tpm2-abrmd>
 
 **Other Dependencies**
 
@@ -73,18 +73,18 @@ To get md2man-roff, see there page at: <https://github.com/sunaku/md2man>
 
 | tpm2-tools version | tpm2-tss version | tpm2-abrmd version|
 |--------------------|------------------|-------------------|
-|[master](https://github.com/01org/tpm2-tools)|[master](https://github.com/01org/tpm2-tss)|[master](https://github.com/01org/tpm2-abrmd)|
-|[2.1.0](https://github.com/01org/tpm2-tools/releases/tag/2.1.0)|[1.2.0](https://github.com/01org/tpm2-tss/releases/tag/1.2.0)|[1.1.1](https://github.com/01org/tpm2-abrmd/releases/tag/1.1.1)|
-|[df751ae](https://github.com/01org/tpm2.0-tools/tree/df751ae5bea0bb057c9ee4cb0c1176c48ff68492)(master)|[1.1.0](https://github.com/01org/TPM2.0-TSS/releases/tag/1.1.0)|[1.0.0](https://github.com/01org/tpm2-abrmd/releases/tag/1.0.0)|
-|[v2.0.0](https://github.com/01org/tpm2.0-tools/releases/tag/2.0.0)|[1.0](https://github.com/01org/TPM2.0-TSS/releases/tag/1.0)|old resourcemgr|
-|[v1.1.0](https://github.com/01org/tpm2.0-tools/releases/tag/v1.1.0)|[1.0](https://github.com/01org/TPM2.0-TSS/releases/tag/1.0)|old resourcemgr|
-|[v1.1-beta_1](https://github.com/01org/tpm2.0-tools/releases/tag/v1.1-beta_1)|[1.0-beta_1](https://github.com/01org/TPM2.0-TSS/releases/tag/1.0-beta_1)|old resourcemgr|
-|[v1.1-beta_0](https://github.com/01org/tpm2.0-tools/releases/tag/v1.1-beta_0)|[v1.0-beta_0](https://github.com/01org/TPM2.0-TSS/releases/tag/v1.0-beta_0)|old resourcemgr|
-|[14a7ff5](https://github.com/01org/tpm2.0-tools/tree/14a7ff527bc0411c215bd9d575f2866e1f2e71cf)|[210b770](https://github.com/01org/TPM2.0-TSS/tree/210b770c1dff47b11be623e1d1e7ffb02298fca5)|old resourcemgr|
-|[4b4cbea](https://github.com/01org/tpm2.0-tools/tree/4b4cbeafe30430f42826592dee2abafec818385f)|[d4f23cc](https://github.com/01org/TPM2.0-TSS/tree/d4f23cc25c4c0fb66dd36897d2fad8e1e37c6443)|old resourcemgr|
-|[e8150e4](https://github.com/01org/tpm2.0-tools/tree/e8150e48dd47f761dff10583631b2a0a30ee4d90)|[60ec042](https://github.com/01org/TPM2.0-TSS/tree/60ec04237b5344666435e129bd85f7496a6a9985)|old resourcemgr|
-|[84d5f26](https://github.com/01org/tpm2.0-tools/tree/84d5f262f281556c57f7ec2fba06eda3acadd26c)|[371fdbc](https://github.com/01org/TPM2.0-TSS/tree/371fdbc638c55b9ac8a0eaec9375dbca0412861c)|old resourcemgr|
-|[v1.0.1](https://github.com/01org/tpm2.0-tools/releases/tag/v1.0.1)|[1.0-alpha_0](https://github.com/01org/TPM2.0-TSS/releases/tag/1.0-alpha_0)|old resourcemgr|
+|[master](https://github.com/tpm2-software/tpm2-tools)|[master](https://github.com/tpm2-software/tpm2-tss)|[master](https://github.com/tpm2-software/tpm2-abrmd)|
+|[2.1.0](https://github.com/tpm2-software/tpm2-tools/releases/tag/2.1.0)|[1.2.0](https://github.com/tpm2-software/tpm2-tss/releases/tag/1.2.0)|[1.1.1](https://github.com/tpm2-software/tpm2-abrmd/releases/tag/1.1.1)|
+|[df751ae](https://github.com/tpm2-software/tpm2.0-tools/tree/df751ae5bea0bb057c9ee4cb0c1176c48ff68492)(master)|[1.1.0](https://github.com/tpm2-software/TPM2.0-TSS/releases/tag/1.1.0)|[1.0.0](https://github.com/tpm2-software/tpm2-abrmd/releases/tag/1.0.0)|
+|[v2.0.0](https://github.com/tpm2-software/tpm2.0-tools/releases/tag/2.0.0)|[1.0](https://github.com/tpm2-software/TPM2.0-TSS/releases/tag/1.0)|old resourcemgr|
+|[v1.1.0](https://github.com/tpm2-software/tpm2.0-tools/releases/tag/v1.1.0)|[1.0](https://github.com/tpm2-software/TPM2.0-TSS/releases/tag/1.0)|old resourcemgr|
+|[v1.1-beta_1](https://github.com/tpm2-software/tpm2.0-tools/releases/tag/v1.1-beta_1)|[1.0-beta_1](https://github.com/tpm2-software/TPM2.0-TSS/releases/tag/1.0-beta_1)|old resourcemgr|
+|[v1.1-beta_0](https://github.com/tpm2-software/tpm2.0-tools/releases/tag/v1.1-beta_0)|[v1.0-beta_0](https://github.com/tpm2-software/TPM2.0-TSS/releases/tag/v1.0-beta_0)|old resourcemgr|
+|[14a7ff5](https://github.com/tpm2-software/tpm2.0-tools/tree/14a7ff527bc0411c215bd9d575f2866e1f2e71cf)|[210b770](https://github.com/tpm2-software/TPM2.0-TSS/tree/210b770c1dff47b11be623e1d1e7ffb02298fca5)|old resourcemgr|
+|[4b4cbea](https://github.com/tpm2-software/tpm2.0-tools/tree/4b4cbeafe30430f42826592dee2abafec818385f)|[d4f23cc](https://github.com/tpm2-software/TPM2.0-TSS/tree/d4f23cc25c4c0fb66dd36897d2fad8e1e37c6443)|old resourcemgr|
+|[e8150e4](https://github.com/tpm2-software/tpm2.0-tools/tree/e8150e48dd47f761dff10583631b2a0a30ee4d90)|[60ec042](https://github.com/tpm2-software/TPM2.0-TSS/tree/60ec04237b5344666435e129bd85f7496a6a9985)|old resourcemgr|
+|[84d5f26](https://github.com/tpm2-software/tpm2.0-tools/tree/84d5f262f281556c57f7ec2fba06eda3acadd26c)|[371fdbc](https://github.com/tpm2-software/TPM2.0-TSS/tree/371fdbc638c55b9ac8a0eaec9375dbca0412861c)|old resourcemgr|
+|[v1.0.1](https://github.com/tpm2-software/tpm2.0-tools/releases/tag/v1.0.1)|[1.0-alpha_0](https://github.com/tpm2-software/TPM2.0-TSS/releases/tag/1.0-alpha_0)|old resourcemgr|
 
 ## Building
 

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 **This site contains the code for the TPM (Trusted Platform Module) 2.0 tools based on tpm2-tss**
 
 ## News
-* Release [3.0.3](https://github.com/01org/tpm2-tools/releases/tag/3.0.3) is now available.
+* Release [3.0.3](https://github.com/tpm2-software/tpm2-tools/releases/tag/3.0.3) is now available.
 * A mailing list now exists for support: https://lists.01.org/mailman/listinfo/tpm2
 * CVE-2017-7524 - Where an HMAC authorization uses the tpm to perform the hmac calculation. This results in a disclosure of the password to
 the tpm where the user would not expect it. It appears likely unreachable in the current code base. This has been fixed on releases greater than version 1.1.1.
@@ -24,7 +24,7 @@ for information on how to submit those.
 ## Resources
 
 The tpm2-tools wiki:
-<https://github.com/01org/tpm2-tools/wiki>
+<https://github.com/tpm2-software/tpm2-tools/wiki>
 
 TPM 2.0 specifications can be found at [Trusted Computing Group](http://www.trustedcomputinggroup.org/).
 

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -8,7 +8,7 @@ rc series. Releases shall be pushed to branch coverity_scan, to inititiate a sca
 
 An example can be found here:
 
-<https://github.com/01org/tpm2-tools/releases/tag/2.1.0-rc0>
+<https://github.com/tpm2-software/tpm2-tools/releases/tag/2.1.0-rc0>
 
 Release candidates will also be announced on the
 [mailing list](https://lists.01.org/mailman/listinfo/tpm2). When a rc has gone 1

--- a/man/common/tcti.md
+++ b/man/common/tcti.md
@@ -16,7 +16,7 @@ The variables respected depend on how the software was configured.
   The current known TCTIs are:
 
 	* tabrmd - The new resource manager, called
-	           [tabrmd](https://github.com/01org/tpm2-abrmd).
+	           [tabrmd](https://github.com/tpm2-software/tpm2-abrmd).
 	           Note that tabrmd and abrmd as a tcti name are synonymous.
 	* socket - Typically used with the old resource manager, or for communicating to
 	           the TPM software simulator.
@@ -41,7 +41,7 @@ available. They override any environment variables.
   * **-T**, **--tcti**=_TCTI\_NAME_**[**:_TCTI\_OPTIONS_**]**:
 	Select the TCTI used for communication with the next component down the TSS
 	stack. In most configurations this will be the resource manager:
-	[tabrmd](https://github.com/01org/tpm2-abrmd)
+	[tabrmd](https://github.com/tpm2-software/tpm2-abrmd)
 	Optionally, tcti specific options can appended to _TCTI\_NAME_ by appending
 	a **:** to _TCTI\_NAME_.
 

--- a/man/common/tcti.md
+++ b/man/common/tcti.md
@@ -18,8 +18,7 @@ The variables respected depend on how the software was configured.
 	* tabrmd - The new resource manager, called
 	           [tabrmd](https://github.com/tpm2-software/tpm2-abrmd).
 	           Note that tabrmd and abrmd as a tcti name are synonymous.
-	* socket - Typically used with the old resource manager, or for communicating to
-	           the TPM software simulator.
+	* mssim  - Typically used for communicating to the TPM software simulator.
 	* device - Used when talking directly to a TPM device file.
 
 One can pass TCTI specific options to a TCTI via the _TPM2TOOLS\_TCTI\_NAME_ environment
@@ -49,9 +48,9 @@ available. They override any environment variables.
       The default is /dev/tpm0.
       Example: **-T device:/dev/tpm0** or **export _TPM2TOOLS\_TCTI\_NAME_="device:/dev/tpm0"**
 
-    * For the socket TCTI, the domain name or IP address and port number used by the socket
+    * For the mssim TCTI, the domain name or IP address and port number used by the simulator
       can be specified. The default are 127.0.0.1 and 2321.
-      Example: **-T socket:tcp://127.0.0.1:2321** or **export _TPM2TOOLS\_TCTI\_NAME_="socket:tcp://127.0.0.1:2321"**
+      Example: **-T mssim:tcp://127.0.0.1:2321** or **export _TPM2TOOLS\_TCTI\_NAME_="mssim:tcp://127.0.0.1:2321"**
 
     * For the abrmd TCTI, the configuration string format is a series of simple key value pairs
       separated by a ',' character. Each key and value string are separated by a '=' character.

--- a/man/tpm2_print.1.md
+++ b/man/tpm2_print.1.md
@@ -44,7 +44,7 @@ cat /path/to/tpm/quote | tpm2_print --type=TPMS_ATTEST
 
 # BUGS
 
-[Github Issues](https://github.com/01org/tpm2-tools/issues)
+[Github Issues](https://github.com/tpm2-software/tpm2-tools/issues)
 
 # HELP
 

--- a/test/system/tests/getmanufec.sh
+++ b/test/system/tests/getmanufec.sh
@@ -38,7 +38,7 @@
 # 2. The suppression option via ASAN_OPTIONS doesn't
 #    exist for 3.6.
 # TODO When this is fixed, remove it.
-# Bug: https://github.com/01org/tpm2-tools/issues/390
+# Bug: https://github.com/tpm2-software/tpm2-tools/issues/390
 if [ "$ASAN_ENABLED" == "true" ]; then
   echo "Skipping ASAN_ENABLED is true"
   exit 0

--- a/test/system/tests/rc_decode.sh
+++ b/test/system/tests/rc_decode.sh
@@ -39,7 +39,7 @@ trap onerror ERR
 
 #
 # codes was generated from the TPM2_RC constants in:
-# https://github.com/01org/tpm2-tss/blob/master/include/sapi/tss2_tpm2_types.h#L68
+# https://github.com/tpm2-software/tpm2-tss/blob/master/include/sapi/tss2_tpm2_types.h#L68
 # Some of these may not be used correctly, which is OK, as tpm2_rc_decode never
 # fails and should attempt to decode it or print some unkown status. This gives
 # us coverage for both known and unkown/malformed inputs.

--- a/tools/tpm2_pcrextend.c
+++ b/tools/tpm2_pcrextend.c
@@ -52,7 +52,7 @@ static bool pcr_extend_one(TSS2_SYS_CONTEXT *sapi_context,
 
     /*
      * TODO SUPPORT AUTH VALUES HERE
-     * Bug: https://github.com/01org/tpm2-tools/issues/388
+     * Bug: https://github.com/tpm2-software/tpm2-tools/issues/388
      */
     TSS2L_SYS_AUTH_RESPONSE sessions_data_out;
     TSS2L_SYS_AUTH_COMMAND sessions_data = { 1, {{ .sessionHandle=TPM2_RS_PW }}};

--- a/tools/tpm2_pcrextend.c
+++ b/tools/tpm2_pcrextend.c
@@ -49,11 +49,6 @@ static tpm_pcr_extend_ctx ctx;
 
 static bool pcr_extend_one(TSS2_SYS_CONTEXT *sapi_context,
         TPMI_DH_PCR pcr_index, TPML_DIGEST_VALUES *digests) {
-
-    /*
-     * TODO SUPPORT AUTH VALUES HERE
-     * Bug: https://github.com/tpm2-software/tpm2-tools/issues/388
-     */
     TSS2L_SYS_AUTH_RESPONSE sessions_data_out;
     TSS2L_SYS_AUTH_COMMAND sessions_data = { 1, {{ .sessionHandle=TPM2_RS_PW }}};
 


### PR DESCRIPTION
- Ensure github links point to the latest repos in the new tpm2-software organisation
- Fix TCTI common options for the socket->mssim rename
- Remove a TODO item which pointed to a bug which is closed WONTFIX