### PR TITLE
fix up headers

### DIFF
--- a/lib/files.c
+++ b/lib/files.c
@@ -32,8 +32,9 @@
 #include <inttypes.h>
 #include <stdbool.h>
 #include <stdio.h>
+#include <string.h>
 
-#include <tss2/tpm20.h>
+#include <tss2/tss2_sys.h>
 #include <tss2/tss2_mu.h>
 
 #include "files.h"

--- a/lib/files.h
+++ b/lib/files.h
@@ -34,7 +34,7 @@
 #include <stdbool.h>
 #include <stdio.h>
 
-#include <tss2/tpm20.h>
+#include <tss2/tss2_sys.h>
 
 /**
  * Reads a series of bytes from a file as a byte array. This is similar to files_read_bytes(),

--- a/lib/log.h
+++ b/lib/log.h
@@ -34,7 +34,7 @@
 #include <stdbool.h>
 #include <stdio.h>
 
-#include <tss2/tpm20.h>
+#include <tss2/tss2_sys.h>
 
 #include "tpm2_error.h"
 #include "tpm2_util.h"

--- a/lib/pcr.c
+++ b/lib/pcr.c
@@ -32,7 +32,7 @@
 #include <stdlib.h>
 #include <string.h>
 
-#include <tss2/tpm20.h>
+#include <tss2/tss2_sys.h>
 #include <stdbool.h>
 
 #include "pcr.h"

--- a/lib/pcr.h
+++ b/lib/pcr.h
@@ -33,7 +33,7 @@
 
 #include <stdbool.h>
 
-#include <tss2/tpm20.h>
+#include <tss2/tss2_sys.h>
 
 bool pcr_parse_selections(const char *arg, TPML_PCR_SELECTION *pcrSels);
 bool pcr_parse_list(const char *str, size_t len, TPMS_PCR_SELECTION *pcrSel);

--- a/lib/tpm2_alg_util.c
+++ b/lib/tpm2_alg_util.c
@@ -32,7 +32,7 @@
 #include <stdlib.h>
 #include <string.h>
 
-#include <tss2/tpm20.h>
+#include <tss2/tss2_sys.h>
 
 #include "files.h"
 #include "log.h"

--- a/lib/tpm2_alg_util.h
+++ b/lib/tpm2_alg_util.h
@@ -33,7 +33,7 @@
 
 #include <stdbool.h>
 
-#include <tss2/tpm20.h>
+#include <tss2/tss2_sys.h>
 
 /**
  * Iterator callback routine for iterating over known algorithm name and value

--- a/lib/tpm2_attr_util.c
+++ b/lib/tpm2_attr_util.c
@@ -32,7 +32,7 @@
 #include <stdlib.h>
 #include <string.h>
 
-#include <tss2/tpm20.h>
+#include <tss2/tss2_sys.h>
 
 #include "log.h"
 #include "tpm2_attr_util.h"

--- a/lib/tpm2_attr_util.h
+++ b/lib/tpm2_attr_util.h
@@ -33,7 +33,7 @@
 
 #include <stdbool.h>
 
-#include <tss2/tpm20.h>
+#include <tss2/tss2_sys.h>
 
 /**
  * Converts a list of | (pipe) separated attributes as defined in tavle 204

--- a/lib/tpm2_convert.h
+++ b/lib/tpm2_convert.h
@@ -30,7 +30,7 @@
 
 #include <stdbool.h>
 
-#include <tss2/tpm20.h>
+#include <tss2/tss2_sys.h>
 
 typedef enum tpm2_convert_pubkey_fmt tpm2_convert_pubkey_fmt;
 enum tpm2_convert_pubkey_fmt {

--- a/lib/tpm2_ctx_mgmt.c
+++ b/lib/tpm2_ctx_mgmt.c
@@ -1,6 +1,6 @@
 #include <stdbool.h>
 
-#include <tss2/tpm20.h>
+#include <tss2/tss2_sys.h>
 
 #include "log.h"
 #include "tpm2_ctx_mgmt.h"

--- a/lib/tpm2_errata.h
+++ b/lib/tpm2_errata.h
@@ -31,7 +31,7 @@
 #ifndef TPM2_ERRATA_H
 #define TPM2_ERRATA_H
 
-#include <tss2/tpm20.h>
+#include <tss2/tss2_sys.h>
 #include <stdbool.h>
 
 /*

--- a/lib/tpm2_error.c
+++ b/lib/tpm2_error.c
@@ -28,8 +28,9 @@
 #include <stdarg.h>
 #include <stdbool.h>
 #include <stdio.h>
+#include <string.h>
 
-#include <tss2/tpm20.h>
+#include <tss2/tss2_sys.h>
 
 #include "tpm2_error.h"
 #include "tpm2_util.h"

--- a/lib/tpm2_error.h
+++ b/lib/tpm2_error.h
@@ -30,7 +30,7 @@
 
 #include <stdbool.h>
 
-#include <tss2/tpm20.h>
+#include <tss2/tss2_sys.h>
 
 /**
  * Number of error layers

--- a/lib/tpm2_hash.c
+++ b/lib/tpm2_hash.c
@@ -31,7 +31,7 @@
 #include <errno.h>
 #include <string.h>
 
-#include <tss2/tpm20.h>
+#include <tss2/tss2_sys.h>
 
 #include "log.h"
 #include "files.h"

--- a/lib/tpm2_hash.h
+++ b/lib/tpm2_hash.h
@@ -33,7 +33,7 @@
 
 #include <stdbool.h>
 
-#include <tss2/tpm20.h>
+#include <tss2/tss2_sys.h>
 
 /**
  * Hashes a BYTE array via the tpm.

--- a/lib/tpm2_header.h
+++ b/lib/tpm2_header.h
@@ -33,7 +33,7 @@
 
 #include <stdbool.h>
 
-#include <tss2/tpm20.h>
+#include <tss2/tss2_sys.h>
 
 #include "tpm2_util.h"
 

--- a/lib/tpm2_hierarchy.c
+++ b/lib/tpm2_hierarchy.c
@@ -30,8 +30,9 @@
 //**********************************************************************;
 
 #include <stdbool.h>
+#include <string.h>
 
-#include <tss2/tpm20.h>
+#include <tss2/tss2_sys.h>
 
 #include "log.h"
 #include "tpm2_hierarchy.h"

--- a/lib/tpm2_hierarchy.h
+++ b/lib/tpm2_hierarchy.h
@@ -34,7 +34,7 @@
 
 #include <stdbool.h>
 
-#include <tss2/tpm20.h>
+#include <tss2/tss2_sys.h>
 
 typedef enum tpm2_hierarchy_flags tpm2_hierarchy_flags;
 

--- a/lib/tpm2_nv_util.h
+++ b/lib/tpm2_nv_util.h
@@ -31,7 +31,7 @@
 #ifndef LIB_TPM2_NV_UTIL_H_
 #define LIB_TPM2_NV_UTIL_H_
 
-#include <tss2/tpm20.h>
+#include <tss2/tss2_sys.h>
 
 #include "log.h"
 #include "tpm2_util.h"

--- a/lib/tpm2_openssl.c
+++ b/lib/tpm2_openssl.c
@@ -25,7 +25,7 @@
 // THE POSSIBILITY OF SUCH DAMAGE.
 //**********************************************************************
 
-#include <tss2/tpm20.h>
+#include <tss2/tss2_sys.h>
 
 #include <openssl/err.h>
 #include <openssl/hmac.h>

--- a/lib/tpm2_openssl.h
+++ b/lib/tpm2_openssl.h
@@ -28,7 +28,7 @@
 #ifndef LIB_TPM2_OPENSSL_H_
 #define LIB_TPM2_OPENSSL_H_
 
-#include <tss2/tpm20.h>
+#include <tss2/tss2_sys.h>
 
 #include <openssl/err.h>
 #include <openssl/hmac.h>

--- a/lib/tpm2_options.c
+++ b/lib/tpm2_options.c
@@ -32,6 +32,7 @@
 #include <errno.h>
 #include <stdbool.h>
 #include <stdio.h>
+#include <stdlib.h>
 #include <string.h>
 
 #include <getopt.h>

--- a/lib/tpm2_options.h
+++ b/lib/tpm2_options.h
@@ -37,7 +37,7 @@
 
 #include <getopt.h>
 
-#include <tss2/tpm20.h>
+#include <tss2/tss2_sys.h>
 
 typedef union tpm2_option_flags tpm2_option_flags;
 union tpm2_option_flags {

--- a/lib/tpm2_password_util.c
+++ b/lib/tpm2_password_util.c
@@ -29,8 +29,9 @@
 // THE POSSIBILITY OF SUCH DAMAGE.
 //**********************************************************************;
 #include <stdbool.h>
+#include <string.h>
 
-#include <tss2/tpm20.h>
+#include <tss2/tss2_sys.h>
 
 #include "log.h"
 #include "tpm2_password_util.h"

--- a/lib/tpm2_password_util.h
+++ b/lib/tpm2_password_util.h
@@ -31,7 +31,7 @@
 #ifndef SRC_PASSWORD_UTIL_H_
 #define SRC_PASSWORD_UTIL_H_
 
-#include <tss2/tpm20.h>
+#include <tss2/tss2_sys.h>
 
 /**
  * Convert a password argument to a valid TPM2B_AUTH structure. Passwords can

--- a/lib/tpm2_policy.h
+++ b/lib/tpm2_policy.h
@@ -33,7 +33,7 @@
 
 #include <stdbool.h>
 
-#include <tss2/tpm20.h>
+#include <tss2/tss2_sys.h>
 
 #include "tpm2_session.h"
 

--- a/lib/tpm2_session.c
+++ b/lib/tpm2_session.c
@@ -29,8 +29,9 @@
 #include <stdbool.h>
 #include <stdio.h>
 #include <stdlib.h>
+#include <string.h>
 
-#include <tss2/tpm20.h>
+#include <tss2/tss2_sys.h>
 
 #include "files.h"
 #include "log.h"

--- a/lib/tpm2_session.h
+++ b/lib/tpm2_session.h
@@ -30,7 +30,7 @@
 
 #include <stdbool.h>
 
-#include <tss2/tpm20.h>
+#include <tss2/tss2_sys.h>
 
 typedef struct tpm2_session_data tpm2_session_data;
 typedef struct tpm2_session tpm2_session;

--- a/lib/tpm2_tcti_ldr.c
+++ b/lib/tpm2_tcti_ldr.c
@@ -30,7 +30,7 @@
 #include <stdio.h>
 #include <dlfcn.h>
 
-#include <tss2/tpm20.h>
+#include <tss2/tss2_sys.h>
 
 #include "log.h"
 #include "tpm2_tcti_ldr.h"

--- a/lib/tpm2_tcti_ldr.h
+++ b/lib/tpm2_tcti_ldr.h
@@ -25,7 +25,7 @@
 // THE POSSIBILITY OF SUCH DAMAGE.
 //**********************************************************************;
 
-#include <tss2/tpm20.h>
+#include <tss2/tss2_sys.h>
 
 #ifndef LIB_TPM2_TCTI_LDR_H_
 #define LIB_TPM2_TCTI_LDR_H_

--- a/lib/tpm2_util.c
+++ b/lib/tpm2_util.c
@@ -31,6 +31,8 @@
 #include <ctype.h>
 #include <errno.h>
 #include <stdbool.h>
+#include <stdlib.h>
+#include <string.h>
 
 #include "log.h"
 #include "files.h"

--- a/lib/tpm2_util.h
+++ b/lib/tpm2_util.h
@@ -35,7 +35,7 @@
 #include <stdint.h>
 #include <stdio.h>
 
-#include <tss2/tpm20.h>
+#include <tss2/tss2_sys.h>
 
 #include "tpm2_error.h"
 
@@ -117,6 +117,11 @@
         } while (tpm2_error_get(__result) == TPM2_RC_RETRY); \
         __result;                                          \
     })
+
+typedef struct {
+    UINT16 size;
+    BYTE buffer[0];
+} TPM2B;
 
 int tpm2_util_hex_to_byte_structure(const char *inStr, UINT16 *byteLenth, BYTE *byteBuffer);
 

--- a/lib/tpm_kdfa.c
+++ b/lib/tpm_kdfa.c
@@ -25,7 +25,7 @@
 // THE POSSIBILITY OF SUCH DAMAGE.
 //**********************************************************************;
 
-#include <tss2/tpm20.h>
+#include <tss2/tss2_sys.h>
 
  #include <openssl/err.h>
 #include <openssl/hmac.h>

--- a/lib/tpm_kdfa.h
+++ b/lib/tpm_kdfa.h
@@ -28,7 +28,7 @@
 #ifndef SRC_TPM_KDFA_H_
 #define SRC_TPM_KDFA_H_
 
-#include <tss2/tpm20.h>
+#include <tss2/tss2_sys.h>
 
 /* TODO DOCUMENT ME */
 /**

--- a/test/unit/test_files.c
+++ b/test/unit/test_files.c
@@ -32,7 +32,7 @@
 #include <setjmp.h>
 
 #include <cmocka.h>
-#include <tss2/tpm20.h>
+#include <tss2/tss2_sys.h>
 
 #include "files.h"
 

--- a/test/unit/test_pcr.c
+++ b/test/unit/test_pcr.c
@@ -30,7 +30,7 @@
 #include <setjmp.h>
 
 #include <cmocka.h>
-#include <tss2/tpm20.h>
+#include <tss2/tss2_sys.h>
 
 #include "pcr.h"
 #include "tpm2_util.h"

--- a/test/unit/test_string_bytes.c
+++ b/test/unit/test_string_bytes.c
@@ -29,7 +29,7 @@
 #include <setjmp.h>
 
 #include <cmocka.h>
-#include <tss2/tpm20.h>
+#include <tss2/tss2_sys.h>
 
 #include "tpm2_util.h"
 

--- a/test/unit/test_tpm2_alg_util.c
+++ b/test/unit/test_tpm2_alg_util.c
@@ -31,7 +31,7 @@
 #include <stdio.h>
 
 #include <cmocka.h>
-#include <tss2/tpm20.h>
+#include <tss2/tss2_sys.h>
 
 #include "tpm2_util.h"
 #include "tpm2_alg_util.h"

--- a/test/unit/test_tpm2_attr_util.c
+++ b/test/unit/test_tpm2_attr_util.c
@@ -30,7 +30,7 @@
 #include <setjmp.h>
 
 #include <cmocka.h>
-#include <tss2/tpm20.h>
+#include <tss2/tss2_sys.h>
 
 #include "tpm2_attr_util.h"
 #include "tpm2_util.h"

--- a/test/unit/test_tpm2_errata.c
+++ b/test/unit/test_tpm2_errata.c
@@ -33,7 +33,7 @@
 #include <setjmp.h>
 #include <cmocka.h>
 
-#include <tss2/tpm20.h>
+#include <tss2/tss2_sys.h>
 
 #include "tpm2_errata.h"
 #include "tpm2_tool.h"

--- a/test/unit/test_tpm2_error.c
+++ b/test/unit/test_tpm2_error.c
@@ -32,7 +32,7 @@
 #include <setjmp.h>
 #include <cmocka.h>
 
-#include <tss2/tpm20.h>
+#include <tss2/tss2_sys.h>
 
 #include "tpm2_error.h"
 

--- a/test/unit/test_tpm2_header.c
+++ b/test/unit/test_tpm2_header.c
@@ -29,7 +29,7 @@
 #include <setjmp.h>
 
 #include <cmocka.h>
-#include <tss2/tpm20.h>
+#include <tss2/tss2_sys.h>
 
 #include "tpm2_header.h"
 

--- a/test/unit/test_tpm2_hierarchy.c
+++ b/test/unit/test_tpm2_hierarchy.c
@@ -30,7 +30,7 @@
 #include <setjmp.h>
 
 #include <cmocka.h>
-#include <tss2/tpm20.h>
+#include <tss2/tss2_sys.h>
 
 #include "tpm2_hierarchy.h"
 #include "tpm2_util.h"

--- a/test/unit/test_tpm2_password_util.c
+++ b/test/unit/test_tpm2_password_util.c
@@ -32,7 +32,7 @@
 #include <setjmp.h>
 
 #include <cmocka.h>
-#include <tss2/tpm20.h>
+#include <tss2/tss2_sys.h>
 
 #include "tpm2_util.h"
 #include "tpm2_password_util.h"

--- a/test/unit/test_tpm2_policy.c
+++ b/test/unit/test_tpm2_policy.c
@@ -34,7 +34,7 @@
 #include <setjmp.h>
 #include <cmocka.h>
 
-#include <tss2/tpm20.h>
+#include <tss2/tss2_sys.h>
 
 #include "pcr.h"
 #include "tpm2_alg_util.h"

--- a/test/unit/test_tpm2_session.c
+++ b/test/unit/test_tpm2_session.c
@@ -34,7 +34,7 @@
 #include <setjmp.h>
 #include <cmocka.h>
 
-#include <tss2/tpm20.h>
+#include <tss2/tss2_sys.h>
 
 #include "tpm2_alg_util.h"
 #include "tpm2_session.h"

--- a/tools/aux/tpm2_print.c
+++ b/tools/aux/tpm2_print.c
@@ -30,6 +30,7 @@
 //**********************************************************************;
 
 #include <stdio.h>
+#include <string.h>
 
 #include "files.h"
 #include "log.h"

--- a/tools/aux/tpm2_rc_decode.c
+++ b/tools/aux/tpm2_rc_decode.c
@@ -29,7 +29,7 @@
 #include <stdbool.h>
 #include <stdlib.h>
 
-#include <tss2/tpm20.h>
+#include <tss2/tss2_sys.h>
 
 #include "log.h"
 #include "tpm2_error.h"

--- a/tools/tpm2_activatecredential.c
+++ b/tools/tpm2_activatecredential.c
@@ -39,7 +39,7 @@
 #include <limits.h>
 #include <ctype.h>
 
-#include <tss2/tpm20.h>
+#include <tss2/tss2_sys.h>
 
 #include "files.h"
 #include "log.h"

--- a/tools/tpm2_certify.c
+++ b/tools/tpm2_certify.c
@@ -35,7 +35,7 @@
 #include <string.h>
 
 #include <limits.h>
-#include <tss2/tpm20.h>
+#include <tss2/tss2_sys.h>
 
 #include "tpm2_convert.h"
 #include "tpm2_options.h"

--- a/tools/tpm2_changeauth.c
+++ b/tools/tpm2_changeauth.c
@@ -33,7 +33,7 @@
 #include <stdlib.h>
 #include <string.h>
 
-#include <tss2/tpm20.h>
+#include <tss2/tss2_sys.h>
 
 #include "log.h"
 #include "tpm2_options.h"

--- a/tools/tpm2_create.c
+++ b/tools/tpm2_create.c
@@ -38,7 +38,7 @@
 #include <stdio.h>
 #include <string.h>
 
-#include <tss2/tpm20.h>
+#include <tss2/tss2_sys.h>
 
 #include "files.h"
 #include "log.h"

--- a/tools/tpm2_createak.c
+++ b/tools/tpm2_createak.c
@@ -36,7 +36,7 @@
 #include <limits.h>
 #include <ctype.h>
 
-#include <tss2/tpm20.h>
+#include <tss2/tss2_sys.h>
 
 #include "tpm2_convert.h"
 #include "tpm2_options.h"

--- a/tools/tpm2_createek.c
+++ b/tools/tpm2_createek.c
@@ -34,7 +34,7 @@
 #include <string.h>
 #include <limits.h>
 
-#include <tss2/tpm20.h>
+#include <tss2/tss2_sys.h>
 
 #include "files.h"
 #include "log.h"

--- a/tools/tpm2_createpolicy.c
+++ b/tools/tpm2_createpolicy.c
@@ -33,7 +33,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 
-#include <tss2/tpm20.h>
+#include <tss2/tss2_sys.h>
 
 #include "files.h"
 #include "log.h"

--- a/tools/tpm2_createprimary.c
+++ b/tools/tpm2_createprimary.c
@@ -37,7 +37,7 @@
 #include <stdio.h>
 #include <string.h>
 
-#include <tss2/tpm20.h>
+#include <tss2/tss2_sys.h>
 
 #include "files.h"
 #include "log.h"

--- a/tools/tpm2_dictionarylockout.c
+++ b/tools/tpm2_dictionarylockout.c
@@ -34,7 +34,7 @@
 #include <stdio.h>
 #include <string.h>
 
-#include <tss2/tpm20.h>
+#include <tss2/tss2_sys.h>
 
 #include "log.h"
 #include "tpm2_options.h"

--- a/tools/tpm2_encryptdecrypt.c
+++ b/tools/tpm2_encryptdecrypt.c
@@ -37,7 +37,7 @@
 #include <limits.h>
 #include <ctype.h>
 
-#include <tss2/tpm20.h>
+#include <tss2/tss2_sys.h>
 
 #include "files.h"
 #include "log.h"

--- a/tools/tpm2_evictcontrol.c
+++ b/tools/tpm2_evictcontrol.c
@@ -37,7 +37,7 @@
 #include <limits.h>
 #include <ctype.h>
 
-#include <tss2/tpm20.h>
+#include <tss2/tss2_sys.h>
 
 #include "files.h"
 #include "log.h"

--- a/tools/tpm2_flushcontext.c
+++ b/tools/tpm2_flushcontext.c
@@ -31,7 +31,7 @@
 
 #include <stdbool.h>
 
-#include <tss2/tpm20.h>
+#include <tss2/tss2_sys.h>
 
 #include "log.h"
 #include "tpm2_options.h"

--- a/tools/tpm2_getcap.c
+++ b/tools/tpm2_getcap.c
@@ -28,11 +28,11 @@
  * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
  * THE POSSIBILITY OF SUCH DAMAGE.
  */
