### PR TITLE
tpm2_certify: fix "'type' may be used uninitialized" warning

### DIFF
--- a/tools/tpm2_certify.c
+++ b/tools/tpm2_certify.c
@@ -98,6 +98,7 @@ static bool get_key_type(TSS2_SYS_CONTEXT *sapi_context, TPMI_DH_OBJECT object_h
             &out_public, &name, &qualified_name, &sessions_data_out));
     if (rval != TPM2_RC_SUCCESS) {
         LOG_PERR(Tss2_Sys_ReadPublic, rval);
+        *type = TPM2_ALG_ERROR;
         return false;
     }
 


### PR DESCRIPTION
get_key_type does not assign a value to 'type' on error conditions,
which makes the compiler believe that it will be used uninitialized in
the LOG_ERR call, in set_scheme. In practice this will never happen
because set_scheme returns immediately if get_key_type retuns false but
the compiler does not understand that logic and fails because warnings
are treated as errors.

Signed-off-by: Carlos Santos <casantos@datacom.ind.br>