### PR TITLE
bootstrap: generate library sources

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,4 @@ Makefile.in
 test-driver
 # dist tarball
 *.gz
+src_vars.mk

--- a/Makefile.am
+++ b/Makefile.am
@@ -1,6 +1,6 @@
 #;**********************************************************************;
 #
-# Copyright (c) 2015, Intel Corporation
+# Copyright (c) 2015-2018, Intel Corporation
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
@@ -30,6 +30,8 @@
 # THE POSSIBILITY OF SUCH DAMAGE.
 #;**********************************************************************;
 @CODE_COVERAGE_RULES@
+
+include src_vars.mk
 
 ACLOCAL_AMFLAGS = -I m4
 
@@ -96,48 +98,7 @@ bin_PROGRAMS = \
     tools/tpm2_verifysignature
 
 noinst_LIBRARIES = $(LIB_COMMON)
-lib_libcommon_a_SOURCES = \
-    lib/files.c \
-    lib/files.h \
-    lib/log.c \
-    lib/log.h \
-    lib/pcr.c \
-    lib/pcr.h \
-    lib/tpm2_alg_util.c \
-    lib/tpm2_alg_util.h \
-    lib/tpm2_attr_util.c \
-    lib/tpm2_attr_util.h \
-    lib/tpm2_ctx_mgmt.c \
-    lib/tpm2_ctx_mgmt.h \
-    lib/tpm2_errata.c \
-    lib/tpm2_errata.h \
-    lib/tpm2_error.c \
-    lib/tpm2_error.h \
-    lib/tpm2_hash.c \
-    lib/tpm2_hash.h \
-    lib/tpm2_header.h \
-    lib/tpm2_hierarchy.c \
-    lib/tpm2_hierarchy.h \
-    lib/tpm2_nv_util.h \
-    lib/tpm2_openssl.c \
-    lib/tpm2_openssl.h \
-    lib/tpm2_password_util.c \
-    lib/tpm2_password_util.h \
-    lib/tpm2_policy.c \
-    lib/tpm2_policy.h \
-    lib/tpm2_util.c \
-    lib/tpm2_util.h \
-    lib/tpm_kdfa.c \
-    lib/tpm_kdfa.h \
-    lib/tpm2_options.c \
-    lib/tpm2_options.h \
-    lib/tpm2_session.c \
-    lib/tpm2_session.h \
-    lib/tpm2_tcti_ldr.c \
-    lib/tpm2_tcti_ldr.h \
-    lib/tpm2_convert.c \
-    lib/tpm2_convert.h
-
+lib_libcommon_a_SOURCES = $(LIB_SRC)
 TOOL_SRC := tools/tpm2_tool.c tools/tpm2_tool.h
 
 tools_aux_tpm2_print_SOURCES = tools/aux/tpm2_print.c $(TOOL_SRC)

--- a/bootstrap
+++ b/bootstrap
@@ -1,6 +1,26 @@
 #! /bin/sh
+set -e
 
+# generate list of source files for use in Makefile.am
+# if you add new source files, you must run ./bootstrap again
+src_listvar () {
+    basedir=$1
+    suffix=$2
+    var=$3
+
+    find "${basedir}" -name "${suffix}" | LC_ALL=C sort | tr '\n' ' ' | (printf "${var} = " && cat)
+    echo ""
+}
+
+VARS_FILE=src_vars.mk
 AUTORECONF=${AUTORECONF:-autoreconf}
+
+echo "Generating file lists: ${VARS_FILE}"
+(
+  src_listvar "lib" "*.c" "LIB_C"
+  src_listvar "lib" "*.h" "LIB_H"
+  printf "LIB_SRC = \$(LIB_C) \$(LIB_H)\n"
+) > ${VARS_FILE}
 
 mkdir -p m4
 ${AUTORECONF} --install --sym


### PR DESCRIPTION
Generate the library sources and create variables for them.

This will help make the Makefile smaller and easier to
maintain.

Signed-off-by: William Roberts <william.c.roberts@intel.com>