### PR TITLE
Tpm2 hmac authentication

### DIFF
--- a/lib/tpm2_auth_util.c
+++ b/lib/tpm2_auth_util.c
@@ -34,43 +34,104 @@
 #include <tss2/tss2_sys.h>
 
 #include "log.h"
+#include "pcr.h"
 #include "tpm2_auth_util.h"
+#include "tpm2_nv_util.h"
+#include "tpm2_policy.h"
 #include "tpm2_session.h"
 #include "tpm2_util.h"
 
+typedef enum tpm2_session_type tpm2_session_type;
+enum tpm2_session_type {
+    tpm2_session_fail = 0,
+    tpm2_session_password,
+    tpm2_session_hmac,
+    tpm2_session_ea
+};
+
 #define HEX_PREFIX "hex:"
-#define HEX_PREFIX_LEN sizeof(HEX_PREFIX) - 1
+#define HEX_PREFIX_LEN (sizeof(HEX_PREFIX) - 1)
 
 #define STR_PREFIX "str:"
-#define STR_PREFIX_LEN sizeof(STR_PREFIX) - 1
+#define STR_PREFIX_LEN (sizeof(STR_PREFIX) - 1)
+
+#define HMAC_PREFIX "hmac:"
+#define HMAC_PREFIX_LEN (sizeof(HMAC_PREFIX) - 1)
 
 #define SESSION_PREFIX "session:"
-#define SESSION_PREFIX_LEN sizeof(SESSION_PREFIX) - 1
+#define SESSION_PREFIX_LEN (sizeof(SESSION_PREFIX) - 1)
 