-#include <assert.h>
 #include <ctype.h>
 #include <stdio.h>
+#include <string.h>
 
-#include <tss2/tpm20.h>
+#include <tss2/tss2_sys.h>
 
 #include "log.h"
 #include "tpm2_alg_util.h"

--- a/tools/tpm2_getmanufec.c
+++ b/tools/tpm2_getmanufec.c
@@ -43,7 +43,7 @@
 #include <openssl/buffer.h>
 #include <openssl/evp.h>
 #include <openssl/sha.h>
-#include <tss2/tpm20.h>
+#include <tss2/tss2_sys.h>
 
 #include "files.h"
 #include "log.h"

--- a/tools/tpm2_getrandom.c
+++ b/tools/tpm2_getrandom.c
@@ -35,7 +35,7 @@
 #include <string.h>
 
 #include <limits.h>
-#include <tss2/tpm20.h>
+#include <tss2/tss2_sys.h>
 
 #include "tpm2_options.h"
 #include "log.h"

--- a/tools/tpm2_hash.c
+++ b/tools/tpm2_hash.c
@@ -36,7 +36,7 @@
 #include <limits.h>
 #include <ctype.h>
 
-#include <tss2/tpm20.h>
+#include <tss2/tss2_sys.h>
 
 #include "files.h"
 #include "log.h"

