### PR TITLE
man/tpm2_evictcontrol: fix long option name for -a

### DIFF
--- a/man/tpm2_evictcontrol.1.md
+++ b/man/tpm2_evictcontrol.1.md
@@ -17,7 +17,7 @@ be evicted.
 
 # OPTIONS
 
-  * **-a**, **--auth-heirarchy**=_AUTH\_HIERARCHY\_:
+  * **-a**, **--hierarchy**=_AUTH\_HIERARCHY\_:
 
     The authorization hierarchy used to authorize the commands. Defaults to the "owner" hierarchy.
     Supported options are:


### PR DESCRIPTION
The -a / --hierarchy option was incorrectly documented as
having a long option name of --auth-heirarchy.

Signed-off-by: Joshua Lock <joshua.g.lock@intel.com>