### PR TITLE
Clarify that file: prefix is not required by tpm2_util_object_load

### DIFF
--- a/man/tpm2_certify.1.md
+++ b/man/tpm2_certify.1.md
@@ -68,7 +68,7 @@ These options control the certification:
 
 ```
 tpm2_certify -H 0x81010002 -k 0x81010001 -P 0x0011 -K 0x00FF -g 0x00B -a <fileName> -s <fileName>
-tpm2_certify -C file:obj.context -c key.context -P 0x0011 -K 0x00FF -g 0x00B -a <fileName> -s <fileName>
+tpm2_certify -C obj.context -c key.context -P 0x0011 -K 0x00FF -g 0x00B -a <fileName> -s <fileName>
 tpm2_certify -H 0x81010002 -k 0x81010001 -P 0011 -K 00FF -X -g 0x00B -a <fileName> -s <fileName>
 ```
 

--- a/man/tpm2_createak.1.md
+++ b/man/tpm2_createak.1.md
@@ -139,7 +139,7 @@ loaded-key:
   handle: 0x80000001
   name: 000b8052c63861b1855c91edd63bca2eb3ea3ad304bb9798a9445ada12d5b5bb36e0
 
-tpm2_createek -g rsa -p ek.pub -c file:ek.ctx
+tpm2_createek -g rsa -p ek.pub -c ek.ctx
 
 # Check that the AK is loaded in transient memory
 # Note the AK is at handle 0x80000001
@@ -155,7 +155,7 @@ tpm2_getcap -c handles-transient
 - 0x80000000
 
 # Reload it via loadexternal
-tpm2_loadexternal -H o -u ak.pub -o file:ak.ctx
+tpm2_loadexternal -H o -u ak.pub -o ak.ctx
 
 # Check that it is re-loaded in transient memory
 $ tpm2_getcap -c handles-transient

--- a/man/tpm2_createek.1.md
+++ b/man/tpm2_createek.1.md
@@ -97,7 +97,7 @@ tpm2_createek -g rsa
 
 Create a transient Endorsement Key, flush it, and reload it.
 ```
-tpm2_createek -g rsa -p ek.pub -c file:ek.ctx
+tpm2_createek -g rsa -p ek.pub -c ek.ctx
 
 # Check that it is loaded in transient memory
 tpm2_getcap -c handles-transient

--- a/man/tpm2_evictcontrol.1.md
+++ b/man/tpm2_evictcontrol.1.md
@@ -61,10 +61,8 @@ be evicted.
 # EXAMPLES
 
 ```
-tpm2_evictcontrol -A o -c file:object.context -S 0x81010002 -P abc123
-tpm2_evictcontrol -A o -c objectctx.dat -S 0x81010002 -P abc123
+tpm2_evictcontrol -A o -c object.context -S 0x81010002 -P abc123
 tpm2_evictcontrol -A o -c 0x81010002 -S 0x81010002 -P abc123
-tpm2_evictcontrol -A o -c 0x81010002 -S 0x81010002 -P 123abc
 ```
 
 # RETURNS

--- a/man/tpm2_hmac.1.md
+++ b/man/tpm2_hmac.1.md
@@ -63,7 +63,7 @@ tpm2_hmac -C 0x81010002 -P abc123 -g sha1 data.in
 
 Perform a SHA1 HMAC on data.in read as a file to stdin and send output to a file:
 ```
-tpm2_hmac -C file:key.context -P abc123 -g sha1 -o hash.out << data.in
+tpm2_hmac -C key.context -P abc123 -g sha1 -o hash.out << data.in
 ```
 Perform a SHA256 HMAC on _stdin_ and send result and possibly ticket to stdout:
 

--- a/man/tpm2_load.1.md
+++ b/man/tpm2_load.1.md
@@ -55,7 +55,7 @@ into the TPM.
 
 ```
 tpm2_load  -C 0x80000000 -P abc123 -u <pubKeyFileName> -r <privKeyFileName> -n <outPutFileName>
