### PR TITLE
tpm2_import: Fix build error due missing break in a case statement

### DIFF
--- a/tools/tpm2_import.c
+++ b/tools/tpm2_import.c
@@ -599,6 +599,7 @@ static bool on_option(char key, char *value) {
                     value);
                 return false;
         }
+        break;
     case 'K':
         ctx.input_public_key_file = value;
         ctx.input_pub_key_buffer_length = RSA_2K_MODULUS_SIZE_IN_BYTES;


### PR DESCRIPTION
This commit fixes the following GCC warning that leads to a compile error:

  CC       tools/tpm2_import.o
tools/tpm2_import.c: In function ‘on_option’:
tools/tpm2_import.c:590:9: error: this statement may fall through [-Werror=implicit-fallthrough=]
         switch(ctx.key_type) {
         ^~~~~~
tools/tpm2_import.c:602:5: note: here
     case 'K':
     ^~~~
cc1: all warnings being treated as errors

Signed-off-by: Javier Martinez Canillas <javierm@redhat.com>