### PR TITLE
main: remove envp param as it is unused

### DIFF
--- a/lib/tpm2_options.c
+++ b/lib/tpm2_options.c
@@ -264,15 +264,13 @@ void tpm2_print_usage(const char *command, struct tpm2_options *tool_opts) {
     }
 }
 
-tpm2_option_code tpm2_handle_options (int argc, char **argv, char **envp,
+tpm2_option_code tpm2_handle_options (int argc, char **argv,
         tpm2_options *tool_opts, tpm2_option_flags *flags,
         TSS2_TCTI_CONTEXT **tcti) {
 
     tpm2_option_code rc = tpm2_option_code_err;
     bool result = false;
     bool show_help = false;
-
-    UNUSED(envp);
 
     /*
      * Handy way to *try* and find all used options:

--- a/lib/tpm2_options.h
+++ b/lib/tpm2_options.h
@@ -178,8 +178,6 @@ enum tpm2_option_code {
  *  The argc from main.
  * @param argv
  *  The argv from main.
- * @param envp
- *  The envp from main.
  * @param tool_opts
  *  The tool options gathered during onstart() lifecycle call.
  * @param flags
@@ -193,7 +191,7 @@ enum tpm2_option_code {
  *  Used by tpm2_tool, and likely should only be used there.
  *
  */
-tpm2_option_code tpm2_handle_options (int argc, char **argv, char **envp,
+tpm2_option_code tpm2_handle_options (int argc, char **argv,
         tpm2_options *tool_opts, tpm2_option_flags *flags,
         TSS2_TCTI_CONTEXT **tcti);
 

--- a/tools/tpm2_tool.c
+++ b/tools/tpm2_tool.c
@@ -99,7 +99,7 @@ static TSS2_SYS_CONTEXT* sapi_ctx_init(TSS2_TCTI_CONTEXT *tcti_ctx) {
  * nothing more than parsing command line options that allow the caller to
  * specify which TCTI to use for the test.
  */
-int main(int argc, char *argv[], char *envp[]) {
+int main(int argc, char *argv[]) {
 
     int ret = 1;
 
@@ -119,7 +119,7 @@ int main(int argc, char *argv[], char *envp[]) {
 
     tpm2_option_flags flags = { .all = 0 };
     TSS2_TCTI_CONTEXT *tcti = NULL;
-    tpm2_option_code rc = tpm2_handle_options(argc, argv, envp, tool_opts, &flags, &tcti);
+    tpm2_option_code rc = tpm2_handle_options(argc, argv, tool_opts, &flags, &tcti);
     if (rc != tpm2_option_code_continue) {
         ret = rc == tpm2_option_code_err ? 1 : 0;
         goto free_opts;


### PR DESCRIPTION
envp is no longer being used, so remove it.

Signed-off-by: William Roberts <william.c.roberts@intel.com>