### PR TITLE
Tests: Show test-suit.log in docker

### DIFF
--- a/.ci/docker.run
+++ b/.ci/docker.run
@@ -139,6 +139,11 @@ pushd ./build
 make -j$(nproc)
 make -j$(nproc) check
 
+if [ -f test-suit.log ]; then
+    echo "test-suit.log:"
+    cat test-suit-log
+fi
+
 popd
 
 # Switch over to the test directory


### PR DESCRIPTION
If the unit tests fail, print out the content of test-suit.log.
This allows developers to directly see the output of the tools
and hopefully speed up debugging.