### PR TITLE
object creation fixes

### DIFF
--- a/lib/tpm2_alg_util.c
+++ b/lib/tpm2_alg_util.c
@@ -568,3 +568,22 @@ bool tpm2_alg_util_set_parent_pub_params(TPMI_ALG_PUBLIC type, TPM2B_PUBLIC *pub
 
     return true;
 }
+
+bool tpm2_alg_util_set_name(TPMI_ALG_HASH halg, TPM2B_PUBLIC *public) {
+
+    switch(halg) {
+    case TPM2_ALG_SHA1:
+    case TPM2_ALG_SHA256:
+    case TPM2_ALG_SHA384:
+    case TPM2_ALG_SHA512:
+    case TPM2_ALG_SM3_256:
+    case TPM2_ALG_NULL:
+        public->publicArea.nameAlg = halg;
+        return true;
+    }
+
+    LOG_ERR("name algorithm \"%s\" not supported!",
+            tpm2_alg_util_algtostr(halg));
+
+    return false;
+}

--- a/lib/tpm2_alg_util.h
+++ b/lib/tpm2_alg_util.h
@@ -202,4 +202,38 @@ bool get_signature_scheme(TSS2_SYS_CONTEXT *sapi_context,
         TPMI_DH_OBJECT keyHandle, TPMI_ALG_HASH halg,
         TPMT_SIG_SCHEME *scheme);
 
+/**
+ * Given the object algorithm type, generate settings for TPMU_PUBLIC_PARMS values for a leaf object
+ * and modify conflicting object attributes if present.
+ *
+ * XXX This likely isn't the best interface for this, eventually we will probably want to
+ * clean up the public structure value settings.
+ *
+ * @param type
+ *  The algorithm type of the object.
+ * @param public
+ *  The public structure to set the TPMU_PUBLIC_PARMS values for.
+ * @param is_sealing
+ *  Whether or not the object is being used to seal data.
+ * @return
+ *  true on success, false otherwise.
+ */
+bool tpm2_alg_util_set_leaf_pub_params(TPMI_ALG_PUBLIC type, TPM2B_PUBLIC *public, bool is_sealing);
+
+/**
+ * Given the object algorithm type, generate settings for TPMU_PUBLIC_PARMS values for a parent object
+ * and modify conflicting object attributes if present.
+ *
+ * XXX This likely isn't the best interface for this, eventually we will probably want to
+ * clean up the public structure value settings.
+ *
+ * @param type
+ *  The algorithm type of the object.
+ * @param public
+ *  The public structure to set the TPMU_PUBLIC_PARMS values for.
+ * @return
+ *  true on success, false otherwise.
+ */
+bool tpm2_alg_util_set_parent_pub_params(TPMI_ALG_PUBLIC type, TPM2B_PUBLIC *public);
+
 #endif /* LIB_TPM2_ALG_UTIL_H_ */

