### PR TITLE
tpm2_encryptdecrypt: support stdin/stdout

### DIFF
--- a/lib/files.c
+++ b/lib/files.c
@@ -39,6 +39,7 @@
 
 #include "files.h"
 #include "log.h"
+#include "tpm2_tool.h"
 #include "tpm2_util.h"
 
 bool files_get_file_size(FILE *fp, unsigned long *file_size, const char *path) {
@@ -131,11 +132,15 @@ bool files_load_bytes_from_path(const char *path, UINT8 *buf, UINT16 *size) {
 
 bool files_save_bytes_to_file(const char *path, UINT8 *buf, UINT16 size) {
 
-    if (!path || !buf) {
+    if (!buf) {
         return false;
     }
 
-    FILE *fp = fopen(path, "wb+");
+    if (!path && !output_enabled) {
+        return true;
+    }
+
+    FILE *fp = path ? fopen(path, "wb+") : stdout;
     if (!fp) {
         LOG_ERR("Could not open file \"%s\", error: %s", path, strerror(errno));
         return false;
@@ -145,7 +150,11 @@ bool files_save_bytes_to_file(const char *path, UINT8 *buf, UINT16 size) {
     if (!result) {
         LOG_ERR("Could not write data to file \"%s\"", path);
     }
-    fclose(fp);
+
+    if (fp != stdout) {
+        fclose(fp);
+    }
+
     return result;
 }
 

--- a/lib/files.h
+++ b/lib/files.h
@@ -68,7 +68,8 @@ bool files_load_bytes_from_file_or_stdin(const char *path, UINT16 *size, BYTE *b
 
 /**
  * Similar to files_write_bytes(), in that it writes an array of bytes to disk,
- * but this routine opens and closes the file on the callers behalf.
+ * but this routine opens and closes the file on the callers behalf. If the path
+ * is NULL and silent output has not been enabled, then stdout is used.
  * @param path
  *  The path to the file to write the data to.
  * @param buf

--- a/man/tpm2_encryptdecrypt.1.md
+++ b/man/tpm2_encryptdecrypt.1.md
@@ -34,7 +34,8 @@ specified symmetric key.
 
   * **-I**, **--in-file**=_INPUT\_FILE_:
 
-    Input file path containing data for decrypt or encrypt operation.
+    Optional. Specifies the input file path for either the encrypted or decrypted
+    data, depending on option **-D**. If not specified, defaults to **stdin**.
 
   * **-S**, **--session**=_SESSION\_FILE_:
 
@@ -43,7 +44,8 @@ specified symmetric key.
 
   * **-o**, **--out-file**=_OUT\_FILE_:
 
-    Output file path to store the data output by the decrypt or encrypt operation.
+    Optional. Specifies the output file path for either the encrypted or decrypted
+    data, depending on option **-D**. If not specified, defaults to **stdout**.
 
 [common options](common/options.md)
 

--- a/test/integration/tests/encryptdecrypt.sh
+++ b/test/integration/tests/encryptdecrypt.sh
@@ -35,7 +35,7 @@ source helpers.sh
 
 cleanup() {
   rm -f primary.ctx decrypt.ctx key.pub key.priv key.name decrypt.out \
-        encrypt.out secret.dat commands.cap
+        encrypt.out secret.dat commands.cap secret2.dat
 
   if [ "$1" != "no-shut-down" ]; then
       shut_down
@@ -78,5 +78,10 @@ tpm2_load -Q -C primary.ctx -u key.pub -r key.priv -n key.name -o decrypt.ctx
 tpm2_encryptdecrypt -Q -c decrypt.ctx  -I secret.dat -o encrypt.out
 
 tpm2_encryptdecrypt -Q -c decrypt.ctx -D -I encrypt.out -o decrypt.out
+
+# Test using stdin/stdout
+cat secret.dat | tpm2_encryptdecrypt -c decrypt.ctx | tpm2_encryptdecrypt -c decrypt.ctx -D > secret2.dat
+
+cmp secret.dat secret2.dat
 
 exit 0


### PR DESCRIPTION
Support using stdin and stdout as a way to encrypt and decrypt data.
This will help prevent spilling a potential secret to disk.

Signed-off-by: William Roberts <william.c.roberts@intel.com>