### PR TITLE
Fix Bugs Found by Clang Scan-build Static Code Analyzer

### DIFF
--- a/lib/tpm2_alg_util.c
+++ b/lib/tpm2_alg_util.c
@@ -347,6 +347,11 @@ UINT8* tpm2_extract_plain_signature(UINT16 *size, TPMT_SIGNATURE *signature) {
     case TPM2_ALG_HMAC: {
         TPMU_HA *hmac_sig = &(signature->signature.hmac.digest);
         *size = tpm2_alg_util_get_hash_size(signature->signature.hmac.hashAlg);
+        if (*size == 0) {
+            LOG_ERR("Hash algorithm %d has 0 size",
+                signature->signature.hmac.hashAlg);
+            goto nomem;
+        }
         buffer = malloc(*size);
         if (!buffer) {
             goto nomem;


### PR DESCRIPTION
Fix warnings about a memory leak in an error condition, 0-sized memcpy(),
0-size malloc(), and malloc() size not matching type.

Fixes #983.

Signed-off-by: Dan Anderson <daniel.anderson@intel.com>