--- a/tools/tpm2_hmac.c
+++ b/tools/tpm2_hmac.c
@@ -36,7 +36,7 @@
 #include <string.h>
 
 #include <limits.h>
-#include <tss2/tpm20.h>
+#include <tss2/tss2_sys.h>
 
 #include "files.h"
 #include "log.h"

--- a/tools/tpm2_import.c
+++ b/tools/tpm2_import.c
@@ -43,7 +43,7 @@
 #include <openssl/rsa.h>
 
 #include <limits.h>
-#include <tss2/tpm20.h>
+#include <tss2/tss2_sys.h>
 #include <tss2/tss2_mu.h>
 
 #include "log.h"

--- a/tools/tpm2_listpersistent.c
+++ b/tools/tpm2_listpersistent.c
@@ -36,7 +36,7 @@
 #include <string.h>
 #include <ctype.h>
 
-#include <tss2/tpm20.h>
+#include <tss2/tss2_sys.h>
 
 
 #include "files.h"

--- a/tools/tpm2_load.c
+++ b/tools/tpm2_load.c
@@ -38,7 +38,7 @@
 #include <ctype.h>
 #include <stdbool.h>
 
-#include <tss2/tpm20.h>
+#include <tss2/tss2_sys.h>
 
 #include "files.h"
 #include "log.h"

