### PR TITLE
configure: fix unit test check

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -46,7 +46,7 @@ AC_DEFUN([unit_test_checks],[
         [])
 ])
 
-AS_IF([test "$unit" != "no"],
+AS_IF([test "x$enable_unit" != xno],
        [unit_test_checks],
        [])
 


### PR DESCRIPTION
configure was attempting to configure for unit tests
when the option was NOT being passed. Fix this by
correcting the check on the option.

Fixes: #995

Signed-off-by: William Roberts <william.c.roberts@intel.com>