### PR TITLE
tpm2_createprimary allow primary key to be created with sign bit

### DIFF
--- a/lib/tpm2_attr_util.c
+++ b/lib/tpm2_attr_util.c
@@ -495,6 +495,7 @@ static bool common_strtoattr(char *attribute_list, void *attrs, dispatch_table *
 
 bool tpm2_attr_util_nv_strtoattr(char *attribute_list, TPMA_NV *nvattrs) {
 
+    memset(nvattrs, 0, sizeof(*nvattrs));
     return common_strtoattr(attribute_list, nvattrs, nv_attr_table, ARRAY_LEN(nv_attr_table));
 }
 

--- a/lib/tpm2_attr_util.c
+++ b/lib/tpm2_attr_util.c
@@ -500,6 +500,7 @@ bool tpm2_attr_util_nv_strtoattr(char *attribute_list, TPMA_NV *nvattrs) {
 
 bool tpm2_attr_util_obj_strtoattr(char *attribute_list, TPMA_OBJECT *objattrs) {
 
+    memset(objattrs, 0, sizeof(*objattrs));
     return common_strtoattr(attribute_list, objattrs, obj_attr_table, ARRAY_LEN(obj_attr_table));
 }
 


### PR DESCRIPTION
Allow a primary key to be created with the sign attribute