### PR TITLE
[RFC] Initial ESAPI Support

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -170,7 +170,6 @@ tools_tpm2_quote_CFLAGS = $(AM_CFLAGS) -DSAPI
 tools_tpm2_changeauth_CFLAGS = $(AM_CFLAGS) -DSAPI
 tools_tpm2_createek_CFLAGS = $(AM_CFLAGS) -DSAPI
 tools_tpm2_createak_CFLAGS = $(AM_CFLAGS) -DSAPI
-tools_tpm2_hash_CFLAGS = $(AM_CFLAGS) -DSAPI
 tools_tpm2_activatecredential_CFLAGS = $(AM_CFLAGS) -DSAPI
 tools_tpm2_makecredential_CFLAGS = $(AM_CFLAGS) -DSAPI
 tools_tpm2_nvlist_CFLAGS = $(AM_CFLAGS) -DSAPI

--- a/Makefile.am
+++ b/Makefile.am
@@ -172,7 +172,6 @@ tools_tpm2_createek_CFLAGS = $(AM_CFLAGS) -DSAPI
 tools_tpm2_createak_CFLAGS = $(AM_CFLAGS) -DSAPI
 tools_tpm2_activatecredential_CFLAGS = $(AM_CFLAGS) -DSAPI
 tools_tpm2_makecredential_CFLAGS = $(AM_CFLAGS) -DSAPI
-tools_tpm2_nvlist_CFLAGS = $(AM_CFLAGS) -DSAPI
 tools_tpm2_nvread_CFLAGS = $(AM_CFLAGS) -DSAPI
 tools_tpm2_nvreadlock_CFLAGS = $(AM_CFLAGS) -DSAPI
 tools_tpm2_nvwrite_CFLAGS = $(AM_CFLAGS) -DSAPI

--- a/Makefile.am
+++ b/Makefile.am
@@ -39,13 +39,13 @@ INCLUDE_DIRS = -I$(top_srcdir)/tools -I$(top_srcdir)/lib
 LIB_COMMON := lib/libcommon.a
 
 AM_CFLAGS := \
-    $(INCLUDE_DIRS) $(EXTRA_CFLAGS) $(TSS2_SYS_CFLAGS) $(CRYPTO_CFLAGS) \
-    $(CODE_COVERAGE_CFLAGS)
+    $(INCLUDE_DIRS) $(EXTRA_CFLAGS) $(TSS2_ESYS_CFLAGS) $(TSS2_SYS_CFLAGS) \
+    $(CRYPTO_CFLAGS) $(CODE_COVERAGE_CFLAGS)
 
 AM_LDFLAGS   := $(EXTRA_LDFLAGS) $(CODE_COVERAGE_LIBS)
 
 LDADD = \
-    $(LIB_COMMON) $(TSS2_SYS_LIBS) $(CRYPTO_LIBS) -ldl
+    $(LIB_COMMON) $(TSS2_ESYS_LIBS) $(TSS2_SYS_LIBS) $(CRYPTO_LIBS) -ldl
 
 # keep me sorted
 bin_PROGRAMS = \
@@ -99,10 +99,13 @@ bin_PROGRAMS = \
 
 noinst_LIBRARIES = $(LIB_COMMON)
 lib_libcommon_a_SOURCES = $(LIB_SRC)
+lib_libcommon_a_CFLAGS = -fPIC $(AM_CFLAGS) -DSAPI
 TOOL_SRC := tools/tpm2_tool.c tools/tpm2_tool.h
 
 tools_aux_tpm2_print_SOURCES = tools/aux/tpm2_print.c $(TOOL_SRC)
 tools_aux_tpm2_rc_decode_SOURCES = tools/aux/tpm2_rc_decode.c $(TOOL_SRC)
+tools_aux_tpm2_print_CFLAGS = $(AM_CFLAGS) -DSAPI
+tools_aux_tpm2_rc_decode_CFLAGS = $(AM_CFLAGS) -DSAPI
 
 tools_tpm2_clear_SOURCES = tools/tpm2_clear.c $(TOOL_SRC)
 tools_tpm2_clearlock_SOURCES = tools/tpm2_clearlock.c $(TOOL_SRC)
@@ -115,7 +118,7 @@ tools_tpm2_load_SOURCES = tools/tpm2_load.c $(TOOL_SRC)
 tools_tpm2_send_SOURCES = tools/tpm2_send.c $(TOOL_SRC)
 tools_tpm2_startup_SOURCES = tools/tpm2_startup.c $(TOOL_SRC)
 tools_tpm2_verifysignature_SOURCES = tools/tpm2_verifysignature.c $(TOOL_SRC)
