### PR TITLE
test: Fix scan-build Warnings

### DIFF
--- a/test/unit/test_files.c
+++ b/test/unit/test_files.c
@@ -136,6 +136,7 @@ static void test_file_read_write_bytes(void **state) {
 
     UINT8 found[1024] = { 0 };
     res = files_read_bytes(f, found, sizeof(found));
+    assert_true(res);
 
     assert_memory_equal(expected, found, sizeof(found));
 }

--- a/test/unit/test_tpm2_session.c
+++ b/test/unit/test_tpm2_session.c
@@ -62,13 +62,14 @@ struct expected_data {
         TPM2_RC rc;
     } output;
 };
+static expected_data *e; /* XXX: Test kludge to quiet scan-build mem leak */
 
 static inline void set_expected(TPMI_DH_OBJECT key, TPMI_DH_ENTITY bind,
         TPM2B_ENCRYPTED_SECRET *encrypted_salt, TPM2_SE session_type,
         TPMT_SYM_DEF *symmetric, TPMI_ALG_HASH auth_hash,
         TPM2B_NONCE *nonce_caller, TPMI_SH_AUTH_SESSION handle, TPM2_RC rc) {
 
-    expected_data *e = calloc(1, sizeof(*e));
+    e = calloc(1, sizeof(*e));
     assert_non_null(e);
 
     e->input.key = key;


### PR DESCRIPTION
Fix scan-build warnings about a memory leak and a variable set but not used
that causes the compilation to fail.

Fixes #996.

Signed-off-by: Dan Anderson <daniel.anderson@intel.com>