--- a/tools/tpm2_loadexternal.c
+++ b/tools/tpm2_loadexternal.c
@@ -35,7 +35,7 @@
 #include <stdio.h>
 #include <string.h>
 
-#include <tss2/tpm20.h>
+#include <tss2/tss2_sys.h>
 
 #include "tpm2_options.h"
 #include "files.h"

--- a/tools/tpm2_makecredential.c
+++ b/tools/tpm2_makecredential.c
@@ -36,7 +36,7 @@
 #include <limits.h>
 #include <ctype.h>
 
-#include <tss2/tpm20.h>
+#include <tss2/tss2_sys.h>
 
 #include "files.h"
 #include "tpm2_options.h"

--- a/tools/tpm2_nvdefine.c
+++ b/tools/tpm2_nvdefine.c
@@ -35,7 +35,7 @@
 #include <string.h>
 #include <limits.h>
 
-#include <tss2/tpm20.h>
+#include <tss2/tss2_sys.h>
 
 #include "files.h"
 #include "log.h"

--- a/tools/tpm2_nvlist.c
+++ b/tools/tpm2_nvlist.c
@@ -33,7 +33,7 @@
 #include <stdlib.h>
 #include <stdio.h>
 
-#include <tss2/tpm20.h>
+#include <tss2/tss2_sys.h>
 
 #include "tpm2_alg_util.h"
 #include "tpm2_attr_util.h"

