### PR TITLE
test: Suppress GCC warnings of implicit declarations

### DIFF
--- a/test/unit/test_files.c
+++ b/test/unit/test_files.c
@@ -29,6 +29,8 @@
 #include <stdbool.h>
 #include <stddef.h>
 #include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
 #include <setjmp.h>
 
 #include <cmocka.h>

--- a/test/unit/test_tpm2_alg_util.c
+++ b/test/unit/test_tpm2_alg_util.c
@@ -29,6 +29,7 @@
 #include <stdbool.h>
 #include <stddef.h>
 #include <stdio.h>
+#include <string.h>
 
 #include <cmocka.h>
 #include <tss2/tss2_sys.h>

--- a/test/unit/test_tpm2_attr_util.c
+++ b/test/unit/test_tpm2_attr_util.c
@@ -27,6 +27,7 @@
 #include <stdarg.h>
 #include <stdbool.h>
 #include <stddef.h>
+#include <stdlib.h>
 #include <setjmp.h>
 
 #include <cmocka.h>

--- a/test/unit/test_tpm2_error.c
+++ b/test/unit/test_tpm2_error.c
@@ -28,6 +28,8 @@
 #include <stdarg.h>
 #include <stddef.h>
 #include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
 
 #include <setjmp.h>
 #include <cmocka.h>

--- a/test/unit/test_tpm2_policy.c
+++ b/test/unit/test_tpm2_policy.c
@@ -30,6 +30,8 @@
 #include <stddef.h>
 
 #include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
 
 #include <setjmp.h>
 #include <cmocka.h>

--- a/test/unit/test_tpm2_session.c
+++ b/test/unit/test_tpm2_session.c
@@ -28,6 +28,8 @@
 #include <stdarg.h>
 #include <stddef.h>
 #include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
 
 #include <unistd.h>
 


### PR DESCRIPTION
GCC would complain about implicit declaration of functions [-Wimplicit-function-declaration] if stdlib.h and string.h is not included directly. (Previously stdlib.h and string.h were indirectly included from sapi/tpm20.h)