### PR TITLE
test: fix no-abrmd testing option

### DIFF
--- a/test/integration/helpers.sh
+++ b/test/integration/helpers.sh
@@ -270,8 +270,11 @@ function start_up() {
         export TPM2TOOLS_TCTI="socket:port=$tpm2_sim_port"
         echo "Not starting tpm2-abrmd"
         echo "Setting TCTI to use mssim"
-        echo "export TPM2TOOLS_TCTI=\"socket:port=$tpm2_sim_port\""
-        export TPM2TOOLS_TCTI="socket:port=$tpm2_sim_port"
+        echo "export TPM2TOOLS_TCTI=\"mssim:port=$tpm2_sim_port\""
+        export TPM2TOOLS_TCTI="mssim:port=$tpm2_sim_port"
+
+        echo "Running tpm2_startup -c"
+        tpm2_startup -c
     fi
 
     echo "Running tpm2_clear"


### PR DESCRIPTION
One can specify no-abrmd as argument 1 to the start_up test
function to get a test env that uses the simulatory directly.

Signed-off-by: William Roberts <william.c.roberts@intel.com>