### PR TITLE
tpm2_createprimary: specify defaults for -g/-G

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## Changelog
 ### next
+  * tpm2_createprimary: -g/-G become optional options.
   * tpm2_verifysignature - Option `-r` changes to `-f` and supports signature format "rsa".
   * tpm2_import - Parent public data option, `-K` is optional.
   * tpm2_import - Supports importing external RSA 2048 keys via pem files.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## Changelog
 ### next
+  * tpm2_create: -g/-G become optional options.
   * tpm2_createprimary: -g/-G become optional options.
   * tpm2_verifysignature - Option `-r` changes to `-f` and supports signature format "rsa".
   * tpm2_import - Parent public data option, `-K` is optional.

--- a/lib/tpm2_util.c
+++ b/lib/tpm2_util.c
@@ -352,6 +352,10 @@ void tpm2_util_public_to_yaml(TPM2B_PUBLIC *public) {
 bool tpm2_util_object_load(TSS2_SYS_CONTEXT *sapi_ctx,
         const char *objectstr, tpm2_loaded_object *outobject) {
 
+    if (!objectstr) {
+        return false;
+    }
+
     bool starts_with_file = !strncmp(objectstr, FILE_PREFIX, FILE_PREFIX_LEN);
     bool result;
 

--- a/man/tpm2_create.1.md
+++ b/man/tpm2_create.1.md
@@ -35,14 +35,17 @@ These options for creating the tpm entity:
     "password for parent key" option: **-P**.
 
   * **-g**, **--halg**=_ALGORITHM_:
-    The hash algorithm to use. Algorithms should follow the
+    The hash algorithm for generating the objects name. This is optional
+    and defaults to sha256 when not specified. Algorithms should follow the
     " formatting standards, see section "Algorithm Specifiers".
     Also, see section "Supported Hash Algorithms" for a list of supported
     hash algorithms.
 
   * **-G**, **--kalg**=_KEY\_ALGORITHM_:
-    The algorithm associated with this object. It accepts friendly names just
-    like -g option. See section "Supported Public Object Algorithms" for a list
+    The key algorithm associated with this object. It defaults to RSA if not
+    specified.
+    It accepts friendly names just like -g option.
+    See section "Supported Public Object Algorithms" for a list
     of supported object algorithms.
 
   * **-A**, **--object-attributes**=_ATTRIBUTES_:

--- a/man/tpm2_createprimary.1.md
+++ b/man/tpm2_createprimary.1.md
@@ -42,13 +42,15 @@ will create and load a Primary Object. The sensitive area is not returned.
     "Authorization Formatting".
 
   * **-g**, **--halg**=_ALGORITHM_:
-    The hash algorithm to use. Algorithms should follow the
-    " formatting standards, see section "Algorithm Specifiers".
-    Also, see section "Supported Hash Algorithms" for a list of supported
-    hash algorithms.
+    The hash algorithm to use for generating the objects name.
+    If not specified, the default name algorithm is SHA256.
+    Algorithms should follow the "formatting standards, see section
+    "Algorithm Specifiers". Also, see section
+    "Supported Hash Algorithms" for a list of supported hash algorithms.
 
   * **-G**, **--kalg**=_KEY\_ALGORITHM_:
     Algorithm type for generated key. It supports friendly names like the -g option.
+    If not specified, the default key algorithm is RSA.
     See section "Supported Public Object Algorithms" for a list of supported
     object algorithms.
 

--- a/test/integration/tests/createprimary.sh
+++ b/test/integration/tests/createprimary.sh
@@ -80,4 +80,7 @@ policy_new=$(yaml_get_kv pub.out \"authorization\ policy\")
 
 test "$policy_orig" == "$policy_new"
 
+# Test that -g/-G do not need to be specified.
+tpm2_createprimary -Q -o context.out
+
 exit 0

--- a/tools/tpm2_create.c
+++ b/tools/tpm2_create.c
@@ -273,16 +273,10 @@ static bool on_option(char key, char *value) {
         break;
     case 'u':
         ctx.opu_path = value;
-        if(files_does_file_exist(ctx.opu_path) != 0) {
-            return false;
-        }
         ctx.flags.u = 1;
         break;
     case 'r':
         ctx.opr_path = value;
-        if(files_does_file_exist(ctx.opr_path) != 0) {
-            return false;
-        }
         ctx.flags.r = 1;
         break;
     case 'C':

--- a/tools/tpm2_createprimary.c
+++ b/tools/tpm2_createprimary.c
@@ -59,8 +59,6 @@ struct tpm_createprimary_ctx {
     tpm2_hierarchy_pdata objdata;
     char *context_file;
     struct {
-        UINT8 g :1;
-        UINT8 G :1;
         UINT8 P :1;
         UINT8 K :1;
     } flags;
@@ -177,7 +175,6 @@ static bool on_option(char key, char *value) {
         if (!res) {
             return false;
         }
-        ctx.flags.g = 1;
     }   break;
     case 'G': {
         TPMI_ALG_PUBLIC type = tpm2_alg_util_from_optarg(value);
@@ -190,7 +187,6 @@ static bool on_option(char key, char *value) {
         if (!res) {
             return false;
         }
-        ctx.flags.G = 1;
     }   break;
     case 'o':
         ctx.context_file = value;
@@ -238,19 +234,11 @@ bool tpm2_tool_onstart(tpm2_options **opts) {
     return *opts != NULL;
 }
 
-static inline bool valid_ctx(void) {
-    return (ctx.flags.g && ctx.flags.G);
-}
-
 int tpm2_tool_onrun(TSS2_SYS_CONTEXT *sapi_context, tpm2_option_flags flags) {
     UNUSED(flags);
 
     bool result;
     int rc = 1;
-
-    if (!valid_ctx()) {
-        goto out;
-    }
 
     if (ctx.flags.P) {
         result = tpm2_auth_util_from_optarg(sapi_context, ctx.parent_auth_str, &ctx.auth.session_data, &ctx.auth.session);


### PR DESCRIPTION
The name hash algorithm and key algorithms have defaults, use
them so -g/-G do not need to be specified.

Now the command tpm2_createprimary -o context.dat will work.

Signed-off-by: William Roberts <william.c.roberts@intel.com>