### PR TITLE
Import work

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -327,6 +327,7 @@ MARKDOWN_COMMON_DEPS = \
 	man/common/pubkey.md \
 	man/common/sign-alg.md \
 	man/common/signature.md \
+	man/common/signschemes.md \
 	man/common/tcti.md
 
 man/man1/%.1 : man/%.1.md $(MARKDOWN_COMMON_DEPS)
@@ -356,6 +357,8 @@ man/man1/%.1 : man/%.1.md $(MARKDOWN_COMMON_DEPS)
 	    -e '/\[signature format specifiers\]/d' \
 	    -e '/\[object attribute specifiers\]/r man/common/obj-attrs.md' \
 	    -e '/\[object attribute specifiers\]/d' \
+	    -e '/\[supported signing schemes\]/r man/common/signschemes.md' \
+	    -e '/\[supported signing schemes\]/d' \
 	    -e '/\[footer\]/r man/common/footer.md' \
 	    -e '/\[footer\]/d' \
 	    < $< | pandoc -s -t man > $@

--- a/lib/tpm2_alg_util.c
+++ b/lib/tpm2_alg_util.c
@@ -172,6 +172,26 @@ bool tpm2_alg_util_is_hash_alg(TPM2_ALG_ID id) {
     return false;
 }
 
+bool tpm2_alg_util_is_signing_scheme(TPM2_ALG_ID id) {
+
+    switch (id) {
+    case TPM2_ALG_RSASSA:
+        /* fallsthrough */
+    case TPM2_ALG_RSAES:
+        /* fallsthrough */
+    case TPM2_ALG_RSAPSS:
+        /* fallsthrough */
+    case TPM2_ALG_OAEP:
+        /* fallsthrough */
+    case TPM2_ALG_HMAC:
+        /* fallsthrough */
+        return true;
+        /* no default */
+    }
+
+    return false;
+}
+
 UINT16 tpm2_alg_util_get_hash_size(TPMI_ALG_HASH id) {
 
     switch (id) {

--- a/lib/tpm2_alg_util.h
+++ b/lib/tpm2_alg_util.h
@@ -96,6 +96,15 @@ TPM2_ALG_ID tpm2_alg_util_from_optarg(char *optarg);
 bool tpm2_alg_util_is_hash_alg(TPM2_ALG_ID id);
 
 /**
+ * Detects if an algorithm is considered a signing scheme.
+ * @param id
+ *  The algorithm id to check.
+ * @return
+ *  True if it is a signing scheme, False otherwise.
+ */
+bool tpm2_alg_util_is_signing_scheme(TPM2_ALG_ID id);
+
+/**
  * Contains the information from parsing an argv style vector of strings for
  * pcr digest language specifications.
  */

--- a/lib/tpm2_convert.h
+++ b/lib/tpm2_convert.h
@@ -1,5 +1,6 @@
 //**********************************************************************;
 // Copyright (c) 2017, SUSE GmbH
+// Copyright (c) 2018, Intel Corporation
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without
@@ -95,5 +96,23 @@ tpm2_convert_sig_fmt tpm2_convert_sig_fmt_from_optarg(const char *label);
  */
 bool tpm2_convert_sig(TPMT_SIGNATURE *signature, tpm2_convert_sig_fmt format,
         const char *path);
+
+/**
+ * Load a signature from path and convert the format
+ * @param path
+ *  The path to load the signature from.
+ * @param format
+ *  The tss signature format
+ * @param sig_alg
+ *  The algorithm used for the signature. Only RSASSA (RSA PKCS1.5) signatures accepted.
+ * @param halg
+ *  The hashing algorithm used.
+ * @param signature
+ *  The signature structure to output too.
+ * @return
+ *  true on success, false on error.
+ */
+bool tpm2_convert_sig_load(const char *path, tpm2_convert_sig_fmt format, TPMI_ALG_SIG_SCHEME sig_alg,
+        TPMI_ALG_HASH halg, TPMT_SIGNATURE *signature);
 
 #endif /* CONVERSION_H */

--- a/lib/tpm2_convert.h
+++ b/lib/tpm2_convert.h
@@ -68,16 +68,6 @@ tpm2_convert_pubkey_fmt tpm2_convert_pubkey_fmt_from_optarg(const char *label);
 bool tpm2_convert_pubkey_save(TPM2B_PUBLIC *public, tpm2_convert_pubkey_fmt format, const char *path);
 
 /**
- * Loads a public key in the TSS format from a file.
- * @param public
- *  The public key to load
- * @param format
- * @param path
- * @return
- */
-bool tpm2_convert_pubkey_load(TPM2B_PUBLIC *public, const char *path);
-
-/**
  * Parses the given command line signature format option string and returns
  * the corresponding signature_format enum value.
  *

--- a/man/common/signschemes.md
+++ b/man/common/signschemes.md
@@ -1,0 +1,11 @@
+# Supported Signing Schemes
+
+Supported hash algorithms are:
+
+  * **0x5**  or **hmac** for **TPM_ALG_HMAC**
+  * **0x14** or **rsassa** for **TPM_ALG_RSASSA**
+  * **0x15** or **rsaes** for **TPM_ALG_RSAES**
+  * **0x16** or **rsapss** for **TPM_ALG_RSAPSS**
+  * **0x17** or **oeap** for **TPM_ALG_OAEP**
+
+**NOTE**: Your TPM may not support all algorithms.

--- a/man/tpm2_import.1.md
+++ b/man/tpm2_import.1.md
@@ -13,7 +13,7 @@ SYNOPSIS
 
 DESCRIPTION
 -----------
-This tool imports an external key (Symmetric AES-128) as TPM managed key object.
+This tool imports an external key either, a symmetric AES-128 or an RSA2K as TPM managed key object.
 It requires the parent handle be persistent and an object of type RSA key.
 
 OPTIONS
@@ -27,12 +27,10 @@ These options control the key importation process:
     Also, see section "Supported Hash Algorithms" for a list of supported
     hash algorithms.
 
-  * `-K`, **--input-public-key-file**=_FILE_:
-    Specifies the file name for the RSA2K modulus when importing RSA2K key.
-
   * `-k`, `--input-key-file`=_FILE_:
     Specifies the filename of symmetric key (128 bit data) to be imported. OR,
-    Specifies the filename for the RSA2K prime (P) value.
+    Specifies the filename for the RSA2K private key file in PEM and PKCS#1
+    format. A typical file is generated with openssl genrsa.
 
   * `-H`, `--parent-key-handle`=_HANDLE_:
     Specifies the persistent parent key handle.
@@ -60,7 +58,7 @@ EXAMPLES
 
 tpm2_import -k sym.key -H 0x81010001 -f parent.pub -q import_key.pub -r import_key.priv
 
-tpm2_import -Q -G rsa -K rsa2k_modulus.bin -k rsa2k_P.bin -H 0x81010005 -f parent.pub \
+tpm2_import -Q -G rsa -k private.pem -H 0x81010005 -f parent.pub \
 -q import_rsa_key.pub -r import_rsa_key.priv
 
 RETURNS

--- a/man/tpm2_import.1.md
+++ b/man/tpm2_import.1.md
@@ -36,8 +36,9 @@ These options control the key importation process:
     Specifies the persistent parent key handle.
 
   * `-K`, `--parent-key-public`=_FILE_:
-    Specifies the parent key public data file input. This can be read with
-    tpm2_readpublic tool.
+    Optional. Specifies the parent key public data file input. This can be read with
+    tpm2_readpublic tool. If not specified, the tool invokes a tpm2_readpublic on the parent
+    object.
 
   * `-r`, `--import-key-private`=_FILE_:
     Specifies the file path required to save the encrypted private portion of

--- a/man/tpm2_import.1.md
+++ b/man/tpm2_import.1.md
@@ -35,7 +35,7 @@ These options control the key importation process:
   * `-H`, `--parent-key-handle`=_HANDLE_:
     Specifies the persistent parent key handle.
 
-  * `-f`, `--parent-key-public`=_FILE_:
+  * `-K`, `--parent-key-public`=_FILE_:
     Specifies the parent key public data file input. This can be read with
     tpm2_readpublic tool.
 

--- a/man/tpm2_verifysignature.1.md
+++ b/man/tpm2_verifysignature.1.md
@@ -51,9 +51,16 @@ symmetric key, both the public and private portions need to be loaded.
 
     The input signature file of the signature to be validated.
 
-  * **-r**, **--raw**:
+  * **-f**, **--format**:
 
-    Set the input signature file to raw type. The default is TPMT_SIGNATURE.
+    Set the input signature file to a specified format. The default is the tpm2.0 TPMT_SIGNATURE
+    data format, however different schemes can be selected if the data came from an external
+    source like OpenSSL. The tool currently only supports rsassa.
+
+    Algorithms should follow the "formatting standards, see section
+    "Algorithm Specifiers".
+    Also, see section "Supported Signing Schemes" for a list of supported hash
+    algorithms.
 
   * **-t**, **--ticket**=_TICKET\_FILE_:
 
@@ -70,6 +77,8 @@ symmetric key, both the public and private portions need to be loaded.
 [authorization formatting](common/password.md)
 
 [supported hash algorithms](common/hash.md)
+
+[supported signing schemes](common/signschemes.md)
 
 [algorithm specifiers](common/alg.md)
 

--- a/test/integration/tests/import.sh
+++ b/test/integration/tests/import.sh
@@ -105,6 +105,6 @@ openssl dgst -verify public.pem -keyform pem -sha256 -signature data.out.signed 
 openssl dgst -sha256 -sign private.pem -out data.out.signed data.in.raw
 
 # Verify with the TPM
-tpm2_verifysignature -Q -c import_rsa_key.ctx -g sha256 -m data.in.raw -r -s data.out.signed -t ticket.out
+tpm2_verifysignature -Q -c import_rsa_key.ctx -g sha256 -m data.in.raw -f rsassa -s data.out.signed -t ticket.out
 
 exit 0

--- a/test/integration/tests/import.sh
+++ b/test/integration/tests/import.sh
@@ -38,7 +38,7 @@ cleanup() {
     rm -f import_key.ctx  import_key.name  import_key.priv  import_key.pub \
           parent.ctx parent.pub  plain.dec.ssl  plain.enc  plain.txt  sym.key \
           import_rsa_key.pub import_rsa_key.priv import_rsa_key.ctx import_rsa_key.name \
-          private.pem public.pem priv.bin pub.bin plain.rsa.enc plain.rsa.dec \
+          private.pem public.pem plain.rsa.enc plain.rsa.dec \
           public.pem data.in.raw data.in.digest data.out.signed
 
     if [ "$1" != "no-shut-down" ]; then
@@ -78,16 +78,7 @@ diff plain.txt plain.dec.ssl
 openssl genrsa -out private.pem 2048
 openssl rsa -in private.pem -pubout > public.pem
 
-# The private key P value, which is the pair of unique primes generated aka P, is always the 5th offset
-# in the file till the end.
-priv_offset=`openssl asn1parse -in private.pem | grep INTEGER | head -n 5 | tail -n 1 | cut -d\: -f1-1 | sed s/' '//g`
-openssl asn1parse -in private.pem -strparse $priv_offset -out priv.bin -noout
-
-# The public modulus is always the second integer item
-pub_offset=`openssl asn1parse -in private.pem | grep INTEGER | head -n 2 | tail -n 1 | cut -d\: -f1-1 | sed s/' '//g`
-openssl asn1parse -in private.pem -strparse $pub_offset -out pub.bin -noout
-
-tpm2_import -Q -G rsa -K pub.bin -k priv.bin -H 0x81010005 -f parent.pub \
+tpm2_import -Q -G rsa -k private.pem -H 0x81010005 -f parent.pub \
 -q import_rsa_key.pub -r import_rsa_key.priv
 
 tpm2_load -Q -H 0x81010005 -u import_rsa_key.pub -r import_rsa_key.priv \

--- a/test/integration/tests/import.sh
+++ b/test/integration/tests/import.sh
@@ -109,4 +109,7 @@ tpm2_sign -Q -c import_rsa_key.ctx -g sha256 -D data.in.digest -f plain -s data.
 
 openssl dgst -verify public.pem -keyform pem -sha256 -signature data.out.signed data.in.raw
 
+# Sign with openssl and verify with TPM
+openssl dgst -sha256 -sign private.pem -out data.out.signed data.in.raw
+
 exit 0

--- a/test/integration/tests/import.sh
+++ b/test/integration/tests/import.sh
@@ -112,4 +112,7 @@ openssl dgst -verify public.pem -keyform pem -sha256 -signature data.out.signed 
 # Sign with openssl and verify with TPM
 openssl dgst -sha256 -sign private.pem -out data.out.signed data.in.raw
 
+# Verify with the TPM
+tpm2_verifysignature -Q -c import_rsa_key.ctx -g sha256 -m data.in.raw -r -s data.out.signed -t ticket.out
+
 exit 0

--- a/test/integration/tests/import.sh
+++ b/test/integration/tests/import.sh
@@ -78,7 +78,8 @@ diff plain.txt plain.dec.ssl
 openssl genrsa -out private.pem 2048
 openssl rsa -in private.pem -pubout > public.pem
 
-tpm2_import -Q -G rsa -k private.pem -H 0x81010005 -K parent.pub \
+# Test an import without the parent public info data to force a readpublic
+tpm2_import -Q -G rsa -k private.pem -H 0x81010005 \
 -q import_rsa_key.pub -r import_rsa_key.priv
 
 tpm2_load -Q -H 0x81010005 -u import_rsa_key.pub -r import_rsa_key.priv \

--- a/test/integration/tests/import.sh
+++ b/test/integration/tests/import.sh
@@ -59,7 +59,7 @@ dd if=/dev/urandom of=sym.key bs=1 count=16 2>/dev/null
 tpm2_readpublic -Q -H 0x81010005 --out-file parent.pub
 
 #Symmetric Key Import Test
-tpm2_import -Q -G aes -k sym.key -H 0x81010005 -f parent.pub -q import_key.pub \
+tpm2_import -Q -G aes -k sym.key -H 0x81010005 -K parent.pub -q import_key.pub \
 -r import_key.priv
 
 tpm2_load -Q -H 0x81010005 -u import_key.pub -r import_key.priv -n import_key.name \
@@ -78,7 +78,7 @@ diff plain.txt plain.dec.ssl
 openssl genrsa -out private.pem 2048
 openssl rsa -in private.pem -pubout > public.pem
 
-tpm2_import -Q -G rsa -k private.pem -H 0x81010005 -f parent.pub \
+tpm2_import -Q -G rsa -k private.pem -H 0x81010005 -K parent.pub \
 -q import_rsa_key.pub -r import_rsa_key.priv
 
 tpm2_load -Q -H 0x81010005 -u import_rsa_key.pub -r import_rsa_key.priv \

--- a/test/unit/test_tpm2_alg_util.c
+++ b/test/unit/test_tpm2_alg_util.c
@@ -430,6 +430,28 @@ static void test_tpm2_alg_util_get_hash_size(void **state) {
     assert_int_equal(hsize, 0);
 }
 
+static void test_tpm2_alg_util_is_signing_scheme(void **state) {
+    UNUSED(state);
+
+    TPM2_ALG_ID good_algs[] = {
+        TPM2_ALG_RSASSA,
+        TPM2_ALG_RSAES,
+        TPM2_ALG_RSAPSS,
+        TPM2_ALG_OAEP,
+        TPM2_ALG_HMAC,
+    };
+
+    size_t i;
+    for(i=0; i < ARRAY_LEN(good_algs); i++) {
+        TPM2_ALG_ID id = good_algs[i];
+        bool res = tpm2_alg_util_is_signing_scheme(id);
+        assert_true(res);
+    }
+
+    bool res = tpm2_alg_util_is_signing_scheme(TPM2_ALG_AES);
+    assert_false(res);
+}
+
 int main(int argc, char* argv[]) {
     (void) argc;
     (void) argv;
@@ -481,7 +503,8 @@ int main(int argc, char* argv[]) {
         cmocka_unit_test(test_pcr_parse_digest_list_compound),
         cmocka_unit_test(test_pcr_parse_digest_list_bad),
         cmocka_unit_test(test_pcr_parse_digest_list_bad_alg),
-        cmocka_unit_test(test_tpm2_alg_util_get_hash_size)
+        cmocka_unit_test(test_tpm2_alg_util_get_hash_size),
+        cmocka_unit_test(test_tpm2_alg_util_is_signing_scheme)
     };
 
     return cmocka_run_group_tests(tests, NULL, NULL);

--- a/test/unit/test_tpm2_alg_util.c
+++ b/test/unit/test_tpm2_alg_util.c
@@ -452,6 +452,28 @@ static void test_tpm2_alg_util_is_signing_scheme(void **state) {
     assert_false(res);
 }
 
+static void test_tpm2_alg_util_is_hash_alg(void **state) {
+    UNUSED(state);
+
+    TPM2_ALG_ID good_algs[] = {
+        TPM2_ALG_SHA1,
+        TPM2_ALG_SHA256,
+        TPM2_ALG_SHA384,
+        TPM2_ALG_SHA512,
+        TPM2_ALG_SM3_256
+    };
+
+    size_t i;
+    for(i=0; i < ARRAY_LEN(good_algs); i++) {
+        TPM2_ALG_ID id = good_algs[i];
+        bool res = tpm2_alg_util_is_hash_alg(id);
+        assert_true(res);
+    }
+
+    bool res = tpm2_alg_util_is_hash_alg(TPM2_ALG_AES);
+    assert_false(res);
+}
+
 int main(int argc, char* argv[]) {
     (void) argc;
     (void) argv;
@@ -504,7 +526,8 @@ int main(int argc, char* argv[]) {
         cmocka_unit_test(test_pcr_parse_digest_list_bad),
         cmocka_unit_test(test_pcr_parse_digest_list_bad_alg),
         cmocka_unit_test(test_tpm2_alg_util_get_hash_size),
-        cmocka_unit_test(test_tpm2_alg_util_is_signing_scheme)
+        cmocka_unit_test(test_tpm2_alg_util_is_signing_scheme),
+        cmocka_unit_test(test_tpm2_alg_util_is_hash_alg)
     };
 
     return cmocka_run_group_tests(tests, NULL, NULL);

--- a/tools/tpm2_import.c
+++ b/tools/tpm2_import.c
@@ -602,7 +602,7 @@ static bool on_option(char key, char *value) {
             return false;
         }
         break;
-    case 'f':
+    case 'K':
         ctx.parent_key_public_file = value;
         break;
     case 'q':
@@ -631,13 +631,13 @@ bool tpm2_tool_onstart(tpm2_options **opts) {
       { "import-key-alg",     required_argument, NULL, 'G'},
       { "input-key-file",     required_argument, NULL, 'k'},
       { "parent-key-handle",  required_argument, NULL, 'H'},
-      { "parent-key-public",  required_argument, NULL, 'f'},
+      { "parent-key-public",  required_argument, NULL, 'K'},
       { "import-key-private", required_argument, NULL, 'r'},
       { "import-key-public",  required_argument, NULL, 'q'},
       { "object-attributes",  required_argument, NULL, 'A' },
     };
 
-    *opts = tpm2_options_new("G:k:H:f:q:r:A:", ARRAY_LEN(topts), topts, on_option,
+    *opts = tpm2_options_new("G:k:H:K:q:r:A:", ARRAY_LEN(topts), topts, on_option,
                              NULL, TPM2_OPTIONS_SHOW_USAGE);
 
     return *opts != NULL;

--- a/tools/tpm2_import.c
+++ b/tools/tpm2_import.c
@@ -637,9 +637,6 @@ bool tpm2_tool_onstart(tpm2_options **opts) {
       { "object-attributes",  required_argument, NULL, 'A' },
     };
 
-    setbuf(stdout, NULL);
-    setvbuf (stdout, NULL, _IONBF, BUFSIZ);
-
     *opts = tpm2_options_new("G:k:H:f:q:r:A:", ARRAY_LEN(topts), topts, on_option,
                              NULL, TPM2_OPTIONS_SHOW_USAGE);
 

--- a/tools/tpm2_verifysignature.c
+++ b/tools/tpm2_verifysignature.c
@@ -38,6 +38,7 @@
 #include "files.h"
 #include "log.h"
 #include "tpm2_alg_util.h"
+#include "tpm2_convert.h"
 #include "tpm2_hash.h"
 #include "tpm2_options.h"
 #include "tpm2_tool.h"
@@ -153,7 +154,10 @@ static bool init(TSS2_SYS_CONTEXT *sapi_context) {
     }
 
     if (ctx.flags.sig) {
-        bool res =  files_load_signature(ctx.sig_file_path, &ctx.signature);
+
+        TPMI_ALG_SIG_SCHEME sig_alg = ctx.flags.raw ? TPM2_ALG_RSASSA : TPM2_ALG_ERROR;
+        tpm2_convert_sig_fmt fmt = ctx.flags.raw ? signature_format_plain : signature_format_tss;
+        bool res = tpm2_convert_sig_load(ctx.sig_file_path, fmt, sig_alg, ctx.halg, &ctx.signature);
         if (!res) {
             goto err;
         }


### PR DESCRIPTION
Updated: 5/1/2018 @ 11:43AM Pacific

Adds tests for import that:
* Sign with the tpm and verify with openssl
* Sign with openssl and verify with the tpm
  * Required -r raw support to be fixed
  * Required conversion routine from plain signature to tss

Additional Changes:
* Changes private key input to openssl PEM file and  supports encrypted private keys.
* Drops a dead function prototype as well
* Drops dead crufty code
* Update tpm2_verifysignature to support `-f --format` instead of `-r --raw`.
  * This is the generic plumbing for taking in a signing scheme, even though only rsassa is supported.
* Add more unit tests

Post-Merge TODO:
Update Changelog to include the tpm2_verifysignature option rename