### PR TITLE
tpm2_nv(read|write): use a default buffer size if TPM reports 0.

### DIFF
--- a/tools/tpm2_nvread.c
+++ b/tools/tpm2_nvread.c
@@ -123,6 +123,9 @@ static bool nv_read(TSS2_SYS_CONTEXT *sapi_context, tpm2_option_flags flags) {
     if (max_data_size > MAX_NV_BUFFER_SIZE) {
         max_data_size = MAX_NV_BUFFER_SIZE;
     }
+    if (max_data_size == 0) {
+        max_data_size = MAX_NV_BUFFER_SIZE;
+    }
 
     UINT8 *data_buffer = malloc(data_size);
     if (!data_buffer) {

--- a/tools/tpm2_nvwrite.c
+++ b/tools/tpm2_nvwrite.c
@@ -119,6 +119,9 @@ static bool nv_write(TSS2_SYS_CONTEXT *sapi_context) {
     if (max_data_size > MAX_NV_BUFFER_SIZE) {
         max_data_size = MAX_NV_BUFFER_SIZE;
     }
+    if (max_data_size == 0) {
+        max_data_size = MAX_NV_BUFFER_SIZE;
+    }
 
     UINT16 data_offset = 0;
     UINT16 bytes_left = ctx.nv_buffer.t.size;


### PR DESCRIPTION
On a NUC5i7RYH, the TPM reports it's max NV buffer size as 0, which
means we can neither read nor write. In this case, default to
MAX_NV_BUFFER_SIZE.