-tools_tpm2_getmanufec_CFLAG = $(AM_CFLAGS) $(CURL_CFLAGS)
+tools_tpm2_getmanufec_CFLAGS = $(AM_CFLAGS) $(CURL_CFLAGS)
 tools_tpm2_getmanufec_LDADD = $(LDADD) $(CURL_LIBS)
 tools_tpm2_getmanufec_SOURCES = tools/tpm2_getmanufec.c $(TOOL_SRC)
 tools_tpm2_quote_SOURCES = tools/tpm2_quote.c $(TOOL_SRC)
@@ -151,6 +154,51 @@ tools_tpm2_flushcontext_SOURCES = tools/tpm2_flushcontext.c $(TOOL_SRC)
 tools_tpm2_startauthsession_SOURCES = tools/tpm2_startauthsession.c $(TOOL_SRC)
 tools_tpm2_policypcr_SOURCES = tools/tpm2_policypcr.c $(TOOL_SRC)
 tools_tpm2_policyrestart_SOURCES = tools/tpm2_policyrestart.c $(TOOL_SRC)
+
+tools_tpm2_clear_CFLAGS = $(AM_CFLAGS) -DSAPI
+tools_tpm2_clearlock_CFLAGS = $(AM_CFLAGS) -DSAPI
+tools_tpm2_create_CFLAGS = $(AM_CFLAGS) -DSAPI
+tools_tpm2_createprimary_CFLAGS = $(AM_CFLAGS) -DSAPI
+tools_tpm2_getcap_CFLAGS = $(AM_CFLAGS) -DSAPI
+tools_tpm2_listpersistent_CFLAGS = $(AM_CFLAGS) -DSAPI
+tools_tpm2_load_CFLAGS = $(AM_CFLAGS) -DSAPI
+tools_tpm2_send_CFLAGS = $(AM_CFLAGS) -DSAPI
+tools_tpm2_startup_CFLAGS = $(AM_CFLAGS) -DSAPI
+tools_tpm2_verifysignature_CFLAGS = $(AM_CFLAGS) -DSAPI
+tools_tpm2_getmanufec_CFLAGS += -DSAPI
+tools_tpm2_quote_CFLAGS = $(AM_CFLAGS) -DSAPI
+tools_tpm2_changeauth_CFLAGS = $(AM_CFLAGS) -DSAPI
+tools_tpm2_createek_CFLAGS = $(AM_CFLAGS) -DSAPI
+tools_tpm2_createak_CFLAGS = $(AM_CFLAGS) -DSAPI
+tools_tpm2_hash_CFLAGS = $(AM_CFLAGS) -DSAPI
+tools_tpm2_activatecredential_CFLAGS = $(AM_CFLAGS) -DSAPI
+tools_tpm2_makecredential_CFLAGS = $(AM_CFLAGS) -DSAPI
+tools_tpm2_nvlist_CFLAGS = $(AM_CFLAGS) -DSAPI
+tools_tpm2_nvread_CFLAGS = $(AM_CFLAGS) -DSAPI
+tools_tpm2_nvreadlock_CFLAGS = $(AM_CFLAGS) -DSAPI
+tools_tpm2_nvwrite_CFLAGS = $(AM_CFLAGS) -DSAPI
+tools_tpm2_nvdefine_CFLAGS = $(AM_CFLAGS) -DSAPI
+tools_tpm2_nvrelease_CFLAGS = $(AM_CFLAGS) -DSAPI
+tools_tpm2_hmac_CFLAGS = $(AM_CFLAGS) -DSAPI
+tools_tpm2_certify_CFLAGS = $(AM_CFLAGS) -DSAPI
+tools_tpm2_readpublic_CFLAGS = $(AM_CFLAGS) -DSAPI
+tools_tpm2_getrandom_CFLAGS = $(AM_CFLAGS) -DSAPI
+tools_tpm2_encryptdecrypt_CFLAGS = $(AM_CFLAGS) -DSAPI
+tools_tpm2_evictcontrol_CFLAGS = $(AM_CFLAGS) -DSAPI
+tools_tpm2_loadexternal_CFLAGS = $(AM_CFLAGS) -DSAPI
+tools_tpm2_rsadecrypt_CFLAGS = $(AM_CFLAGS) -DSAPI
+tools_tpm2_rsaencrypt_CFLAGS = $(AM_CFLAGS) -DSAPI
+tools_tpm2_sign_CFLAGS = $(AM_CFLAGS) -DSAPI
+tools_tpm2_unseal_CFLAGS = $(AM_CFLAGS) -DSAPI
+tools_tpm2_dictionarylockout_CFLAGS = $(AM_CFLAGS) -DSAPI
+tools_tpm2_createpolicy_CFLAGS = $(AM_CFLAGS) -DSAPI
+tools_tpm2_pcrextend_CFLAGS = $(AM_CFLAGS) -DSAPI
+tools_tpm2_pcrevent_CFLAGS = $(AM_CFLAGS) -DSAPI
+tools_tpm2_import_CFLAGS = $(AM_CFLAGS) -DSAPI
+tools_tpm2_flushcontext_CFLAGS = $(AM_CFLAGS) -DSAPI
+tools_tpm2_startauthsession_CFLAGS = $(AM_CFLAGS) -DSAPI
+tools_tpm2_policypcr_CFLAGS = $(AM_CFLAGS) -DSAPI
+tools_tpm2_policyrestart_CFLAGS = $(AM_CFLAGS) -DSAPI
 
 if UNIT
 TESTS = $(check_PROGRAMS)
