### PR TITLE
man: Fix tpm2_pcrlist Example and Spelling Errors

### DIFF
--- a/man/common/alg.md
+++ b/man/common/alg.md
@@ -1,4 +1,4 @@
-# Algorithm Specfiers
+# Algorithm Specifiers
 
 Options that take algorithms support "nice-names". Nice names, like sha1 can be
 used in place of the raw hex for sha1: 0x4. The nice names are converted by

--- a/man/common/pcr.md
+++ b/man/common/pcr.md
@@ -1,4 +1,4 @@
-# PCR Bank Specfiers
+# PCR Bank Specifiers
 
 PCR Bank Selection lists follow the below specification:
 
@@ -11,12 +11,12 @@ multiple banks may be separated by '+'.
 For example:
 
 ```
-sha:3,4+sha256:5,6
+sha1:3,4+sha256:5,6
 ```
-will select PCRs 3 and 4 from the SHA bank and PCRs 5 and 6
+will select PCRs 3 and 4 from the SHA1 bank and PCRs 5 and 6
 from the SHA256 bank.
 
 ## Note
 PCR Selections allow for up to 5 hash to pcr selection mappings.
-This is a limitaion in design in the single call to the tpm to
+This is a limitation in design in the single call to the tpm to
 get the pcr values.

--- a/man/common/pubkey.md
+++ b/man/common/pubkey.md
@@ -1,6 +1,6 @@
   * **-f**, **--format**:
 
     Format selection for the public key output file. 'tss' (the default) will
-    output a binary blob according to the TPM 2.0 secification. 'pem' will output
-    an OpenSSL compatible PEM encoded public key. 'der' will output an
+    output a binary blob according to the TPM 2.0 Specification. 'pem' will
+    output an OpenSSL compatible PEM encoded public key. 'der' will output an
     OpenSSL compatible DER encoded public key.

--- a/man/tpm2_changeauth.1.md
+++ b/man/tpm2_changeauth.1.md
@@ -13,7 +13,7 @@ and lockout authorizations.
 
 # DESCRIPTION
 
-**tpm2_changeauth**(1) - set the various (owner, endorse, locakout)
+**tpm2_changeauth**(1) - set the various (owner, endorse, lockout)
 authorization values.
 
 # OPTIONS

--- a/man/tpm2_makecredential.1.md
+++ b/man/tpm2_makecredential.1.md
@@ -14,7 +14,7 @@ TPM.
 # DESCRIPTION
 
 **tpm2_makecredential**(1) - Use a TPM public key to protect a secret that is used
-to encrypt the AK certififcate.
+to encrypt the AK certificate.
 
 # OPTIONS
 

--- a/man/tpm2_nvread.1.md
+++ b/man/tpm2_nvread.1.md
@@ -51,7 +51,7 @@
 
     The list of pcr banks and selected PCRs' ids.
     _PCR\_SELECTION\_LIST_ values should follow the
-    pcr bank specifiers standards, see section "PCR Bank Specfiers".
+    pcr bank specifiers standards, see section "PCR Bank Specifiers".
 
   * **-F**,**--pcr-input-file=_PCR\_INPUT\_FILE_
 

--- a/man/tpm2_nvwrite.1.md
+++ b/man/tpm2_nvwrite.1.md
@@ -44,7 +44,7 @@ If _FILE_ is not specified, it defaults to stdin.
 
     The list of pcr banks and selected PCRs' ids.
     _PCR\_SELECTION\_LIST_ values should follow the
-    pcr bank specifiers standards, see section "PCR Bank Specfiers".
+    pcr bank specifiers standards, see section "PCR Bank Specifiers".
 
   * **-F**,**--pcr-input-file**=_PCR\_INPUT\_FILE_
 

--- a/man/tpm2_pcrlist.1.md
+++ b/man/tpm2_pcrlist.1.md
@@ -20,6 +20,7 @@ Output is written in a YAML format to stdout, with each algorithm followed by
 a PCR index and its value. As a simple example assume just sha1 and sha256
 support and only 1 PCR. The output would be:
 ```
+$ tpm2_pcrlist -L sha1:0+sha256:0
 sha1 :
   0  : 0000000000000000000000000000000000000003
 sha256 :
@@ -42,7 +43,7 @@ sha256 :
 
     The list of pcr banks and selected PCRs' ids for each bank to display.
     _PCR\_SELECTION\_LIST_ values should follow the
-    pcr bank specifiers standards, see section "PCR Bank Specfiers".
+    pcr bank specifiers standards, see section "PCR Bank Specifiers".
 
   * **-s**, **--algs**:
     Output the list of supported algorithms.

--- a/man/tpm2_quote.1.md
+++ b/man/tpm2_quote.1.md
@@ -37,7 +37,7 @@
 
     The list of pcr banks and selected PCRs' ids for each bank.
     _PCR\_SELECTION\_LIST_ values should follow the
-    pcr bank specifiers standards, see section "PCR Bank Specfiers".
+    pcr bank specifiers standards, see section "PCR Bank Specifiers".
 
   * **-m**, **--message**:
 

--- a/man/tpm2_unseal.1.md
+++ b/man/tpm2_unseal.1.md
@@ -48,7 +48,7 @@ alive and pass that session using the **--input-session-handle** option.
 
     The list of pcr banks and selected PCRs' ids.
     _PCR\_SELECTION\_LIST_ values should follow the
-    pcr bank specifiers standards, see section "PCR Bank Specfiers".
+    pcr bank specifiers standards, see section "PCR Bank Specifiers".
     **-S** is mutually exclusive of this option.
 
   * **-F**,**--pcr-input-file**=_PCR\_INPUT\_FILE_


### PR DESCRIPTION
The tpm2_pcrlist example is incorrect. This: `sha:3,4+sha256:5,6`
should be: `sha1:3,4+sha256:5,6`

Add the command for the `tpm2_pcrlist -L sha1:0+sha256:0` example.

Fix these spelling errors:
s/secification/specification
s/Specfiers/Specifiers
s/limitaion/limitation
s/certififcate/certificate
s/locakout/lockout

Fixes #1034.

Signed-off-by: Dan Anderson <daniel.anderson@intel.com>