### PR TITLE
Implicit H follow on

### DIFF
--- a/test/system/tests/createak.sh
+++ b/test/system/tests/createak.sh
@@ -31,6 +31,8 @@
 # THE POSSIBILITY OF SUCH DAMAGE.
 #;**********************************************************************;
 
+source helpers.sh
+
 onerror() {
     echo "$BASH_COMMAND on line ${BASH_LINENO[0]} failed: $?"
     exit 1
@@ -38,7 +40,7 @@ onerror() {
 trap onerror ERR
 
 cleanup() {
-    rm -f ek.pub ak.pub ak.name ak.name
+    rm -f ek.pub ak.pub ak.name ak.name ak.log
 
     # Evict persistent handles, we want them to always succeed and never trip
     # the onerror trap.
@@ -54,6 +56,11 @@ cleanup
 
 tpm2_createek -Q -H 0x8101000b -g rsa -p ek.pub
 
-tpm2_createak -Q -E 0x8101000b  -k 0x8101000c -g rsa -D sha256 -s rsassa -p ak.pub  -n ak.name
+tpm2_createak -Q -E 0x8101000b -k 0x8101000c -g rsa -D sha256 -s rsassa -p ak.pub -n ak.name
+
+# Find a vacant persistent handle
+tpm2_createak -E 0x8101000b -k - -g rsa -D sha256 -s rsassa -p ak.pub -n ak.name > ak.log
+phandle=`yaml_get_kv ak.log \"ak\-persistent\-handle\"`
+tpm2_evictcontrol -Q -a o -H $phandle
 
 exit 0

--- a/test/system/tests/createek.sh
+++ b/test/system/tests/createek.sh
@@ -31,6 +31,8 @@
 # THE POSSIBILITY OF SUCH DAMAGE.
 #;**********************************************************************;
 
+source helpers.sh
+
 onerror() {
     echo "$BASH_COMMAND on line ${BASH_LINENO[0]} failed: $?"
     exit 1
@@ -38,7 +40,7 @@ onerror() {
 trap onerror ERR
 
 cleanup() {
-    rm -f ek.pub
+    rm -f ek.pub ek.log
 
     # Evict persistent handles, we want them to always succeed and never trip
     # the onerror trap.
@@ -49,5 +51,11 @@ trap cleanup EXIT
 cleanup
 
 tpm2_createek -H 0x81010005 -g rsa -p ek.pub
+
+cleanup
+
+tpm2_createek -H - -g rsa -p ek.pub > ek.log
+phandle=`yaml_get_kv ek.log \"persistent\-handle\"`
+tpm2_evictcontrol -Q -a o -H $phandle
 
 exit 0

--- a/test/system/tests/createprimary.sh
+++ b/test/system/tests/createprimary.sh
@@ -56,6 +56,8 @@ cleanup
 # values.
 for gAlg in `populate_hash_algs mixed`; do
     for GAlg in 0x01 keyedhash ecc 0x25; do
+        tpm2_createprimary -Q -g $gAlg -G $GAlg -C context.out
+        cleanup keep_context
         for Atype in o e n; do
             tpm2_createprimary -Q -a $Atype -g $gAlg -G $GAlg -C context.out
             cleanup keep_context

--- a/test/system/tests/evictcontrol.sh
+++ b/test/system/tests/evictcontrol.sh
@@ -31,6 +31,8 @@
 # THE POSSIBILITY OF SUCH DAMAGE.
 #;**********************************************************************;
 
+source helpers.sh
+
 onerror() {
     echo "$BASH_COMMAND on line ${BASH_LINENO[0]} failed: $?"
     exit 1
@@ -67,5 +69,7 @@ tpm2_evictcontrol -Q -a o -H 0x81010003
 tpm2_evictcontrol -a o -c key.ctx > evict.log
 phandle=`grep "persistentHandle: " evict.log | awk '{print $2}'`
 tpm2_evictcontrol -Q -a o -H $phandle
+
+yaml_verify evict.log
 
 exit 0

--- a/test/system/tests/getmanufec.sh
+++ b/test/system/tests/getmanufec.sh
@@ -31,6 +31,8 @@
 # THE POSSIBILITY OF SUCH DAMAGE.
 #;**********************************************************************;
 
+source helpers.sh
+
 # Building with asan on clang, the leak sanitizer
 # portion (lsan) on ancient versions is:
 # 1. Detecting a leak that (maybe) doesn't exist.
@@ -49,7 +51,7 @@ opass=abc123
 epass=abc123
 
 cleanup() {
-    rm -f test_ek.pub ECcert.bin ECcert2.bin test_ek.pub
+    rm -f test_ek.pub ECcert.bin ECcert2.bin test_ek.pub man.log
 }
 
 trap cleanup EXIT
@@ -95,5 +97,12 @@ if [ $(md5sum ECcert.bin| awk '{ print $1 }') != "56af9eb8a271bbf7ac41b780acd91f
  echo "Failed: retrieving endorsement certificate"
  exit 1
 fi
+
+# Test with automatic persistent handle
+tpm2_getmanufec -H - -U -E ECcert2.bin -f test_ek.pub -o $opass -e $epass \
+                https://ekop.intel.com/ekcertservice/ > man.log
+phandle=`yaml_get_kv man.log \"persistent\-handle\"`
+
+tpm2_evictcontrol -Q -H $phandle -a o -P $opass
 
 exit 0

--- a/test/system/tests/loadexternal.sh
+++ b/test/system/tests/loadexternal.sh
@@ -80,4 +80,11 @@ tpm2_create -Q -H $Handle_parent   -g $alg_create_obj  -G $alg_create_key -u $fi
 
 tpm2_loadexternal -Q -a n   -u $file_loadexternal_key_pub
 
+# Test with default hierarchy (and handle)
+cleanup keep_handle
+
+tpm2_create -Q -H $Handle_parent -g $alg_create_obj -G $alg_create_key -u $file_loadexternal_key_pub -r  $file_loadexternal_key_priv
+
+tpm2_loadexternal -Q -u $file_loadexternal_key_pub
+
 exit 0

--- a/tools/tpm2_createprimary.c
+++ b/tools/tpm2_createprimary.c
@@ -59,7 +59,6 @@ struct tpm_createprimary_ctx {
     tpm2_hierarchy_pdata objdata;
     char *context_file;
     struct {
-        UINT8 a :1;
         UINT8 g :1;
         UINT8 G :1;
     } flags;
@@ -154,7 +153,6 @@ static bool on_option(char key, char *value) {
         if (!res) {
             return false;
         }
-        ctx.flags.a = 1;
         break;
     case 'P':
         res = tpm2_auth_util_from_optarg(value, &ctx.auth.session_data, &ctx.auth.session);
@@ -245,7 +243,7 @@ bool tpm2_tool_onstart(tpm2_options **opts) {
 }
 
 static inline bool valid_ctx(void) {
-    return (ctx.flags.a && ctx.flags.g && ctx.flags.G);
+    return (ctx.flags.g && ctx.flags.G);
 }
 
 int tpm2_tool_onrun(TSS2_SYS_CONTEXT *sapi_context, tpm2_option_flags flags) {

--- a/tools/tpm2_loadexternal.c
+++ b/tools/tpm2_loadexternal.c
@@ -53,7 +53,6 @@ struct tpm_loadexternal_ctx {
     TPM2B_SENSITIVE private_key;
     bool save_to_context_file;
     struct {
-        UINT8 H : 1;
         UINT8 u : 1;
     } flags;
 };
@@ -91,7 +90,6 @@ static bool on_option(char key, char *value) {
         if (!result) {
             return false;
         }
-        ctx.flags.H = 1;
         break;
     case 'u':
         if(!files_load_public(value, &ctx.public_key)) {
@@ -133,8 +131,8 @@ int tpm2_tool_onrun(TSS2_SYS_CONTEXT *sapi_context, tpm2_option_flags flags) {
 
     UNUSED(flags);
 
-    if (!(ctx.flags.H && ctx.flags.u)) {
-        LOG_ERR("Expected H and u options");
+    if (!ctx.flags.u) {
+        LOG_ERR("Expected u option");
         return 1;
     }
 


### PR DESCRIPTION
Following on from #950 and #959 this series fixes **tpm2_createprimary** and **tpm2_loadexternal** to not require an explicit hierarchy option be passed, using the default of **TPM2_OWNER** when one isn't specified.

Further we add some tests for the default owner hierarchy and persistent handle finding changes made in #950.