### PR TITLE
[v2] tools: Fix save and load for TPM2B_PRIVATE

### DIFF
--- a/lib/files.c
+++ b/lib/files.c
@@ -606,6 +606,9 @@ bool files_load_bytes_from_file_or_stdin(const char *path, UINT16 *size, BYTE *b
         return rc == TPM_RC_SUCCESS; \
     }
 
+SAVE_TYPE(TPM2B_PRIVATE, private)
+LOAD_TYPE(TPM2B_PRIVATE, private)
+
 SAVE_TYPE(TPM2B_PUBLIC, public)
 LOAD_TYPE(TPM2B_PUBLIC, public)
 

--- a/lib/files.h
+++ b/lib/files.h
@@ -109,6 +109,28 @@ bool files_save_tpm_context_to_file(TSS2_SYS_CONTEXT *sapi_context, TPM_HANDLE h
 bool files_load_tpm_context_from_file(TSS2_SYS_CONTEXT *sapi_context, TPM_HANDLE *handle, const char *path);
 
 /**
+ * Serializes a TPM2B_PPRIVATE to the file path provided.
+ * @param private
+ *  The TPM2B_PRIVATE to save to disk.
+ * @param path
+ *  The path to save to.
+ * @return
+ *  true on success, false on error.
+ */
+bool files_save_private(TPM2B_PRIVATE *private, const char *path);
+
+/**
+ * Loads a TPM2B_PRIVATE from disk that was saved with files_save_private()
+ * @param path
+ *  The path to load from.
+ * @param private
+ *  The TPM2B_PRIVATE to load.
+ * @return
+ *  true on success, false on error.
+ */
+bool files_load_private(const char *path, TPM2B_PRIVATE *private);
+
+/**
  * Serializes a TPM2B_PUBLIC to the file path provided.
  * @param public
  *  The TPM2B_PUBLIC to save to disk.

--- a/tools/tpm2_create.c
+++ b/tools/tpm2_create.c
@@ -220,7 +220,7 @@ int create(TSS2_SYS_CONTEXT *sapi_context)
     }
 
     if (ctx.flags.O) {
-        bool res = files_save_bytes_to_file(ctx.opr_path, outPrivate.t.buffer, outPrivate.t.size);
+        bool res = files_save_private(&outPrivate, ctx.opr_path);
         if (!res) {
             return -4;
         }

--- a/tools/tpm2_load.c
+++ b/tools/tpm2_load.c
@@ -144,8 +144,7 @@ static bool on_option(char key, char *value) {
         ctx.flags.u = 1;
         break;
     case 'r':
-        ctx.in_private.t.size = sizeof(ctx.in_private.t.buffer);
-        if(!files_load_bytes_from_path(value, ctx.in_private.t.buffer, &ctx.in_private.t.size)) {
+        if(!files_load_private(value, &ctx.in_private)) {
             return false;
         }
         ctx.flags.r = 1;


### PR DESCRIPTION
The tpm2_create tools is only storing the TPM2B_PRIVATE .buffer field but
not it's .size field. This causes the private keys stored with the stable
version of the tools, to fail loading when using the latest master branch.

Fix this by storing the whole TPM2B_PRIVATE object, including size field.

Fixes: #976

Signed-off-by: William Roberts <william.c.roberts@intel.com>