### PR TITLE
autotools: allow man page installation without pandoc being available

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -256,8 +256,7 @@ EXTRA_DIST = $(top_srcdir)/man \
 	     README.md \
 	     RELEASE.md \
 	     test/integration
-
-if HAVE_PANDOC
+if HAVE_MAN_PAGES
     man1_MANS := \
     man/man1/tpm2_activatecredential.1 \
     man/man1/tpm2_certify.1 \
@@ -305,7 +304,9 @@ if HAVE_PANDOC
     man/man1/tpm2_startup.1 \
     man/man1/tpm2_unseal.1 \
     man/man1/tpm2_verifysignature.1
+endif
 
+if HAVE_PANDOC
 # If pandoc is enabled, we want to generate the manpages for the dist tarball
 EXTRA_DIST += $(man1_MANS)
 else

--- a/configure.ac
+++ b/configure.ac
@@ -15,6 +15,9 @@ AS_IF(
     [],
     [AC_MSG_WARN([Required executable pandoc not found, man pages will not be built])])
 AM_CONDITIONAL([HAVE_PANDOC],[test "x${PANDOC}" = "xyes"])
+AM_CONDITIONAL(
+    [HAVE_MAN_PAGES],
+    [test -d "${srcdir}/man/man1" -o "x${PANDOC}" = "xyes"])
 PKG_CHECK_MODULES([TSS2_SYS],[tss2-sys])
 PKG_CHECK_MODULES([CRYPTO], [libcrypto >= 1.0.2g])
 PKG_CHECK_MODULES([CURL],[libcurl])


### PR DESCRIPTION
The changes introduced for issue #925 still don't work out completely. The man
pages are now distributed in the release tarball, but they won't be installed
by automake, because the install targets are not setup when `pandoc` is not
around.

With this change the man page install targets will be setup even if
pandoc is not installed but generated man pages are available in
man/man1.

The test is not perfect, maybe you have a better idea how to achieve this.