-static bool handle_hex(const char *password, TPMS_AUTH_COMMAND *auth) {
+#define PCR_PREFIX "pcr:"
+#define PCR_PREFIX_LEN (sizeof(PCR_PREFIX) - 1)
 
-    /* if it is hex, then skip the prefix */
-    password += HEX_PREFIX_LEN;
+static tpm2_session_type handle_hex(const char *password, TPMS_AUTH_COMMAND *auth) {
 
     auth->hmac.size = BUFFER_SIZE(typeof(auth->hmac), buffer);
     int rc = tpm2_util_hex_to_byte_structure(password, &auth->hmac.size, auth->hmac.buffer);
     if (rc) {
         auth->hmac.size = 0;
+        return tpm2_session_fail;
+    }
+
+    return tpm2_session_password;
+}
+
+static tpm2_session_type copy_password(TPM2B_AUTH *hmac, const char *password) {
+    /*
+     * Per the man page:
+     * "a return value of size or more means that the output was truncated."
+     */
+    size_t wrote = snprintf((char *)hmac->buffer, sizeof(hmac->buffer), "%s", password);
+    if (wrote >= sizeof(hmac->buffer)) {
+        hmac->size = 0;
+        memset(hmac->buffer, 0, sizeof(hmac->buffer));
         return false;
     }
 
+    hmac->size = wrote;
     return true;
 }
 
-static bool handle_session(const char *path, TPMS_AUTH_COMMAND *auth,
-        tpm2_session **session) {
+static tpm2_session_type handle_hmac(TSS2_SYS_CONTEXT *sapi, const char *password, TPMS_AUTH_COMMAND *auth,
+        tpm2_session **session, tpm2_auth_cb *cb) {
 
-    /* if it is session, then skip the prefix */
-    path += SESSION_PREFIX_LEN;
+    bool result = copy_password(&auth->hmac, password);
+    if (!result) {
+        return tpm2_session_fail;
+    }
+
+    tpm2_session_data *d = tpm2_session_data_new(TPM2_SE_HMAC);
+    if (!d) {
+        LOG_ERR("Could not allocate new session data");
+        return tpm2_session_fail;
+    }
+
+    if (cb && cb->hmac.init) {
+        result = cb->hmac.init(d);
+        if (!result) {
+            LOG_ERR("hmac callback failed");
+            tpm2_session_data_free(&d);
+            return tpm2_session_fail;
+        }
+    }
+
+    *session = tpm2_session_new(sapi, d);
+    if (!*session) {
+        LOG_ERR("Could not start new session");
+        return tpm2_session_fail;
+    }
+
+    auth->sessionHandle = tpm2_session_get_handle(*session);
+
+    return tpm2_session_hmac;
+}
+
+static tpm2_session_type handle_session(const char *path, TPMS_AUTH_COMMAND *auth,
+        tpm2_session **session) {
 
     *session = tpm2_session_restore(path);
     if (!*session) {
-        return false;
+        return tpm2_session_fail;
     }
 
     auth->sessionHandle = tpm2_session_get_handle(*session);
@@ -80,13 +141,65 @@ static bool handle_session(const char *path, TPMS_AUTH_COMMAND *auth,
         LOG_ERR("A trial session cannot be used to authenticate, "
                 "Please use an hmac or policy session");
         tpm2_session_free(session);
-        return false;
+        return tpm2_session_fail;
     }
 
-    return true;
+    return tpm2_session_ea;
 }
 
-static bool handle_str(const char *password, TPMS_AUTH_COMMAND *auth) {
+static tpm2_session_type handle_pcr(TSS2_SYS_CONTEXT *sapi, const char *spec, TPMS_AUTH_COMMAND *auth,
+        tpm2_session **session) {
+
+    /*
+     * Handle the parsing of a PCR spec which is pcr:f=<path> or pcr:p=<pcr spec>
+     */
+    TPML_PCR_SELECTION pcrs = { .count = 0 };
+    const char *pcr_file = NULL;
+    if (!strncmp(spec, "f=", 2)) {
+        pcr_file = &spec[2];
+    } else if(!strncmp(spec, "p=", 2)) {
+        const char *pcr_spec = &spec[2];
+        bool result = pcr_parse_selections(pcr_spec, &pcrs);
+        if (!result) {
+            LOG_ERR("Could not parse PCR selections, got: \"%s\"", pcr_spec);
+            return tpm2_session_fail;
+        }
+    } else {
+        LOG_ERR("Expected either a file (f=) or pcr (p=) based PCR spec,"
+                "got: \"%s\"", spec);
+        return tpm2_session_fail;
+    }
+
+    tpm2_session_data *d =
+            tpm2_session_data_new(TPM2_SE_POLICY);
+    if (!d) {
+        LOG_ERR("oom");
+        return tpm2_session_fail;
+    }
+
+    tpm2_session *s = tpm2_session_new(sapi, d);
+    if (!s) {
+        LOG_ERR("Could not start tpm session");
+        return tpm2_session_fail;
+    }
+
+    bool result = tpm2_policy_build_pcr(sapi, s,
+            pcr_file,
+            &pcrs);
+    if (!result) {
+        LOG_ERR("Could not build a pcr policy");
+        tpm2_session_free(&s);
+        return tpm2_session_fail;
+    }
+
+    auth->sessionHandle = tpm2_session_get_handle(s);
+    auth->sessionAttributes |= TPMA_SESSION_CONTINUESESSION;
+
+    *session = s;
+    return tpm2_session_ea;
+}
+
+static tpm2_session_type handle_str(const char *password, TPMS_AUTH_COMMAND *auth) {
 
     /* str may or may not have the str: prefix */
     bool is_str_prefix = !strncmp(password, STR_PREFIX, STR_PREFIX_LEN);
@@ -94,26 +207,17 @@ static bool handle_str(const char *password, TPMS_AUTH_COMMAND *auth) {
         password += STR_PREFIX_LEN;
     }
 
-    /*
-     * Per the man page:
-     * "a return value of size or more means that the output was truncated."
-     */
-    size_t wrote = snprintf((char *)&auth->hmac.buffer, BUFFER_SIZE(typeof(auth->hmac), buffer), "%s", password);
-    if (wrote >= BUFFER_SIZE(typeof(auth->hmac), buffer)) {
-        auth->hmac.size = 0;
-        return false;
-    }
-
-    auth->hmac.size = wrote;
-
-    return true;
+    bool result = copy_password(&auth->hmac, password);
+    return result ? tpm2_session_password : tpm2_session_fail;
 }
 
-bool tpm2_auth_util_from_optarg(const char *password, TPMS_AUTH_COMMAND *auth,
-        tpm2_session **session) {
+tpm2_session_type tpm2_auth_util_from_optarg2(TSS2_SYS_CONTEXT *sapi, const char *password, TPMS_AUTH_COMMAND *auth,
+        tpm2_session **session, tpm2_auth_cb *cb) {
 
     bool is_hex = !strncmp(password, HEX_PREFIX, HEX_PREFIX_LEN);
     if (is_hex) {
+
+        password += HEX_PREFIX_LEN;
         return handle_hex(password, auth);
     }
 
@@ -123,9 +227,310 @@ bool tpm2_auth_util_from_optarg(const char *password, TPMS_AUTH_COMMAND *auth,
             LOG_ERR("Tool does not support sessions for this auth value");
             return false;
         }
+
+        password += SESSION_PREFIX_LEN;
         return handle_session(password, auth, session);
     }
 
+    bool is_hmac = !strncmp(password, HMAC_PREFIX, HMAC_PREFIX_LEN);
+    if (is_hmac) {
+        if (!session) {
+            LOG_ERR("Tool does not support HMAC for this auth value");
+            return false;
+        }
+
+        password += HMAC_PREFIX_LEN;
+        return handle_hmac(sapi, password, auth, session, cb);
+    }
+
+    bool is_pcr = !strncmp(password, PCR_PREFIX, PCR_PREFIX_LEN);
+    if (is_pcr) {
+        if (!session) {
+            LOG_ERR("Tool does not support PCR for this auth value");
+            return false;
+        }
+
+        password += PCR_PREFIX_LEN;
+        return handle_pcr(sapi, password, auth, session);
+    }
     /* must be string, handle it */
     return handle_str(password, auth);
+}
+
+bool tpm2_auth_util_from_optarg(const char *password, TPMS_AUTH_COMMAND *auth,
+        tpm2_session **session) {
+    return tpm2_auth_util_from_optarg2(NULL, password, auth, session, NULL) != tpm2_session_fail;
+}
+
+bool tpm2_auth_util_from_options(TSS2_SYS_CONTEXT *sapi, tpm2_auth *auth, tpm2_auth_cb *cb,
+        bool support_sessions) {
+
+    if (!auth->cnt) {
+        /*
+         * default to the empty password.
+         * The password and handle were set in the init macro.
+         */
+        auth->auth_list.count++;
+        return true;
+    }
+
+    auth->cb = *cb;
+
+    unsigned i;
+    for (i=0; i < auth->cnt; i++) {
+
+        const char *o = auth->optargs[i];
+        TPMS_AUTH_COMMAND *a = &auth->auth_list.auths[i];
+        tpm2_session **s = support_sessions ? &auth->sessions[i] : NULL;
+        tpm2_session_type stype = tpm2_auth_util_from_optarg2(sapi, o, a, s, cb);
+        if (stype == tpm2_session_fail) {
+            tpm2_auth_util_free(sapi, auth);
+            return false;
+        } else if(stype == tpm2_session_hmac) {
+            auth->hmac_indexes |= 1 << i;
+        }
+
+        auth->auth_list.count++;
+    }
+
+    return true;
+}
+
+bool tpm2_read_transient_persistent_obj_name(TSS2_SYS_CONTEXT *sapi_context,
+    TPM2_HANDLE entity_handle, TPM2B_NAME *entity_name) {
+
+    TPM2B_PUBLIC object_public;
+    TSS2L_SYS_AUTH_RESPONSE sessions_data_out;
+    TPM2B_NAME qualified_name = TPM2B_TYPE_INIT(TPM2B_NAME, name);
+    TSS2_RC rval = TSS2_RETRY_EXP( Tss2_Sys_ReadPublic(sapi_context, entity_handle,
+                                        NULL, &object_public, entity_name, &qualified_name,
+                                        &sessions_data_out));
+    if (rval != TSS2_RC_SUCCESS) {
+        LOG_PERR(Tss2_Sys_ReadPublic, rval);
+        return false;
+    }
+    return true;
+}
+
+bool tpm2_hmac_auth_get_entity_name(TSS2_SYS_CONTEXT *sapi_context, TPM2_HANDLE entity_handle,
+    TPM2B_NAME *entity_name) {
+
+    TPM2B_NV_PUBLIC nv_public = TPM2B_EMPTY_INIT;
+    bool res;
+    uint8_t temp[4];
+    unsigned i;
+    //Get Entity names from handles
+    switch(entity_handle & TPM2_HR_RANGE_MASK) {
+        case TPM2_HR_NV_INDEX:
+            res = tpm2_util_nv_read_public2(sapi_context,entity_handle, &nv_public,
+                entity_name);
+            if (!res) {
+                LOG_ERR("Failed reading NV public when calculating name");
+                return false;
+            }
+            break;
+        case TPM2_HR_TRANSIENT:
+        case TPM2_HR_PERSISTENT:
+            res = tpm2_read_transient_persistent_obj_name(sapi_context,
+                    entity_handle, entity_name);
+            if (!res) {
+                LOG_ERR("Failed reading Object public when calculating name");
+                return false;
+            }
+            break;
+        case TPM2_HR_PCR:
+        case TPM2_HR_HMAC_SESSION:
+        case TPM2_HR_POLICY_SESSION:
+        case TPM2_HR_PERMANENT:
+            entity_name->size = sizeof(TPM2_HANDLE);
+            memcpy(temp, &entity_handle, sizeof(TPM2_HANDLE));
+            for (i = 0; i < sizeof(TPM2_HANDLE); i++) {
+               entity_name->name[i] = temp[3-i];
+            }
+            break;
+        default:
+            LOG_ERR("Handle not valid for HMAC auth");
+            return false;
+    }
+    return true;
+}
+
+// TODO Figure out how I work and refactor me
+#include <openssl/bio.h>
+#include <openssl/buffer.h>
+#include <openssl/evp.h>
+#include <openssl/hmac.h>
+#include <openssl/sha.h>
+
+static bool command_authentication_hmac(tpm2_session *hmac_session, uint8_t *cp_hash,
+    TPMS_AUTH_COMMAND *session_data, TPMS_AUTH_RESPONSE *response_data, char *optargs) {
+
+    if (response_data->nonce.size) {
+        tpm2_session_update_nonce_older(hmac_session, &response_data->nonce);
+        session_data->hmac.size = strlen(optargs);
+        memcpy(session_data->hmac.buffer,optargs,strlen(optargs));
+    }
+
+    const TPM2B_NONCE *nonce_tpm =
+        tpm2_session_get_nonce_tpm(hmac_session);
+
+    uint8_t *to_hmac_buffer = malloc(SHA256_DIGEST_LENGTH + nonce_tpm->size
+                          + sizeof(TPMA_SESSION));
+    if (!to_hmac_buffer) {
+        LOG_ERR("oom");
+        return false;
+    }
+
+    memcpy(to_hmac_buffer, cp_hash, SHA256_DIGEST_LENGTH);
+
+    memcpy(to_hmac_buffer + SHA256_DIGEST_LENGTH, nonce_tpm->buffer, nonce_tpm->size);
+
+    memcpy(to_hmac_buffer + SHA256_DIGEST_LENGTH + nonce_tpm->size,
+           &session_data->sessionAttributes, sizeof(TPMA_SESSION));
+
+    unsigned int temp_hash_len = 0;
+    HMAC(EVP_sha256(), session_data->hmac.buffer, session_data->hmac.size,
+        to_hmac_buffer, SHA256_DIGEST_LENGTH + nonce_tpm->size + sizeof(TPMA_SESSION),
+        session_data->hmac.buffer, &temp_hash_len);
+    session_data->hmac.size = temp_hash_len;
+    free(to_hmac_buffer);
+
+    return true;
+}
+
+uint8_t *get_cp_hash(TSS2_SYS_CONTEXT *sapi_context,
+    TPM2B_NAME entity_1_name, TPM2B_NAME entity_2_name) {
+
+    SHA256_CTX sha256;
+    int is_success = SHA256_Init(&sha256);
+    if (!is_success) {
+        LOG_ERR("SHA256_Init failed when calculating HMAC");
+        return NULL;
+    }
+
+    uint8_t cmd_code[4];
+    TSS2_RC rval = Tss2_Sys_GetCommandCode(sapi_context, cmd_code);
+    if (rval != TSS2_RC_SUCCESS) {
+        LOG_PERR(Tss2_Sys_GetCommandCode, rval);
+        return NULL;
+    }
+
+    is_success = SHA256_Update(&sha256, cmd_code, sizeof(cmd_code));
+    if (!is_success) {
+        LOG_ERR ("SHA256_Update failed when calculating HMAC");
+        return NULL;
+    }
+
+    is_success = SHA256_Update(&sha256, entity_1_name.name, entity_1_name.size);
+    if (!is_success) {
+        LOG_ERR ("SHA256_Update failed when calculating HMAC");
+        return NULL;
+    }
+    is_success = SHA256_Update(&sha256, entity_2_name.name, entity_2_name.size);
+    if (!is_success) {
+        LOG_ERR ("SHA256_Update failed when calculating HMAC");
+        return NULL;
+    }
+
+    size_t command_params_size;
+    const uint8_t *command_params;
+    rval = Tss2_Sys_GetCpBuffer(sapi_context, &command_params_size, &command_params);
+    if (rval != TPM2_RC_SUCCESS) {
+        LOG_PERR(Tss2_Sys_GetCpBuffer, rval);
+        return NULL;
+    }
+
+    is_success = SHA256_Update(&sha256, command_params, command_params_size);
+    if (!is_success) {
+        LOG_ERR ("SHA256_Update failed when calculating HMAC");
+        return NULL;
+    }
+
+    uint8_t *cp_hash = malloc(SHA256_DIGEST_LENGTH);
+    if (!cp_hash) {
+        LOG_ERR ("OOM");
+        return NULL;
+    }
+
+    is_success = SHA256_Final(cp_hash, &sha256);
+    if (!is_success) {
+        LOG_ERR ("SHA256_Final failed when calculating HMAC");
+        free(cp_hash);
+        return NULL;
+    }
+
+    return cp_hash;
+}
+
+static bool tpm2_hmac_auth_get_command_buffer_hmac(TSS2_SYS_CONTEXT *sapi_context, TPMS_AUTH_COMMAND *auth,
+    tpm2_session *hmac_session, TPM2B_NAME entity_1_name,
+    TPM2B_NAME entity_2_name, TPMS_AUTH_RESPONSE *response_data, char *optargs) {
+
+    uint8_t *cp_hash = get_cp_hash(sapi_context, entity_1_name, entity_2_name);
+    if (!cp_hash) {
+        LOG_ERR("Command Parameter hash failed");
+        return false;
+    }
+
+    command_authentication_hmac(hmac_session, cp_hash, auth, response_data, optargs);
+    free(cp_hash);
+    return true;
+}
+
+static bool tpm2b_auth_update_for_hmac(TSS2_SYS_CONTEXT *sapi,
+        tpm2_auth_cb *cb, tpm2_session *s, TPMS_AUTH_COMMAND *a,
+        void *udata, TPMS_AUTH_RESPONSE *response_data, char *optargs) {
+
+    const TPM2_HANDLE *h = tpm2_session_get_auth_handles(s);
+
+    unsigned i;
+    TPM2B_NAME names[2];
+    for (i=0; i < 2; i++) {
+        bool result = tpm2_hmac_auth_get_entity_name(sapi, h[i], &names[i]);
+        if (!result) {
+            return false;
+        }
+    }
+
+    if (cb && cb->hmac.update) {
+        bool result = cb->hmac.update(sapi, udata);
+        if (!result) {
+            return false;
+        }
+    }
+
+    return tpm2_hmac_auth_get_command_buffer_hmac(sapi, a, s, names[0], names[1],
+            response_data, optargs);
+}
+
+bool tpm2b_auth_update(TSS2_SYS_CONTEXT *sapi, tpm2_auth *auth, void *udata) {
+
+    unsigned i;
+    for (i=0; i < auth->cnt; i++) {
+        if (auth->hmac_indexes & (1 << i)) {
+            bool result = tpm2b_auth_update_for_hmac(sapi, &auth->cb,
+                    auth->sessions[i], &auth->auth_list.auths[i], udata,
+                    &auth->resp_list.auths[i], (char *)auth->optargs[i]+HMAC_PREFIX_LEN);
+            if (!result) {
+                return false;
+            }
+        }
+    }
+
+    return true;
+}
+
+bool tpm2_auth_util_free(TSS2_SYS_CONTEXT *sapi, tpm2_auth *auth) {
+
+    bool result = true;
+    unsigned i;
+    for (i=0; i < auth->cnt; i++) {
+        tpm2_session *s = auth->sessions[i];
+        if (s) {
+            result &= tpm2_session_close(sapi, s);
+            tpm2_session_free(&s);
+        }
+    }
+
+    return result;
 }

--- a/lib/tpm2_nv_util.h
+++ b/lib/tpm2_nv_util.h
@@ -52,19 +52,23 @@
  * @return
  *  True on success, false otherwise.
  */
-static inline bool tpm2_util_nv_read_public(TSS2_SYS_CONTEXT *sapi_context,
-        TPMI_RH_NV_INDEX nv_index, TPM2B_NV_PUBLIC *nv_public) {
-
-    TPM2B_NAME nv_name = TPM2B_TYPE_INIT(TPM2B_NAME, name);
+static inline bool tpm2_util_nv_read_public2(TSS2_SYS_CONTEXT *sapi_context,
+        TPMI_RH_NV_INDEX nv_index, TPM2B_NV_PUBLIC *nv_public, TPM2B_NAME *nv_name) {
 
     TSS2_RC rval = TSS2_RETRY_EXP(Tss2_Sys_NV_ReadPublic(sapi_context, nv_index, NULL, nv_public,
-            &nv_name, NULL));
+            nv_name, NULL));
     if (rval != TSS2_RC_SUCCESS) {
         LOG_PERR(Tss2_Sys_NV_ReadPublic, rval);
         return false;
     }
 
     return true;
+}
+
+static inline bool tpm2_util_nv_read_public(TSS2_SYS_CONTEXT *sapi_context,
+        TPMI_RH_NV_INDEX nv_index, TPM2B_NV_PUBLIC *nv_public) {
+    TPM2B_NAME nv_name = TPM2B_TYPE_INIT(TPM2B_NAME, name);
+    return tpm2_util_nv_read_public2(sapi_context, nv_index, nv_public, &nv_name);
 }
 
 /**

--- a/lib/tpm2_session.h
+++ b/lib/tpm2_session.h
@@ -57,6 +57,14 @@ typedef struct tpm2_session tpm2_session;
  *  A tpm2_session_data object on success, NULL on failure.
  */
 tpm2_session_data *tpm2_session_data_new(TPM2_SE type);
+void tpm2_session_data_free(tpm2_session_data **d);
+
+// TODO get the sizes known in here.
+void tpm2_session_set_auth_handles(tpm2_session_data *data, TPM2_HANDLE auth_handles[2]);
+const TPM2_HANDLE* tpm2_session_get_auth_handles(tpm2_session *session);
+
+void tpm2_session_update_nonce_older(tpm2_session *session,
+	TPM2B_NONCE *nonce_in_response);
 
 /**
  * Sets the tpmKey parameter.
@@ -143,6 +151,16 @@ TPMI_SH_AUTH_SESSION tpm2_session_get_handle(tpm2_session *session);
 TPM2_SE tpm2_session_get_type(tpm2_session *session);
 
 /**
+ * Retrieves the session nonce when an auth session is started.
+ * The session nonce is used in calculating the session HMAC for authentication
+ * @param data
+ *  The session object to modify.
+ * @return
+ *  The TPM2B_NONCE nonce value.
+ */
+const TPM2B_NONCE *tpm2_session_get_nonce_tpm(tpm2_session *session);
+
+/**
  * True if a session is of type TPM2_SE_TRIAL
  * @param session
  *  The session to check the type of.
@@ -210,6 +228,19 @@ tpm2_session *tpm2_session_restore(const char *path);
  *  true on success, false otherwise.
  */
 bool tpm2_session_restart(TSS2_SYS_CONTEXT *sapi_context, tpm2_session *s);
+
+/**
+ * Closes a session. If the session was started, it is flushed, if the session
+ * was restored from a session context file, it is saved back to that session
+ * context file.
+ * @param sapi_context
+ *  The system apiu context
+ * @param s
+ *  The session to close.
+ * @return
+ *  true on success, false otherwise.
+ */
+bool tpm2_session_close(TSS2_SYS_CONTEXT *sapi_context, tpm2_session *s);
 
 /**
  * Frees a tpm2_sessio but DOES NOT FLUSH the handle. Frees the associated

--- a/man/common/authorizations.md
+++ b/man/common/authorizations.md
@@ -19,6 +19,9 @@ with special prefix values, they are:
 
   * str: - Used to indicate it is a raw string. Useful for escaping a password that starts
          with the "hex:" prefix.
+  * hmac:- Use to indicate, the subsequent string specified be used in calculating
+           the command buffer HMAC to prevent presenting clear text passwords on
+           the TPM interfaces. See CVE-2017-7524 for details.
   * hex: - Used when specifying a password in hex string format.
 
 ## HMAC


### PR DESCRIPTION
Enabling HMAC authentication for the tools using passwords.

Since there are existing issues with tpm2-abrmd regarding session continuation, this feature can only be tested directly with the TPM. This necessitates issue#971.

In order to test.
Setup NV Index  -- tpm2_nvdefine -x 0x1500016 -a 0x40000001 -s 32 -t 0x2020006 -I "hmactest" --tcti=mssim:tcp://127.0.0.1
Setup owner password -- tpm2_changeauth -o test --tcti=mssim:tcp://127.0.0.1

Test#1 - Write with NV Index password
tpm2_nvwrite  -x 0x1500016 -a 0x1500016  -P hmactest test.nv --tcti=mssim:tcp://127.0.0.1

Test#2 - Write with TPM owner password
tpm2_nvwrite  -x 0x1500016 -a 0x40000001  -P test test.nv --tcti=mssim:tcp://127.0.0.1

For PCR Policy Test
tpm2_pcrlist -Q -L sha1:"0,1,2,3" -o pcrs.file
tpm2_createpolicy -Q -P -L sha1:"0,1,2,3" -F pcrs.file -f pcrs.policy
tpm2_nvdefine -Q -x 0x1500016 -a 0x40000001 -s 32 -L pcrs.policy -t "policyread|policywrite"
tpm2_nvwrite -Q -x 0x1500016 -a 0x1500016 -L sha1:"0,1,2,3" -F pcrs.file test.nv
