### PR TITLE
tpm2_tool: define ABI version locally

### DIFF
--- a/tools/tpm2_tool.c
+++ b/tools/tpm2_tool.c
@@ -67,14 +67,17 @@ static void sapi_teardown_full (TSS2_SYS_CONTEXT *sapi_context) {
     tcti_teardown (tcti_context);
 }
 
+#define SUPPORTED_ABI_VERSION \
+{ \
+    .tssCreator = 1, \
+    .tssFamily = 2, \
+    .tssLevel = 1, \
+    .tssVersion = 108, \
+}
+
 static TSS2_SYS_CONTEXT* sapi_ctx_init(TSS2_TCTI_CONTEXT *tcti_ctx) {
 
-    TSS2_ABI_VERSION abi_version = {
-            .tssCreator = TSSWG_INTEROP,
-            .tssFamily = TSS_SAPI_FIRST_FAMILY,
-            .tssLevel = TSS_SAPI_FIRST_LEVEL,
-            .tssVersion = TSS_SAPI_FIRST_VERSION,
-    };
+    TSS2_ABI_VERSION abi_version = SUPPORTED_ABI_VERSION;
 
     size_t size = Tss2_Sys_GetContextSize(0);
     TSS2_SYS_CONTEXT *sapi_ctx = (TSS2_SYS_CONTEXT*) calloc(1, size);


### PR DESCRIPTION
TSS doesn't export the ABI defines in public heades anymore.
This is a followup for https://github.com/tpm2-software/tpm2-tss/pull/864