@@ -199,7 +247,7 @@ test_unit_test_tpm2_auth_util_LDADD    = $(CMOCKA_LIBS) $(LIB_COMMON) $(LDADD)
 test_unit_test_tpm2_auth_util_SOURCES  = test/unit/test_tpm2_auth_util.c
 
 test_unit_test_tpm2_errata_CFLAGS   = $(AM_CFLAGS) $(CMOCKA_CFLAGS)
-test_unit_test_tpm2_errata_LDFLAGS  = -Wl,--wrap=Tss2_Sys_GetCapability
+test_unit_test_tpm2_errata_LDFLAGS  = -Wl,--wrap=Esys_GetCapability
 test_unit_test_tpm2_errata_LDADD    = $(CMOCKA_LIBS) $(LIB_COMMON) $(LDADD)
 test_unit_test_tpm2_errata_SOURCES  = test/unit/test_tpm2_errata.c
 

--- a/Makefile.am
+++ b/Makefile.am
@@ -182,7 +182,6 @@ tools_tpm2_nvrelease_CFLAGS = $(AM_CFLAGS) -DSAPI
 tools_tpm2_hmac_CFLAGS = $(AM_CFLAGS) -DSAPI
 tools_tpm2_certify_CFLAGS = $(AM_CFLAGS) -DSAPI
 tools_tpm2_readpublic_CFLAGS = $(AM_CFLAGS) -DSAPI
-tools_tpm2_getrandom_CFLAGS = $(AM_CFLAGS) -DSAPI
 tools_tpm2_encryptdecrypt_CFLAGS = $(AM_CFLAGS) -DSAPI
 tools_tpm2_evictcontrol_CFLAGS = $(AM_CFLAGS) -DSAPI
 tools_tpm2_loadexternal_CFLAGS = $(AM_CFLAGS) -DSAPI

--- a/Makefile.am
+++ b/Makefile.am
@@ -162,7 +162,6 @@ tools_tpm2_createprimary_CFLAGS = $(AM_CFLAGS) -DSAPI
 tools_tpm2_getcap_CFLAGS = $(AM_CFLAGS) -DSAPI
 tools_tpm2_listpersistent_CFLAGS = $(AM_CFLAGS) -DSAPI
 tools_tpm2_load_CFLAGS = $(AM_CFLAGS) -DSAPI
-tools_tpm2_startup_CFLAGS = $(AM_CFLAGS) -DSAPI
 tools_tpm2_verifysignature_CFLAGS = $(AM_CFLAGS) -DSAPI
 tools_tpm2_getmanufec_CFLAGS += -DSAPI
 tools_tpm2_quote_CFLAGS = $(AM_CFLAGS) -DSAPI

--- a/Makefile.am
+++ b/Makefile.am
@@ -162,7 +162,6 @@ tools_tpm2_createprimary_CFLAGS = $(AM_CFLAGS) -DSAPI
 tools_tpm2_getcap_CFLAGS = $(AM_CFLAGS) -DSAPI
 tools_tpm2_listpersistent_CFLAGS = $(AM_CFLAGS) -DSAPI
 tools_tpm2_load_CFLAGS = $(AM_CFLAGS) -DSAPI
-tools_tpm2_send_CFLAGS = $(AM_CFLAGS) -DSAPI
 tools_tpm2_startup_CFLAGS = $(AM_CFLAGS) -DSAPI
 tools_tpm2_verifysignature_CFLAGS = $(AM_CFLAGS) -DSAPI
 tools_tpm2_getmanufec_CFLAGS += -DSAPI

--- a/configure.ac
+++ b/configure.ac
@@ -15,6 +15,7 @@ AS_IF(
     [],
     [AC_MSG_WARN([Required executable pandoc not found, man pages will not be built])])
 AM_CONDITIONAL([HAVE_PANDOC],[test "x${PANDOC}" = "xyes"])