-tpm2_load  -C file:parent.context -P abc123 -u <pubKeyFileName> -r <privKeyFileName> -n <outPutFileName> -o object.context
+tpm2_load  -C parent.context -P abc123 -u <pubKeyFileName> -r <privKeyFileName> -n <outPutFileName> -o object.context
 tpm2_load  -C 0x80000000 -P "hex:123abc" -u <pubKeyFileName> -r <privKeyFileName> -n <outPutFileName>
 
 ```

--- a/man/tpm2_policypcr.1.md
+++ b/man/tpm2_policypcr.1.md
@@ -67,10 +67,10 @@ tpm2_policypcr -Q -S session.dat -L "sha1:0,1,2,3" -F pcr.dat -f policy.dat
 
 tpm2_flushcontext -H "$handle"
 
-tpm2_create -Q -g sha256 -G keyedhash -u key.pub -r key.priv -C file:primary.ctx -L policy.dat \
+tpm2_create -Q -g sha256 -G keyedhash -u key.pub -r key.priv -C primary.ctx -L policy.dat \
   -A 'sign|fixedtpm|fixedparent|sensitivedataorigin' -I- <<< "12345678"
 
-tpm2_load -Q -C file:primary.ctx -u key.pub -r key.priv -n unseal.key.name -o unseal.key.ctx
+tpm2_load -Q -C primary.ctx -u key.pub -r key.priv -n unseal.key.name -o unseal.key.ctx
 
 # Now that an object is created and a policy is required to access it, satisfy the policy on
 # a session and use it to unseal the data stored in the object.
@@ -79,7 +79,7 @@ handle=`tpm2_startauthsession -a -S session.dat | cut -d' ' -f 2-2`
 
 tpm2_policypcr -Q -S session.dat -L "sha1:0,1,2,3" -F pcr.dat -f policy.dat
 
-unsealed=`tpm2_unseal -S session.dat -c file:unseal.key.ctx`
+unsealed=`tpm2_unseal -S session.dat -c unseal.key.ctx`
 
 echo "$unsealed"
 

--- a/man/tpm2_policyrestart.1.md
+++ b/man/tpm2_policyrestart.1.md
@@ -41,7 +41,7 @@ tpm2_startauthsession -S session.dat -a
 tpm2_policypcr -Q -S session.dat -L "sha1:0,1,2,3" -F pcr.dat -f policy.dat
 
 # pcr event occurs here causing unseal to fail
-tpm2_unseal -S session.dat -c file:unseal.key.ctx
+tpm2_unseal -S session.dat -c unseal.key.ctx
 "Sys_Unseal failed. Error Code: 0x00000128"
 
 # restart the session, try again, pcr state must satisfy policy
@@ -49,7 +49,7 @@ tpm2_sessionrestart -S session.dat
 
 tpm2_policypcr -Q -S session.dat -L "sha1:0,1,2,3" -F pcr.dat -f policy.dat
 
-tpm2_unseal -S session.dat -c file:unseal.key.ctx
+tpm2_unseal -S session.dat -c unseal.key.ctx
 
 ```
 

--- a/man/tpm2_quote.1.md
+++ b/man/tpm2_quote.1.md
@@ -79,7 +79,7 @@
 
 ```
 tpm2_quote -C 0x81010002 -P abc123 -L sha1 -l 16,17,18
-tpm2_quote -C file:ak.context -P "str:abc123" -L sha1 -l 16,17,18
+tpm2_quote -C ak.context -P "str:abc123" -L sha1 -l 16,17,18
 tpm2_quote -C 0x81010002 -L sha1 -l 16,17,18
 tpm2_quote -C ak.dat -L sha1 -l 16,17,18
 tpm2_quote -C 0x81010002 -P "hex:123abc" -L sha1:16,17,18+sha256:16,17,18 -q 11aa22bb

--- a/man/tpm2_sign.1.md
+++ b/man/tpm2_sign.1.md
@@ -84,7 +84,7 @@ data and validation shall indicate that hashed data did not start with
 
 ```
 tpm2_sign -C 0x81010001 -P abc123 -g sha256 -m <filePath> -s <filePath> -t <filePath>
-tpm2_sign -C file:key.context -P abc123 -g sha256 -m <filePath> -s <filePath> -t <filePath>
+tpm2_sign -C key.context -P abc123 -g sha256 -m <filePath> -s <filePath> -t <filePath>
 ```
 
 # RETURNS

--- a/man/tpm2_unseal.1.md
+++ b/man/tpm2_unseal.1.md
@@ -67,9 +67,9 @@ alive and pass that session using the **--input-session-handle** option.
 
 ```
 tpm2_unseal -H 0x81010001 -P abc123 -o out.dat
-tpm2_unseal -c file:item.context -P abc123 -o out.dat
+tpm2_unseal -c item.context -P abc123 -o out.dat
 tpm2_unseal -c 0x81010001 -P "hex:123abc" -o out.dat
-tpm2_unseal -c file:item.context -L sha1:0,1,2 -F out.dat
+tpm2_unseal -c item.context -L sha1:0,1,2 -F out.dat
 ```
 
 # RETURNS

--- a/man/tpm2_verifysignature.1.md
+++ b/man/tpm2_verifysignature.1.md
@@ -86,7 +86,7 @@ symmetric key, both the public and private portions need to be loaded.
 ```
 tpm2_verifysignature -C 0x81010001 -g sha256 -m <filePath> -s <filePath> -t <filePath>
 tpm2_verifysignature -C 0x81010001 -D <filePath> -s <filePath> -t <filePath>