--- a/tools/tpm2_nvread.c
+++ b/tools/tpm2_nvread.c
@@ -34,7 +34,7 @@
 #include <stdio.h>
 #include <string.h>
 
-#include <tss2/tpm20.h>
+#include <tss2/tss2_sys.h>
 
 #include "files.h"
 #include "log.h"

--- a/tools/tpm2_nvreadlock.c
+++ b/tools/tpm2_nvreadlock.c
@@ -36,7 +36,7 @@
 #include <stdio.h>
 #include <string.h>
 
-#include <tss2/tpm20.h>
+#include <tss2/tss2_sys.h>
 
 #include "log.h"
 #include "tpm2_hierarchy.h"

--- a/tools/tpm2_nvrelease.c
+++ b/tools/tpm2_nvrelease.c
@@ -34,7 +34,7 @@
 #include <stdio.h>
 #include <string.h>
 
-#include <tss2/tpm20.h>
+#include <tss2/tss2_sys.h>
 
 #include "log.h"
 #include "tpm2_hierarchy.h"

--- a/tools/tpm2_nvwrite.c
+++ b/tools/tpm2_nvwrite.c
@@ -37,7 +37,7 @@
 
 #include <limits.h>
 
-#include <tss2/tpm20.h>
+#include <tss2/tss2_sys.h>
 
 #include "files.h"
 #include "log.h"

