### PR TITLE
progress on "object" class options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## Changelog
 ### next
+  * tpm2_activatecredential: Option `--Password` changes to `--auth-key`.
   * system tests are now run with make check when --enable-unit is used in configure.
   * tpm2_unseal: Option `--pwdk` changes to `--auth-key`.
   * tpm2_sign: Option `--pwdk` changes to `--auth-key`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## Changelog
 ### next
+  * tpm2_verifysignature: Option `-r` and `--raw` have been removed. This were unused within the tool.
   * tpm2_hmac: Option `--algorithm` changes to `--halg`, which is in line with the manpage.
   * tpm2_makecredential: Option `--sec` changes to `--secret`.
   * tpm2_activatecredential: Option `--Password` changes to `--auth-key`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## Changelog
 ### next
+  * tpm2_pcrlist: Option `--algorithm` changes to `--halg`, which is in line with other tools.
   * tpm2_verifysignature: Option `-r` and `--raw` have been removed. This were unused within the tool.
   * tpm2_hmac: Option `--algorithm` changes to `--halg`, which is in line with the manpage.
   * tpm2_makecredential: Option `--sec` changes to `--secret`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## Changelog
 ### next
+  * tpm2_makecredential: Option `--sec` changes to `--secret`.
   * tpm2_activatecredential: Option `--Password` changes to `--auth-key`.
   * system tests are now run with make check when --enable-unit is used in configure.
   * tpm2_unseal: Option `--pwdk` changes to `--auth-key`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## Changelog
 ### next
+  * tpm2_hmac: Option `--algorithm` changes to `--halg`, which is in line with the manpage.
   * tpm2_makecredential: Option `--sec` changes to `--secret`.
   * tpm2_activatecredential: Option `--Password` changes to `--auth-key`.
   * system tests are now run with make check when --enable-unit is used in configure.

--- a/man/tpm2_activatecredential.1.md
+++ b/man/tpm2_activatecredential.1.md
@@ -31,8 +31,8 @@ These options control the object verification:
   * **-C**, **--key-context**=_KEY\_CONTEXT\_FILE_:
     _KEY\_CONTEXT\_FILE_ is the path to a context file.
 
-  * **-P**, **--password**=_PASSWORD_:
-    Use _PASSWORD_ for providing an authorization value for the _KEY\_HANDLE_.
+  * **-P**, **--auth-key**=_AUTH\_VALUE_:
+    Use _AUTH\_VALUE_ for providing an authorization value for the _KEY\_HANDLE_.
     Passwords should follow the authorization formatting standards, see section
     "Authorization Formatting".
 

--- a/man/tpm2_makecredential.1.md
+++ b/man/tpm2_makecredential.1.md
@@ -21,7 +21,7 @@ to encrypt the AK certififcate.
   * **-e**, **--enckey**=_PUBLIC\_FILE_:
     A tpm Public Key which was used to wrap the seed.
 
-  * **-s**, **--sec**=_SECRET\_DATA\_FILE_:
+  * **-s**, **--secret**=_SECRET\_DATA\_FILE_:
     The secret which will be protected by the key derived from the random seed.
 
   * **-n**, **--name**=_NAME_

--- a/man/tpm2_pcrlist.1.md
+++ b/man/tpm2_pcrlist.1.md
@@ -28,7 +28,7 @@ sha256 :
 
 # OPTIONS
 
-  * **-g**, **--algorithm**=_HASH\_ALGORITHM_:
+  * **-g**, **--halg**=_HASH\_ALGORITHM_:
     Only output PCR banks with the given algorithm.
     Algorithms should follow the "formatting standards, see section
     "Algorithm Specifiers".

--- a/man/tpm2_quote.1.md
+++ b/man/tpm2_quote.1.md
@@ -70,17 +70,15 @@
 
 [common tcti options](common/tcti.md)
 
-[authorization formatting](common/password.md)
+[authorization formatting](common/authorizations.md)
 
