### PR TITLE
Change more tools to default to owner hierarchy

### DIFF
--- a/man/tpm2_nvdefine.1.md
+++ b/man/tpm2_nvdefine.1.md
@@ -20,7 +20,8 @@
     Specifies the index to define the space at.
 
   * **-a**, **--auth-handle**=_AUTH_:
-    specifies the handle used to authorize.
+    specifies the handle used to authorize. Defaults to **o**, **TPM_RH_OWNER**,
+    when no value has been specified.
     Supported options are:
       * **o** for **TPM_RH_OWNER**
       * **p** for **TPM_RH_PLATFORM**

--- a/man/tpm2_nvread.1.md
+++ b/man/tpm2_nvread.1.md
@@ -20,7 +20,8 @@
     Specifies the index to define the space at.
 
   * **-a**, **--auth-handle**=_AUTH_:
-    specifies the handle used to authorize.
+    specifies the handle used to authorize. Defaults to **o**, **TPM_RH_OWNER**,
+    when no value has been specified.
     Supported options are:
       * **o** for **TPM_RH_OWNER**
       * **p** for **TPM_RH_PLATFORM**

--- a/man/tpm2_nvreadlock.1.md
+++ b/man/tpm2_nvreadlock.1.md
@@ -24,6 +24,8 @@ is released on subsequent restart of the machine.
     specifies the handle used to authorize:
     * **0x40000001** for **TPM_RH_OWNER**
     * **0x4000000C** for **TPM_RH_PLATFORM**
+    Defaults to **0x40000001**, **TPM_RH_OWNER**, when no value has been
+    specified.
 
   * **-P**, **--handle-passwd**=_HANDLE\_PASSWORD_:
     specifies the password of authHandle. Passwords should follow the

--- a/man/tpm2_nvreadlock.1.md
+++ b/man/tpm2_nvreadlock.1.md
@@ -22,9 +22,9 @@ is released on subsequent restart of the machine.
 
   * **-a**, **--auth-handle**=_SECRET\_DATA\_FILE_:
     specifies the handle used to authorize:
-    * **0x40000001** for **TPM_RH_OWNER**
-    * **0x4000000C** for **TPM_RH_PLATFORM**
-    Defaults to **0x40000001**, **TPM_RH_OWNER**, when no value has been
+    * **o** for **TPM_RH_OWNER**
+    * **p** for **TPM_RH_PLATFORM**
+    Defaults to **o**, **TPM_RH_OWNER**, when no value has been
     specified.
 
   * **-P**, **--handle-passwd**=_HANDLE\_PASSWORD_:

--- a/man/tpm2_nvwrite.1.md
+++ b/man/tpm2_nvwrite.1.md
@@ -24,7 +24,8 @@ If _FILE_ is not specified, it defaults to stdin.
     The offset within the NV index to start writing at.
 
   * **-a**, **--auth-handle**=_AUTH_:
-    specifies the handle used to authorize.
+    specifies the handle used to authorize. Defaults to **o**, **TPM_RH_OWNER**,
+    when no value has been specified.
     Supported options are:
       * **o** for **TPM_RH_OWNER**
       * **p** for **TPM_RH_PLATFORM**

--- a/tools/tpm2_nvdefine.c
+++ b/tools/tpm2_nvdefine.c
@@ -59,7 +59,7 @@ struct tpm_nvdefine_ctx {
 };
 
 static tpm_nvdefine_ctx ctx = {
-    .auth = TPM2_RH_PLATFORM,
+    .auth = TPM2_RH_OWNER,
     .nvAttribute = 0,
     .session_data = TPMS_AUTH_COMMAND_INIT(TPM2_RS_PW),
     .nvAuth = TPM2B_EMPTY_INIT,

--- a/tools/tpm2_nvread.c
+++ b/tools/tpm2_nvread.c
@@ -65,7 +65,7 @@ struct tpm_nvread_ctx {
 };
 
 static tpm_nvread_ctx ctx = {
-    .auth_handle = TPM2_RH_PLATFORM,
+    .auth_handle = TPM2_RH_OWNER,
     .session_data = TPMS_AUTH_COMMAND_INIT(TPM2_RS_PW),
 };
 

--- a/tools/tpm2_nvreadlock.c
+++ b/tools/tpm2_nvreadlock.c
@@ -56,7 +56,7 @@ struct tpm_nvreadlock_ctx {
 };
 
 static tpm_nvreadlock_ctx ctx = {
-    .auth_handle = TPM2_RH_PLATFORM,
+    .auth_handle = TPM2_RH_OWNER,
     .session_data = TPMS_AUTH_COMMAND_INIT(TPM2_RS_PW),
 
 };

--- a/tools/tpm2_nvwrite.c
+++ b/tools/tpm2_nvwrite.c
@@ -68,7 +68,7 @@ struct tpm_nvwrite_ctx {
 };
 
 static tpm_nvwrite_ctx ctx = {
-    .auth_handle = TPM2_RH_PLATFORM,
+    .auth_handle = TPM2_RH_OWNER,
     .session_data = TPMS_AUTH_COMMAND_INIT(TPM2_RS_PW),
 };
 


### PR DESCRIPTION
My previous attempt to set the default hierarchy for all tools to the owner hierarchy in #950 turned out not to include all tools. This series fixes up some tools I missed.