--- a/tools/tpm2_pcrevent.c
+++ b/tools/tpm2_pcrevent.c
@@ -35,7 +35,7 @@
 #include <stdio.h>
 #include <string.h>
 
-#include <tss2/tpm20.h>
+#include <tss2/tss2_sys.h>
 
 #include "files.h"
 #include "log.h"

--- a/tools/tpm2_pcrextend.c
+++ b/tools/tpm2_pcrextend.c
@@ -31,7 +31,7 @@
 
 #include <stdlib.h>
 
-#include <tss2/tpm20.h>
+#include <tss2/tss2_sys.h>
 
 #include "log.h"
 #include "tpm2_alg_util.h"

--- a/tools/tpm2_pcrlist.c
+++ b/tools/tpm2_pcrlist.c
@@ -35,7 +35,7 @@
 #include <stdio.h>
 #include <string.h>
 
-#include <tss2/tpm20.h>
+#include <tss2/tss2_sys.h>
 
 #include "tpm2_options.h"
 #include "log.h"

--- a/tools/tpm2_policypcr.c
+++ b/tools/tpm2_policypcr.c
@@ -36,7 +36,7 @@
 #include <limits.h>
 #include <ctype.h>
 
-#include <tss2/tpm20.h>
+#include <tss2/tss2_sys.h>
 
 #include "files.h"
 #include "log.h"