-[pcr bank specifiers](common/password.md)
+[pcr bank specifiers](common/pcr.md)
 
 [signature format specifiers](common/signature.md)
 
 # EXAMPLES
 
 ```
-tpm2_quote -k 0x81010002 -P abc123 -g sha1 -l 16,17,18
-tpm2_quote -c ak.context -P "str:abc123" -g sha1 -l 16,17,18
 tpm2_quote -k 0x81010002 -g sha1 -l 16,17,18
 tpm2_quote -c ak.context -g sha1 -l 16,17,18
 tpm2_quote -k 0x81010002 -P "hex:123abc" -L sha1:16,17,18+sha256:16,17,18 -q 11aa22bb

--- a/man/tpm2_unseal.1.md
+++ b/man/tpm2_unseal.1.md
@@ -60,9 +60,9 @@ alive and pass that session using the **--input-session-handle** option.
 
 [common tcti options](common/tcti.md)
 
-[authorization formatting](common/password.md)
+[authorization formatting](common/authorizations.md)
 
-[pcr bank specifiers](common/password.md)
+[pcr bank specifiers](common/pcr.md)
 
 # EXAMPLES
 

--- a/man/tpm2_verifysignature.1.md
+++ b/man/tpm2_verifysignature.1.md
@@ -51,10 +51,6 @@ symmetric key, both the public and private portions need to be loaded.
 
     The input signature file of the signature to be validated.
 
-  * **-r**, **--raw**:
-
-    Set the input signature file to raw type. The default is TPMT_SIGNATURE.
-
   * **-t**, **--ticket**=_TICKET\_FILE_:
 
     The ticket file to record the validation structure.

--- a/scripts/utils/analyze.py
+++ b/scripts/utils/analyze.py
@@ -159,7 +159,7 @@ class ToolConflictor(object):
                 ],
                 "tools": [],
                 "conflict": None,
-                "ignore": set()
+                "ignore": set(['a', 'hierarchy', 'x', 'index', 'S', 'session', 't', 'attributes'])
             },
             {
                 "gname": "capability",

--- a/scripts/utils/analyze.py
+++ b/scripts/utils/analyze.py
@@ -77,7 +77,7 @@ class ToolConflictor(object):
                 ],
                 "tools": [],
                 "conflict": None,
-                "ignore": set(['r', 'privfile', 'u', 'pubfile'])
+                "ignore": set(['r', 'privfile', 'u', 'pubfile', 's', 'secret'])
             },
             {
                 "gname": "duplication",

--- a/scripts/utils/analyze.py
+++ b/scripts/utils/analyze.py
@@ -99,7 +99,7 @@ class ToolConflictor(object):
                 ["tpm2_encryptdecrypt", "tpm2_hmac", "tpm2_hash"],
                 "tools": [],
                 "conflict": None,
-                "ignore": set()
+                "ignore": set(['a', 'hierarchy', 'D', 'decrypt', 't', 'ticket'])
             },
             {
                 "gname": "random",

--- a/scripts/utils/analyze.py
+++ b/scripts/utils/analyze.py
@@ -113,7 +113,7 @@ class ToolConflictor(object):
                 "tools-in-group": ["tpm2_certify", "tpm2_quote"],
                 "tools": [],
                 "conflict": None,
-                "ignore": set()
+                "ignore": set(['g', 'halg', 'm', 'message', 's', 'signature'])
             },
             {
                 "gname": "signing",

--- a/scripts/utils/analyze.py
+++ b/scripts/utils/analyze.py
@@ -142,7 +142,7 @@ class ToolConflictor(object):
                 "tools-in-group": ["tpm2_clear", "tpm2_clearlock"],
                 "tools": [],
                 "conflict": None,
-                "ignore": set()
+                "ignore": set(['c', 'clear'])
             },
             {
                 "gname": "context",

--- a/scripts/utils/analyze.py
+++ b/scripts/utils/analyze.py
@@ -149,7 +149,7 @@ class ToolConflictor(object):
                 "tools-in-group": ["tpm2_flushcontext", "tpm2_evictcontrol"],
                 "tools": [],
                 "conflict": None,
-                "ignore": set()
+                "ignore": set(['S', 'session', 'p', 'persistent', 'a', 'hierarchy'])
             },
             {
                 "gname": "nv",

--- a/scripts/utils/analyze.py
+++ b/scripts/utils/analyze.py
@@ -1,0 +1,312 @@
+#!/usr/bin/env python
+''' A tool for analyzing the tools options for conflicts.
+
+This tool analyzes the c files in the directory given as the first argument for
+conflicting options within tpm command groups. The groups themselves are
+organized by the standard document:
+https://trustedcomputinggroup.org/wp-content/uploads/TPM-Rev-2.0-Part-3-Commands-01.38.pdf
+
+The tool outputs the group, the tools in the group, and the conflicting options. From there
+a human will need to make a plan of action to correct the tools so they conform.
+
+The tool exits with a status of non-zero on error, making this useful for checking
+PRs and can thus be added to travis.
+'''
+
+import glob
+import os
+import re
+import sys
+
+class Tool(object):
+    '''Represents a tool name and it's options'''
+
+    def __init__(self, name, options):
+        self._name = name
+        self._options = options
+
+    @property
+    def options(self):
+        '''Returns the tools options'''
+        return self._options
+
+    @property
+    def name(self):
+        '''Returns the tools name'''
+        return self._name
+
+    def __str__(self, *args, **kwargs):
+        return "%s: %s" % (self._name, str(self._options))
+
+
+class ToolConflictor(object):
+    '''Finds option conflicts in tools '''
+
+    _ignore = ["tpm2_tool"]
+
+    def __init__(self, tools):
+
+        # Using the command summary here:
+        # https://trustedcomputinggroup.org/wp-content/uploads/TPM-Rev-2.0-Part-3-Commands-01.38.pdf
+        # We organize the tools into their grouping
+        #
+        # Our names in the tools might not be exactly the same, so fix them up in the map
+        self._tools_by_group = [
+            {
+                "gname": "start-up",
+                "tools-in-group": ["tpm2_startup"],
+                "tools": [],
+                "conflict": None,
+                "ignore": set(),
+            },
+            {
+                "gname": "session",
+                "tools-in-group":
+                ["tpm2_startauthsession", "tpm2_policyrestart"],
+                "tools": [],
+                "conflict": None,
+                "ignore": set()
+            },
+            {
+                "gname": "object",
+                "tools-in-group": [
+                    "tpm2_create", "tpm2_createprimary", "tpm2_changeauth",
+                    "tpm2_load", "tpm2_loadexternal", "tpm2_readpublic",
+                    "tpm2_activatecredential", "tpm2_makecredential",
+                    "tpm2_unseal"
+                ],
+                "tools": [],
+                "conflict": None,
+                "ignore": set(['r', 'privfile', 'u', 'pubfile'])
+            },
+            {
+                "gname": "duplication",
+                "tools-in-group": ["tpm2_import"],
+                "tools": [],
+                "conflict": None,
+                "ignore": set()
+            },
+            {
+                "gname": "asymmetric",
+                "tools-in-group": ["tpm2_rsaencrypt", "tpm2_rsadecrypt"],
+                "tools": [],
+                "conflict": None,
+                "ignore": set()
+            },
+            {
+                "gname": "symmetric",
+                "tools-in-group":
+                ["tpm2_encryptdecrypt", "tpm2_hmac", "tpm2_hash"],
+                "tools": [],
+                "conflict": None,
+                "ignore": set()
+            },
+            {
+                "gname": "random",
+                "tools-in-group": ["tpm2_getrandom"],
+                "tools": [],
+                "conflict": None,
+                "ignore": set()
+            },
+            {
+                "gname": "attestation",
+                "tools-in-group": ["tpm2_certify", "tpm2_quote"],
+                "tools": [],
+                "conflict": None,
+                "ignore": set()
+            },
+            {
+                "gname": "signing",
+                "tools-in-group": ["tpm2_verifysignature", "tpm2_sign"],
+                "tools": [],
+                "conflict": None,
+                "ignore": set()
+            },
+            {
+                "gname": "integrity",
+                "tools-in-group":
+                ["tpm2_pcrextend", "tpm2_pcrevent", "tpm2_pcrlist"],
+                "tools": [],
+                "conflict": None,
+                "ignore": set()
+            },
+            {
+                "gname": "ea",
+                "tools-in-group": ["tpm2_policypcr", "tpm2_createpolicy"],
+                "tools": [],
+                "conflict": None,
+                "ignore": set()
+            },
+            {
+                "gname": "hierarchy",
+                "tools-in-group": ["tpm2_clear", "tpm2_clearlock"],
+                "tools": [],
+                "conflict": None,
+                "ignore": set()
+            },
+            {
+                "gname": "context",
+                "tools-in-group": ["tpm2_flushcontext", "tpm2_evictcontrol"],
+                "tools": [],
+                "conflict": None,
+                "ignore": set()
+            },
+            {
+                "gname": "nv",
+                "tools-in-group": [
+                    "tpm2_nvreadlock", "tpm2_nvrelease", "tpm2_nvdefine",
+                    "tpm2_nvread", "tpm2_nvwrite", "tpm2_nvlist"
+                ],
+                "tools": [],
+                "conflict": None,
+                "ignore": set()
+            },
+            {
+                "gname": "capability",
+                "tools-in-group": ["tpm2_getcap"],
+                "tools": [],
+                "conflict": None,
+                "ignore": set()
+            },
+            {
+                "gname": "dictionary",
+                "tools-in-group": ["tpm2_dictionarylockout"],
+                "tools": [],
+                "conflict": None,
+                "ignore": set()
+            },
+            {
+                "gname": "custom",
+                "tools-in-group": [
+                    "tpm2_send", "tpm2_createak", "tpm2_createek",
+                    "tpm2_getmanufec", "tpm2_listpersistent"
+                ],
+                "tools": [],
+                "conflict": None,
+                "ignore": set()
+            },
+        ]
+
+        for tool in tools:
+            if tool.name in ToolConflictor._ignore:
+                continue
+
+            found = False
+            for tool_group in self._tools_by_group:
+                if tool.name in tool_group['tools-in-group']:
+                    tool_group["tools"].append(tool)
+                    found = True
+                    break
+            if not found:
+                sys.exit("Did not find group for tool: %s", tool.name)
+
+    def process(self):
+        '''Processes the tool groups and generates the conflict data'''
+
+        #
+        # Now that we have the tools mapped onto a group, lets figure out conflicts within the
+        # group, and record them in the conflict field.
+        #
+
+        for tool_group in self._tools_by_group:
+
+            # If their is only one tool, it can't conflict
+            if len(tool_group['tools']) == 1:
+                continue
+
+            option_sets = [
+                set(t.options.keys()) | set(t.options.values())
+                for t in tool_group['tools']
+            ]
+            diff = set()
+            for option_set in option_sets:
+                diff ^= option_set
+
+            diff -= tool_group['ignore']
+
+            if len(diff) > 0:
+                tool_group['conflict'] = diff
+
+    def report(self):
+        '''Prints a conflict report to stdout
+
+        It returns True if conflicts were detected or false otherwise
+        '''
+
+        has_conflicts = False
+
+        for tool_group in self._tools_by_group:
+            gname = tool_group["gname"]
+            conflicts = tool_group["conflict"]
+            tools = tool_group["tools"]
+            if conflicts is None:
+                continue
+
+            has_conflicts = True
+            print "group: %s:" % (gname)
+            print "\ttools: %s" % str([t.name for t in tools])
+            print "\tconflicts: %s" % (str(conflicts))
+
+        return has_conflicts
+
+# pylint: disable=locally-disabled, too-few-public-methods
+class Parser(object):
+    '''Parses C files for long option style option blocks'''
+
+    regx = re.compile(
+        r'^\s*{\s*"(\w+)"\s*,\s*(?:required_argument|no_argument)\s*,\s*\w+\s*,\s*\'(\w)\'\s*},+$',
+        re.MULTILINE)
+
+    def __init__(self, path=os.getcwd()):
+        self._path = path
+
+    @staticmethod
+    def _extract_options(source_file):
+        with open(source_file) as open_file:
+            contents = open_file.read()
+
+            # This returns a list of tuples, where each tuple
+            # is group 1 ... N of the matched options
+            # We want to build a dict() of short to long option
+            # and thus need to swap the positions in the tuple,
+            # as match order is long option then short option
+            match_obj = Parser.regx.findall(contents)
+            if match_obj is None:
+                return {}
+
+            # Reverse the tuples in the list and make a dictionary
+            # of short option to long option.
+            return dict([t[::-1] for t in match_obj])
+
+    def parse(self):
+        '''Parses the directory and aggregates tool option data'''
+        tools = []
+        path = os.path.join(self._path, "*.c")
+        for c_file in glob.glob(path):
+            name = (os.path.split(c_file)[-1])[:-2]
+            opts = Parser._extract_options(c_file)
+            tools.append(Tool(name, opts))
+
+        return tools
+
+
+def main():
+    '''main entry point to program'''
+
+    if len(sys.argv) != 2:
+        sys.exit("Expected file path argument, got %d arguments" %
+                 (len(sys.argv)))
+
+    parser = Parser(sys.argv[1])
+    tools = parser.parse()
+
+    conflictor = ToolConflictor(tools)
+    conflictor.process()
+
+    has_conflicts = conflictor.report()
+
+    # If it had conflicts, exit non-zero
+    sys.exit(has_conflicts)
+
+if __name__ == "__main__":
+    main()

--- a/scripts/utils/analyze.py
+++ b/scripts/utils/analyze.py
@@ -135,7 +135,7 @@ class ToolConflictor(object):
                 "tools-in-group": ["tpm2_policypcr", "tpm2_createpolicy"],
                 "tools": [],
                 "conflict": None,
-                "ignore": set()
+                "ignore": set(['S', 'session'])
             },
             {
                 "gname": "hierarchy",

--- a/scripts/utils/analyze.py
+++ b/scripts/utils/analyze.py
@@ -128,7 +128,7 @@ class ToolConflictor(object):
                 ["tpm2_pcrextend", "tpm2_pcrevent", "tpm2_pcrlist"],
                 "tools": [],
                 "conflict": None,
-                "ignore": set()
+                "ignore": set(['g', 'halg', 'f', 'format', 's', 'algs'])
             },
             {
                 "gname": "ea",

--- a/tools/tpm2_activatecredential.c
+++ b/tools/tpm2_activatecredential.c
@@ -290,7 +290,7 @@ bool tpm2_tool_onstart(tpm2_options **opts) {
          {"context",        required_argument, NULL, 'c'},
          {"key-handle",     required_argument, NULL, 'k'},
          {"key-context",    required_argument, NULL, 'C'},
-         {"Password",       required_argument, NULL, 'P'},
+         {"auth-key",       required_argument, NULL, 'P'},
          {"endorse-passwd", required_argument, NULL, 'e'},
          {"in-file",        required_argument, NULL, 'f'},
          {"out-file",       required_argument, NULL, 'o'},

--- a/tools/tpm2_activatecredential.c
+++ b/tools/tpm2_activatecredential.c
@@ -294,10 +294,9 @@ bool tpm2_tool_onstart(tpm2_options **opts) {
          {"endorse-passwd", required_argument, NULL, 'e'},
          {"in-file",        required_argument, NULL, 'f'},
          {"out-file",       required_argument, NULL, 'o'},
-         {"passwdInHex",    no_argument,       NULL, 'X'},
     };
 
-    *opts = tpm2_options_new("H:c:k:C:P:e:f:o:X", ARRAY_LEN(topts), topts,
+    *opts = tpm2_options_new("H:c:k:C:P:e:f:o:", ARRAY_LEN(topts), topts,
                              on_option, NULL, TPM2_OPTIONS_SHOW_USAGE);
 
     return *opts != NULL;

--- a/tools/tpm2_hmac.c
+++ b/tools/tpm2_hmac.c
@@ -280,7 +280,7 @@ bool tpm2_tool_onstart(tpm2_options **opts) {
         { "key-handle",           required_argument, NULL, 'k' },
         { "key-context",          required_argument, NULL, 'c' },
         { "auth-key",             required_argument, NULL, 'P' },
-        { "algorithm",            required_argument, NULL, 'g' },
+        { "halg",                 required_argument, NULL, 'g' },
         { "out-file",             required_argument, NULL, 'o' },
     };
 

--- a/tools/tpm2_makecredential.c
+++ b/tools/tpm2_makecredential.c
@@ -190,8 +190,8 @@ bool tpm2_tool_onstart(tpm2_options **opts) {
 
     const struct option topts[] = {
       {"enc-key"  ,required_argument, NULL, 'e'},
-      {"sec"     ,required_argument, NULL, 's'},
-      {"name"    ,required_argument, NULL, 'n'},
+      {"secret"   ,required_argument, NULL, 's'},
+      {"name"     ,required_argument, NULL, 'n'},
       {"out-file" ,required_argument, NULL, 'o'},
     };
 

--- a/tools/tpm2_nvdefine.c
+++ b/tools/tpm2_nvdefine.c
@@ -187,7 +187,7 @@ bool tpm2_tool_onstart(tpm2_options **opts) {
         { "index",                  required_argument,  NULL,   'x' },
         { "hierarchy",              required_argument,  NULL,   'a' },
         { "size",                   required_argument,  NULL,   's' },
-        { "attribute",              required_argument,  NULL,   't' },
+        { "attributes",             required_argument,  NULL,   't' },
         { "auth-hierarchy",         required_argument,  NULL,   'P' },
         { "auth-index",             required_argument,  NULL,   'I' },
         { "policy-file",            required_argument,  NULL,   'L' },

--- a/tools/tpm2_nvdefine.c
+++ b/tools/tpm2_nvdefine.c
@@ -190,12 +190,11 @@ bool tpm2_tool_onstart(tpm2_options **opts) {
         { "attribute",              required_argument,  NULL,   't' },
         { "auth-hierarchy",         required_argument,  NULL,   'P' },
         { "auth-index",             required_argument,  NULL,   'I' },
-        { "passwdInHex",            no_argument,        NULL,   'X' },
         { "policy-file",            required_argument,  NULL,   'L' },
         { "session",                required_argument,  NULL,   'S' },
     };
 
-    *opts = tpm2_options_new("x:a:s:t:P:I:XL:", ARRAY_LEN(topts), topts,
+    *opts = tpm2_options_new("x:a:s:t:P:I:L:", ARRAY_LEN(topts), topts,
                              on_option, NULL, TPM2_OPTIONS_SHOW_USAGE);
 
     return *opts != NULL;

--- a/tools/tpm2_nvreadlock.c
+++ b/tools/tpm2_nvreadlock.c
@@ -126,10 +126,9 @@ bool tpm2_tool_onstart(tpm2_options **opts) {
         { "index",                required_argument, NULL, 'x' },
         { "hierarchy",       required_argument, NULL, 'a' },
         { "handle-passwd",        required_argument, NULL, 'P' },
-        { "passwdInHex",          no_argument,       NULL, 'X' },
     };
 
-    *opts = tpm2_options_new("x:a:P:X", ARRAY_LEN(topts), topts,
+    *opts = tpm2_options_new("x:a:P:", ARRAY_LEN(topts), topts,
                              on_option, NULL, TPM2_OPTIONS_SHOW_USAGE);
 
     return *opts != NULL;

--- a/tools/tpm2_pcrlist.c
+++ b/tools/tpm2_pcrlist.c
@@ -392,7 +392,7 @@ static bool on_option(char key, char *value) {
 bool tpm2_tool_onstart(tpm2_options **opts) {
 
     static struct option topts[] = {
-         { "algorithm", required_argument, NULL, 'g' },
+         { "halg",      required_argument, NULL, 'g' },
          { "out-file",  required_argument, NULL, 'o' },
          { "algs",      no_argument,       NULL, 's' },
          { "sel-list",  required_argument, NULL, 'L' },

--- a/tools/tpm2_quote.c
+++ b/tools/tpm2_quote.c
@@ -64,7 +64,7 @@ static tpm2_convert_sig_fmt sig_format;
 static TPMI_ALG_HASH sig_hash_algorithm;
 static TPM2B_DATA qualifyingData = TPM2B_EMPTY_INIT;
 static TPML_PCR_SELECTION  pcrSelections;
-static int k_flag, c_flag, l_flag, g_flag, L_flag, o_flag, G_flag;
+static int k_flag, c_flag, l_flag, L_flag, o_flag, G_flag;
 static char *contextFilePath;
 static TPM2_HANDLE akHandle;
 
@@ -159,16 +159,6 @@ static bool on_option(char key, char *value) {
         }
         l_flag = 1;
         break;
-    case 'g':
-        pcrSelections.pcrSelections[0].hash = tpm2_alg_util_from_optarg(value);
-        if (pcrSelections.pcrSelections[0].hash == TPM2_ALG_ERROR)
-        {
-            LOG_ERR("Could not convert pcr hash selection, got: \"%s\"", value);
-            return false;
-        }
-        pcrSelections.count = 1;
-        g_flag = 1;
-        break;
     case 'L':
         if(!pcr_parse_selections(value, &pcrSelections))
         {
@@ -222,7 +212,6 @@ bool tpm2_tool_onstart(tpm2_options **opts) {
         { "ak-context",           required_argument, NULL, 'c' },
         { "auth-ak",              required_argument, NULL, 'P' },
         { "id-list",              required_argument, NULL, 'l' },
-        { "algorithm",            required_argument, NULL, 'g' },
         { "sel-list",             required_argument, NULL, 'L' },
         { "qualify-data",         required_argument, NULL, 'q' },
         { "signature",            required_argument, NULL, 's' },

--- a/tools/tpm2_verifysignature.c
+++ b/tools/tpm2_verifysignature.c
@@ -51,7 +51,6 @@ struct tpm2_verifysig_ctx {
             UINT8 digest :1;
             UINT8 halg :1;
             UINT8 msg :1;
-            UINT8 raw :1;
             UINT8 sig :1;
             UINT8 ticket :1;
             UINT8 key_context :1;
@@ -227,9 +226,6 @@ static bool on_option(char key, char *value) {
 		ctx.flags.digest = 1;
 	}
 		break;
-	case 'r':
-		ctx.flags.raw = 1;
-		break;
 	case 's':
 		ctx.sig_file_path = value;
 		ctx.flags.sig = 1;
@@ -259,14 +255,13 @@ bool tpm2_tool_onstart(tpm2_options **opts) {
             { "digest",      required_argument, NULL, 'D' },
             { "halg",        required_argument, NULL, 'g' },
             { "message",     required_argument, NULL, 'm' },
-            { "raw",         no_argument,       NULL, 'r' },
             { "sig",         required_argument, NULL, 's' },
             { "ticket",      required_argument, NULL, 't' },
             { "key-context", required_argument, NULL, 'c' },
     };
 
 
-    *opts = tpm2_options_new("k:g:m:D:rs:t:c:", ARRAY_LEN(topts), topts,
+    *opts = tpm2_options_new("k:g:m:D:s:t:c:", ARRAY_LEN(topts), topts,
                              on_option, NULL, TPM2_OPTIONS_SHOW_USAGE);
 
     return *opts != NULL;


### PR DESCRIPTION
This PR helps to make progress towards #957 which rectifies the option conflicts in the tools.

The script isn't perfect. It uses sets, for the diff, so you lose the coupling of short/long option, however, if things differ, it will complain about at least one of them. It doesn't look outside of the option group to see if unknown/conflicting options are used in other groups outside of it's own. So you manually need to add it to it's ignore set.

The script however, does point out conflicting areas in groups. When resolving a conflict, the human needs to see if it should be ignored or modified based on more intelligence then I can whip up in a reasonable amount of time.
