### PR TITLE
Set heirarchy to owner by default for all tools, make -H optional 

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -1,6 +1,6 @@
 #;**********************************************************************;
 #
-# Copyright (c) 2015-2018, Intel Corporation
+# Copyright (c) 2015, Intel Corporation
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/lib/tpm2_capability.c
+++ b/lib/tpm2_capability.c
@@ -1,0 +1,69 @@
+//**********************************************************************;
+// Copyright (c) 2018, Intel Corporation
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+// 1. Redistributions of source code must retain the above copyright notice,
+// this list of conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright notice,
+// this list of conditions and the following disclaimer in the documentation
+// and/or other materials provided with the distribution.
+//
+// 3. Neither the name of Intel Corporation nor the names of its contributors
+// may be used to endorse or promote products derived from this software without
+// specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+// THE POSSIBILITY OF SUCH DAMAGE.
+//**********************************************************************;
+
+#include <stdbool.h>
+
+#include <tss2/tss2_sys.h>
+
+#include "log.h"
+
+#include "tpm2_capability.h"
+
+bool tpm2_capability_get (TSS2_SYS_CONTEXT *sapi_ctx,
+        TPM2_CAP capability,
+        UINT32 property,
+        UINT32 count,
+        TPMS_CAPABILITY_DATA *capability_data) {
+
+    TPMI_YES_NO            more_data;
+
+    TSS2_RC rval = TSS2_RETRY_EXP(Tss2_Sys_GetCapability (sapi_ctx,
+                                NULL,
+                                capability,
+                                property,
+                                count,
+                                &more_data,
+                                capability_data,
+                                NULL));
+
+    if (rval != TPM2_RC_SUCCESS) {
+        LOG_ERR("Failed to GetCapability: capability: 0x%x, property: 0x%x",
+                 capability, property);
+        LOG_PERR(Tss2_Sys_GetCapability, rval);
+        return false;
+    } else if (more_data) {
+        LOG_WARN("More data to be queried: capability: 0x%x, property: "
+                 "0x%x\n", capability, property);
+        return false;
+    }
+
+    return true;
+}

--- a/lib/tpm2_capability.h
+++ b/lib/tpm2_capability.h
@@ -56,4 +56,16 @@ bool tpm2_capability_get (TSS2_SYS_CONTEXT *sapi_ctx,
         UINT32 count,
         TPMS_CAPABILITY_DATA *capability_data);
 
+/**
+ * Attempts to find a vacant handle in the persistent handle namespace.
+ * @param sapi_ctx
+ *  system api context
+ * @param vacant
+ *  the vacant handle found by the function if True returned
+ * @return
+ *  True if a vacant handle was found succesfully, False otherwise.
+ */
+bool tpm2_capability_find_vacant_persistent_handle (TSS2_SYS_CONTEXT *sapi_ctx,
+        UINT32 *vacant);
+
 #endif /* LIB_TPM2_CAPABILITY_H_ */

--- a/lib/tpm2_capability.h
+++ b/lib/tpm2_capability.h
@@ -1,0 +1,59 @@
+//**********************************************************************;
+// Copyright (c) 2018, Intel Corporation
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+// 1. Redistributions of source code must retain the above copyright notice,
+// this list of conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright notice,
+// this list of conditions and the following disclaimer in the documentation
+// and/or other materials provided with the distribution.
+//
+// 3. Neither the name of Intel Corporation nor the names of its contributors
+// may be used to endorse or promote products derived from this software without
+// specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+// THE POSSIBILITY OF SUCH DAMAGE.
+//**********************************************************************;
+
+#ifndef LIB_TPM2_CAPABILITY_H_
+#define LIB_TPM2_CAPABILITY_H_
+
+
+/**
+ * Invokes GetCapability to retrieve the current value of a capability from the
+ * TPM.
+ * @param sapi_ctx
+ *  system api context
+ * @param capability
+ *  the capability being requested from the TPM
+ * @param property
+ *  property
+ * @param count
+ *  maximum number of values to return
+ * @param capability_data
+ *  capability data structure to populate
+ * @return
+ *  True if the capability_data structure is succesfully filled, False if the
+ *  call to the TPM fails.
+ */
+bool tpm2_capability_get (TSS2_SYS_CONTEXT *sapi_ctx,
+        TPM2_CAP capability,
+        UINT32 property,
+        UINT32 count,
+        TPMS_CAPABILITY_DATA *capability_data);
+
+#endif /* LIB_TPM2_CAPABILITY_H_ */