+PKG_CHECK_MODULES([TSS2_ESYS],[tss2-esys])
 PKG_CHECK_MODULES([TSS2_SYS],[tss2-sys])
 PKG_CHECK_MODULES([CRYPTO], [libcrypto >= 1.0.2g])
 PKG_CHECK_MODULES([CURL],[libcurl])

--- a/lib/tpm2_errata.h
+++ b/lib/tpm2_errata.h
@@ -31,6 +31,7 @@
 #ifndef TPM2_ERRATA_H
 #define TPM2_ERRATA_H
 
+#include <tss2/tss2_esys.h>
 #include <tss2/tss2_sys.h>
 #include <stdbool.h>
 
@@ -49,10 +50,11 @@ typedef enum {
 /**
  * Initialize errata subsystem
  *
- * @param sapi_ctx
- *  SAPI context to be queried.
+ * @param ctx
+ *  ESAPI context to be queried.
  */
-void tpm2_errata_init(TSS2_SYS_CONTEXT *sapi_ctx);
+void tpm2_errata_init(ESYS_CONTEXT *ctx);
+void tpm2_errata_init_sapi(TSS2_SYS_CONTEXT *sapi_ctx);
 
 /**
  * Request an errata correction for a specific errata version.

--- a/lib/tpm2_hash.h
+++ b/lib/tpm2_hash.h
@@ -34,11 +34,12 @@
 #include <stdbool.h>
 
 #include <tss2/tss2_sys.h>
+#include <tss2/tss2_esys.h>
 
 /**
  * Hashes a BYTE array via the tpm.
- * @param sapi_context
- *  The system api context.
+ * @param context
+ *  The esapi context.
  * @param hash_alg
  *  The hashing algorithm to use.
  * @param hierarchy
@@ -55,14 +56,18 @@
  * @return
  *  True on success, false otherwise.
  */
-bool tpm2_hash_compute_data(TSS2_SYS_CONTEXT *sapi_context, TPMI_ALG_HASH halg,
+bool tpm2_hash_compute_data(ESYS_CONTEXT *context, TPMI_ALG_HASH halg,
+        TPMI_RH_HIERARCHY hierarchy, BYTE *buffer, UINT16 length,
+        TPM2B_DIGEST **result, TPMT_TK_HASHCHECK **validation);
+
+bool tpm2_hash_compute_data_sapi(TSS2_SYS_CONTEXT *context, TPMI_ALG_HASH halg,
         TPMI_RH_HIERARCHY hierarchy, BYTE *buffer, UINT16 length,
         TPM2B_DIGEST *result, TPMT_TK_HASHCHECK *validation);
 
 /**
  * Hashes a FILE * object via the tpm.
- * @param sapi_context
- *  The system api context.
+ * @param context
+ *  The esapi context.
  * @param hash_alg
  *  The hashing algorithm to use.
  * @param hierarchy
@@ -77,7 +82,11 @@ bool tpm2_hash_compute_data(TSS2_SYS_CONTEXT *sapi_context, TPMI_ALG_HASH halg,
  * @return
  *  True on success, false otherwise.
  */
-bool tpm2_hash_file(TSS2_SYS_CONTEXT *sapi_context, TPMI_ALG_HASH halg,
+bool tpm2_hash_file(ESYS_CONTEXT *context, TPMI_ALG_HASH halg,
+        TPMI_RH_HIERARCHY hierarchy, FILE *input, TPM2B_DIGEST **result,
+        TPMT_TK_HASHCHECK **validation);
+
+bool tpm2_hash_file_sapi(TSS2_SYS_CONTEXT *context, TPMI_ALG_HASH halg,
         TPMI_RH_HIERARCHY hierarchy, FILE *input, TPM2B_DIGEST *result,
         TPMT_TK_HASHCHECK *validation);
 

--- a/lib/tpm2_nv_util.h
+++ b/lib/tpm2_nv_util.h
@@ -31,6 +31,7 @@
 #ifndef LIB_TPM2_NV_UTIL_H_
 #define LIB_TPM2_NV_UTIL_H_
 
+#include <tss2/tss2_esys.h>
 #include <tss2/tss2_sys.h>
 
 #include "log.h"
@@ -38,8 +39,8 @@
 
 /**
  * Reads the public portion of a Non-Volatile (nv) index.
- * @param sapi_context
- *  The system API context.
+ * @param context
+ *  The ESAPI context.
  * @param nv_index
  *  The index to read.
  * @param nv_public
@@ -47,7 +48,38 @@
  * @return
  *  True on success, false otherwise.
  */
-static inline bool tpm2_util_nv_read_public(TSS2_SYS_CONTEXT *sapi_context,
+static inline bool tpm2_util_nv_read_public(ESYS_CONTEXT *context,
+        TPMI_RH_NV_INDEX nv_index, TPM2B_NV_PUBLIC **nv_public) {
+
+    TSS2_RC rval;
+    ESYS_TR tr_object;
+
+    rval = Esys_TR_FromTPMPublic(context, nv_index,
+                                 ESYS_TR_NONE, ESYS_TR_NONE, ESYS_TR_NONE,
+                                 &tr_object);
+    if (rval != TSS2_RC_SUCCESS) {
+        LOG_PERR(Esys_TR_FromTPMPublic, rval);
+        return false;
+    }
+
+    rval = Esys_NV_ReadPublic(context, tr_object,
+                              ESYS_TR_NONE, ESYS_TR_NONE, ESYS_TR_NONE, 
+                              nv_public, NULL);
+    if (rval != TSS2_RC_SUCCESS) {
+        LOG_PERR(Esys_NV_ReadPublic, rval);
+        return false;
+    }
+
+    rval = Esys_TR_Close(context, &tr_object);
+    if (rval != TSS2_RC_SUCCESS) {
+        LOG_PERR(Esys_NV_ReadPublic, rval);
+        return false;
+    }
+
+    return true;
+}
+
+static inline bool tpm2_util_nv_read_public_sapi(TSS2_SYS_CONTEXT *sapi_context,
         TPMI_RH_NV_INDEX nv_index, TPM2B_NV_PUBLIC *nv_public) {
 
     TPM2B_NAME nv_name = TPM2B_TYPE_INIT(TPM2B_NAME, name);

--- a/tools/tpm2_hash.c
+++ b/tools/tpm2_hash.c
@@ -61,45 +61,53 @@ static tpm_hash_ctx ctx = {
     .halg = TPM2_ALG_SHA1,
 };
 
-static bool hash_and_save(TSS2_SYS_CONTEXT *sapi_context) {
+static bool hash_and_save(ESYS_CONTEXT *context) {
 
-    TPM2B_DIGEST outHash = TPM2B_TYPE_INIT(TPM2B_DIGEST, buffer);
-    TPMT_TK_HASHCHECK validation;
+    TPM2B_DIGEST *outHash;
+    TPMT_TK_HASHCHECK *validation;
 
-    bool res = tpm2_hash_file(sapi_context, ctx.halg, ctx.hierarchyValue, ctx.input_file, &outHash, &validation);
+    bool res = tpm2_hash_file(context, ctx.halg, ctx.hierarchyValue,
+                              ctx.input_file, &outHash, &validation);
     if (!res) {
         return false;
     }
 
-    if (outHash.size) {
+    if (outHash->size) {
         UINT16 i;
         tpm2_tool_output("%s: ", tpm2_alg_util_algtostr(ctx.halg));
-        for (i = 0; i < outHash.size; i++) {
-            tpm2_tool_output("%02x", outHash.buffer[i]);
+        for (i = 0; i < outHash->size; i++) {
+            tpm2_tool_output("%02x", outHash->buffer[i]);
         }
         tpm2_tool_output("\n");
     }
 
-    if (validation.digest.size) {
+    if (validation->digest.size) {
         UINT16 i;
         tpm2_tool_output("ticket:");
-        for (i = 0; i < validation.digest.size; i++) {
-            tpm2_tool_output("%02x", validation.digest.buffer[i]);
+        for (i = 0; i < validation->digest.size; i++) {
+            tpm2_tool_output("%02x", validation->digest.buffer[i]);
         }
         tpm2_tool_output("\n");
     }
 
     if (ctx.outHashFilePath) {
-        bool result = files_save_bytes_to_file(ctx.outHashFilePath, outHash.buffer,
-                outHash.size);
+        bool result = files_save_bytes_to_file(ctx.outHashFilePath,
+                                               &outHash->buffer[0],
+                                               outHash->size);
         if (!result) {
             return false;
         }
     }
 
     if (ctx.outTicketFilePath) {
-        return files_save_validation(&validation, ctx.outTicketFilePath);
+        bool result = files_save_validation(validation, ctx.outTicketFilePath);
+        if (!result) {
+            return false;
+        }
     }
+
+    free(outHash);
+    free(validation);
 
     return true;
 }
@@ -167,13 +175,13 @@ bool tpm2_tool_onstart(tpm2_options **opts) {
     return *opts != NULL;
 }
 
-int tpm2_tool_onrun(TSS2_SYS_CONTEXT *sapi_context, tpm2_option_flags flags) {
+int tpm2_tool_onrun(ESYS_CONTEXT *context, tpm2_option_flags flags) {
 
     UNUSED(flags);
 
     int rc = 1;
 
-    bool res = hash_and_save(sapi_context);
+    bool res = hash_and_save(context);
     if (!res) {
         goto out;
     }

--- a/tools/tpm2_nvread.c
+++ b/tools/tpm2_nvread.c
@@ -80,7 +80,7 @@ static bool nv_read(TSS2_SYS_CONTEXT *sapi_context, tpm2_option_flags flags) {
     TSS2L_SYS_AUTH_COMMAND sessions_data = { 1, { ctx.auth.session_data }};
 
     TPM2B_NV_PUBLIC nv_public = TPM2B_EMPTY_INIT;
-    bool res = tpm2_util_nv_read_public(sapi_context, ctx.nv_index, &nv_public);
+    bool res = tpm2_util_nv_read_public_sapi(sapi_context, ctx.nv_index, &nv_public);
     if (!res) {
         LOG_ERR("Failed to read NVRAM public area at index 0x%X",
                 ctx.nv_index);

--- a/tools/tpm2_nvwrite.c
+++ b/tools/tpm2_nvwrite.c
@@ -95,7 +95,7 @@ static bool nv_write(TSS2_SYS_CONTEXT *sapi_context) {
      * from being partially written to the index.
      */
     TPM2B_NV_PUBLIC nv_public = TPM2B_EMPTY_INIT;
-    bool res = tpm2_util_nv_read_public(sapi_context, ctx.nv_index, &nv_public);
+    bool res = tpm2_util_nv_read_public_sapi(sapi_context, ctx.nv_index, &nv_public);
     if (!res) {
         LOG_ERR("Failed to write NVRAM public area at index 0x%X",
                 ctx.nv_index);

--- a/tools/tpm2_pcrlist.c
+++ b/tools/tpm2_pcrlist.c
@@ -1,5 +1,6 @@
 //**********************************************************************;
 // Copyright (c) 2015, Intel Corporation
+// Copyright (c) 2018, Fraunhofer SIT
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without
@@ -35,7 +36,7 @@
 #include <stdio.h>
 #include <string.h>
 
-#include <tss2/tss2_sys.h>
+#include <tss2/tss2_esys.h>
 
 #include "tpm2_options.h"
 #include "log.h"
@@ -125,10 +126,10 @@ static bool unset_pcr_sections(TPML_PCR_SELECTION *s) {
     return true;
 }
 
-static bool read_pcr_values(TSS2_SYS_CONTEXT *sapi_context) {
+static bool read_pcr_values(ESYS_CONTEXT *esys_context) {
 
     TPML_PCR_SELECTION pcr_selection_tmp;
-    TPML_PCR_SELECTION pcr_selection_out;
+    TPML_PCR_SELECTION *pcr_selection_out;
     UINT32 pcr_update_counter;
 
     //1. prepare pcrSelectionIn with g_pcrSelections
@@ -137,17 +138,24 @@ static bool read_pcr_values(TSS2_SYS_CONTEXT *sapi_context) {
     //2. call pcr_read
     ctx.pcrs.count = 0;
     do {
-        UINT32 rval = TSS2_RETRY_EXP(Tss2_Sys_PCR_Read(sapi_context, no_argument, &pcr_selection_tmp,
-                &pcr_update_counter, &pcr_selection_out,
-                &ctx.pcrs.pcr_values[ctx.pcrs.count], 0));
+        TPML_DIGEST *v;
+        UINT32 rval = Esys_PCR_Read(esys_context, ESYS_TR_NONE, ESYS_TR_NONE,
+                ESYS_TR_NONE, &pcr_selection_tmp,
+                &pcr_update_counter, &pcr_selection_out, &v);
 
         if (rval != TPM2_RC_SUCCESS) {
-            LOG_PERR(Tss2_Sys_PCR_Read, rval);
+            LOG_PERR(Esys_PCR_Read, rval);
             return -1;
         }
 
+        ctx.pcrs.pcr_values[ctx.pcrs.count] = *v;
+
+        free(v);
+
         //3. unmask pcrSelectionOut bits from pcrSelectionIn
-        update_pcr_selections(&pcr_selection_tmp, &pcr_selection_out);
+        update_pcr_selections(&pcr_selection_tmp, pcr_selection_out);
+
+        free(pcr_selection_out);
 
         //4. goto step 2 if pcrSelctionIn still has bits set
     } while (++ctx.pcrs.count < 24 && !unset_pcr_sections(&pcr_selection_tmp));
@@ -294,12 +302,12 @@ static bool show_pcr_values(void) {
     return true;
 }
 
-static bool show_selected_pcr_values(TSS2_SYS_CONTEXT *sapi_context, bool check) {
+static bool show_selected_pcr_values(ESYS_CONTEXT *esys_context, bool check) {
 
     if (check && !check_pcr_selection())
         return false;
 
-    if (!read_pcr_values(sapi_context))
+    if (!read_pcr_values(esys_context))
         return false;
 
     if (!show_pcr_values())
@@ -308,34 +316,37 @@ static bool show_selected_pcr_values(TSS2_SYS_CONTEXT *sapi_context, bool check)
     return true;
 }
 
-static bool show_all_pcr_values(TSS2_SYS_CONTEXT *sapi_context) {
+static bool show_all_pcr_values(ESYS_CONTEXT *esys_context) {
 
     if (!init_pcr_selection())
         return false;
 
-    return show_selected_pcr_values(sapi_context, false);
+    return show_selected_pcr_values(esys_context, false);
 }
 
-static bool show_alg_pcr_values(TSS2_SYS_CONTEXT *sapi_context) {
+static bool show_alg_pcr_values(ESYS_CONTEXT *esys_context) {
 
     if (!init_pcr_selection())
         return false;
 
-    return show_selected_pcr_values(sapi_context, false);
+    return show_selected_pcr_values(esys_context, false);
 }
 
-static bool get_banks(TSS2_SYS_CONTEXT *sapi_context) {
+static bool get_banks(ESYS_CONTEXT *esys_context) {
 
     TPMI_YES_NO more_data;
-    TPMS_CAPABILITY_DATA *capability_data = &ctx.cap_data;
+    TPMS_CAPABILITY_DATA *capability_data;
     UINT32 rval;
 
-    rval = TSS2_RETRY_EXP(Tss2_Sys_GetCapability(sapi_context, no_argument, TPM2_CAP_PCRS, no_argument, required_argument,
-            &more_data, capability_data, 0));
+    rval = Esys_GetCapability(esys_context, ESYS_TR_NONE, ESYS_TR_NONE,
+            ESYS_TR_NONE, TPM2_CAP_PCRS, no_argument, required_argument,
+            &more_data, &capability_data);
     if (rval != TPM2_RC_SUCCESS) {
-        LOG_PERR(Tss2_Sys_GetCapability, rval);
+        LOG_PERR(Esys_GetCapability, rval);
         return false;
     }
+
+    ctx.cap_data = *capability_data;
 
     unsigned i;
     for (i = 0; i < capability_data->data.assignedPCR.count; i++) {
@@ -344,6 +355,7 @@ static bool get_banks(TSS2_SYS_CONTEXT *sapi_context) {
     }
     ctx.algs.count = capability_data->data.assignedPCR.count;
 
+    free(capability_data);
     return true;
 }
 
@@ -405,7 +417,7 @@ bool tpm2_tool_onstart(tpm2_options **opts) {
     return *opts != NULL;
 }
 
-int tpm2_tool_onrun(TSS2_SYS_CONTEXT *sapi_context, tpm2_option_flags flags) {
+int tpm2_tool_onrun(ESYS_CONTEXT *esys_context, tpm2_option_flags flags) {
 
     UNUSED(flags);
 
@@ -430,7 +442,7 @@ int tpm2_tool_onrun(TSS2_SYS_CONTEXT *sapi_context, tpm2_option_flags flags) {
         }
     }
 
-    success = get_banks(sapi_context);
+    success = get_banks(esys_context);
     if (!success) {
         goto error;
     }
@@ -438,11 +450,11 @@ int tpm2_tool_onrun(TSS2_SYS_CONTEXT *sapi_context, tpm2_option_flags flags) {
     if (ctx.flags.s) {
         show_banks(&ctx.algs);
     } else if (ctx.flags.g) {
-        success = show_alg_pcr_values(sapi_context);
+        success = show_alg_pcr_values(esys_context);
     } else if (ctx.flags.L) {
-        success = show_selected_pcr_values(sapi_context, true);
+        success = show_selected_pcr_values(esys_context, true);
     } else {
-        success = show_all_pcr_values(sapi_context);
+        success = show_all_pcr_values(esys_context);
     }
 
 error:

--- a/tools/tpm2_send.c
+++ b/tools/tpm2_send.c
@@ -172,7 +172,7 @@ bool tpm2_tool_onstart(tpm2_options **opts) {
  * in network byte order (big-endian). We output the response in the same
  * form.
  */
-int tpm2_tool_onrun(TSS2_SYS_CONTEXT *sapi_context, tpm2_option_flags flags) {
+int tpm2_tool_onrun(ESYS_CONTEXT *context, tpm2_option_flags flags) {
 
     UNUSED(flags);
 
@@ -187,9 +187,9 @@ int tpm2_tool_onrun(TSS2_SYS_CONTEXT *sapi_context, tpm2_option_flags flags) {
     }
 
     TSS2_TCTI_CONTEXT *tcti_context;
-    TSS2_RC rval = Tss2_Sys_GetTctiContext(sapi_context, &tcti_context);
+    TSS2_RC rval = Esys_GetTcti(context, &tcti_context);
     if (rval != TPM2_RC_SUCCESS) {
-        LOG_PERR(Tss2_Sys_GetTctiContext, rval);
+        LOG_PERR(Esys_GetTctiContext, rval);
         goto out;
     }
 

--- a/tools/tpm2_sign.c
+++ b/tools/tpm2_sign.c
@@ -93,7 +93,7 @@ static bool sign_and_save(TSS2_SYS_CONTEXT *sapi_context) {
     TSS2L_SYS_AUTH_RESPONSE sessions_data_out;
 
     if (!ctx.flags.D) {
-      bool res = tpm2_hash_compute_data(sapi_context, ctx.halg, TPM2_RH_NULL,
+      bool res = tpm2_hash_compute_data_sapi(sapi_context, ctx.halg, TPM2_RH_NULL,
               ctx.msg, ctx.length, &ctx.digest, NULL);
       if (!res) {
           LOG_ERR("Compute message hash failed!");

--- a/tools/tpm2_startup.c
+++ b/tools/tpm2_startup.c
@@ -76,7 +76,7 @@ bool tpm2_tool_onstart(tpm2_options **opts) {
     return *opts != NULL;
 }
 
-int tpm2_tool_onrun(TSS2_SYS_CONTEXT *sapi_context, tpm2_option_flags flags) {
+int tpm2_tool_onrun(ESYS_CONTEXT *context, tpm2_option_flags flags) {
 
     UNUSED(flags);
 
@@ -85,9 +85,9 @@ int tpm2_tool_onrun(TSS2_SYS_CONTEXT *sapi_context, tpm2_option_flags flags) {
     LOG_INFO ("Sending TPM_Startup command with type: %s",
             ctx.clear ? "TPM2_SU_CLEAR" : "TPM2_SU_STATE");
 
-    TSS2_RC rval = TSS2_RETRY_EXP(Tss2_Sys_Startup (sapi_context, startup_type));
+    TSS2_RC rval = Esys_Startup (context, startup_type);
     if (rval != TPM2_RC_SUCCESS && rval != TPM2_RC_INITIALIZE) {
-        LOG_PERR(Tss2_Sys_Startup, rval);
+        LOG_PERR(Esys_Startup, rval);
         return 1;
     }
 

--- a/tools/tpm2_tool.h
+++ b/tools/tpm2_tool.h
@@ -31,7 +31,14 @@
 #ifndef MAIN_H
 #define MAIN_H
 
+#ifdef SAPI
+#define THE_CONTEXT() TSS2_SYS_CONTEXT
 #include <tss2/tss2_sys.h>
+#else
+#define THE_CONTEXT() ESYS_CONTEXT
+#include <tss2/tss2_esys.h>
+#endif
+
 #include <stdbool.h>
 
 #include "tpm2_options.h"
@@ -52,16 +59,16 @@ extern bool output_enabled;
 bool tpm2_tool_onstart(tpm2_options **opts) __attribute__((weak));
 
 /**
- * This is the main interface for tools, after tcti and sapi initialization
+ * This is the main interface for tools, after tcti and sapi/esapi initialization
  * are performed.
- * @param sapi_context
- *  The system api context.
+ * @param context
+ *  The system/esapi api context.
  * @param flags
  *  Flags that tools may wish to respect.
  * @return
  *  0 on success.
  */
-int tpm2_tool_onrun (TSS2_SYS_CONTEXT *sapi_context, tpm2_option_flags flags) __attribute__((weak));
+int tpm2_tool_onrun (THE_CONTEXT() *context, tpm2_option_flags flags) __attribute__((weak));
 
 /**
  * Called when the tool is exiting, useful for cleanup.

--- a/tools/tpm2_verifysignature.c
+++ b/tools/tpm2_verifysignature.c
@@ -177,7 +177,7 @@ static bool init(TSS2_SYS_CONTEXT *sapi_context) {
             LOG_ERR("No digest set and no message file to compute from, cannot compute message hash!");
             goto err;
         }
-        bool res = tpm2_hash_compute_data(sapi_context, ctx.halg,
+        bool res = tpm2_hash_compute_data_sapi(sapi_context, ctx.halg,
                 TPM2_RH_NULL, msg->buffer, msg->size, &ctx.msgHash, NULL);
         if (!res) {
             LOG_ERR("Compute message hash failed!");


### PR DESCRIPTION
This patch introduces the step-by-step transition to ESAPI into the tools.
It introduces the basic recurring infrastructure in main.c and moves the
first command tpm2_pcrlist over to esapi.

Please let me know what to change...

For the future, I guess the handling of data formats for session and transient objects will be the biggest obstacles... Please let me know, if we want to make them big one-step changes...