-tpm2_verifysignature -C file:key.context -g sha256 -m <filePath> -s <filePath> -t <filePath>
+tpm2_verifysignature -C key.context -g sha256 -m <filePath> -s <filePath> -t <filePath>
 ```
 
 # RETURNS

--- a/test/integration/tests/certify.sh
+++ b/test/integration/tests/certify.sh
@@ -51,10 +51,10 @@ tpm2_clear -Q
 
 tpm2_createprimary -Q -a e -g sha256 -G rsa -o primary.ctx
 
-tpm2_create -Q -g sha256 -G rsa -u certify.pub -r certify.priv  -C file:primary.ctx
+tpm2_create -Q -g sha256 -G rsa -u certify.pub -r certify.priv  -C primary.ctx
 
-tpm2_load -Q -C file:primary.ctx -u certify.pub -r certify.priv -n certify.name -o certify.ctx
+tpm2_load -Q -C primary.ctx -u certify.pub -r certify.priv -n certify.name -o certify.ctx
 
-tpm2_certify -Q -c file:primary.ctx -C file:certify.ctx -g sha256 -a attest.out -s sig.out
+tpm2_certify -Q -c primary.ctx -C certify.ctx -g sha256 -a attest.out -s sig.out
 
 exit 0

--- a/test/integration/tests/create.sh
+++ b/test/integration/tests/create.sh
@@ -68,7 +68,7 @@ cleanup "keep-context" "no-shut-down"
 policy_orig="f28230c080bbe417141199e36d18978228d8948fc10a6a24921b9eba6bb1d988"
 echo "$policy_orig" | xxd -r -p > policy.bin
 
-tpm2_create -C file:context.out -g sha256 -G 0x1 -L policy.bin -u key.pub -r key.priv \
+tpm2_create -C context.out -g sha256 -G 0x1 -L policy.bin -u key.pub -r key.priv \
   -A 'sign|fixedtpm|fixedparent|sensitivedataorigin' > out.pub
 
 policy_new=$(yaml_get_kv out.pub \"authorization\ policy\")

--- a/test/integration/tests/createprimary.sh
+++ b/test/integration/tests/createprimary.sh
@@ -74,7 +74,7 @@ echo -n "$policy_orig" | xxd -r -p > policy.bin
 tpm2_createprimary -Q -a o -G rsa -g sha256 -o context.out -L policy.bin \
   -A 'restricted|decrypt|fixedtpm|fixedparent|sensitivedataorigin'
 
-tpm2_readpublic -c file:context.out > pub.out
+tpm2_readpublic -c context.out > pub.out
 
 policy_new=$(yaml_get_kv pub.out \"authorization\ policy\")
 

--- a/test/integration/tests/encryptdecrypt.sh
+++ b/test/integration/tests/encryptdecrypt.sh
@@ -71,12 +71,12 @@ tpm2_clear -Q
 
 tpm2_createprimary -Q -a e -g sha1 -G rsa -o primary.ctx
 
-tpm2_create -Q -g sha256 -G symcipher -u key.pub -r key.priv -C file:primary.ctx
+tpm2_create -Q -g sha256 -G symcipher -u key.pub -r key.priv -C primary.ctx
 
-tpm2_load -Q -C file:primary.ctx -u key.pub -r key.priv -n key.name -o decrypt.ctx
+tpm2_load -Q -C primary.ctx -u key.pub -r key.priv -n key.name -o decrypt.ctx
 
-tpm2_encryptdecrypt -Q -c file:decrypt.ctx  -I secret.dat -o encrypt.out
+tpm2_encryptdecrypt -Q -c decrypt.ctx  -I secret.dat -o encrypt.out
 
-tpm2_encryptdecrypt -Q -c file:decrypt.ctx -D -I encrypt.out -o decrypt.out
+tpm2_encryptdecrypt -Q -c decrypt.ctx -D -I encrypt.out -o decrypt.out
 
 exit 0

--- a/test/integration/tests/evictcontrol.sh
+++ b/test/integration/tests/evictcontrol.sh
@@ -51,9 +51,9 @@ tpm2_clear -Q
 
 tpm2_createprimary -Q -a e -g sha256 -G rsa -o primary.ctx
 
-tpm2_create -Q -g sha256 -G keyedhash -u key.pub -r key.priv  -C file:primary.ctx
+tpm2_create -Q -g sha256 -G keyedhash -u key.pub -r key.priv  -C primary.ctx
 
-tpm2_load -Q -C file:primary.ctx  -u key.pub  -r key.priv -n key.name -o key.dat
+tpm2_load -Q -C primary.ctx  -u key.pub  -r key.priv -n key.name -o key.dat
 
 # Load the context into a specific handle, delete it
 tpm2_evictcontrol -Q -c key.dat -p 0x81010003

--- a/test/integration/tests/hmac.sh
+++ b/test/integration/tests/hmac.sh
@@ -76,22 +76,22 @@ tpm2_clear
 
 tpm2_createprimary -Q -a e -g $alg_primary_obj -G $alg_primary_key -o $file_primary_key_ctx
 
-tpm2_create -Q -g $alg_create_obj -G $alg_create_key -u $file_hmac_key_pub -r $file_hmac_key_priv  -C file:$file_primary_key_ctx
+tpm2_create -Q -g $alg_create_obj -G $alg_create_key -u $file_hmac_key_pub -r $file_hmac_key_priv  -C $file_primary_key_ctx
 
-tpm2_load -Q -C file:$file_primary_key_ctx  -u $file_hmac_key_pub  -r $file_hmac_key_priv -n $file_hmac_key_name -o $file_hmac_key_ctx
+tpm2_load -Q -C $file_primary_key_ctx  -u $file_hmac_key_pub  -r $file_hmac_key_priv -n $file_hmac_key_name -o $file_hmac_key_ctx
 
-cat $file_input_data | tpm2_hmac -Q -C file:$file_hmac_key_ctx  -g $halg -o $file_hmac_output
+cat $file_input_data | tpm2_hmac -Q -C $file_hmac_key_ctx  -g $halg -o $file_hmac_output
 
 cleanup "keep-context" "no-shut-down"
 
 # Test large file, ie sequence hmac'ing.
 dd if=/dev/urandom of=$file_input_data bs=2093 count=1 2>/dev/null
-tpm2_hmac -Q -C file:$file_hmac_key_ctx -g $halg -o $file_hmac_output $file_input_data
+tpm2_hmac -Q -C $file_hmac_key_ctx -g $halg -o $file_hmac_output $file_input_data
 
 ####handle test
 rm -f $file_hmac_output
 
-tpm2_evictcontrol -a o -c file:$file_hmac_key_ctx -p $handle_hmac_key > evict.log
+tpm2_evictcontrol -a o -c $file_hmac_key_ctx -p $handle_hmac_key > evict.log
 grep -q "persistentHandle: "$handle_hmac_key"" evict.log
 
 echo "12345678" > $file_input_data
@@ -106,20 +106,20 @@ tpm2_clear
 
 tpm2_createprimary -Q -a e -g $alg_primary_obj -G $alg_primary_key -o $file_primary_key_ctx
 
-tpm2_create -Q -g sha1 -G $alg_create_key -u $file_hmac_key_pub -r $file_hmac_key_priv  -C file:$file_primary_key_ctx
+tpm2_create -Q -g sha1 -G $alg_create_key -u $file_hmac_key_pub -r $file_hmac_key_priv  -C $file_primary_key_ctx
 
-tpm2_load -Q -C file:$file_primary_key_ctx  -u $file_hmac_key_pub  -r $file_hmac_key_priv -n $file_hmac_key_name -o $file_hmac_key_ctx
+tpm2_load -Q -C $file_primary_key_ctx  -u $file_hmac_key_pub  -r $file_hmac_key_priv -n $file_hmac_key_name -o $file_hmac_key_ctx
 
-cat $file_input_data | tpm2_hmac -Q -C file:$file_hmac_key_ctx -o $file_hmac_output
+cat $file_input_data | tpm2_hmac -Q -C $file_hmac_key_ctx -o $file_hmac_output
 
 # test no output file
-cat $file_input_data | tpm2_hmac -C file:$file_hmac_key_ctx 1>/dev/null
+cat $file_input_data | tpm2_hmac -C $file_hmac_key_ctx 1>/dev/null
 
 # test no output file with halg
-cat $file_input_data | tpm2_hmac -g sha1 -C file:$file_hmac_key_ctx 1>/dev/null
+cat $file_input_data | tpm2_hmac -g sha1 -C $file_hmac_key_ctx 1>/dev/null
 
 # verify that silent is indeed silent
-stdout=`cat $file_input_data | tpm2_hmac -Q -g sha1 -C file:$file_hmac_key_ctx`
+stdout=`cat $file_input_data | tpm2_hmac -Q -g sha1 -C $file_hmac_key_ctx`
 if [ -n "$stdout" ]; then
     echo "Expected no output when run in quiet mode, got\"$stdout\""
     exit 1

--- a/test/integration/tests/import.sh
+++ b/test/integration/tests/import.sh
@@ -52,7 +52,7 @@ start_up
 cleanup "no-shut-down"
 
 tpm2_createprimary -Q -G 1 -g 0xb -a o -o parent.ctx
-tpm2_evictcontrol -Q -a o -c file:parent.ctx -p 0x81010005
+tpm2_evictcontrol -Q -a o -c parent.ctx -p 0x81010005
 
 dd if=/dev/urandom of=sym.key bs=1 count=16 2>/dev/null
 
@@ -67,7 +67,7 @@ tpm2_load -Q -C 0x81010005 -u import_key.pub -r import_key.priv -n import_key.na
 
 echo "plaintext" > "plain.txt"
 
-tpm2_encryptdecrypt -c file:import_key.ctx  -I plain.txt -o plain.enc
+tpm2_encryptdecrypt -c import_key.ctx  -I plain.txt -o plain.enc
 
 openssl enc -in plain.enc -out plain.dec.ssl -d -K `xxd -p sym.key` -iv 0 \
 -aes-128-cfb

--- a/test/integration/tests/listpersistent.sh
+++ b/test/integration/tests/listpersistent.sh
@@ -79,7 +79,7 @@ for idx in "${!keys[@]}"
 do
     tpm2_createprimary -Q -a "$auth" -g "${hashes[$idx]}" -G "${keys[$idx]}" -o primary.context
     handle=$(printf "0x%X\n" $(($handle_base + $idx)))
-    tpm2_evictcontrol -Q -a "$auth" -p "$handle" -c file:primary.context
+    tpm2_evictcontrol -Q -a "$auth" -p "$handle" -c primary.context
 done
 
 tpm2_listpersistent > out.yaml

--- a/test/integration/tests/load.sh
+++ b/test/integration/tests/load.sh
@@ -78,15 +78,15 @@ tpm2_clear
 
 tpm2_createprimary -Q -a e -g $alg_primary_obj -G $alg_primary_key -o $file_primary_key_ctx
 
-tpm2_create -Q -g $alg_create_obj -G $alg_create_key -u $file_load_key_pub -r $file_load_key_priv  -C file:$file_primary_key_ctx
+tpm2_create -Q -g $alg_create_obj -G $alg_create_key -u $file_load_key_pub -r $file_load_key_priv  -C $file_primary_key_ctx
 
-tpm2_load -Q -C file:$file_primary_key_ctx  -u $file_load_key_pub  -r $file_load_key_priv -n $file_load_key_name -o $file_load_key_ctx
+tpm2_load -Q -C $file_primary_key_ctx  -u $file_load_key_pub  -r $file_load_key_priv -n $file_load_key_name -o $file_load_key_ctx
 
 #####handle test
 
 cleanup "keep_ctx" "no-shut-down"
 
-tpm2_evictcontrol -Q -a o -c file:$file_primary_key_ctx -p $Handle_parent
+tpm2_evictcontrol -Q -a o -c $file_primary_key_ctx -p $Handle_parent
 
 tpm2_create -Q -C $Handle_parent   -g $alg_create_obj  -G $alg_create_key -u $file_load_key_pub  -r  $file_load_key_priv
 

--- a/test/integration/tests/loadexternal.sh
+++ b/test/integration/tests/loadexternal.sh
@@ -72,11 +72,11 @@ tpm2_clear
 
 tpm2_createprimary -Q -a e -g $alg_primary_obj -G $alg_primary_key -o $file_primary_key_ctx
 
-tpm2_create -Q -g $alg_create_obj -G $alg_create_key -u $file_loadexternal_key_pub -r $file_loadexternal_key_priv  -C file:$file_primary_key_ctx
+tpm2_create -Q -g $alg_create_obj -G $alg_create_key -u $file_loadexternal_key_pub -r $file_loadexternal_key_priv  -C $file_primary_key_ctx
 
 tpm2_loadexternal -Q -a n   -u $file_loadexternal_key_pub   -o $file_loadexternal_key_ctx
 
-tpm2_evictcontrol -Q -a o -c file:$file_primary_key_ctx -p $Handle_parent
+tpm2_evictcontrol -Q -a o -c $file_primary_key_ctx -p $Handle_parent
 
 # Test with Handle
 cleanup "keep_handle" "no-shut-down"

--- a/test/integration/tests/quote.sh
+++ b/test/integration/tests/quote.sh
@@ -86,18 +86,18 @@ tpm2_clear
 
 tpm2_createprimary -Q -a e -g $alg_primary_obj -G $alg_primary_key -o $file_primary_key_ctx
 
-tpm2_create -Q -g $alg_create_obj -G $alg_create_key -u $file_quote_key_pub -r $file_quote_key_priv  -C file:$file_primary_key_ctx
+tpm2_create -Q -g $alg_create_obj -G $alg_create_key -u $file_quote_key_pub -r $file_quote_key_priv  -C $file_primary_key_ctx
 
-tpm2_load -Q -C file:$file_primary_key_ctx  -u $file_quote_key_pub  -r $file_quote_key_priv -n $file_quote_key_name -o $file_quote_key_ctx
+tpm2_load -Q -C $file_primary_key_ctx  -u $file_quote_key_pub  -r $file_quote_key_priv -n $file_quote_key_name -o $file_quote_key_ctx
 
-tpm2_quote -C file:$file_quote_key_ctx  -g $alg_quote -l 16,17,18 -q $nonce > $out
+tpm2_quote -C $file_quote_key_ctx  -g $alg_quote -l 16,17,18 -q $nonce > $out
 
 yaml_verify $out
 
-tpm2_quote -Q -C file:$file_quote_key_ctx  -L $alg_quote:16,17,18+$alg_quote1:16,17,18 -q $nonce
+tpm2_quote -Q -C $file_quote_key_ctx  -L $alg_quote:16,17,18+$alg_quote1:16,17,18 -q $nonce
 
 #####handle testing
-tpm2_evictcontrol -Q -a o -c file:$file_quote_key_ctx -p $Handle_ak_quote
+tpm2_evictcontrol -Q -a o -c $file_quote_key_ctx -p $Handle_ak_quote
 
 tpm2_quote -Q -C $Handle_ak_quote  -g $alg_quote -l 16,17,18 -q $nonce
 

--- a/test/integration/tests/readpublic.sh
+++ b/test/integration/tests/readpublic.sh
@@ -67,13 +67,13 @@ tpm2_clear
 
 tpm2_createprimary -Q -a e -g $alg_primary_obj -G $alg_primary_key -o $file_primary_key_ctx
 
-tpm2_create -Q -g $alg_create_obj -G $alg_create_key -u $file_readpub_key_pub -r $file_readpub_key_priv  -C file:$file_primary_key_ctx
+tpm2_create -Q -g $alg_create_obj -G $alg_create_key -u $file_readpub_key_pub -r $file_readpub_key_priv  -C $file_primary_key_ctx
 
-tpm2_load -Q -C file:$file_primary_key_ctx  -u $file_readpub_key_pub  -r $file_readpub_key_priv -n $file_readpub_key_name -o $file_readpub_key_ctx
+tpm2_load -Q -C $file_primary_key_ctx  -u $file_readpub_key_pub  -r $file_readpub_key_priv -n $file_readpub_key_name -o $file_readpub_key_ctx
 
-tpm2_readpublic -Q -c file:$file_readpub_key_ctx -o $file_readpub_output
+tpm2_readpublic -Q -c $file_readpub_key_ctx -o $file_readpub_output
 
-tpm2_evictcontrol -Q -a o -c file:$file_readpub_key_ctx -p $Handle_readpub
+tpm2_evictcontrol -Q -a o -c $file_readpub_key_ctx -p $Handle_readpub
 
 rm -f $file_readpub_output
 tpm2_readpublic -Q -c $Handle_readpub -o $file_readpub_output

--- a/test/integration/tests/rsadecrypt.sh
+++ b/test/integration/tests/rsadecrypt.sh
@@ -70,14 +70,14 @@ tpm2_clear
 
 tpm2_createprimary -Q -a e -g $alg_hash -G $alg_primary_key -o $file_primary_key_ctx
 
-tpm2_create -Q -g $alg_hash -G $alg_rsaencrypt_key -u $file_rsaencrypt_key_pub -r $file_rsaencrypt_key_priv  -C file:$file_primary_key_ctx
+tpm2_create -Q -g $alg_hash -G $alg_rsaencrypt_key -u $file_rsaencrypt_key_pub -r $file_rsaencrypt_key_priv  -C $file_primary_key_ctx
 
 tpm2_loadexternal -Q -a n   -u $file_rsaencrypt_key_pub  -o $file_rsaencrypt_key_ctx
 
-tpm2_rsaencrypt -Q -c file:$file_rsaencrypt_key_ctx -o $file_rsa_en_output_data < $file_input_data
+tpm2_rsaencrypt -Q -c $file_rsaencrypt_key_ctx -o $file_rsa_en_output_data < $file_input_data
 
-tpm2_load -Q -C file:$file_primary_key_ctx -u $file_rsaencrypt_key_pub -r $file_rsaencrypt_key_priv  -n $file_rsaencrypt_key_name  -o $file_rsadecrypt_key_ctx
+tpm2_load -Q -C $file_primary_key_ctx -u $file_rsaencrypt_key_pub -r $file_rsaencrypt_key_priv  -n $file_rsaencrypt_key_name  -o $file_rsadecrypt_key_ctx
 
-tpm2_rsadecrypt -Q -c file:$file_rsadecrypt_key_ctx  -I  $file_rsa_en_output_data -o  $file_rsa_de_output_data
+tpm2_rsadecrypt -Q -c $file_rsadecrypt_key_ctx  -I  $file_rsa_en_output_data -o  $file_rsa_de_output_data
 
 exit 0

--- a/test/integration/tests/rsaencrypt.sh
+++ b/test/integration/tests/rsaencrypt.sh
@@ -67,14 +67,14 @@ tpm2_clear
 
 tpm2_createprimary -Q -a e -g $alg_hash -G $alg_primary_key -o $file_primary_key_ctx
 
-tpm2_create -Q -g $alg_hash -G $alg_rsaencrypt_key -u $file_rsaencrypt_key_pub -r $file_rsaencrypt_key_priv  -C file:$file_primary_key_ctx
+tpm2_create -Q -g $alg_hash -G $alg_rsaencrypt_key -u $file_rsaencrypt_key_pub -r $file_rsaencrypt_key_priv  -C $file_primary_key_ctx
 
 tpm2_loadexternal -Q -a n   -u $file_rsaencrypt_key_pub  -o $file_rsaencrypt_key_ctx
 
 #./tpm2_rsaencrypt -c context_loadexternal_out6.out -I secret.data -o rsa_en.out
-tpm2_rsaencrypt -Q -c file:$file_rsaencrypt_key_ctx -o $file_rsa_en_output_data $file_input_data
+tpm2_rsaencrypt -Q -c $file_rsaencrypt_key_ctx -o $file_rsa_en_output_data $file_input_data
 
 # Test stdout for -o and ensure that output is xxd format, test that stdin pipe works as well.
-cat $file_input_data | tpm2_rsaencrypt -c file:$file_rsaencrypt_key_ctx | xxd -r > /dev/null
+cat $file_input_data | tpm2_rsaencrypt -c $file_rsaencrypt_key_ctx | xxd -r > /dev/null
 
 exit 0

--- a/test/integration/tests/sign.sh
+++ b/test/integration/tests/sign.sh
@@ -74,15 +74,15 @@ tpm2_clear
 
 tpm2_createprimary -Q -a e -g $alg_hash -G $alg_primary_key -o $file_primary_key_ctx
 
-tpm2_create -Q -g $alg_hash -G $alg_signing_key -u $file_signing_key_pub -r $file_signing_key_priv  -C file:$file_primary_key_ctx
+tpm2_create -Q -g $alg_hash -G $alg_signing_key -u $file_signing_key_pub -r $file_signing_key_priv  -C $file_primary_key_ctx
 
-tpm2_load -Q -C file:$file_primary_key_ctx  -u $file_signing_key_pub  -r $file_signing_key_priv -n $file_signing_key_name -o $file_signing_key_ctx
+tpm2_load -Q -C $file_primary_key_ctx  -u $file_signing_key_pub  -r $file_signing_key_priv -n $file_signing_key_name -o $file_signing_key_ctx
 
-tpm2_sign -Q -c file:$file_signing_key_ctx -g $alg_hash -m $file_input_data -s $file_output_data
+tpm2_sign -Q -c $file_signing_key_ctx -g $alg_hash -m $file_input_data -s $file_output_data
 
 rm -f $file_output_data
 
-tpm2_evictcontrol -Q -a o -c file:$file_signing_key_ctx -p $handle_signing_key
+tpm2_evictcontrol -Q -a o -c $file_signing_key_ctx -p $handle_signing_key
 
 tpm2_sign -Q -c $handle_signing_key -g $alg_hash -m $file_input_data -s $file_output_data
 

--- a/test/integration/tests/tcti/abrmd/extended-sessions.sh
+++ b/test/integration/tests/tcti/abrmd/extended-sessions.sh
@@ -104,17 +104,17 @@ tpm2_policypcr -Q -S $file_session_file -L ${alg_pcr_policy}:${pcr_ids} -F $file
 
 tpm2_flushcontext -S $file_session_file
 
-tpm2_create -Q -g $alg_create_obj -G $alg_create_key -u $file_unseal_key_pub -r $file_unseal_key_priv -I- -C file:$file_primary_key_ctx -L $file_policy \
+tpm2_create -Q -g $alg_create_obj -G $alg_create_key -u $file_unseal_key_pub -r $file_unseal_key_priv -I- -C $file_primary_key_ctx -L $file_policy \
   -A 'sign|fixedtpm|fixedparent|sensitivedataorigin' <<< $secret
 
-tpm2_load -Q -C file:$file_primary_key_ctx -u $file_unseal_key_pub -r $file_unseal_key_priv -n $file_unseal_key_name -o $file_unseal_key_ctx
+tpm2_load -Q -C $file_primary_key_ctx -u $file_unseal_key_pub -r $file_unseal_key_priv -n $file_unseal_key_name -o $file_unseal_key_ctx
 
 # Start a REAL policy session (-a option) and perform a pcr policy event
 handle=`tpm2_startauthsession -a -S $file_session_file | cut -d' ' -f 2-2`
 
 tpm2_policypcr -Q -S $file_session_file -L ${alg_pcr_policy}:${pcr_ids} -F $file_pcr_value -f $file_policy
 
-unsealed=`tpm2_unseal -P"session:$file_session_file" -c file:$file_unseal_key_ctx`
+unsealed=`tpm2_unseal -P"session:$file_session_file" -c $file_unseal_key_ctx`
 
 test "$unsealed" == "$secret"
 
@@ -124,7 +124,7 @@ tpm2_policyrestart -S $file_session_file
 # negative test, clear the error handler
 trap - ERR
 
-tpm2_unseal -P"session:$file_session_file" -c file:$file_unseal_key_ctx 2>/dev/null
+tpm2_unseal -P"session:$file_session_file" -c $file_unseal_key_ctx 2>/dev/null
 rc=$?
 
 # restore the error handler

--- a/test/integration/tests/unseal.sh
+++ b/test/integration/tests/unseal.sh
@@ -74,11 +74,11 @@ tpm2_clear
 
 tpm2_createprimary -Q -a e -g $alg_primary_obj -G $alg_primary_key -o $file_primary_key_ctx
 
-tpm2_create -Q -g $alg_create_obj -G $alg_create_key -u $file_unseal_key_pub -r $file_unseal_key_priv -I $file_input_data -C file:$file_primary_key_ctx
+tpm2_create -Q -g $alg_create_obj -G $alg_create_key -u $file_unseal_key_pub -r $file_unseal_key_priv -I $file_input_data -C $file_primary_key_ctx
 
-tpm2_load -Q -C file:$file_primary_key_ctx  -u $file_unseal_key_pub  -r $file_unseal_key_priv -n $file_unseal_key_name -o $file_unseal_key_ctx
+tpm2_load -Q -C $file_primary_key_ctx  -u $file_unseal_key_pub  -r $file_unseal_key_priv -n $file_unseal_key_name -o $file_unseal_key_ctx
 
-tpm2_unseal -Q -c file:$file_unseal_key_ctx -o $file_unseal_output_data
+tpm2_unseal -Q -c $file_unseal_key_ctx -o $file_unseal_output_data
 
 cmp -s $file_unseal_output_data $file_input_data
 
@@ -86,11 +86,11 @@ cmp -s $file_unseal_output_data $file_input_data
 
 rm $file_unseal_key_pub $file_unseal_key_priv $file_unseal_key_name
 
-cat $file_input_data | tpm2_create -Q -g $alg_create_obj -G $alg_create_key -u $file_unseal_key_pub -r $file_unseal_key_priv -I- -C file:$file_primary_key_ctx
+cat $file_input_data | tpm2_create -Q -g $alg_create_obj -G $alg_create_key -u $file_unseal_key_pub -r $file_unseal_key_priv -I- -C $file_primary_key_ctx
 
-tpm2_load -Q -C file:$file_primary_key_ctx  -u $file_unseal_key_pub  -r $file_unseal_key_priv -n $file_unseal_key_name -o $file_unseal_key_ctx
+tpm2_load -Q -C $file_primary_key_ctx  -u $file_unseal_key_pub  -r $file_unseal_key_priv -n $file_unseal_key_name -o $file_unseal_key_ctx
 
-tpm2_unseal -Q -c file:$file_unseal_key_ctx -o $file_unseal_output_data
+tpm2_unseal -Q -c $file_unseal_key_ctx -o $file_unseal_output_data
 
 cmp -s $file_unseal_output_data $file_input_data
 
@@ -102,12 +102,12 @@ tpm2_pcrlist -Q -L ${alg_pcr_policy}:${pcr_ids} -o $file_pcr_value
 
 tpm2_createpolicy -Q -P -L ${alg_pcr_policy}:${pcr_ids} -F $file_pcr_value -f $file_policy
 
-tpm2_create -Q -g $alg_create_obj -G $alg_create_key -u $file_unseal_key_pub -r $file_unseal_key_priv -I- -C file:$file_primary_key_ctx -L $file_policy \
+tpm2_create -Q -g $alg_create_obj -G $alg_create_key -u $file_unseal_key_pub -r $file_unseal_key_priv -I- -C $file_primary_key_ctx -L $file_policy \
   -A 'sign|fixedtpm|fixedparent|sensitivedataorigin' <<< $secret
 
-tpm2_load -Q -C file:$file_primary_key_ctx  -u $file_unseal_key_pub  -r $file_unseal_key_priv -n $file_unseal_key_name -o $file_unseal_key_ctx
+tpm2_load -Q -C $file_primary_key_ctx  -u $file_unseal_key_pub  -r $file_unseal_key_priv -n $file_unseal_key_name -o $file_unseal_key_ctx
 
-unsealed=`tpm2_unseal -c file:$file_unseal_key_ctx -L ${alg_pcr_policy}:${pcr_ids} -F $file_pcr_value`
+unsealed=`tpm2_unseal -c $file_unseal_key_ctx -L ${alg_pcr_policy}:${pcr_ids} -F $file_pcr_value`
 
 test "$unsealed" == "$secret"
 

--- a/test/integration/tests/verifysignature.sh
+++ b/test/integration/tests/verifysignature.sh
@@ -73,22 +73,22 @@ tpm2_clear
 
 tpm2_createprimary -Q -a e -g $alg_hash -G $alg_primary_key -o $file_primary_key_ctx
 
-tpm2_create -Q -g $alg_hash -G $alg_signing_key -u $file_signing_key_pub -r $file_signing_key_priv  -C file:$file_primary_key_ctx
+tpm2_create -Q -g $alg_hash -G $alg_signing_key -u $file_signing_key_pub -r $file_signing_key_priv  -C $file_primary_key_ctx
 
-tpm2_load -Q -C file:$file_primary_key_ctx  -u $file_signing_key_pub  -r $file_signing_key_priv -n $file_signing_key_name -o $file_signing_key_ctx
+tpm2_load -Q -C $file_primary_key_ctx  -u $file_signing_key_pub  -r $file_signing_key_priv -n $file_signing_key_name -o $file_signing_key_ctx
 
-tpm2_sign -Q -c file:$file_signing_key_ctx -g $alg_hash -m $file_input_data -s $file_output_data
+tpm2_sign -Q -c $file_signing_key_ctx -g $alg_hash -m $file_input_data -s $file_output_data
 
-tpm2_verifysignature -Q -c file:$file_signing_key_ctx  -g $alg_hash -m $file_input_data  -s $file_output_data -t $file_verify_tk_data
+tpm2_verifysignature -Q -c $file_signing_key_ctx  -g $alg_hash -m $file_input_data  -s $file_output_data -t $file_verify_tk_data
 
 tpm2_hash -Q -a n -g $alg_hash -o $file_input_data_hash -t $file_input_data_hash_tk $file_input_data
 
 rm -f $file_verify_tk_data
-tpm2_verifysignature -Q -c file:$file_signing_key_ctx  -D  $file_input_data_hash -s $file_output_data  -t $file_verify_tk_data
+tpm2_verifysignature -Q -c $file_signing_key_ctx  -D  $file_input_data_hash -s $file_output_data  -t $file_verify_tk_data
 
 rm -f $file_verify_tk_data $file_signing_key_ctx  -rf
 tpm2_loadexternal -Q -a n -u $file_signing_key_pub -o  $file_signing_key_ctx
 
-tpm2_verifysignature -Q -c file:$file_signing_key_ctx  -g $alg_hash -m $file_input_data  -s $file_output_data -t $file_verify_tk_data
+tpm2_verifysignature -Q -c $file_signing_key_ctx  -g $alg_hash -m $file_input_data  -s $file_output_data -t $file_verify_tk_data
 
 exit 0


### PR DESCRIPTION
The object loading code doesn't require a file: prefix for files, except in cases where the file name could be confused for a handle. Update the examples in the manual pages and the tests to not use the file: prefix, as doing so might suggest the prefix is required.

Possibly addresses #1040 