--- a/lib/tpm2_hierarchy.h
+++ b/lib/tpm2_hierarchy.h
@@ -100,7 +100,7 @@ struct tpm2_hierearchy_pdata {
     .in = { \
         .public = _PUBLIC_AREA_TPMA_OBJECT_DEFAULT_INIT, \
         .sensitive = TPM2B_SENSITIVE_CREATE_EMPTY_INIT, \
-        .hierarchy = TPM2_RH_NULL \
+        .hierarchy = TPM2_RH_OWNER \
     }, \
 }
 

--- a/man/tpm2_createak.1.md
+++ b/man/tpm2_createak.1.md
@@ -44,10 +44,12 @@ loaded-key:
     Same formatting as the endorse password value or -e option.
 
   * **-E**, **--ek-handle**=_EK\_HANDLE_:
-    Specifies the handle used to make EK persistent.
+    Specifies the persistent handle of the EK.
 
   * **-k**, **--ak-handle**=_AK\_HANDLE_:
     Specifies the handle used to make AK persistent.
+    If a value of **-** is passed the tool will find a vacant persistent handle
+    to use and print out the automatically selected handle.
 
   * **-c**, **--context**=_PATH_:
     Optional, specifies a path to save the context of the AK handle. If one saves

--- a/man/tpm2_createek.1.md
+++ b/man/tpm2_createek.1.md
@@ -34,7 +34,9 @@ Refer to:
     Same formatting as the endorse password value or -e option.
 
   * **-H**, **--handle**=_HANDLE_:
-    Optional, specifies the handle used to make EK  persistent (hex).
+    Optional, specifies the handle used to make EK persistent (hex).
+    If a value of **-** is passed the tool will find a vacant persistent handle
+    to use and print out the automatically selected handle.
 
   * **-c**, **--context**=_PATH_:
     Optional, specifies a path to save the context of the EK handle. If one saves

--- a/man/tpm2_createprimary.1.md
+++ b/man/tpm2_createprimary.1.md
@@ -22,6 +22,7 @@ will create and load a Primary Object. The sensitive area is not returned.
 
   * **-H**, **--hierarchy**=_HIERARCHY_:
     Specify the hierarchy under which the object is created. This will also dictate which authorization secret (if any) must be supplied.
+    Defaults to **o**, **TPM_RH_OWNER**, when no value specified.
     Supported options are:
       * **o** for **TPM_RH_OWNER**
       * **p** for **TPM_RH_PLATFORM**

--- a/man/tpm2_evictcontrol.1.md
+++ b/man/tpm2_evictcontrol.1.md
@@ -29,8 +29,9 @@ be evicted.
 
     The handle of a loaded transient or a persistent object.
 
-    If the handle is for a transient object, then a handle that will be assigned to the persisted
-    object must also be specified with the **-p** option.
+    If the handle is for a transient object it will be persisted, either to the
+    handle specified by the **-p** option, or to the first available vacant
+    persistent handle.
 
     If the handle is for a persistent object, then the **-p** does not need to be provided since the
     handle must be the same for both options.

--- a/man/tpm2_getmanufec.1.md
+++ b/man/tpm2_getmanufec.1.md
@@ -34,6 +34,8 @@ server.
 
   * **-H**, **--handle**=_HANDLE_:
     specifies the handle used to make EK  persistent (hex).
