### PR TITLE
options: use TPM2TOOLS_TCTI as environment variable for configuration

### DIFF
--- a/lib/tpm2_options.c
+++ b/lib/tpm2_options.c
@@ -51,7 +51,7 @@
   #define VERSION "UNKNOWN"
 #endif
 
-#define TPM2TOOLS_ENV_TCTI_NAME      "TPM2TOOLS_TCTI_NAME"
+#define TPM2TOOLS_ENV_TCTI      "TPM2TOOLS_TCTI"
 #define TPM2TOOLS_ENV_ENABLE_ERRATA  "TPM2TOOLS_ENABLE_ERRATA"
 
 tpm2_options *tpm2_options_new(const char *short_opts, size_t len,
@@ -174,7 +174,7 @@ static tcti_conf tcti_get_config(const char *optstr) {
 
     /* no tcti config supplied, get it from env */
     if (!optstr) {
-        optstr = getenv (TPM2TOOLS_ENV_TCTI_NAME);
+        optstr = getenv (TPM2TOOLS_ENV_TCTI);
         if (!optstr) {
             /* nothing user supplied, use default */
             return conf;

--- a/man/common/tcti.md
+++ b/man/common/tcti.md
@@ -7,7 +7,7 @@ mediums.
 To control the TCTI, the tools respect:
 
   1. The command line option **-T** or **--tcti**
-  2. The environment variable: _TPM2TOOLS\_TCTI\_NAME_.
+  2. The environment variable: _TPM2TOOLS\_TCTI_.
 
 **Note:** The command line option always overrides the environment variable.
 
@@ -57,14 +57,14 @@ available:
     the device TCTI can be specified. The default is */dev/tpm0*.
 
     Example: **-T device:/dev/tpm0** or
-    **export _TPM2TOOLS\_TCTI\_NAME_="device:/dev/tpm0"**
+    **export _TPM2TOOLS\_TCTI_="device:/dev/tpm0"**
 
   * **mssim**:
   * For the mssim TCTI, the domain name or IP address and port number used by
     the simulator can be specified. The default are 127.0.0.1 and 2321.
 
     Example: **-T mssim:tcp://127.0.0.1:2321** or
-    **export _TPM2TOOLS\_TCTI\_NAME_="mssim:tcp://127.0.0.1:2321"**
+    **export _TPM2TOOLS\_TCTI_="mssim:tcp://127.0.0.1:2321"**
 
   * **abrmd**:
     For the abrmd TCTI, the configuration string format is a series of simple


### PR DESCRIPTION
The tools used two different environment variables to configure the TCTI:
TPM2TOOLS_TCTI_NAME that was used to set TCTI name and per TCTI variable
that was used to set properties that were specific to a particular TCTI.

For example, the device TCTI used TPM2TOOLS_DEVICE_FILE to choose which
TPM character device is used and so on. Later this was changed to only
need a single variable and both the TCTI name and properties could be
set by separating them using a ':' character.

But the variable name was left as TPM2TOOLS_TCTI_NAME which is kind of
misleading due being formerly use just to configure the TCTI name. So I
think that's better to change the variable name to TPM2TOOLS_TCTI which
is a more generic name and better reflects current variable's semantics.

Signed-off-by: Javier Martinez Canillas <javierm@redhat.com>