--- a/lib/tpm2_alg_util.h
+++ b/lib/tpm2_alg_util.h
@@ -236,4 +236,15 @@ bool tpm2_alg_util_set_leaf_pub_params(TPMI_ALG_PUBLIC type, TPM2B_PUBLIC *publi
  */
 bool tpm2_alg_util_set_parent_pub_params(TPMI_ALG_PUBLIC type, TPM2B_PUBLIC *public);
 
+/**
+ * Sets the name algorithm in the public structure checking for validity.
+ * @param halg
+ *  The hahsing algorithm to use for name generation.
+ * @param public
+ *  The public structure to set the name hashing algorithm on.
+ * @return
+ *  true on success, false otherwise.
+ */
+bool tpm2_alg_util_set_name(TPMI_ALG_HASH halg, TPM2B_PUBLIC *public);
+
 #endif /* LIB_TPM2_ALG_UTIL_H_ */

--- a/lib/tpm2_attr_util.c
+++ b/lib/tpm2_attr_util.c
@@ -495,6 +495,7 @@ static bool common_strtoattr(char *attribute_list, void *attrs, dispatch_table *
 
 bool tpm2_attr_util_nv_strtoattr(char *attribute_list, TPMA_NV *nvattrs) {
 
+    memset(nvattrs, 0, sizeof(*nvattrs));
     return common_strtoattr(attribute_list, nvattrs, nv_attr_table, ARRAY_LEN(nv_attr_table));
 }
 

--- a/lib/tpm2_attr_util.c
+++ b/lib/tpm2_attr_util.c
@@ -500,6 +500,7 @@ bool tpm2_attr_util_nv_strtoattr(char *attribute_list, TPMA_NV *nvattrs) {
 
 bool tpm2_attr_util_obj_strtoattr(char *attribute_list, TPMA_OBJECT *objattrs) {
 
+    memset(objattrs, 0, sizeof(*objattrs));
     return common_strtoattr(attribute_list, objattrs, obj_attr_table, ARRAY_LEN(obj_attr_table));
 }
 

--- a/tools/tpm2_create.c
+++ b/tools/tpm2_create.c
@@ -109,25 +109,6 @@ static tpm_create_ctx ctx = {
     .alg = TPM2_ALG_RSA
 };
 
-static bool set_name_alg(TPMI_ALG_HASH halg, TPM2B_PUBLIC *public) {
-
-    switch(halg) {
-    case TPM2_ALG_SHA1:
-    case TPM2_ALG_SHA256:
-    case TPM2_ALG_SHA384:
-    case TPM2_ALG_SHA512:
-    case TPM2_ALG_SM3_256:
-    case TPM2_ALG_NULL:
-        public->publicArea.nameAlg = halg;
-        return true;
-    }
-
-    LOG_ERR("name algorithm \"%s\" not supported!",
-            tpm2_alg_util_algtostr(halg));
-
-    return false;
-}
-
 static bool create(TSS2_SYS_CONTEXT *sapi_context) {
     TSS2_RC rval;
     TSS2L_SYS_AUTH_COMMAND sessionsData =
@@ -198,7 +179,7 @@ static bool on_option(char key, char *value) {
             return false;
         }
 
-        bool res = set_name_alg(halg, &ctx.in_public);
+        bool res = tpm2_alg_util_set_name(halg, &ctx.in_public);
         if (!res) {
             return false;
         }

--- a/tools/tpm2_createprimary.c
+++ b/tools/tpm2_createprimary.c
@@ -71,27 +71,6 @@ static tpm_createprimary_ctx ctx = {
     .objdata = TPM2_HIERARCHY_DATA_INIT
 };
 
-
-static bool set_name_alg(TPMI_ALG_HASH halg, TPM2B_PUBLIC *public) {
-
-    switch(halg) {
-    case TPM2_ALG_SHA1:
-    case TPM2_ALG_SHA256:
-    case TPM2_ALG_SHA384:
-    case TPM2_ALG_SHA512:
-    case TPM2_ALG_SM3_256:
-    case TPM2_ALG_NULL:
-        public->publicArea.nameAlg = halg;
-        return true;
-    }
-
-    LOG_ERR("name algorithm \"%s\" not supported!",
-            tpm2_alg_util_algtostr(halg));
-
-    return false;
-}
-
-
 static bool on_option(char key, char *value) {
 
     bool res;
@@ -119,7 +98,7 @@ static bool on_option(char key, char *value) {
             return false;
         }
 
-        res = set_name_alg(halg, &ctx.objdata.in.public);
+        res = tpm2_alg_util_set_name(halg, &ctx.objdata.in.public);
         if (!res) {
             return false;
         }

--- a/tools/tpm2_createprimary.c
+++ b/tools/tpm2_createprimary.c
@@ -91,58 +91,6 @@ static bool set_name_alg(TPMI_ALG_HASH halg, TPM2B_PUBLIC *public) {
     return false;
 }
 
-static bool set_alg(TPMI_ALG_PUBLIC type, TPM2B_PUBLIC *public) {
-
-
-    switch(type) {
-    case TPM2_ALG_RSA: {
-        TPMS_RSA_PARMS *r = &public->publicArea.parameters.rsaDetail;
-       r->symmetric.algorithm = TPM2_ALG_AES;
-       r->symmetric.keyBits.aes = 128;
-       r->symmetric.mode.aes = TPM2_ALG_CFB;
-       r->scheme.scheme = TPM2_ALG_NULL;
-       r->keyBits = 2048;
-       r->exponent = 0;
-       public->publicArea.unique.rsa.size = 0;
-    } break;
-    case TPM2_ALG_KEYEDHASH: {
-        TPMT_KEYEDHASH_SCHEME *s = &public->publicArea.parameters.keyedHashDetail.scheme;
-       s->scheme = TPM2_ALG_XOR;
-       s->details.exclusiveOr.hashAlg = TPM2_ALG_SHA256;
-       s->details.exclusiveOr.kdf = TPM2_ALG_KDF1_SP800_108;
-       public->publicArea.unique.keyedHash.size = 0;
-    } break;
-    case TPM2_ALG_ECC: {
-        TPMS_ECC_PARMS *e = &public->publicArea.parameters.eccDetail;
-       e->symmetric.algorithm = TPM2_ALG_AES;
-       e->symmetric.keyBits.aes = 128;
-       e->symmetric.mode.sym = TPM2_ALG_CFB;
-       e->scheme.scheme = TPM2_ALG_NULL;
-       e->curveID = TPM2_ECC_NIST_P256;
-       e->kdf.scheme = TPM2_ALG_NULL;
-       public->publicArea.unique.ecc.x.size = 0;
-       public->publicArea.unique.ecc.y.size = 0;
-    } break;
-    case TPM2_ALG_SYMCIPHER: {
-        TPMS_SYMCIPHER_PARMS *s = &public->publicArea.parameters.symDetail;
-       s->sym.algorithm = TPM2_ALG_AES;
-       s->sym.keyBits.sym = 128;
-       s->sym.mode.sym = TPM2_ALG_CFB;
-       public->publicArea.unique.sym.size = 0;
-    } break;
-    default:
-        LOG_ERR("type algorithm \"%s\" not supported!",
-                tpm2_alg_util_algtostr(public->publicArea.type));
-
-        return false;
-    }
-
-    public->publicArea.type = type;
-
-    return true;
-}
-
-
 
 static bool on_option(char key, char *value) {
 
@@ -183,7 +131,7 @@ static bool on_option(char key, char *value) {
             return false;
         }
 
-        res = set_alg(type, &ctx.objdata.in.public);
+        res = tpm2_alg_util_set_parent_pub_params(type, &ctx.objdata.in.public);
         if (!res) {
             return false;
         }

--- a/tools/tpm2_load.c
+++ b/tools/tpm2_load.c
@@ -130,9 +130,6 @@ static bool on_option(char key, char *value) {
         break;
     case 'n':
         ctx.out_name_file = value;
-        if(files_does_file_exist(ctx.out_name_file)) {
-            return false;
-        }
         break;
     case 'C':
         ctx.context_arg = value;

--- a/tools/tpm2_load.c
+++ b/tools/tpm2_load.c
@@ -58,7 +58,7 @@ struct tpm_load_ctx {
     } auth;
     TPM2B_PUBLIC  in_public;
     TPM2B_PRIVATE in_private;
-    char *out_file;
+    char *out_name_file;
     char *context_file;
     char *parent_auth_str;
     const char *context_arg;
@@ -97,8 +97,8 @@ int load (TSS2_SYS_CONTEXT *sapi_context) {
     }
     tpm2_tool_output("handle: 0x%08x\n", handle);
 
-    if (ctx.out_file) {
-        if(!files_save_bytes_to_file(ctx.out_file, nameExt.name, nameExt.size)) {
+    if (ctx.out_name_file) {
+        if(!files_save_bytes_to_file(ctx.out_name_file, nameExt.name, nameExt.size)) {
             return -2;
         }
     }
@@ -129,8 +129,8 @@ static bool on_option(char key, char *value) {
         ctx.flags.r = 1;
         break;
     case 'n':
-        ctx.out_file = value;
-        if(files_does_file_exist(ctx.out_file)) {
+        ctx.out_name_file = value;
+        if(files_does_file_exist(ctx.out_name_file)) {
             return false;
         }
         break;


### PR DESCRIPTION
* Clean up some code
* Allow for parent secondary objects to be created via the restricted attribute in tpm2_create
* Add the memsets that got abandoned, did they get cherry-picked to 3.0.4? (check this)