+    If a value of **-** is passed the tool will find a vacant persistent handle
+    to use and print out the automatically selected handle.
 
   * **-g**, **--algorithm**=_ALGORITHM_:
     specifies the algorithm type of EK.

--- a/man/tpm2_hash.1.md
+++ b/man/tpm2_hash.1.md
@@ -21,7 +21,8 @@ sign.
 # OPTIONS
 
   * **-H**, **--hierarchy**=_HIERARCHY_:
-    hierarchy to use for the ticket.
+    hierarchy to use for the ticket. Defaults to **o**, **TPM_RH_OWNER**, when
+    no value has been specified.
     Supported options are:
       * **o** for **TPM_RH_OWNER**
       * **p** for **TPM_RH_PLATFORM**

--- a/man/tpm2_loadexternal.1.md
+++ b/man/tpm2_loadexternal.1.md
@@ -24,7 +24,7 @@ scalar.
 # OPTIONS
 
   * **-H**, **--hierarchy**=_HIERARCHY_:
-    hierarchy to use for the ticket.
+    hierarchy to use for the ticket, optional. Defaults to **o**, **TPM_RH_OWNER**.
     Supported options are:
       * **o** for **TPM_RH_OWNER**
       * **p** for **TPM_RH_PLATFORM**

--- a/test/system/tests/evictcontrol.sh
+++ b/test/system/tests/evictcontrol.sh
@@ -53,8 +53,12 @@ tpm2_create -Q -g sha256 -G keyedhash -u key.pub -r key.priv  -c primary.ctx
 
 tpm2_load -Q -c primary.ctx  -u key.pub  -r key.priv -n key.name -C key.ctx
 
+# Load the context into a specific handle, delete it
+tpm2_evictcontrol -Q -c key.ctx -p 0x81010003
+tpm2_evictcontrol -Q -H 0x81010003 -p 0x81010003
+# Load the context into a specific handle, delete it without an explicit -p
 tpm2_evictcontrol -Q -A o -c key.ctx -p 0x81010003
 
-tpm2_evictcontrol -Q -A o -H 0x81010003 -p 0x81010003
+tpm2_evictcontrol -Q -A o -H 0x81010003
 
 exit 0

--- a/test/system/tests/evictcontrol.sh
+++ b/test/system/tests/evictcontrol.sh
@@ -39,7 +39,7 @@ trap onerror ERR
 
 cleanup() {
   rm -f primary.ctx decrypt.ctx key.pub key.priv key.name decrypt.out \
-        encrypt.out secret.dat key.ctx
+        encrypt.out secret.dat key.ctx evict.log
 }
 trap cleanup EXIT
 
@@ -55,10 +55,17 @@ tpm2_load -Q -c primary.ctx  -u key.pub  -r key.priv -n key.name -C key.ctx
 
 # Load the context into a specific handle, delete it
 tpm2_evictcontrol -Q -c key.ctx -p 0x81010003
+
 tpm2_evictcontrol -Q -H 0x81010003 -p 0x81010003
+
 # Load the context into a specific handle, delete it without an explicit -p
 tpm2_evictcontrol -Q -A o -c key.ctx -p 0x81010003
 
 tpm2_evictcontrol -Q -A o -H 0x81010003
+
+# Load the context into an available handle, delete it
+tpm2_evictcontrol -A o -c key.ctx > evict.log
+phandle=`grep "persistentHandle: " evict.log | awk '{print $2}'`
+tpm2_evictcontrol -Q -A o -H $phandle
 
 exit 0

--- a/test/system/tests/hash.sh
+++ b/test/system/tests/hash.sh
@@ -80,7 +80,7 @@ cleanup
 
 # Test stdout output as well as no options.
 # Validate that hash outputs are as expected.