--- a/tools/tpm2_policyrestart.c
+++ b/tools/tpm2_policyrestart.c
@@ -36,7 +36,7 @@
 #include <limits.h>
 #include <ctype.h>
 
-#include <tss2/tpm20.h>
+#include <tss2/tss2_sys.h>
 
 #include "files.h"
 #include "log.h"

--- a/tools/tpm2_quote.c
+++ b/tools/tpm2_quote.c
@@ -34,7 +34,7 @@
 #include <string.h>
 #include <errno.h>
 
-#include <tss2/tpm20.h>
+#include <tss2/tss2_sys.h>
 
 #include "tpm2_convert.h"
 #include "files.h"

--- a/tools/tpm2_readpublic.c
+++ b/tools/tpm2_readpublic.c
@@ -33,7 +33,7 @@
 #include <stdlib.h>
 #include <string.h>
 
-#include <tss2/tpm20.h>
+#include <tss2/tss2_sys.h>
 
 #include "tpm2_convert.h"
 #include "files.h"

--- a/tools/tpm2_rsadecrypt.c
+++ b/tools/tpm2_rsadecrypt.c
@@ -33,7 +33,7 @@
 #include <stdlib.h>
 #include <string.h>
 
-#include <tss2/tpm20.h>
+#include <tss2/tss2_sys.h>
 
 #include "files.h"
 #include "log.h"

