### PR TITLE
all: Switch TPMA_OBJECT_SIGN to _ENCRYPT

### DIFF
--- a/lib/tpm2_attr_util.c
+++ b/lib/tpm2_attr_util.c
@@ -348,7 +348,7 @@ static bool decrypt(TPMA_OBJECT *obj, char *arg) {
 static bool sign(TPMA_OBJECT *obj, char *arg) {
 
     UNUSED(arg);
-    *obj |= TPMA_OBJECT_SIGN;
+    *obj |= TPMA_OBJECT_SIGN_ENCRYPT;
     return true;
 }
 

--- a/lib/tpm2_errata.c
+++ b/lib/tpm2_errata.c
@@ -222,7 +222,7 @@ static void fixup_sign_decrypt_attribute_encoding(va_list *ap) {
 
     TPMA_OBJECT *attrs = va_arg(*ap, TPMA_OBJECT *);
 
-    *attrs &= ~TPMA_OBJECT_SIGN;
+    *attrs &= ~TPMA_OBJECT_SIGN_ENCRYPT;
 }
 
 static bool errata_match(struct tpm2_errata_desc *errata) {

--- a/man/common/obj-attrs.md
+++ b/man/common/obj-attrs.md
@@ -12,7 +12,7 @@ prefix **TPMA_OBJECT_** and lowercasing the result. Thus, **TPMA_OBJECT_FIXEDTPM
 fixedtpm. Nice names can be joined using the bitwise or "|" symbol.
 
 For instance, to set The fields **TPMA_OBJECT_FIXEDTPM**,
-**TPMA_OBJECT_NODA**, and **TPMA_OBJECT_SIGN**, the argument
+**TPMA_OBJECT_NODA**, and **TPMA_OBJECT_SIGN_ENCRYPT**, the argument
 would be:
 
 **fixedtpm|noda|sign**

--- a/man/tpm2_create.1.md
+++ b/man/tpm2_create.1.md
@@ -49,7 +49,7 @@ These options for creating the tpm entity:
     The object attributes, optional. Object attribytes follow the specifications
     as outlined in "object attribute specifiers". The default for created objects is:
 
-    `TPMA_OBJECT_SIGN|TPMA_OBJECT_FIXEDTPM|TPMA_OBJECT_FIXEDPARENT|TPMA_OBJECT_SENSITIVEDATAORIGIN|TPMA_OBJECT_USERWITHAUTH`
+    `TPMA_OBJECT_SIGN_ENCRYPT|TPMA_OBJECT_FIXEDTPM|TPMA_OBJECT_FIXEDPARENT|TPMA_OBJECT_SENSITIVEDATAORIGIN|TPMA_OBJECT_USERWITHAUTH`
 
   * **-I**, **--in-file**=_FILE_:
     The data file to be sealed, optional. If file is -, read from stdin.

--- a/test/unit/test_tpm2_attr_util.c
+++ b/test/unit/test_tpm2_attr_util.c
@@ -269,7 +269,7 @@ obj_single_item_test("noda", TPMA_OBJECT_NODA);
 obj_single_item_test("encryptedduplication", TPMA_OBJECT_ENCRYPTEDDUPLICATION);
 obj_single_item_test("restricted", TPMA_OBJECT_RESTRICTED);
 obj_single_item_test("decrypt", TPMA_OBJECT_DECRYPT);
-obj_single_item_test("sign", TPMA_OBJECT_SIGN);
+obj_single_item_test("sign", TPMA_OBJECT_SIGN_ENCRYPT);
 
 #define OBJ_ALL_FIELDS \
         "<reserved(0)>|fixedtpm|stclear|<reserved(3)>|fixedparent" \
@@ -309,7 +309,7 @@ test_obj_attrtostr(TPMA_OBJECT_NODA, "noda");
 test_obj_attrtostr(TPMA_OBJECT_ENCRYPTEDDUPLICATION, "encryptedduplication");
 test_obj_attrtostr(TPMA_OBJECT_RESTRICTED, "restricted");
 test_obj_attrtostr(TPMA_OBJECT_DECRYPT, "decrypt");
-test_obj_attrtostr(TPMA_OBJECT_SIGN, "sign");
+test_obj_attrtostr(TPMA_OBJECT_SIGN_ENCRYPT, "sign");
 
 test_obj_attrtostr(TPMA_OBJECT_RESERVED1_MASK, "<reserved(0)>");
 test_obj_attrtostr(TPMA_OBJECT_RESERVED2_MASK, "<reserved(3)>");
@@ -330,11 +330,11 @@ static void test_tpm2_attr_util_obj_strtoattr_multiple_good(void **state) {
     bool res = tpm2_attr_util_obj_strtoattr(arg, &objattrs);
     assert_true(res);
     assert_true(objattrs & TPMA_OBJECT_ADMINWITHPOLICY);
-    assert_true(objattrs & TPMA_OBJECT_SIGN);
+    assert_true(objattrs & TPMA_OBJECT_SIGN_ENCRYPT);
     assert_true(objattrs & TPMA_OBJECT_NODA);
 
     assert_int_equal(objattrs,
-            TPMA_OBJECT_SIGN|TPMA_OBJECT_NODA|TPMA_OBJECT_ADMINWITHPOLICY);
+            TPMA_OBJECT_SIGN_ENCRYPT|TPMA_OBJECT_NODA|TPMA_OBJECT_ADMINWITHPOLICY);
 }
 
 static void test_tpm2_attr_util_obj_strtoattr_token_unknown(void **state) {
@@ -448,7 +448,7 @@ int main(int argc, char* argv[]) {
             test_obj_strtoattr_get(TPMA_OBJECT_RESTRICTED),
             test_obj_strtoattr_get(TPMA_OBJECT_DECRYPT),
             test_obj_strtoattr_get(TPMA_OBJECT_ADMINWITHPOLICY),
-            test_obj_strtoattr_get(TPMA_OBJECT_SIGN),
+            test_obj_strtoattr_get(TPMA_OBJECT_SIGN_ENCRYPT),
 
             /* From attribute to string value */
             test_obj_attrtostr_get(0xFFFFFFFF),
@@ -462,7 +462,7 @@ int main(int argc, char* argv[]) {
             test_obj_attrtostr_get(TPMA_OBJECT_ENCRYPTEDDUPLICATION),
             test_obj_attrtostr_get(TPMA_OBJECT_RESTRICTED),
             test_obj_attrtostr_get(TPMA_OBJECT_DECRYPT),
-            test_obj_attrtostr_get(TPMA_OBJECT_SIGN),
+            test_obj_attrtostr_get(TPMA_OBJECT_SIGN_ENCRYPT),
             test_obj_attrtostr_get(TPMA_OBJECT_RESERVED1_MASK),
             test_obj_attrtostr_get(TPMA_OBJECT_RESERVED2_MASK),
             test_obj_attrtostr_get(TPMA_OBJECT_RESERVED3_MASK),

--- a/test/unit/test_tpm2_errata.c
+++ b/test/unit/test_tpm2_errata.c
@@ -92,13 +92,13 @@ TSS2_RC __wrap_Tss2_Sys_GetCapability(TSS2_SYS_CONTEXT *sysContext,
 static void test_tpm2_errata_no_init_and_apply(void **state) {
     UNUSED(state);
 
-    TPM2B_PUBLIC in_public = TPM2B_PUBLIC_INIT(TPMA_OBJECT_SIGN);
+    TPM2B_PUBLIC in_public = TPM2B_PUBLIC_INIT(TPMA_OBJECT_SIGN_ENCRYPT);
 
     tpm2_errata_fixup(SPEC_116_ERRATA_2_7,
                       &in_public.publicArea.objectAttributes);
 
-    assert_int_equal(in_public.publicArea.objectAttributes & TPMA_OBJECT_SIGN,
-                    TPMA_OBJECT_SIGN);
+    assert_int_equal(in_public.publicArea.objectAttributes & TPMA_OBJECT_SIGN_ENCRYPT,
+                    TPMA_OBJECT_SIGN_ENCRYPT);
 }
 
 static void test_tpm2_errata_bad_init_and_apply(void **state) {
@@ -108,13 +108,13 @@ static void test_tpm2_errata_bad_init_and_apply(void **state) {
     tpm2_errata_init((TSS2_SYS_CONTEXT *) 0xDEADBEEF);
 
 
-    TPM2B_PUBLIC in_public = TPM2B_PUBLIC_INIT(TPMA_OBJECT_SIGN);
+    TPM2B_PUBLIC in_public = TPM2B_PUBLIC_INIT(TPMA_OBJECT_SIGN_ENCRYPT);
 
     tpm2_errata_fixup(SPEC_116_ERRATA_2_7,
                       &in_public.publicArea.objectAttributes);
 
-    assert_int_equal(in_public.publicArea.objectAttributes & TPMA_OBJECT_SIGN,
-                    TPMA_OBJECT_SIGN);
+    assert_int_equal(in_public.publicArea.objectAttributes & TPMA_OBJECT_SIGN_ENCRYPT,
+                    TPMA_OBJECT_SIGN_ENCRYPT);
 }
 
 static void test_tpm2_errata_init_good_and_apply(void **state) {
@@ -123,12 +123,12 @@ static void test_tpm2_errata_init_good_and_apply(void **state) {
     setcaps(00, 116, 303, 2014, TPM2_RC_SUCCESS);
     tpm2_errata_init((TSS2_SYS_CONTEXT *) 0xDEADBEEF);
 
-    TPM2B_PUBLIC in_public = TPM2B_PUBLIC_INIT(TPMA_OBJECT_SIGN);
+    TPM2B_PUBLIC in_public = TPM2B_PUBLIC_INIT(TPMA_OBJECT_SIGN_ENCRYPT);
 
     tpm2_errata_fixup(SPEC_116_ERRATA_2_7,
                       &in_public.publicArea.objectAttributes);
 
-    assert_int_equal(in_public.publicArea.objectAttributes & TPMA_OBJECT_SIGN,
+    assert_int_equal(in_public.publicArea.objectAttributes & TPMA_OBJECT_SIGN_ENCRYPT,
                      0);
 }
 
@@ -139,13 +139,13 @@ static void test_tpm2_errata_init_good_and_no_match(void **state) {
     //Tss2_Sys_GetCapability
     tpm2_errata_init((TSS2_SYS_CONTEXT *) 0xDEADBEEF);
 
-    TPM2B_PUBLIC in_public = TPM2B_PUBLIC_INIT(TPMA_OBJECT_SIGN);
+    TPM2B_PUBLIC in_public = TPM2B_PUBLIC_INIT(TPMA_OBJECT_SIGN_ENCRYPT);
 
     tpm2_errata_fixup(SPEC_116_ERRATA_2_7,
                       &in_public.publicArea.objectAttributes);
 
-    assert_int_equal(in_public.publicArea.objectAttributes & TPMA_OBJECT_SIGN,
-                    TPMA_OBJECT_SIGN);
+    assert_int_equal(in_public.publicArea.objectAttributes & TPMA_OBJECT_SIGN_ENCRYPT,
+                    TPMA_OBJECT_SIGN_ENCRYPT);
 }
 
 static void test_tpm2_errata_init_no_match_and_apply(void **state) {
@@ -156,13 +156,13 @@ static void test_tpm2_errata_init_no_match_and_apply(void **state) {
     //Tss2_Sys_GetCapability
     tpm2_errata_init((TSS2_SYS_CONTEXT *) 0xDEADBEEF);
 
-    TPM2B_PUBLIC in_public = TPM2B_PUBLIC_INIT(TPMA_OBJECT_SIGN);
+    TPM2B_PUBLIC in_public = TPM2B_PUBLIC_INIT(TPMA_OBJECT_SIGN_ENCRYPT);
 
     tpm2_errata_fixup(SPEC_116_ERRATA_2_7,
                       &in_public.publicArea.objectAttributes);
 
-    assert_int_equal(in_public.publicArea.objectAttributes & TPMA_OBJECT_SIGN,
-                    TPMA_OBJECT_SIGN);
+    assert_int_equal(in_public.publicArea.objectAttributes & TPMA_OBJECT_SIGN_ENCRYPT,
+                    TPMA_OBJECT_SIGN_ENCRYPT);
 }
 
 int main(int argc, char *argv[]) {

--- a/tools/tpm2_create.c
+++ b/tools/tpm2_create.c
@@ -81,7 +81,7 @@ struct tpm_create_ctx {
 #define PUBLIC_AREA_TPMA_OBJECT_DEFAULT_INIT { \
     .publicArea = { \
         .objectAttributes = \
-                  TPMA_OBJECT_DECRYPT|TPMA_OBJECT_SIGN|TPMA_OBJECT_FIXEDTPM \
+                  TPMA_OBJECT_DECRYPT|TPMA_OBJECT_SIGN_ENCRYPT|TPMA_OBJECT_FIXEDTPM \
                   |TPMA_OBJECT_FIXEDPARENT|TPMA_OBJECT_SENSITIVEDATAORIGIN| \
                    TPMA_OBJECT_USERWITHAUTH \
     }, \
@@ -127,12 +127,12 @@ int setup_alg()
         ctx.in_public.publicArea.objectAttributes &= ~TPMA_OBJECT_DECRYPT;
         if (ctx.flags.I) {
             // sealing
-            ctx.in_public.publicArea.objectAttributes &= ~TPMA_OBJECT_SIGN;
+            ctx.in_public.publicArea.objectAttributes &= ~TPMA_OBJECT_SIGN_ENCRYPT;
             ctx.in_public.publicArea.objectAttributes &= ~TPMA_OBJECT_SENSITIVEDATAORIGIN;
             ctx.in_public.publicArea.parameters.keyedHashDetail.scheme.scheme = TPM2_ALG_NULL;
         } else {
             // hmac
-            ctx.in_public.publicArea.objectAttributes |= TPMA_OBJECT_SIGN;
+            ctx.in_public.publicArea.objectAttributes |= TPMA_OBJECT_SIGN_ENCRYPT;
             ctx.in_public.publicArea.parameters.keyedHashDetail.scheme.scheme = TPM2_ALG_HMAC;
             ctx.in_public.publicArea.parameters.keyedHashDetail.scheme.details.hmac.hashAlg = ctx.nameAlg;  //for tpm2_hmac multi alg
         }

--- a/tools/tpm2_createak.c
+++ b/tools/tpm2_createak.c
@@ -183,7 +183,7 @@ static bool set_key_algorithm(TPM2B_PUBLIC *in_public)
     in_public->publicArea.objectAttributes = 0;
     in_public->publicArea.objectAttributes |= TPMA_OBJECT_RESTRICTED;
     in_public->publicArea.objectAttributes |= TPMA_OBJECT_USERWITHAUTH;
-    in_public->publicArea.objectAttributes |= TPMA_OBJECT_SIGN;
+    in_public->publicArea.objectAttributes |= TPMA_OBJECT_SIGN_ENCRYPT;
     in_public->publicArea.objectAttributes &= ~TPMA_OBJECT_DECRYPT;
     in_public->publicArea.objectAttributes |= TPMA_OBJECT_FIXEDTPM;
     in_public->publicArea.objectAttributes |= TPMA_OBJECT_FIXEDPARENT;

--- a/tools/tpm2_getmanufec.c
+++ b/tools/tpm2_getmanufec.c
@@ -92,7 +92,7 @@ int set_key_algorithm(TPM2B_PUBLIC *inPublic) {
     inPublic->publicArea.objectAttributes |= TPMA_OBJECT_RESTRICTED;
     inPublic->publicArea.objectAttributes &= ~TPMA_OBJECT_USERWITHAUTH;
     inPublic->publicArea.objectAttributes |= TPMA_OBJECT_ADMINWITHPOLICY;
-    inPublic->publicArea.objectAttributes &= ~TPMA_OBJECT_SIGN;
+    inPublic->publicArea.objectAttributes &= ~TPMA_OBJECT_SIGN_ENCRYPT;
     inPublic->publicArea.objectAttributes |= TPMA_OBJECT_DECRYPT;
     inPublic->publicArea.objectAttributes |= TPMA_OBJECT_FIXEDTPM;
     inPublic->publicArea.objectAttributes |= TPMA_OBJECT_FIXEDPARENT;

--- a/tools/tpm2_import.c
+++ b/tools/tpm2_import.c
@@ -280,7 +280,7 @@ static bool calc_sensitive_unique_data(void) {
     (X).publicArea.objectAttributes &= ~TPMA_OBJECT_RESTRICTED;\
     (X).publicArea.objectAttributes |= TPMA_OBJECT_USERWITHAUTH;\
     (X).publicArea.objectAttributes |= TPMA_OBJECT_DECRYPT;\
-    (X).publicArea.objectAttributes |= TPMA_OBJECT_SIGN;\
+    (X).publicArea.objectAttributes |= TPMA_OBJECT_SIGN_ENCRYPT;\
     (X).publicArea.objectAttributes &= ~TPMA_OBJECT_FIXEDTPM;\
     (X).publicArea.objectAttributes &= ~TPMA_OBJECT_FIXEDPARENT;\
     (X).publicArea.objectAttributes &= ~TPMA_OBJECT_SENSITIVEDATAORIGIN;\


### PR DESCRIPTION
Removes all mentions of TPMA_OBJECT_SIGN, since upstream will remove them after https://github.com/tpm2-software/tpm2-tss/pull/868 is merged.

The build currently fails, because upstream removed tpm20.h though...

I guess I or anyone should rebase, once a patch for tpm20.h removal is in master...