-tpm_hash_val=`echo 1234 | tpm2_hash | tee $out | grep sha1 | cut -d\: -f 2-2 | tr -d '[:space:]'`
+tpm_hash_val=`echo 1234 | tpm2_hash -H n | tee $out | grep sha1 | cut -d\: -f 2-2 | tr -d '[:space:]'`
 sha1sum_val=`echo 1234 | sha1sum  | cut -d\  -f 1-2 | tr -d '[:space:]'`
 if [ "$tpm_hash_val" != "$sha1sum_val" ]; then
   echo "Expected tpm and sha1sum to produce same hashes."

--- a/tools/tpm2_getcap.c
+++ b/tools/tpm2_getcap.c
@@ -38,6 +38,7 @@
 #include "tpm2_alg_util.h"
 #include "tpm2_tool.h"
 #include "tpm2_util.h"
+#include "tpm2_capability.h"
 
 /* convenience macro to convert flags into "1" / "0" strings */
 #define prop_str(val) val ? "1" : "0"
@@ -860,27 +861,8 @@ dump_handles (TPM2_HANDLE     handles[],
 static TSS2_RC
 get_tpm_capability_all (TSS2_SYS_CONTEXT *sapi_ctx,
                         TPMS_CAPABILITY_DATA  *capability_data) {
-
-    TPMI_YES_NO            more_data;
-
-    TSS2_RC rval = TSS2_RETRY_EXP(Tss2_Sys_GetCapability (sapi_ctx,
-                                 NULL,
-                                 options.capability,
-                                 options.property,
-                                 options.count,
-                                 &more_data,
-                                 capability_data,
-                                 NULL));
-    if (rval != TPM2_RC_SUCCESS) {
-        LOG_ERR("Failed to GetCapability: capability: 0x%x, property: 0x%x",
-                 options.capability, options.property);
-        LOG_PERR(Tss2_Sys_GetCapability, rval);
-    } else if (more_data) {
-        LOG_WARN("More data to be queried: capability: 0x%x, property: "
-                 "0x%x\n", options.capability, options.property);
-    }
-
-    return rval;
+    return tpm2_capability_get(sapi_ctx, options.capability, options.property,
+                            options.count, capability_data);
 }
 
 /*
@@ -986,8 +968,6 @@ int tpm2_tool_onrun(TSS2_SYS_CONTEXT *sapi_context, tpm2_option_flags flags) {
     }
 
     /* List a capability, ie -c <arg> option */
-
-    TSS2_RC rc;
     TPMS_CAPABILITY_DATA capability_data = TPMS_CAPABILITY_DATA_EMPTY_INIT;
     int ret;
 
@@ -997,8 +977,7 @@ int tpm2_tool_onrun(TSS2_SYS_CONTEXT *sapi_context, tpm2_option_flags flags) {
         return 1;
     }
     /* get requested capability from TPM, dump it to stdout */
-    rc = get_tpm_capability_all(sapi_context, &capability_data);
-    if (rc != TPM2_RC_SUCCESS)
+    if (!get_tpm_capability_all(sapi_context, &capability_data))
         return 1;
 
     bool result = dump_tpm_capability(&capability_data.data);

--- a/tools/tpm2_getcap.c
+++ b/tools/tpm2_getcap.c
@@ -47,7 +47,7 @@
 /* Structure to map a string to the appropriate TPM2_CAP / TPM2_PT pair */
 typedef struct capability_map_entry {
     char     *capability_string;
-    TPM2_CAP   capability;
+    TPM2_CAP  capability;
     UINT32    property;
     UINT32    count;
 } capability_map_entry_t;
@@ -134,7 +134,7 @@ capability_map_entry_t capability_map[] = {
  */
 typedef struct capability_opts {
     char            *capability_string;
-    TPM2_CAP          capability;
+    TPM2_CAP         capability;
     UINT32           property;
     UINT32           count;
     bool             list;
@@ -143,14 +143,13 @@ typedef struct capability_opts {
 static capability_opts_t options;
 
 /*
- * This function uses the 'param' field in the capabilities_opts structure to
- * locate the same string in the capability_map array and then populates the
- * 'capability' and 'property' fields of the capability_opts_t structure with
- * the appropriate values from the capability_map.
+ * This function uses the 'capability_string' field in the capabilities_opts
+ * structure to locate the same string in the capability_map array and then
+ * populates the 'capability' and 'property' fields of the capability_opts_t
+ * structure with the appropriate values from the capability_map.
  * Return values:
  * 0 - the function executed normally.
- * 1 - the parameter 'param' in the capability_opts_t structure is NULL.
- * 2 - no matching entry found in capability_map.
+ * 1 - no matching entry found in capability_map.
  */
 int sanity_check_capability_opts (void) {
 
@@ -174,7 +173,7 @@ int sanity_check_capability_opts (void) {
     LOG_ERR("invalid capability string: %s, see --help",
             options.capability_string);
 
-    return 2;
+    return 1;
 }
 
 static void print_cap_map() {
@@ -994,9 +993,6 @@ int tpm2_tool_onrun(TSS2_SYS_CONTEXT *sapi_context, tpm2_option_flags flags) {
 
     ret = sanity_check_capability_opts();
     if (ret == 1) {
-        LOG_ERR("Missing capability string. See --help.\n");
-        return 1;
-    } else if (ret == 2) {
         LOG_ERR("Invalid capability string. See --help.\n");
         return 1;
     }

--- a/tools/tpm2_hash.c
+++ b/tools/tpm2_hash.c
@@ -45,6 +45,7 @@
 #include "tpm2_options.h"
 #include "tpm2_tool.h"
 #include "tpm2_util.h"
+#include "tpm2_hierarchy.h"
 
 typedef struct tpm_hash_ctx tpm_hash_ctx;
 struct tpm_hash_ctx {
@@ -59,36 +60,6 @@ static tpm_hash_ctx ctx = {
     .hierarchyValue = TPM2_RH_NULL,
     .halg = TPM2_ALG_SHA1,
 };
-
-static bool get_hierarchy_value(const char *hiearchy_code,
-        TPMI_RH_HIERARCHY *hierarchy_value) {
-
-    size_t len = strlen(hiearchy_code);
-    if (len != 1) {
-        LOG_ERR("Hierarchy Values are single characters, got: %s",
-                hiearchy_code);
-        return false;
-    }
-
-    switch (hiearchy_code[0]) {
-    case 'e':
-        *hierarchy_value = TPM2_RH_ENDORSEMENT;
-        break;
-    case 'o':
-        *hierarchy_value = TPM2_RH_OWNER;
-        break;
-    case 'p':
-        *hierarchy_value = TPM2_RH_PLATFORM;
-        break;
-    case 'n':
-        *hierarchy_value = TPM2_RH_NULL;
-        break;
-    default:
-        LOG_ERR("Unknown hierarchy value: %s", hiearchy_code);
-        return false;
-    }
-    return true;
-}
 
 static bool hash_and_save(TSS2_SYS_CONTEXT *sapi_context) {
 
@@ -155,7 +126,8 @@ static bool on_option(char key, char *value) {
     bool res;
     switch (key) {
     case 'H':
-        res = get_hierarchy_value(value, &ctx.hierarchyValue);
+        res = tpm2_hierarchy_from_optarg(value, &ctx.hierarchyValue,
+                TPM2_HIERARCHY_FLAGS_ALL);
         if (!res) {
             return false;
         }

--- a/tools/tpm2_hash.c
+++ b/tools/tpm2_hash.c
@@ -57,7 +57,7 @@ struct tpm_hash_ctx {
 };
 
 static tpm_hash_ctx ctx = {
-    .hierarchyValue = TPM2_RH_NULL,
+    .hierarchyValue = TPM2_RH_OWNER,
     .halg = TPM2_ALG_SHA1,
 };
 

--- a/tools/tpm2_loadexternal.c
+++ b/tools/tpm2_loadexternal.c
@@ -57,7 +57,9 @@ struct tpm_loadexternal_ctx {
     } flags;
 };
 
-static tpm_loadexternal_ctx ctx;
+static tpm_loadexternal_ctx ctx = {
+    .hierarchy_value = TPM2_RH_OWNER,
+};
 
 static bool get_hierarchy_value(const char *argument_opt,
         TPMI_RH_HIERARCHY *hierarchy_value) {

--- a/tools/tpm2_loadexternal.c
+++ b/tools/tpm2_loadexternal.c
@@ -144,7 +144,7 @@ static bool on_option(char key, char *value) {
 bool tpm2_tool_onstart(tpm2_options **opts) {
 
     const struct option topts[] = {
-      { "Hierachy", required_argument, NULL, 'H'},
+      { "hierarchy", required_argument, NULL, 'H'},
       { "pubfile",  required_argument, NULL, 'u'},
       { "privfile", required_argument, NULL, 'r'},
       { "context",  required_argument, NULL, 'C'},

--- a/tools/tpm2_loadexternal.c
+++ b/tools/tpm2_loadexternal.c
@@ -42,6 +42,7 @@
 #include "log.h"
 #include "tpm2_tool.h"
 #include "tpm2_util.h"
+#include "tpm2_hierarchy.h"
 
 typedef struct tpm_loadexternal_ctx tpm_loadexternal_ctx;
 struct tpm_loadexternal_ctx {
@@ -60,37 +61,6 @@ struct tpm_loadexternal_ctx {
 static tpm_loadexternal_ctx ctx = {
     .hierarchy_value = TPM2_RH_OWNER,
 };
-
-static bool get_hierarchy_value(const char *argument_opt,
-        TPMI_RH_HIERARCHY *hierarchy_value) {
-
-    if (strlen(argument_opt) != 1) {
-        LOG_ERR("Wrong Hierarchy Value, got: \"%s\", expected one of e,o,p,n",
-                argument_opt);
-        return false;
-    }
-
-    switch (argument_opt[0]) {
-    case 'e':
-        *hierarchy_value = TPM2_RH_ENDORSEMENT;
-        break;
-    case 'o':
-        *hierarchy_value = TPM2_RH_OWNER;
-        break;
-    case 'p':
-        *hierarchy_value = TPM2_RH_PLATFORM;
-        break;
-    case 'n':
-        *hierarchy_value = TPM2_RH_NULL;
-        break;
-    default:
-        LOG_ERR("Wrong Hierarchy Value, got: \"%s\", expected one of e,o,p,n",
-                argument_opt);
-        return false;
-    }
-
-    return true;
-}
 
 static bool load_external(TSS2_SYS_CONTEXT *sapi_context) {
 
@@ -116,12 +86,13 @@ static bool on_option(char key, char *value) {
 
     switch(key) {
     case 'H':
-        result = get_hierarchy_value(value, &ctx.hierarchy_value);
+        result = tpm2_hierarchy_from_optarg(value, &ctx.hierarchy_value,
+                   TPM2_HIERARCHY_FLAGS_ALL);
         if (!result) {
             return false;
         }
         ctx.flags.H = 1;
-    break;
+        break;
     case 'u':
         if(!files_load_public(value, &ctx.public_key)) {
             return false;;


### PR DESCRIPTION
The following series of patches implements a solution to issue #892. The changes within:

changes all tools which take a hierarchy argument to make that argument optional and default to the owner hierarchy when no value is passed
for tools which take a handle argument in order to specificy a persistent handle when making a transient object persistent no longer require a handle to be specified.
The tpm2_evictcontrol tool will do the right thing and, when a handle to a transient object is specified without a matching permanent handle we now automatically try and find an open slot in the persistent handle namespace.
tools which take an optional handle to persist a transient object at now have the option of specifying - as a handle. When passed a handle of (-* the tool will automatically find an open handle (as above) and use it, printing out the address of the used handle.
Note: this series also includes the changes from #947, as otherwise the man page changes within would need rebasing after #947 landed.

Fixes: #947
Fixes: #892