### PR TITLE
tpm2_loadexternal: improve error message

### DIFF
--- a/lib/files.c
+++ b/lib/files.c
@@ -615,6 +615,7 @@ bool files_load_bytes_from_file_or_stdin(const char *path, UINT16 *size, BYTE *b
         TSS2_RC rc = Tss2_MU_##type##_Unmarshal(buffer, size, &offset, name); \
         if (rc != TSS2_RC_SUCCESS) { \
             LOG_ERR("Error serializing "str(name)" structure: 0x%x", rc); \
+            LOG_ERR("The input file needs to be a valid "xstr(type)" data structure"); \
             return false; \
         } \
         \


### PR DESCRIPTION
When -u is provided and is an invalid structure,
the error message is not always clear:

echo "this is public" > public
tpm2_loadexternal  --tcti device -a o -u public
WARNING:marshal:src/tss2-mu/tpm2b-types.c:355:
Tss2_MU_TPM2B_PUBLIC_Unmarshal() buffer_size: 20 with offset: 2 are insufficient for object of size 21608
ERROR: Error serializing public structure: 0x90006

Update the error output to indicate that the file needs to be a TPM2B_PUBLIC data structure.
tpm2_loadexternal -a o -u public
WARNING:marshal:src/tss2-mu/tpm2b-types.c:355:Tss2_MU_TPM2B_PUBLIC_Unmarshal() buffer_size: 15 with offset: 2 are insufficient for object of size 29800
ERROR: Error serializing public structure: 0x90006

This will also issue errors of similair construct for other file types loaded up.

Fixes: #985

Signed-off-by: William Roberts <william.c.roberts@intel.com>