### PR TITLE
Reduce need for duplicate args in tpm2_nvwrite/tpm2_nvread

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## Changelog
 ### next
+  * tpm2_nvwrite and tpm2_nvread: when -P is "index" -a is optional and defaults to
+    the NV_INDEX value passed to -x.
+  * Load TCTI's by SONAME, not raw .so file
   * tpm2_encryptdecrypt: supports input and output to stdin and stdout respectively.
   * tpm2_create: -g/-G become optional options.
   * tpm2_createprimary: -g/-G become optional options.

--- a/man/tpm2_nvread.1.md
+++ b/man/tpm2_nvread.1.md
@@ -27,8 +27,8 @@
       * **p** for **TPM_RH_PLATFORM**
       * **`<num>`** where a raw number can be used.
 
-    **NOTE**: To authorize against the index, specify the index handle as
-    the argument to option **-a**. The index auth value is set via the
+    When **-a** isn't explicitly passed the index handle will be used to
+    authorize against the index. The index auth value is set via the
     **-I** option to tpm2_nvdefine(1).
 
   * **-f**, **--out-file**=_FILE_:

--- a/man/tpm2_nvwrite.1.md
+++ b/man/tpm2_nvwrite.1.md
@@ -31,8 +31,8 @@ If _FILE_ is not specified, it defaults to stdin.
       * **p** for **TPM_RH_PLATFORM**
       * **`<num>`** where a raw number can be used.
 
-    **NOTE**: To authorize against the index, specify the index handle as
-    the argument to option **-a**. The index auth value is set via the
+    When **-a** isn't explicitly passed the index handle will be used to
+    authorize against the index. The index auth value is set via the
     **-I** option to tpm2_nvdefine(1).
 
   * **-P**, **--auth-hierarchy**=_HIERARCHY\_AUTH_:
@@ -62,7 +62,7 @@ If _FILE_ is not specified, it defaults to stdin.
 To write the file nv.data to index 0x150016:
 
 ```
-tpm2_nvwrite -x 0x1500016 -a 0x40000001 -f nv.data
+tpm2_nvwrite -x 0x1500016 -P "index" -f nv.data
 ```
 
 # RETURNS

--- a/test/integration/tests/nv.sh
+++ b/test/integration/tests/nv.sh
@@ -196,7 +196,7 @@ tpm2_nvdefine -x 0x1500015 -a 0x40000001 -s 32 \
 
 # Use index password write/read
 tpm2_nvwrite -Q -x 0x1500015 -P "index" nv.test_w
-tpm2_nvread -Q -x 0x1500015 -a 0x1500015 -P "index"
+tpm2_nvread -Q -x 0x1500015 -P "index"
 
 # use owner password
 tpm2_nvwrite -Q -x 0x1500015 -a 0x40000001 -P "owner" nv.test_w

--- a/test/integration/tests/nv.sh
+++ b/test/integration/tests/nv.sh
@@ -195,7 +195,7 @@ tpm2_nvdefine -x 0x1500015 -a 0x40000001 -s 32 \
   -I "index" -P "owner"
 
 # Use index password write/read
-tpm2_nvwrite -Q -x 0x1500015 -a 0x1500015 -P "index" nv.test_w
+tpm2_nvwrite -Q -x 0x1500015 -P "index" nv.test_w
 tpm2_nvread -Q -x 0x1500015 -a 0x1500015 -P "index"
 
 # use owner password

--- a/tools/tpm2_nvwrite.c
+++ b/tools/tpm2_nvwrite.c
@@ -68,6 +68,7 @@ struct tpm_nvwrite_ctx {
     struct {
         UINT8 L : 1;
         UINT8 P : 1;
+        UINT8 a : 1;
     } flags;
     char *hierarchy_auth_str;
 };
@@ -176,6 +177,7 @@ static bool on_option(char key, char *value) {
         if (!result) {
             return false;
         }
+        ctx.flags.a = 1;
         break;
     case 'P':
         ctx.flags.P = 1;
@@ -223,8 +225,8 @@ bool tpm2_tool_onstart(tpm2_options **opts) {
 
     const struct option topts[] = {
         { "index",                required_argument, NULL, 'x' },
-        { "hierarchy",       required_argument, NULL, 'a' },
-        { "auth-hierarchy", required_argument, NULL, 'P' },
+        { "hierarchy",            required_argument, NULL, 'a' },
+        { "auth-hierarchy",       required_argument, NULL, 'P' },
         { "offset",               required_argument, NULL, 'o' },
         { "set-list",             required_argument, NULL, 'L' },
         { "pcr-input-file",       required_argument, NULL, 'F' },
@@ -286,6 +288,20 @@ int tpm2_tool_onrun(TSS2_SYS_CONTEXT *sapi_context, tpm2_option_flags flags) {
         result = start_auth_session(sapi_context);
         if (!result) {
             goto out;
+        }
+    }
+
+    /* If the users specifies "index" for auth-hierarchy and doesn't explicitly
+     * pass a value to -a use the index passed to -x/--index for the
+     * authorisation index.
+     */
+    if (!ctx.flags.a && ctx.flags.P) {
+        // we don't have an auth hierarchy set, use the index
+        if (!strcmp(ctx.hierarchy_auth_str, "index")) {
+            ctx.auth.hierarchy = ctx.nv_index;
+        } else {
+            LOG_ERR("Invalid auth options, use either an explicit -a or a -P"
+                    " value of \"index\".");
         }
     }
 


### PR DESCRIPTION
Update `tpm2_nvwrite` and `tpm2_nvread` such that when **-P** is "index", **-a** is optional and defaults to the _NV\_INDEX_ value passed to **-x**. Fixes #941 