### PR TITLE
3.1 fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,10 @@
 ## Changelog
+### 3.1 - TBD
+  * Update to use TSS version 2.0
+  * When user supplies nv attributes use those exclusively, not in addition to the defaults
+  * When user supplies object attributes use those exclusively, not in addition to the defaults
+  * Load TCTI's by SONAME, not raw .so file
+
 ### 3.0.4 - 2018-05-30
   * Fix save and load for TPM2B_PRIVATE object.
   * Use a default buffer size for tpm2_nv{read,write} if the TPM reports a 0 size.

--- a/lib/tpm2_policy.h
+++ b/lib/tpm2_policy.h
@@ -40,19 +40,19 @@
 
 TSS2_RC tpm2_policy_pcr_build(TSS2_SYS_CONTEXT *sapi_context,
                              SESSION *policy_session,
-                             TPML_PCR_SELECTION pcr_selections,
+                             TPML_PCR_SELECTION *pcr_selections,
                              char *raw_pcrs_file);
 TSS2_RC tpm2_policy_build(TSS2_SYS_CONTEXT *sapi_context,
                          SESSION **policy_session,
                          TPM2_SE policy_session_type,
                          TPMI_ALG_HASH policy_digest_hash_alg,
-                         TPML_PCR_SELECTION pcr_selections,
+                         TPML_PCR_SELECTION *pcr_selections,
                          char *raw_pcrs_file,
                          TPM2B_DIGEST *policy_digest,
                          bool extend_policy_session,
         TSS2_RC (*build_policy_function)(TSS2_SYS_CONTEXT *sapi_context,
                                         SESSION *policy_session,
-                                        TPML_PCR_SELECTION pcr_selections,
+                                        TPML_PCR_SELECTION *pcr_selections,
                                         char *raw_pcrs_file));
 
 #endif /* SRC_POLICY_H_ */

--- a/test/unit/test_tpm2_alg_util.c
+++ b/test/unit/test_tpm2_alg_util.c
@@ -333,7 +333,7 @@ static void test_pcr_parse_digest_list_compound(void **state) {
     assert_int_equal(3, dspec->digests.count);
 
     size_t i;
-    for (i=0; i < dspec->digests.count; i++) {
+    for (i=0; i < dspec->digests.count && i < TPM2_NUM_PCR_BANKS; i++) {
         TPMT_HA *digest = &dspec->digests.digests[i];
 
         switch (i) {

--- a/tools/tpm2_createpolicy.c
+++ b/tools/tpm2_createpolicy.c
@@ -104,7 +104,7 @@ static TSS2_RC parse_policy_type_specific_command(TSS2_SYS_CONTEXT *sapi_context
                                  &pctx.common_policy_options.policy_session,
                                  pctx.common_policy_options.policy_session_type,
                                  pctx.common_policy_options.policy_digest_hash_alg,
-                                 pctx.pcr_policy_options.pcr_selections,
+                                 &pctx.pcr_policy_options.pcr_selections,
                                  pctx.pcr_policy_options.raw_pcrs_file,
                                  &pctx.common_policy_options.policy_digest,
                                  pctx.common_policy_options.extend_policy_session,

--- a/tools/tpm2_nvread.c
+++ b/tools/tpm2_nvread.c
@@ -272,7 +272,7 @@ int tpm2_tool_onrun(TSS2_SYS_CONTEXT *sapi_context, tpm2_option_flags flags) {
         TPM2B_DIGEST pcr_digest = TPM2B_TYPE_INIT(TPM2B_DIGEST, buffer);
 
         TSS2_RC rval = tpm2_policy_build(sapi_context, &ctx.policy_session,
-                                        TPM2_SE_POLICY, TPM2_ALG_SHA256, ctx.pcr_selection,
+                                        TPM2_SE_POLICY, TPM2_ALG_SHA256, &ctx.pcr_selection,
                                         ctx.raw_pcrs_file, &pcr_digest, true,
                                         tpm2_policy_pcr_build);
         if (rval != TSS2_RC_SUCCESS) {

--- a/tools/tpm2_nvwrite.c
+++ b/tools/tpm2_nvwrite.c
@@ -260,7 +260,7 @@ int tpm2_tool_onrun(TSS2_SYS_CONTEXT *sapi_context, tpm2_option_flags flags) {
         TPM2B_DIGEST pcr_digest = TPM2B_TYPE_INIT(TPM2B_DIGEST, buffer);
 
         TSS2_RC rval = tpm2_policy_build(sapi_context, &ctx.policy_session,
-                                        TPM2_SE_POLICY, TPM2_ALG_SHA256, ctx.pcr_selection,
+                                        TPM2_SE_POLICY, TPM2_ALG_SHA256, &ctx.pcr_selection,
                                         ctx.raw_pcrs_file, &pcr_digest, true,
                                         tpm2_policy_pcr_build);
         if (rval != TSS2_RC_SUCCESS) {

--- a/tools/tpm2_unseal.c
+++ b/tools/tpm2_unseal.c
@@ -109,7 +109,7 @@ static bool init(TSS2_SYS_CONTEXT *sapi_context) {
         TPM2B_DIGEST pcr_digest = TPM2B_TYPE_INIT(TPM2B_DIGEST, buffer);
 
         TSS2_RC rval = tpm2_policy_build(sapi_context, &ctx.policy_session,
-                                        TPM2_SE_POLICY, TPM2_ALG_SHA256, ctx.pcr_selection,
+                                        TPM2_SE_POLICY, TPM2_ALG_SHA256, &ctx.pcr_selection,
                                         ctx.raw_pcrs_file, &pcr_digest, true,
                                         tpm2_policy_pcr_build);
         if (rval != TPM2_RC_SUCCESS) {


### PR DESCRIPTION
Various fixes ahead of the 3.1 release

- Pulls in the TCTI loader fix from pull #1058 (addresses issue #1057)
- Resolves a low impact pass-by-value issue reported by Coverity
- fixes an array out of bands error in `test_tpm2_alg_util.c`