--- a/tools/tpm2_rsaencrypt.c
+++ b/tools/tpm2_rsaencrypt.c
@@ -34,7 +34,7 @@
 #include <stdlib.h>
 #include <string.h>
 
-#include <tss2/tpm20.h>
+#include <tss2/tss2_sys.h>
 
 #include "files.h"
 #include "log.h"

--- a/tools/tpm2_send.c
+++ b/tools/tpm2_send.c
@@ -31,10 +31,9 @@
 #include <errno.h>
 #include <stdbool.h>
 #include <stdio.h>
+#include <stdlib.h>
 #include <string.h>
 #include <unistd.h>
-
-#include <getopt.h>
 
 #include "tpm2_header.h"
 #include "files.h"

--- a/tools/tpm2_sign.c
+++ b/tools/tpm2_sign.c
@@ -36,7 +36,7 @@
 #include <string.h>
 
 #include <getopt.h>
-#include <tss2/tpm20.h>
+#include <tss2/tss2_sys.h>
 
 #include "tpm2_convert.h"
 #include "files.h"

--- a/tools/tpm2_startauthsession.c
+++ b/tools/tpm2_startauthsession.c
@@ -37,7 +37,7 @@
 #include <limits.h>
 #include <ctype.h>
 
-#include <tss2/tpm20.h>
+#include <tss2/tss2_sys.h>
 
 #include "files.h"
 #include "log.h"

--- a/tools/tpm2_tool.c
+++ b/tools/tpm2_tool.c
@@ -29,8 +29,9 @@
  * THE POSSIBILITY OF SUCH DAMAGE.
  */
 #include <stdbool.h>
+#include <stdlib.h>
 
- #include <unistd.h>
+#include <unistd.h>
 
 #include "log.h"
 #include "tpm2_tcti_ldr.h"

--- a/tools/tpm2_tool.h
+++ b/tools/tpm2_tool.h
@@ -31,7 +31,7 @@
 #ifndef MAIN_H
 #define MAIN_H
 
-#include <tss2/tpm20.h>
+#include <tss2/tss2_sys.h>
 #include <stdbool.h>
 
 #include "tpm2_options.h"

--- a/tools/tpm2_unseal.c
+++ b/tools/tpm2_unseal.c
@@ -34,7 +34,7 @@
 #include <stdio.h>
 #include <string.h>
 
-#include <tss2/tpm20.h>
+#include <tss2/tss2_sys.h>
 
 #include "files.h"
 #include "log.h"

--- a/tools/tpm2_verifysignature.c
+++ b/tools/tpm2_verifysignature.c
@@ -33,7 +33,7 @@
 #include <stdio.h>
 #include <string.h>
 
-#include <tss2/tpm20.h>
+#include <tss2/tss2_sys.h>
 
 #include "files.h"
 #include "log.h"


### PR DESCRIPTION
tpm20.h was removed from the TSS. Change to the new tss2_sys.h
header file. This introduced issues in where we were missing
standard header files via include directives, as tpm20.h was
including them, correct these.

Also, the TPM2B type was removed, re-declare this in tpm2_util.h,
as that generic container type is convenient.

Signed-off-by: William Roberts <william.c.roberts@intel.com>