### PR TITLE
tests/docker: shallow clone git repos

### DIFF
--- a/.ci/download-deps.sh
+++ b/.ci/download-deps.sh
@@ -36,7 +36,7 @@ function get_deps() {
 	echo "pwd starting: `pwd`"
 	pushd "$1"
 	echo "pwd clone tss: `pwd`"
-	git clone https://github.com/tpm2-software/tpm2-tss.git
+	git clone --depth=1 https://github.com/tpm2-software/tpm2-tss.git
 	pushd tpm2-tss
 	echo "pwd build tss: `pwd`"
 	./bootstrap
@@ -47,7 +47,7 @@ function get_deps() {
 	echo "pwd done tss: `pwd`"
 
 	echo "pwd clone abrmd: `pwd`"
-	git clone https://github.com/tpm2-software/tpm2-abrmd.git
+	git clone --depth=1 https://github.com/tpm2-software/tpm2-abrmd.git
 	pushd tpm2-abrmd
 	echo "pwd build abrmd: `pwd`"
 	./bootstrap


### PR DESCRIPTION
In order to speed up the process, use shallow clones of the dependency
git repositories tpm2-tss and tpm2-abrmd instead of full history clones.

Signed-off-by: Andreas Fuchs <andreas.fuchs@sit.fraunhofer.de>