### PR TITLE
tpm2_create and tpm2_createprimary: move to common pub init

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## Changelog
 ### next
+  * tpm2_hash: -g changes to -G
   * tpm2_encryptdecrypt: Support IVs via -i and algorithm modes via -G.
   * tpm2_hmac: drop -g, just use the algorithm associated with the object.
   * tpm2_getmanufec: -g changes to -G

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## Changelog
 ### next
+  * tpm2_hmac: drop -g, just use the algorithm associated with the object.
+  * tpm2_getmanufec: -g changes to -G
+  * tpm2_createek: -g changes to -G
+  * tpm2_createak: -g changes to -G
   * tpm2_verifysignature: -g becomes -G
   * tpm2_sign: -g becomes -G
   * tpm2_import: support specifying parent key with a context file,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## Changelog
 ### next
+  * tpm2_encryptdecrypt: Support IVs via -i and algorithm modes via -G.
   * tpm2_hmac: drop -g, just use the algorithm associated with the object.
   * tpm2_getmanufec: -g changes to -G
   * tpm2_createek: -g changes to -G

--- a/Makefile.am
+++ b/Makefile.am
@@ -171,6 +171,8 @@ check_PROGRAMS = \
 
 TESTS += $(ALL_SYSTEM_TESTS)
 
+XFAIL_TESTS = test/integration/tests/import.sh
+
 test_unit_test_string_bytes_CFLAGS   = $(AM_CFLAGS) $(CMOCKA_CFLAGS)
 test_unit_test_string_bytes_LDADD    = $(CMOCKA_LIBS) $(LIB_COMMON) $(LDADD)
 test_unit_test_string_bytes_SOURCES  = test/unit/test_string_bytes.c

--- a/lib/pcr.c
+++ b/lib/pcr.c
@@ -77,7 +77,7 @@ static bool pcr_parse_selection(const char *str, size_t len, TPMS_PCR_SELECTION 
 
     snprintf(buf, strLeft - str + 1, "%s", str);
 
-    pcrSel->hash = tpm2_alg_util_from_optarg(buf);
+    pcrSel->hash = tpm2_alg_util_from_optarg(buf, tpm2_alg_util_flags_hash);
 
     if (pcrSel->hash == TPM2_ALG_ERROR) {
         return false;

--- a/lib/tpm2_util.h
+++ b/lib/tpm2_util.h
@@ -293,16 +293,20 @@ void print_yaml_indent(size_t indent_count);
  * Convert a TPM2B_PUBLIC into a yaml format and output if not quiet.
  * @param public
  *  The TPM2B_PUBLIC to output in YAML format.
+ * @param indent
+ *  The level of indentation, can be NULL
  */
-void tpm2_util_public_to_yaml(TPM2B_PUBLIC *public);
+void tpm2_util_public_to_yaml(TPM2B_PUBLIC *public, char *indent);
 
 
 /**
  * Convert a TPMA_OBJECT to a yaml format and output if not quiet.
  * @param obj
  *  The TPMA_OBJECT attributes to print.
+ * @param indent
+ *  The level of indentation, can be NULL
  */
-void tpm2_util_tpma_object_to_yaml(TPMA_OBJECT obj);
+void tpm2_util_tpma_object_to_yaml(TPMA_OBJECT obj, char *indent);
 
 /**
  * Parses a string representation of a context object, either a file or handle,

--- a/man/common/object-alg.md
+++ b/man/common/object-alg.md
@@ -2,9 +2,127 @@
 
 Supported public object algorithms are:
 
-  * **0x1** or **rsa** for **TPM_ALG_RSA** (**default**).
-  * **0x8** or **keyedhash** for **TPM_ALG_KEYEDHASH**.
-  * **0x23** or **ecc** for **TPM_ALG_ECC**.
-  * **0x25** or **symcipher** for **TPM_ALG_SYMCIPHER**.
+## Symmetric
+###  AES
+The AES cipher has a bitsize and a mode. When the mode is not specified, ie a
+"NULL" mode, the TPM will allow any mode usages on subsequent key uses. If the
+mode is specified during object creation, only that mode is allowed in
+subsequent use cases.
+
+  * **aes** - Default AES selection. The default AES Selection is AES 256 with
+    a NULL mode.
+
+  * **aes[128|192|256]** - AES with a key size of 128, 192 and 256 respectively
+    with a NULL mode.
+
+  * **aes[128|192|256][cbc|ocb|cfb|ecb]** - AES with a key size of 128, 192 and
+    256 and a mode of cbc, ocb, cfb and ecb respectively.
+
+#### Examples
+
+  * aes256cbc - AES with a key bitsize of 256 and a mode of cbc.
+
+  * aes192cfb - AES with a bitsize of 192 and mode of cfb.
+
+  * aes128 - AES with a bitsize of 128 and NULL mode.
+
+## Asymmetric
+
+### RSA
+
+The RSA cipher has a bitsize, and the TPM (optionally) supports associating a symmetric
+key along with the RSA algorithm. The AES key will be used for encryption modes that rely
+on an RSA scheme, like RSAES_OAEP.
+
+  * **rsa** -
+    Default RSA algorithm. The default bitsize is 2048. Depending on if the object
+    is a restricted object (aka a parent object), the algorithms encryption options will default to:
+
+    * restricted object - scheme of null and a NULL symmetric algorithm.
+
+    * non-restricted object - scheme of null and an aes256cfb symmetric algorithm.
+
+  * **rsa[1024|2048]** -
+    Similar to **rsa** option, but provides control over the key
+    size to either 1024 or 2048 respectively.
+
+  * **rsa[1024|2048|4096]:[oaep|rsaes]** -
+    Similar to **rsa[1024|2048|4096]** option, but provides the ability
+    to control the scheme. The algorithms encryption options will default to:
+    aes256cfb.
+
+  * **rsa[1024|2048]:[oaep|rsaes]:[aes]**
+    Similar to **rsa[1024|2048]:[oaep|rsaes]** option, but provides
+    full control over the aes key options. See the section **AES**
+    for details of these AES strings.
+
+#### Examples
+
+  * rsa1024 - Creates an RSA 1024 key with a scheme and symmetric algorithm dependent on the restricted attribute.
+
+  * rsa:oeap:aes - Creates an RSA 2048 key with an AES-OEAP scheme and an AES default key based on attributes.
+
+  * rsa1024:null:aes128cbc - Creates an RSA 1024 key with a NULL encryption scheme and an AES key of 128 for use ONLY with CBC.
+
+### ECC
+
+The ECC cipher has a size, and the TPM (optionally) supports associating a symmetric
+key along with the ECC algorithm. The AES key will be used for encryption modes that rely
+on an asymmetric encryption scheme, like RSAES_OAEP.
+
+  * **ecc** -
+    Default ECC algorithm. The default curve size is 256. Depending on if the object
+    is a restricted object (aka a parent object), the algorithms encryption options will default to:
+
+    * restricted object - scheme of null and a NULL symmetric algorithm.
+
+    * non-restricted object - scheme of null and an aes256cfb symmetric algorithm.
+
+  * **ecc[224|256|384|521]** -
+    Similar to **ecc** option, but provides control over the curve
+    size to either 224,256,384 or 521 respectively.
+
+  * **ecc[224|256|384|521]:[oaep|rsaes]** -
+    Similar to **ecc[224|256|384|521]** option, but provides the ability
+    to control the scheme. The algorithms encryption options will default to:
+    aes256cfb.
+
+  * **ecc[224|256|384|521]:[oaep|rsaes]:[aes]**
+    Similar to **ecc[224|256|384|521]:[oaep|rsaes]** option, but provides
+    full control over the aes key options. See the section **AES**
+    for details of these AES strings.
+
+#### Examples
+
+  * ecc224 - Creates an ECC 224 key with a scheme and symmetric algorithm dependent on the restricted attribute.
+
+  * ecc:oeap:aes - Creates an ECC 256 key with an AES-OEAP scheme and an AES default key based on attributes.
+
+  * ecc384:null:aes128cbc - Creates an ECC 384 key with a NULL encryption scheme and an AES key of 128 for use ONLY with CBC.
+
+## KeyedHash
+
+ The keyedhash algorithms are hmac and xor.
+
+### HMAC
+
+The HMAC algorithm needs a hashing algorithm and nothing more. It defaults to
+sha256 if not specified.
+
+  * **hmac:[sha256|sha384|sha512]** -
+    Generate an HMAC key valid for the associated hash algorithm, defaults to
+    sha256 if not specified.
+
+
+### XOR
+
+The XOR algorithm needs a hashing algorithm and nothing more. It defaults to
+sha256 if not specified. The XOR scheme should be used where confidentiality
+of the objects is desired, but secrecy is not mandatory. The algorithm is
+lightweight and quick.
+
+  * **xor:[sha256|sha384|sha512]** -
+    Generate an XOR key valid for the associated hash algorithm, defaults to
+    sha256 if not specified.
 
 **NOTE**: Your TPM may not support all algorithms.

--- a/man/tpm2_create.1.md
+++ b/man/tpm2_create.1.md
@@ -42,21 +42,26 @@ These options for creating the tpm entity:
     hash algorithms.
 
   * **-G**, **--kalg**=_KEY\_ALGORITHM_:
-    The key algorithm associated with this object. It defaults to RSA if not
+    The key algorithm associated with this object. It defaults to "rsa" if not
     specified.
     It accepts friendly names just like -g option.
     See section "Supported Public Object Algorithms" for a list
-    of supported object algorithms.
+    of supported object algorithms. Mutually exclusive of **-I**.
 
   * **-A**, **--object-attributes**=_ATTRIBUTES_:
     The object attributes, optional. Object attributes follow the specifications
     as outlined in "object attribute specifiers". The default for created objects is:
 
-    `TPMA_OBJECT_SIGN_ENCRYPT|TPMA_OBJECT_FIXEDTPM|TPMA_OBJECT_FIXEDPARENT|TPMA_OBJECT_SENSITIVEDATAORIGIN|TPMA_OBJECT_USERWITHAUTH`
+    `TPMA_OBJECT_SIGN_ENCRYPT|TPMA_OBJECT_DECRYPT|TPMA_OBJECT_FIXEDTPM|TPMA_OBJECT_FIXEDPARENT|TPMA_OBJECT_SENSITIVEDATAORIGIN|TPMA_OBJECT_USERWITHAUTH`
+
+    When **-I** is specified for sealing, `TPMA_OBJECT_SIGN_ENCRYPT` and `TPMA_OBJECT_DECRYPT` are removed from the default attribute set.
+    The algorithm is set in a way where the the object is only good for sealing and unsealing. Ie one cannot use an object for sealing and cryptography
+    operations.
 
   * **-I**, **--in-file**=_FILE_:
     The data file to be sealed, optional. If file is -, read from stdin.
-    When sealing data only the TPM_ALG_KEYEDHASH algorithm is allowed.
+    When sealing data only the _TPM_ALG_KEYEDHASH_ algorithm with a NULL scheme is allowed. Thus, **-G** cannot
+    be specified.
 
   * **-L**, **--policy-file**=_POLICY\_FILE_:
     The input policy file, optional.

--- a/man/tpm2_createak.1.md
+++ b/man/tpm2_createak.1.md
@@ -57,14 +57,15 @@ loaded-key:
     the context file via this option and the public key via the **-p** option, the
     AK can be restored via a call to tpm2_loadexternal(1).
 
-  * **-g**, **--algorithm**=_ALGORITHM_:
-    Specifies the algorithm type of AK. Algorithms should follow the
-    "formatting standards", see section "Algorithm Specifiers".
-    See section "Supported Public Object Algorithms" for a list of supported
-    object algorithms.
+  * **-G**, **--algorithm**=_ALGORITHM_:
+    Specifies the algorithm type of AK. Supports:
+    * ecc - An P256 key.
+    * rsa - An RSA2048 key.
+    * keyedhash - hmac key.
 
   * **-D**, **--digest-alg**=_HASH\_ALGORITHM_:
-    Like -g, but specifies the digest algorithm. Algorithms should follow the
+    Like -g, but specifies the digest algorithm used for signing.
+    Algorithms should follow the
     "formatting standards", see section "Algorithm Specifiers".
     See section "Supported Hash Algorithms" for a list of supported hash
     algorithms.

--- a/man/tpm2_createek.1.md
+++ b/man/tpm2_createek.1.md
@@ -44,11 +44,11 @@ Refer to:
     If one saves the context file via this option and the public key via the
     **-p** option, the EK can be restored via a call to tpm2_loadexternal(1).
 
-  * **-g**, **--algorithm**=_ALGORITHM_:
-    specifies the algorithm type of EK.
-    See section "Supported Public Object Algorithms" for a list of supported
-    object algorithms. See section "Algorithm Specifiers" on how to specify
-    an algorithm argument.
+  * **-G**, **--algorithm**=_ALGORITHM_:
+    specifies the algorithm type of EK. Supports:
+    * ecc - An P256 key.
+    * rsa - An RSA2048 key.
+    * keyedhash - hmac key.
 
   * **-p**, **--file**=_FILE_:
     Optional: specifies the file used to save the public portion of EK. This defaults

--- a/man/tpm2_createprimary.1.md
+++ b/man/tpm2_createprimary.1.md
@@ -50,10 +50,9 @@ will create and load a Primary Object. The sensitive area is not returned.
     "Supported Hash Algorithms" for a list of supported hash algorithms.
 
   * **-G**, **--kalg**=_KEY\_ALGORITHM_:
-    Algorithm type for generated key. It supports friendly names like the -g option.
-    If not specified, the default key algorithm is RSA.
-    See section "Supported Public Object Algorithms" for a list of supported
-    object algorithms.
+    Algorithm type for generated key. If not specified, the default key
+    algorithm is RSA. See section "Supported Public Object Algorithms"
+    for a list of supported object algorithms.
 
   * **-o**, **--out-context**=_CONTEXT\_FILE_:
     An optional file used to store the object context returned.

--- a/man/tpm2_encryptdecrypt.1.md
+++ b/man/tpm2_encryptdecrypt.1.md
@@ -47,6 +47,22 @@ specified symmetric key.
     Optional. Specifies the output file path for either the encrypted or decrypted
     data, depending on option **-D**. If not specified, defaults to **stdout**.
 
+  * **-G**, **--mode**=_CIPHER\_MODE_ALGORITHM_:
+
+    The key algorithm associated with this object. It defaults to the objects
+    mode or CFB if the objects mode is not configured.
+
+    It accepts friendly names just like -g option.
+    See section "Supported Public Object Algorithms" for a list
+    of supported object algorithms.
+
+  * **-i**, **--iv**=_IV\_INPUT\_FILE_ : [ _IV\_OUTPUT\_FILE_ ]:
+
+  Optional. The initialization vector to use. Defaults to 0's. The specification
+  syntax allows for an input file and output file source to be specified. The input file
+  path is first, optionally followed by a colon ":" and the output iv path. This the output
+  iv can be saved for subsequent calls when chaining.
+
 [common options](common/options.md)
 
 [common tcti options](common/tcti.md)

--- a/man/tpm2_hash.1.md
+++ b/man/tpm2_hash.1.md
@@ -29,7 +29,7 @@ sign.
       * **e** for **TPM_RH_ENDORSEMENT**
       * **n** for **TPM_RH_NULL**
 
-  * **-g**, **--halg**=_HASH\_ALGORITHM_:
+  * **-G**, **--halg**=_HASH\_ALGORITHM_:
     The hash algorithm to use.
     Algorithms should follow the "formatting standards", see section
     "Algorithm Specifiers".
@@ -55,7 +55,7 @@ sign.
 Hash a file with sha1 hash algorithm and save the hash and ticket to a file:
 
 ```
-tpm2_hash -H e -g sha1 -o hash.bin -t ticket.bin data.txt
+tpm2_hash -H e -G sha1 -o hash.bin -t ticket.bin data.txt
 ```
 
 # RETURNS

--- a/man/tpm2_hmac.1.md
+++ b/man/tpm2_hmac.1.md
@@ -27,13 +27,6 @@ _FILE_ is not specified, then data is read from stdin.
     Authorization values should follow the "authorization formatting standards",
     see section "Authorization Formatting".
 
-  * **-g**, **--halg**=_HASH\_ALGORITHM_:
-    The hash algorithm to use.
-    Algorithms should follow the "formatting standards, see section
-    "Algorithm Specifiers".
-    Also, see section "Supported Hash Algorithms" for a list of supported hash
-    algorithms.
-
   * **-o**, **--out-file**=_OUT\_FILE_
     Optional file record of the HMAC result. Defaults to stdout.
 
@@ -55,20 +48,20 @@ _FILE_ is not specified, then data is read from stdin.
 
 # EXAMPLES
 
-Perform a SHA1 HMAC on data.in and send output and possibly ticket to stdout:
+Perform an HMAC on data.in and send output and possibly ticket to stdout:
 
 ```
-tpm2_hmac -C 0x81010002 -P abc123 -g sha1 data.in
+tpm2_hmac -C 0x81010002 -P abc123 data.in
 ```
 
-Perform a SHA1 HMAC on data.in read as a file to stdin and send output to a file:
+Perform an HMAC on data.in read as a file to stdin and send output to a file:
 ```
-tpm2_hmac -C key.context -P abc123 -g sha1 -o hash.out << data.in
+tpm2_hmac -C key.context -P abc123 -o hash.out << data.in
 ```
-Perform a SHA256 HMAC on _stdin_ and send result and possibly ticket to stdout:
+Perform an HMAC on _stdin_ and send result and possibly ticket to stdout:
 
 ```
-cat data.in | tpm2_hmac -C 0x81010002 -g sha256 -o hash.out
+cat data.in | tpm2_hmac -C 0x81010002 -o hash.out
 ```
 
 # RETURNS

--- a/man/tpm2_import.1.md
+++ b/man/tpm2_import.1.md
@@ -22,9 +22,9 @@ OPTIONS
 These options control the key importation process:
 
   * **-G**, **--import-key-alg**=_ALGORITHM_:
-    The algorithm used by the key to be imported, AES and RSA keys are supported.
-    Algorithms should follow the "formatting standards", see section
-    "Algorithm Specifiers".
+    The algorithm used by the key to be imported. Supports:
+    * aes - AES 128 key.
+    * rsa - RSA 2048 key.
 
   * **-k**, **--input-key-file**=_FILE_:
     Specifies the filename of symmetric key (128 bit data) to be imported. OR,

--- a/man/tpm2_listpersistent.1.md
+++ b/man/tpm2_listpersistent.1.md
@@ -25,8 +25,8 @@ These options for listing the persistent objects:
     hash algorithms.
 
   * **-G**, **--kalg**=_KEY\_ALGORITHM_:
-    Only display persistent objects using this key algorithm. It accepts friendly
-    names just like **-g** option. See section "Supported Public Object Algorithms"
+    Only display persistent objects using this key algorithm.
+    See section "Supported Public Object Algorithms"
     for a list of supported object algorithms.
 
 [common options](common/options.md)

--- a/scripts/utils/analyze.py
+++ b/scripts/utils/analyze.py
@@ -100,7 +100,7 @@ class ToolConflictor(object):
                 ["tpm2_encryptdecrypt", "tpm2_hmac", "tpm2_hash"],
                 "tools": [],
                 "conflict": None,
-                "ignore": set(['a', 'hierarchy', 'D', 'decrypt', 't', 'ticket'])
+                "ignore": set(['a', 'hierarchy', 'D', 'decrypt', 't', 'ticket', 'i', 'iv', 'mode', 'halg'])
             },
             {
                 "gname": "random",

--- a/test/integration/tests/activecredential.sh
+++ b/test/integration/tests/activecredential.sh
@@ -53,9 +53,9 @@ cleanup "no-shut-down"
 
 echo "12345678" > secret.data
 
-tpm2_createek -Q -c 0x81010009 -g rsa -p ek.pub
+tpm2_createek -Q -c 0x81010009 -G rsa -p ek.pub
 
-tpm2_createak -C 0x81010009 -k 0x8101000a -g rsa -D sha256 -s rsassa -p ak.pub -n ak.name > ak.out
+tpm2_createak -C 0x81010009 -k 0x8101000a -G rsa -D sha256 -s rsassa -p ak.pub -n ak.name > ak.out
 
 # Capture the yaml output and verify that its the same as the name output
 loaded_key_name_yaml=`python << pyscript

--- a/test/integration/tests/createak.sh
+++ b/test/integration/tests/createak.sh
@@ -54,12 +54,12 @@ start_up
 
 cleanup "no-shut-down"
 
-tpm2_createek -Q -c 0x8101000b -g rsa -p ek.pub
+tpm2_createek -Q -c 0x8101000b -G rsa -p ek.pub
 
-tpm2_createak -Q -C 0x8101000b -k 0x8101000c -g rsa -D sha256 -s rsassa -p ak.pub -n ak.name
+tpm2_createak -Q -C 0x8101000b -k 0x8101000c -G rsa -D sha256 -s rsassa -p ak.pub -n ak.name
 
 # Find a vacant persistent handle
-tpm2_createak -C 0x8101000b -k - -g rsa -D sha256 -s rsassa -p ak.pub -n ak.name > ak.log
+tpm2_createak -C 0x8101000b -k - -G rsa -D sha256 -s rsassa -p ak.pub -n ak.name > ak.log
 phandle=`yaml_get_kv ak.log \"ak\-persistent\-handle\"`
 tpm2_evictcontrol -Q -a o -c $phandle
 

--- a/test/integration/tests/createek.sh
+++ b/test/integration/tests/createek.sh
@@ -50,11 +50,11 @@ start_up
 
 cleanup "no-shut-down"
 
-tpm2_createek -c 0x81010005 -g rsa -p ek.pub
+tpm2_createek -c 0x81010005 -G rsa -p ek.pub
 
 cleanup "no-shut-down"
 
-tpm2_createek -c - -g rsa -p ek.pub > ek.log
+tpm2_createek -c - -G rsa -p ek.pub > ek.log
 phandle=`yaml_get_kv ek.log \"persistent\-handle\"`
 tpm2_evictcontrol -Q -a o -c $phandle
 

--- a/test/integration/tests/encryptdecrypt.sh
+++ b/test/integration/tests/encryptdecrypt.sh
@@ -71,7 +71,7 @@ tpm2_clear -Q
 
 tpm2_createprimary -Q -a e -g sha1 -G rsa -o primary.ctx
 
-tpm2_create -Q -g sha256 -G symcipher -u key.pub -r key.priv -C primary.ctx
+tpm2_create -Q -g sha256 -G aes -u key.pub -r key.priv -C primary.ctx
 
 tpm2_load -Q -C primary.ctx -u key.pub -r key.priv -n key.name -o decrypt.ctx
 

--- a/test/integration/tests/encryptdecrypt.sh
+++ b/test/integration/tests/encryptdecrypt.sh
@@ -35,7 +35,7 @@ source helpers.sh
 
 cleanup() {
   rm -f primary.ctx decrypt.ctx key.pub key.priv key.name decrypt.out \
-        encrypt.out secret.dat commands.cap secret2.dat
+        encrypt.out secret.dat commands.cap secret2.dat iv.dat iv2.dat
 
   if [ "$1" != "no-shut-down" ]; then
       shut_down
@@ -81,6 +81,10 @@ tpm2_encryptdecrypt -Q -c decrypt.ctx -D -I encrypt.out -o decrypt.out
 
 # Test using stdin/stdout
 cat secret.dat | tpm2_encryptdecrypt -c decrypt.ctx | tpm2_encryptdecrypt -c decrypt.ctx -D > secret2.dat
+
+# test using IVs
+dd if=/dev/urandom of=iv.dat bs=16 count=1
+cat secret.dat | tpm2_encryptdecrypt -c decrypt.ctx --iv iv.dat | tpm2_encryptdecrypt -c decrypt.ctx --iv iv.dat:iv2.dat -D > secret2.dat
 
 cmp secret.dat secret2.dat
 

--- a/test/integration/tests/evictcontrol.sh
+++ b/test/integration/tests/evictcontrol.sh
@@ -51,7 +51,7 @@ tpm2_clear -Q
 
 tpm2_createprimary -Q -a e -g sha256 -G rsa -o primary.ctx
 
-tpm2_create -Q -g sha256 -G keyedhash -u key.pub -r key.priv  -C primary.ctx
+tpm2_create -Q -g sha256 -G aes -u key.pub -r key.priv  -C primary.ctx
 
 tpm2_load -Q -C primary.ctx  -u key.pub  -r key.priv -n key.name -o key.dat
 

--- a/test/integration/tests/getmanufec.sh
+++ b/test/integration/tests/getmanufec.sh
@@ -71,10 +71,10 @@ bc3e1d4084e835c7c8906a1c05b4d2d30fdbebc1dbad950fa6b165bd4b6a
 79a8f32938dd8197e29dae839f5b4ca0f5de27c9522c23c54e1c2ce57859
 525118bd4470b18180eef78ae4267bcd" | xxd -r -p > test_ek.pub
 
-tpm2_getmanufec -g rsa -O test_ek.pub -N -U -E ECcert.bin https://ekop.intel.com/ekcertservice/
+tpm2_getmanufec -G rsa -O test_ek.pub -N -U -E ECcert.bin https://ekop.intel.com/ekcertservice/
 
 # Test that stdoutput is the same
-tpm2_getmanufec -g rsa -N -U -O test_ek.pub https://ekop.intel.com/ekcertservice/ > ECcert2.bin
+tpm2_getmanufec -G rsa -N -U -O test_ek.pub https://ekop.intel.com/ekcertservice/ > ECcert2.bin
 
 # stdout file should match -E file.
 cmp ECcert.bin ECcert2.bin

--- a/test/integration/tests/hash.sh
+++ b/test/integration/tests/hash.sh
@@ -57,7 +57,7 @@ echo "T0naX0u123abc" > $hash_in_file
 
 # Test with ticket and hash output files and verify that the output hash
 # is correct. Ticket is not stable and changes run to run, don't verify it.
-tpm2_hash -a e -g sha1 -o $hash_out_file -t $ticket_file $hash_in_file 1>/dev/null
+tpm2_hash -a e -G sha1 -o $hash_out_file -t $ticket_file $hash_in_file 1>/dev/null
 
 expected=`sha1sum $hash_in_file | awk '{print $1}'`
 actual=`cat $hash_out_file | xxd -p -c 20`
@@ -69,7 +69,7 @@ cleanup "no-shut-down"
 # Test platform hierarchy with multiple files and verify output against sha256sum
 # Test a file redirection as well.
 echo "T0naX0u123abc" > $hash_in_file
-tpm2_hash -a p -g sha256 -Q -o $hash_out_file -t $ticket_file < $hash_in_file
+tpm2_hash -a p -G sha256 -Q -o $hash_out_file -t $ticket_file < $hash_in_file
 
 expected=`sha256sum $hash_in_file | awk '{print $1}'`
 actual=`cat $hash_out_file | xxd -p -c 256`

--- a/test/integration/tests/listpersistent.sh
+++ b/test/integration/tests/listpersistent.sh
@@ -38,7 +38,7 @@ handle_base=0x81000000
 auth=o
 
 declare -a hashes=("sha1" "sha256")
-declare -a keys=("ecc" "keyedhash")
+declare -a keys=("ecc" "xor")
 
 cleanup() {
     for idx in "${!keys[@]}"
@@ -94,6 +94,9 @@ fi
 # Test filtering by key algorithm
 for alg in "${keys[@]}"
 do
+    tpm2_listpersistent -G "$alg"
+    echo "Bill"
+    echo "tpm2_listpersistent -G \"$alg\" | grep -q \"$alg\""
     tpm2_listpersistent -G "$alg" | grep -q "$alg"
 done
 

--- a/test/integration/tests/load.sh
+++ b/test/integration/tests/load.sh
@@ -35,12 +35,12 @@ source helpers.sh
 
 start_up
 
-alg_primary_obj=0x000B
-alg_primary_key=0x0001
-alg_create_obj=0x000B
-alg_create_key=0x0008
+alg_primary_obj=sha256
+alg_primary_key=rsa
+alg_create_obj=sha256
+alg_create_key=hmac
 
-alg_load=0x0004
+alg_load=sha1
 
 file_primary_key_ctx=context.p_"$alg_primary_obj"_"$alg_primary_key"
 file_load_key_pub=opu_"$alg_create_obj"_"$alg_create_key"

--- a/test/integration/tests/loadexternal.sh
+++ b/test/integration/tests/loadexternal.sh
@@ -33,10 +33,10 @@
 
 source helpers.sh
 
-alg_primary_obj=0x000B
-alg_primary_key=0x0001
-alg_create_obj=0x000B
-alg_create_key=0x0008
+alg_primary_obj=sha256
+alg_primary_key=rsa
+alg_create_obj=sha256
+alg_create_key=hmac
 
 file_primary_key_ctx=context.p_"$alg_primary_obj"_"$alg_primary_key"
 file_loadexternal_key_pub=opu_"$alg_create_obj"_"$alg_create_key"

--- a/test/integration/tests/makecredential.sh
+++ b/test/integration/tests/makecredential.sh
@@ -35,10 +35,10 @@ source helpers.sh
 
 handle_ek=0x81010007
 handle_ak=0x81010008
-ek_alg=0x001
-ak_alg=0x0001
-digestAlg=0x000B
-signAlg=0x0014
+ek_alg=rsa
+ak_alg=rsa
+digestAlg=sha256
+signAlg=rsassa
 
 file_input_data=secret.data
 output_ek_pub=ek_pub.out
@@ -65,9 +65,9 @@ cleanup "no-shut-down"
 
 echo "12345678" > $file_input_data
 
-tpm2_createek -Q -c $handle_ek -g $ek_alg -p $output_ek_pub
+tpm2_createek -Q -c $handle_ek -G $ek_alg -p $output_ek_pub
 
-tpm2_createak -Q -C $handle_ek  -k $handle_ak -g $ak_alg -D $digestAlg -s $signAlg -p $output_ak_pub -n $output_ak_pub_name
+tpm2_createak -Q -C $handle_ek  -k $handle_ak -G $ak_alg -D $digestAlg -s $signAlg -p $output_ak_pub -n $output_ak_pub_name
 
 # Use -c in xxd so there is no line wrapping
 file_size=`stat --printf="%s" $output_ak_pub_name`

--- a/test/integration/tests/output_formats.sh
+++ b/test/integration/tests/output_formats.sh
@@ -82,7 +82,7 @@ start_up
 
 head -c 4096 /dev/random > $file_hash_input
 
-tpm2_createek -Q -g $alg_ek -p "$file_pubek_orig" -c $handle_ek
+tpm2_createek -Q -G $alg_ek -p "$file_pubek_orig" -c $handle_ek
 
 for fmt in tss pem der; do
 
@@ -98,7 +98,7 @@ for fmt in tss pem der; do
 
 done
 
-tpm2_createak -Q -g $alg_ak -C $handle_ek -k $handle_ak -p "$file_pubak_tss" -n "$file_pubak_name"
+tpm2_createak -Q -G $alg_ak -C $handle_ek -k $handle_ak -p "$file_pubak_tss" -n "$file_pubak_name"
 
 tpm2_readpublic -Q -c $handle_ak -f "pem" -o "$file_pubak_pem"
 

--- a/test/integration/tests/output_formats.sh
+++ b/test/integration/tests/output_formats.sh
@@ -102,7 +102,7 @@ tpm2_createak -Q -G $alg_ak -C $handle_ek -k $handle_ak -p "$file_pubak_tss" -n 
 
 tpm2_readpublic -Q -c $handle_ak -f "pem" -o "$file_pubak_pem"
 
-tpm2_hash -Q -a e -g $alg_hash -t "$file_hash_ticket" -o "$file_hash_result" "$file_hash_input"
+tpm2_hash -Q -a e -G $alg_hash -t "$file_hash_ticket" -o "$file_hash_result" "$file_hash_input"
 
 for fmt in tss plain; do
     this_sig="${file_sig_base}.${fmt}"

--- a/test/integration/tests/quote.sh
+++ b/test/integration/tests/quote.sh
@@ -36,7 +36,7 @@ source helpers.sh
 alg_primary_obj=sha256
 alg_primary_key=rsa
 alg_create_obj=0x000B
-alg_create_key=0x0008
+alg_create_key=hmac
 
 alg_quote=0x0004
 alg_quote1=0x000b
@@ -104,7 +104,7 @@ tpm2_quote -Q -C $Handle_ak_quote -L $alg_quote:16,17,18 -q $nonce
 tpm2_quote -Q -C $Handle_ak_quote  -L $alg_quote:16,17,18+$alg_quote1:16,17,18 -q $nonce
 
 #####AK
-tpm2_createek -Q -c $Handle_ek_quote -g 0x01 -p ek.pub2
+tpm2_createek -Q -c $Handle_ek_quote -G 0x01 -p ek.pub2
 
 tpm2_createak -Q -C $Handle_ek_quote -k  $Handle_ak_quote2 -p ak.pub2 -n ak.name_2
 

--- a/test/integration/tests/readpublic.sh
+++ b/test/integration/tests/readpublic.sh
@@ -36,7 +36,7 @@ source helpers.sh
 alg_primary_obj=0x000B
 alg_primary_key=0x0001
 alg_create_obj=0x000B
-alg_create_key=0x0008
+alg_create_key=hmac
 
 file_primary_key_ctx=context.p_"$alg_primary_obj"_"$alg_primary_key"
 file_readpub_key_pub=opu_"$alg_create_obj"_"$alg_create_key"

--- a/test/integration/tests/sign.sh
+++ b/test/integration/tests/sign.sh
@@ -48,7 +48,7 @@ handle_signing_key=0x81010005
 
 alg_hash=sha256
 alg_primary_key=0x0001
-alg_signing_key=0x0008
+alg_signing_key=hmac
 
 cleanup() {
     rm -f $file_input_data $file_primary_key_ctx $file_signing_key_pub \

--- a/test/integration/tests/sign.sh
+++ b/test/integration/tests/sign.sh
@@ -90,7 +90,7 @@ rm -f $file_output_data
 
 # generate hash and test validation
 
-tpm2_hash -Q -a e -g $alg_hash -o $file_output_hash -t $file_output_ticket $file_input_data
+tpm2_hash -Q -a e -G $alg_hash -o $file_output_hash -t $file_output_ticket $file_input_data
 
 tpm2_sign -Q -c $handle_signing_key -G $alg_hash -s $file_output_data -m $file_input_data -t $file_output_ticket
 

--- a/test/integration/tests/tcti/abrmd/extended-sessions.sh
+++ b/test/integration/tests/tcti/abrmd/extended-sessions.sh
@@ -36,7 +36,6 @@ source helpers.sh
 alg_primary_obj=sha256
 alg_primary_key=ecc
 alg_create_obj=sha256
-alg_create_key=keyedhash
 alg_pcr_policy=sha1
 
 pcr_ids="0,1,2,3"
@@ -45,10 +44,10 @@ file_pcr_value=pcr.bin
 file_input_data=secret.data
 file_policy=policy.data
 file_primary_key_ctx=context.p_"$alg_primary_obj"_"$alg_primary_key"
-file_unseal_key_pub=opu_"$alg_create_obj"_"$alg_create_key"
-file_unseal_key_priv=opr_"$alg_create_obj"_"$alg_create_key"
-file_unseal_key_ctx=ctx_load_out_"$alg_primary_obj"_"$alg_primary_key"-"$alg_create_obj"_"$alg_create_key"
-file_unseal_key_name=name.load_"$alg_primary_obj"_"$alg_primary_key"-"$alg_create_obj"_"$alg_create_key"
+file_unseal_key_pub=opu_"$alg_create_obj"
+file_unseal_key_priv=opr_"$alg_create_obj"
+file_unseal_key_ctx=ctx_load_out_"$alg_primary_obj"_"$alg_primary_key"-"$alg_create_obj"
+file_unseal_key_name=name.load_"$alg_primary_obj"_"$alg_primary_key"-"$alg_create_obj"
 file_unseal_output_data=usl_"$file_unseal_key_ctx"
 file_session_file="session.dat"
 
@@ -104,8 +103,8 @@ tpm2_policypcr -Q -S $file_session_file -L ${alg_pcr_policy}:${pcr_ids} -F $file
 
 tpm2_flushcontext -S $file_session_file
 
-tpm2_create -Q -g $alg_create_obj -G $alg_create_key -u $file_unseal_key_pub -r $file_unseal_key_priv -I- -C $file_primary_key_ctx -L $file_policy \
-  -A 'sign|fixedtpm|fixedparent|sensitivedataorigin' <<< $secret
+tpm2_create -Q -g $alg_create_obj -u $file_unseal_key_pub -r $file_unseal_key_priv -I- -C $file_primary_key_ctx -L $file_policy \
+  -A 'fixedtpm|fixedparent' <<< $secret
 
 tpm2_load -Q -C $file_primary_key_ctx -u $file_unseal_key_pub -r $file_unseal_key_priv -n $file_unseal_key_name -o $file_unseal_key_ctx
 

--- a/test/integration/tests/verifysignature.sh
+++ b/test/integration/tests/verifysignature.sh
@@ -81,7 +81,7 @@ tpm2_sign -Q -c $file_signing_key_ctx -G $alg_hash -m $file_input_data -s $file_
 
 tpm2_verifysignature -Q -c $file_signing_key_ctx  -G $alg_hash -m $file_input_data  -s $file_output_data -t $file_verify_tk_data
 
-tpm2_hash -Q -a n -g $alg_hash -o $file_input_data_hash -t $file_input_data_hash_tk $file_input_data
+tpm2_hash -Q -a n -G $alg_hash -o $file_input_data_hash -t $file_input_data_hash_tk $file_input_data
 
 rm -f $file_verify_tk_data
 tpm2_verifysignature -Q -c $file_signing_key_ctx  -D  $file_input_data_hash -s $file_output_data  -t $file_verify_tk_data

--- a/tools/aux/tpm2_print.c
+++ b/tools/aux/tpm2_print.c
@@ -125,12 +125,11 @@ static bool print_TPMS_QUOTE_INFO(FILE* fd, size_t indent_count) {
         if (!res) {
             goto read_error;
         }
-        res = tpm2_alg_util_is_hash_alg(hash_type);
-        if (!res) {
+        const char* const hash_name = tpm2_alg_util_algtostr(hash_type, tpm2_alg_util_flags_hash);
+        if (!hash_name) {
             LOG_ERR("Invalid hash type in quote");
             goto error;
         }
-        const char* const hash_name = tpm2_alg_util_algtostr(hash_type);
         print_yaml_indent(indent_count + 3);
         tpm2_tool_output("hash: %u (%s)\n", (unsigned int)hash_type, hash_name);
 

--- a/tools/tpm2_certify.c
+++ b/tools/tpm2_certify.c
@@ -198,7 +198,7 @@ static bool on_option(char key, char *value) {
         ctx.key_auth_str = value;
         break;
     case 'g':
-        ctx.halg = tpm2_alg_util_from_optarg(value);
+        ctx.halg = tpm2_alg_util_from_optarg(value, tpm2_alg_util_flags_hash);
         if (ctx.halg == TPM2_ALG_ERROR) {
             LOG_ERR("Could not format algorithm to number, got: \"%s\"", value);
             return false;

--- a/tools/tpm2_createak.c
+++ b/tools/tpm2_createak.c
@@ -457,22 +457,22 @@ static bool on_option(char key, char *value) {
             }
         }
         break;
-    case 'g':
-        ctx.ak.in.alg.type = tpm2_alg_util_from_optarg(value);
+    case 'G':
+        ctx.ak.in.alg.type = tpm2_alg_util_from_optarg(value, tpm2_alg_util_flags_base);
         if (ctx.ak.in.alg.type == TPM2_ALG_ERROR) {
             LOG_ERR("Could not convert algorithm. got: \"%s\".", value);
             return false;
         }
         break;
     case 'D':
-        ctx.ak.in.alg.digest = tpm2_alg_util_from_optarg(value);
+        ctx.ak.in.alg.digest = tpm2_alg_util_from_optarg(value, tpm2_alg_util_flags_hash);
         if (ctx.ak.in.alg.digest == TPM2_ALG_ERROR) {
             LOG_ERR("Could not convert digest algorithm.");
             return false;
         }
         break;
     case 's':
-        ctx.ak.in.alg.sign = tpm2_alg_util_from_optarg(value);
+        ctx.ak.in.alg.sign = tpm2_alg_util_from_optarg(value, tpm2_alg_util_flags_sig);
         if (ctx.ak.in.alg.sign == TPM2_ALG_ERROR) {
             LOG_ERR("Could not convert signing algorithm.");
             return false;
@@ -522,7 +522,7 @@ bool tpm2_tool_onstart(tpm2_options **opts) {
         { "auth-ak",        required_argument, NULL, 'P' },
         { "ek-context",     required_argument, NULL, 'C' },
         { "ak-handle",      required_argument, NULL, 'k' },
-        { "algorithm",      required_argument, NULL, 'g' },
+        { "algorithm",      required_argument, NULL, 'G' },
         { "digest-alg",     required_argument, NULL, 'D' },
         { "sign-alg",       required_argument, NULL, 's' },
         { "file",           required_argument, NULL, 'p' },
@@ -532,7 +532,7 @@ bool tpm2_tool_onstart(tpm2_options **opts) {
         { "privfile",       required_argument, NULL, 'r'},
     };
 
-    *opts = tpm2_options_new("o:C:E:k:g:D:s:P:f:n:p:c:r:", ARRAY_LEN(topts), topts,
+    *opts = tpm2_options_new("o:C:E:k:G:D:s:P:f:n:p:c:r:", ARRAY_LEN(topts), topts,
                              on_option, NULL, 0);
 
     return *opts != NULL;

--- a/tools/tpm2_createek.c
+++ b/tools/tpm2_createek.c
@@ -210,10 +210,10 @@ static bool on_option(char key, char *value) {
         ctx.flags.P = 1;
         ctx.ek_auth_str = value;
         break;
-    case 'g': {
-        TPMI_ALG_PUBLIC type = tpm2_alg_util_from_optarg(value);
+    case 'G': {
+        TPMI_ALG_PUBLIC type = tpm2_alg_util_from_optarg(value, tpm2_alg_util_flags_base);
         if (type == TPM2_ALG_ERROR) {
-            LOG_ERR("Invalid key algorithm, got\"%s\"", value);
+            LOG_ERR("Invalid key algorithm, got \"%s\"", value);
             return false;
         }
         ctx.objdata.in.public.publicArea.type = type;
@@ -246,13 +246,13 @@ bool tpm2_tool_onstart(tpm2_options **opts) {
         { "auth-endorse",         required_argument, NULL, 'e' },
         { "auth-owner",           required_argument, NULL, 'o' },
         { "auth-ek",              required_argument, NULL, 'P' },
-        { "algorithm",            required_argument, NULL, 'g' },
+        { "algorithm",            required_argument, NULL, 'G' },
         { "file",                 required_argument, NULL, 'p' },
         { "format",               required_argument, NULL, 'f' },
         { "context",              required_argument, NULL, 'c' },
     };
 
-    *opts = tpm2_options_new("e:o:P:g:p:f:c:", ARRAY_LEN(topts), topts,
+    *opts = tpm2_options_new("e:o:P:G:p:f:c:", ARRAY_LEN(topts), topts,
                              on_option, NULL, 0);
 
     return *opts != NULL;

--- a/tools/tpm2_createpolicy.c
+++ b/tools/tpm2_createpolicy.c
@@ -159,7 +159,7 @@ static bool on_option(char key, char *value) {
         break;
     case 'g':
         pctx.common_policy_options.policy_digest_hash_alg
-            = tpm2_alg_util_from_optarg(value);
+            = tpm2_alg_util_from_optarg(value, tpm2_alg_util_flags_hash);
         if(pctx.common_policy_options.policy_digest_hash_alg == TPM2_ALG_ERROR) {
             LOG_ERR("Invalid choice for policy digest hash algorithm");
             return false;

--- a/tools/tpm2_createprimary.c
+++ b/tools/tpm2_createprimary.c
@@ -50,6 +50,13 @@
 #include "tpm2_tool.h"
 #include "tpm2_util.h"
 
+#define DEFAULT_ATTRS \
+     TPMA_OBJECT_RESTRICTED|TPMA_OBJECT_DECRYPT \
+    |TPMA_OBJECT_FIXEDTPM|TPMA_OBJECT_FIXEDPARENT \
+    |TPMA_OBJECT_SENSITIVEDATAORIGIN|TPMA_OBJECT_USERWITHAUTH
+
+#define DEFAULT_PRIMARY_KEY_ALG "rsa2048:aes256"
+
 typedef struct tpm_createprimary_ctx tpm_createprimary_ctx;
 struct tpm_createprimary_ctx {
     struct {
@@ -60,15 +67,26 @@ struct tpm_createprimary_ctx {
     char *context_file;
     struct {
         UINT8 P :1;
-        UINT8 k :1;
+        UINT8 K :1;
     } flags;
     char *parent_auth_str;
     char *key_auth_str;
+
+    char *alg;
+    char *halg;
+    char *attrs;
+    char *policy;
 };
 
 static tpm_createprimary_ctx ctx = {
+    .alg = DEFAULT_PRIMARY_KEY_ALG,
     .auth = { .session_data = TPMS_AUTH_COMMAND_INIT(TPM2_RS_PW) },
-    .objdata = TPM2_HIERARCHY_DATA_INIT
+    .objdata = {
+        .in = {
+            .sensitive = TPM2B_SENSITIVE_CREATE_EMPTY_INIT,
+            .hierarchy = TPM2_RH_OWNER
+        },
+    },
 };
 
 static bool on_option(char key, char *value) {
@@ -87,56 +105,29 @@ static bool on_option(char key, char *value) {
         ctx.flags.P = 1;
         ctx.parent_auth_str = value;
         break;
-    case 'k': {
-        ctx.flags.k = 1;
+    case 'k':
+        ctx.flags.K = 1;
         ctx.key_auth_str = value;
-    } break;
-    case 'g': {
-        TPMI_ALG_HASH halg = tpm2_alg_util_from_optarg(value);
-        if (halg == TPM2_ALG_ERROR) {
-            LOG_ERR("Invalid hash algorithm, got\"%s\"", value);
-            return false;
-        }
-
-        res = tpm2_alg_util_set_name(halg, &ctx.objdata.in.public);
-        if (!res) {
-            return false;
-        }
-    }   break;
-    case 'G': {
-        TPMI_ALG_PUBLIC type = tpm2_alg_util_from_optarg(value);
-        if (type == TPM2_ALG_ERROR) {
-            LOG_ERR("Invalid key algorithm, got\"%s\"", value);
-            return false;
-        }
-
-        res = tpm2_alg_util_set_parent_pub_params(type, &ctx.objdata.in.public);
-        if (!res) {
-            return false;
-        }
-    }   break;
+        break;
+    case 'g':
+        ctx.halg = value;
+        break;
+    case 'G':
+        ctx.alg = value;
+        break;
     case 'o':
         ctx.context_file = value;
         if (ctx.context_file == NULL || ctx.context_file[0] == '\0') {
             return false;
         }
         break;
-    case 'L': {
-        TPM2B_DIGEST *auth_policy = &ctx.objdata.in.public.publicArea.authPolicy;
-        auth_policy->size = BUFFER_SIZE(TPM2B_DIGEST, buffer);
-        if (!files_load_bytes_from_path(value,
-                auth_policy->buffer, &auth_policy->size)) {
-            return false;
-        }
-    }   break;
-    case 'A': {
-        bool res = tpm2_attr_util_obj_from_optarg(value,
-                &ctx.objdata.in.public.publicArea.objectAttributes);
-        if (!res) {
-            LOG_ERR("Invalid object attribute, got\"%s\"", value);
-            return false;
-        }
-    }   break;
+    case 'L':
+        ctx.policy=value;
+    break;
+    case 'A':
+        ctx.attrs = value;
+    break;
+    /* no default */
     }
 
     return true;
@@ -147,7 +138,7 @@ bool tpm2_tool_onstart(tpm2_options **opts) {
     const struct option topts[] = {
         { "hierarchy",            required_argument, NULL, 'a' },
         { "auth-hierarchy",       required_argument, NULL, 'P' },
-        { "auth-object",          required_argument, NULL, 'k' },
+        { "auth-object",          required_argument, NULL, 'K' },
         { "halg",                 required_argument, NULL, 'g' },
         { "kalg",                 required_argument, NULL, 'G' },
         { "out-context",          required_argument, NULL, 'o' },
@@ -155,7 +146,7 @@ bool tpm2_tool_onstart(tpm2_options **opts) {
         { "object-attributes",    required_argument, NULL, 'A' },
     };
 
-    *opts = tpm2_options_new("A:P:k:g:G:o:L:a:", ARRAY_LEN(topts), topts,
+    *opts = tpm2_options_new("A:P:K:g:G:o:L:a:", ARRAY_LEN(topts), topts,
             on_option, NULL, 0);
 
     return *opts != NULL;
@@ -175,7 +166,7 @@ int tpm2_tool_onrun(TSS2_SYS_CONTEXT *sapi_context, tpm2_option_flags flags) {
         }
     }
 
-    if (ctx.flags.k) {
+    if (ctx.flags.K) {
         TPMS_AUTH_COMMAND tmp;
         result = tpm2_auth_util_from_optarg(sapi_context, ctx.key_auth_str, &tmp, NULL);
         if (!result) {
@@ -185,12 +176,18 @@ int tpm2_tool_onrun(TSS2_SYS_CONTEXT *sapi_context, tpm2_option_flags flags) {
         ctx.objdata.in.sensitive.sensitive.userAuth = tmp.hmac;
     }
 
+    result = tpm2_alg_util_public_init(ctx.alg, ctx.halg, ctx.attrs, ctx.policy, DEFAULT_ATTRS,
+            &ctx.objdata.in.public);
+    if(!result) {
+        goto out;
+    }
+
     result = tpm2_hierarchy_create_primary(sapi_context, &ctx.auth.session_data, &ctx.objdata);
     if (!result) {
         goto out;
     }
 
-    tpm2_util_tpma_object_to_yaml(ctx.objdata.in.public.publicArea.objectAttributes);
+    tpm2_util_tpma_object_to_yaml(ctx.objdata.in.public.publicArea.objectAttributes, NULL);
     tpm2_tool_output("handle: 0x%X\n", ctx.objdata.out.handle);
 
     if (ctx.context_file) {

--- a/tools/tpm2_encryptdecrypt.c
+++ b/tools/tpm2_encryptdecrypt.c
@@ -41,6 +41,7 @@
 
 #include "files.h"
 #include "log.h"
+#include "tpm2_alg_util.h"
 #include "tpm2_auth_util.h"
 #include "tpm2_options.h"
 #include "tpm2_session.h"
@@ -59,6 +60,11 @@ struct tpm_encrypt_decrypt_ctx {
     char *out_file_path;
     const char *context_arg;
     tpm2_loaded_object key_context_object;
+    TPMI_ALG_SYM_MODE mode;
+    struct {
+        char *in;
+        char *out;
+    } iv;
     struct {
         UINT8 P : 1;
         UINT8 D : 1;
@@ -69,10 +75,29 @@ struct tpm_encrypt_decrypt_ctx {
 };
 
 static tpm_encrypt_decrypt_ctx ctx = {
+    .mode = TPM2_ALG_NULL,
     .auth = { .session_data = TPMS_AUTH_COMMAND_INIT(TPM2_RS_PW) },
 };
 
-static bool encrypt_decrypt(TSS2_SYS_CONTEXT *sapi_context) {
+static bool readpub(TSS2_SYS_CONTEXT *sapi_context, TPM2B_PUBLIC *public) {
+
+    TSS2L_SYS_AUTH_RESPONSE sessions_out_data;
+
+    TPM2B_NAME name = TPM2B_TYPE_INIT(TPM2B_NAME, name);
+
+    TPM2B_NAME qualified_name = TPM2B_TYPE_INIT(TPM2B_NAME, name);
+
+    TSS2_RC rval = TSS2_RETRY_EXP(Tss2_Sys_ReadPublic(sapi_context, ctx.key_context_object.handle, 0,
+            public, &name, &qualified_name, &sessions_out_data));
+    if (rval != TPM2_RC_SUCCESS) {
+        LOG_PERR(Tss2_Sys_ReadPublic, rval);
+        return false;
+    }
+
+    return true;
+}
+
+static bool encrypt_decrypt(TSS2_SYS_CONTEXT *sapi_context, TPM2B_IV *iv_in) {
 
     TPM2B_MAX_BUFFER out_data = TPM2B_TYPE_INIT(TPM2B_MAX_BUFFER, buffer);
 
@@ -81,11 +106,6 @@ static bool encrypt_decrypt(TSS2_SYS_CONTEXT *sapi_context) {
     TSS2L_SYS_AUTH_COMMAND sessions_data = { 1, { ctx.auth.session_data }};
     TSS2L_SYS_AUTH_RESPONSE sessions_data_out;
 
-    TPM2B_IV iv_in = {
-        .size = TPM2_MAX_SYM_BLOCK_SIZE,
-        .buffer = { 0 }
-    };
-
     /*
      * try EncryptDecrypt2 first, and if the command is not supported by the TPM, fallback to
      * EncryptDecrypt. Keep track of which version you ran, for error reporting.
@@ -93,13 +113,13 @@ static bool encrypt_decrypt(TSS2_SYS_CONTEXT *sapi_context) {
     unsigned version = 2;
     TSS2_RC rval = TSS2_RETRY_EXP(Tss2_Sys_EncryptDecrypt2(sapi_context,
             ctx.key_context_object.handle, &sessions_data, &ctx.data,
-            ctx.is_decrypt, TPM2_ALG_NULL, &iv_in, &out_data, &iv_out,
+            ctx.is_decrypt, TPM2_ALG_CFB, iv_in, &out_data, &iv_out,
             &sessions_data_out));
     if (tpm2_error_get(rval) == TPM2_RC_COMMAND_CODE) {
         version = 1;
         rval = TSS2_RETRY_EXP(Tss2_Sys_EncryptDecrypt(sapi_context,
                 ctx.key_context_object.handle, &sessions_data, ctx.is_decrypt,
-                TPM2_ALG_NULL, &iv_in, &ctx.data, &out_data, &iv_out,
+                TPM2_ALG_NULL, iv_in, &ctx.data, &out_data, &iv_out,
                 &sessions_data_out));
     }
     if (rval != TPM2_RC_SUCCESS) {
@@ -111,13 +131,30 @@ static bool encrypt_decrypt(TSS2_SYS_CONTEXT *sapi_context) {
         return false;
     }
 
-    return files_save_bytes_to_file(ctx.out_file_path, out_data.buffer,
+    bool result = files_save_bytes_to_file(ctx.out_file_path, out_data.buffer,
             out_data.size);
+    if (!result) {
+        return false;
+    }
+
+    return ctx.iv.out ? files_save_bytes_to_file(ctx.iv.out, iv_out.buffer, iv_out.size) : true;
+}
+
+static void parse_iv(char *value) {
+
+    ctx.iv.in = value;
+
+    char *split = strchr(value, ':');
+    if (split) {
+        *split = '\0';
+        split++;
+        if (split) {
+            ctx.iv.out = split;
+        }
+    }
 }
 
 static bool on_option(char key, char *value) {
-
-    bool result;
 
     switch (key) {
     case 'c':
@@ -135,11 +172,17 @@ static bool on_option(char key, char *value) {
         ctx.flags.I = 1;
         break;
     case 'o':
-        result = files_does_file_exist(value);
-        if (result) {
+        ctx.out_file_path = value;
+        break;
+    case 'G':
+        ctx.mode = tpm2_alg_util_strtoalg(value, tpm2_alg_util_flags_mode);
+        if (ctx.mode == TPM2_ALG_ERROR) {
+            LOG_ERR("Invalid mode, got: %s", value);
             return false;
         }
-        ctx.out_file_path = value;
+        break;
+    case 'i':
+        parse_iv(value);
         break;
     }
 
@@ -152,11 +195,13 @@ bool tpm2_tool_onstart(tpm2_options **opts) {
         { "auth-key",             required_argument, NULL, 'P' },
         { "decrypt",              no_argument,       NULL, 'D' },
         { "in-file",              required_argument, NULL, 'I' },
+        { "iv",                   required_argument, NULL, 'i' },
+        { "mode",                 required_argument, NULL, 'G' },
         { "out-file",             required_argument, NULL, 'o' },
         { "key-context",          required_argument, NULL, 'c' },
     };
 
-    *opts = tpm2_options_new("P:DI:o:c:", ARRAY_LEN(topts), topts, on_option,
+    *opts = tpm2_options_new("P:DI:o:c:i:G:", ARRAY_LEN(topts), topts, on_option,
                              NULL, 0);
 
     return *opts != NULL;
@@ -198,7 +243,53 @@ int tpm2_tool_onrun(TSS2_SYS_CONTEXT *sapi_context, tpm2_option_flags flags) {
         }
     }
 
-    result = encrypt_decrypt(sapi_context);
+    /*
+     * Sym objects can have a NULL mode, which means the caller can and must determine mode.
+     * Thus if the caller doesn't specify an algorithm, and the object has a default mode, choose it,
+     * else choose CFB.
+     * If the caller specifies an invalid mode, just pass it to the TPM and let it error out.
+     */
+    if (ctx.mode == TPM2_ALG_NULL) {
+
+        TPM2B_PUBLIC public = TPM2B_EMPTY_INIT;
+        result = readpub(sapi_context,&public);
+        if (!result) {
+            goto out;
+        }
+
+        TPMI_ALG_SYM_MODE objmode = public.publicArea.parameters.symDetail.sym.mode.sym;
+        if (objmode == TPM2_ALG_NULL) {
+            ctx.mode = TPM2_ALG_CFB;
+        } else {
+            ctx.mode = objmode;
+        }
+    }
+
+    TPM2B_IV iv = { .size = sizeof(iv.buffer), .buffer = { 0 } };
+    if (ctx.iv.in) {
+        unsigned long file_size;
+        result = files_get_file_size_path(ctx.iv.in, &file_size);
+        if (!result) {
+            goto out;
+        }
+
+        if (file_size != iv.size) {
+            LOG_ERR("Iv should be 16 bytes, got %lu", file_size);
+            goto out;
+        }
+
+        result = files_load_bytes_from_path(ctx.iv.in, iv.buffer, &iv.size);
+        if (!result) {
+            goto out;
+        }
+
+    }
+
+    if (!ctx.iv.in) {
+        LOG_WARN("Using a weak IV, try specifying an IV");
+    }
+
+    result = encrypt_decrypt(sapi_context, &iv);
     if (!result) {
         goto out;
     }

--- a/tools/tpm2_getcap.c
+++ b/tools/tpm2_getcap.c
@@ -574,7 +574,7 @@ static void
 dump_algorithm_properties (TPM2_ALG_ID       id,
                            TPMA_ALGORITHM   alg_attrs)
 {
-    const char *id_name = tpm2_alg_util_algtostr(id);
+    const char *id_name = tpm2_alg_util_algtostr(id, tpm2_alg_util_flags_any);
     bool is_unknown = id_name == NULL;
     id_name = id_name ? id_name : "unknown";
 

--- a/tools/tpm2_getmanufec.c
+++ b/tools/tpm2_getmanufec.c
@@ -465,8 +465,8 @@ static bool on_option(char key, char *value) {
         ctx.flags.P = 1;
         ctx.ek_auth_str = value;
     }   break;
-    case 'g':
-        ctx.algorithm_type = tpm2_alg_util_from_optarg(value);
+    case 'G':
+        ctx.algorithm_type = tpm2_alg_util_from_optarg(value, tpm2_alg_util_flags_base);
         if (ctx.algorithm_type == TPM2_ALG_ERROR) {
              LOG_ERR("Please input the algorithm type in correct format.");
             return false;
@@ -516,7 +516,7 @@ bool tpm2_tool_onstart(tpm2_options **opts) {
         { "owner-passwd",         required_argument, NULL, 'o' },
         { "ek-passwd",            required_argument, NULL, 'P' },
         { "handle",               required_argument, NULL, 'H' },
-        { "algorithm",            required_argument, NULL, 'g' },
+        { "algorithm",            required_argument, NULL, 'G' },
         { "out-file",             required_argument, NULL, 'f' },
         { "non-persistent",       no_argument,       NULL, 'N' },
         { "offline",              required_argument, NULL, 'O' },
@@ -524,7 +524,7 @@ bool tpm2_tool_onstart(tpm2_options **opts) {
         { "SSL-NO-VERIFY",        no_argument,       NULL, 'U' },
     };
 
-    *opts = tpm2_options_new("e:o:H:P:g:f:NO:E:i:U", ARRAY_LEN(topts), topts,
+    *opts = tpm2_options_new("e:o:H:P:G:f:NO:E:i:U", ARRAY_LEN(topts), topts,
                              on_option, on_args, 0);
 
     return *opts != NULL;

--- a/tools/tpm2_hash.c
+++ b/tools/tpm2_hash.c
@@ -132,7 +132,7 @@ static bool on_option(char key, char *value) {
             return false;
         }
         break;
-    case 'g':
+    case 'G':
         ctx.halg = tpm2_alg_util_from_optarg(value, tpm2_alg_util_flags_hash);
         if (ctx.halg == TPM2_ALG_ERROR) {
             return false;
@@ -153,7 +153,7 @@ bool tpm2_tool_onstart(tpm2_options **opts) {
 
     static struct option topts[] = {
         {"hierarchy", required_argument, NULL, 'a'},
-        {"halg",      required_argument, NULL, 'g'},
+        {"halg",      required_argument, NULL, 'G'},
         {"out-file",  required_argument, NULL, 'o'},
         {"ticket",    required_argument, NULL, 't'},
     };
@@ -161,7 +161,7 @@ bool tpm2_tool_onstart(tpm2_options **opts) {
     /* set up non-static defaults here */
     ctx.input_file = stdin;
 
-    *opts = tpm2_options_new("a:g:o:t:", ARRAY_LEN(topts), topts, on_option,
+    *opts = tpm2_options_new("a:G:o:t:", ARRAY_LEN(topts), topts, on_option,
                              on_args, 0);
 
     return *opts != NULL;

--- a/tools/tpm2_hash.c
+++ b/tools/tpm2_hash.c
@@ -73,7 +73,7 @@ static bool hash_and_save(TSS2_SYS_CONTEXT *sapi_context) {
 
     if (outHash.size) {
         UINT16 i;
-        tpm2_tool_output("%s: ", tpm2_alg_util_algtostr(ctx.halg));
+        tpm2_tool_output("%s: ", tpm2_alg_util_algtostr(ctx.halg, tpm2_alg_util_flags_hash));
         for (i = 0; i < outHash.size; i++) {
             tpm2_tool_output("%02x", outHash.buffer[i]);
         }
@@ -133,7 +133,7 @@ static bool on_option(char key, char *value) {
         }
         break;
     case 'g':
-        ctx.halg = tpm2_alg_util_from_optarg(value);
+        ctx.halg = tpm2_alg_util_from_optarg(value, tpm2_alg_util_flags_hash);
         if (ctx.halg == TPM2_ALG_ERROR) {
             return false;
         }

--- a/tools/tpm2_import.c
+++ b/tools/tpm2_import.c
@@ -356,7 +356,7 @@ static bool create_import_key_public_data_and_name(void) {
         ctx.import_key_public.publicArea.objectAttributes = ctx.objectAttributes;
     }
 
-    tpm2_util_tpma_object_to_yaml(ctx.import_key_public.publicArea.objectAttributes);
+    tpm2_util_tpma_object_to_yaml(ctx.import_key_public.publicArea.objectAttributes, NULL);
 
     size_t public_area_marshalled_offset = 0;
     TPM2B_PUBLIC *marshalled_bytes = malloc(sizeof(ctx.import_key_public));
@@ -596,7 +596,9 @@ static bool on_option(char key, char *value) {
 
     switch(key) {
     case 'G':
-        ctx.key_type = tpm2_alg_util_from_optarg(value);
+        ctx.key_type = tpm2_alg_util_from_optarg(value,
+                tpm2_alg_util_flags_asymmetric
+                |tpm2_alg_util_flags_symmetric);
         switch(ctx.key_type) {
             case TPM2_ALG_AES:
                 ctx.input_key_buffer_length = TPM2_MAX_SYM_BLOCK_SIZE;

--- a/tools/tpm2_nvlist.c
+++ b/tools/tpm2_nvlist.c
@@ -50,7 +50,7 @@ static void print_nv_public(TPM2B_NV_PUBLIC *nv_public) {
         LOG_ERR("Could not convert attributes to string form");
     }
 
-    const char *alg = tpm2_alg_util_algtostr(nv_public->nvPublic.nameAlg);
+    const char *alg = tpm2_alg_util_algtostr(nv_public->nvPublic.nameAlg, tpm2_alg_util_flags_hash);
     if (!alg) {
         LOG_ERR("Could not convert algorithm to string form");
     }

--- a/tools/tpm2_pcrevent.c
+++ b/tools/tpm2_pcrevent.c
@@ -218,7 +218,7 @@ static bool do_hmac_and_output(TSS2_SYS_CONTEXT *sapi_context) {
     for (i = 0; i < digests.count; i++) {
         TPMT_HA *d = &digests.digests[i];
 
-        tpm2_tool_output("%s: ", tpm2_alg_util_algtostr(d->hashAlg));
+        tpm2_tool_output("%s: ", tpm2_alg_util_algtostr(d->hashAlg, tpm2_alg_util_flags_hash));
 
         BYTE *bytes;
         size_t size;

--- a/tools/tpm2_pcrlist.c
+++ b/tools/tpm2_pcrlist.c
@@ -229,7 +229,7 @@ static bool check_pcr_selection(void) {
         }
 
         if (j >= cap_data->data.assignedPCR.count) {
-            const char *alg_name = tpm2_alg_util_algtostr(pcr_sel->pcrSelections[i].hash);
+            const char *alg_name = tpm2_alg_util_algtostr(pcr_sel->pcrSelections[i].hash, tpm2_alg_util_flags_hash);
             LOG_WARN("Ignore unsupported bank/algorithm: %s(0x%04x)", alg_name, pcr_sel->pcrSelections[i].hash);
             pcr_sel->pcrSelections[i].hash = 0; //mark it as to be removed
         }
@@ -249,7 +249,8 @@ static bool show_pcr_values(void) {
 
     for (i = 0; i < ctx.pcr_selections.count; i++) {
         const char *alg_name = tpm2_alg_util_algtostr(
-                ctx.pcr_selections.pcrSelections[i].hash);
+                ctx.pcr_selections.pcrSelections[i].hash,
+                tpm2_alg_util_flags_hash);
 
         tpm2_tool_output("%s:\n", alg_name);
 
@@ -352,7 +353,7 @@ static void show_banks(tpm2_algorithm *g_banks) {
     tpm2_tool_output("Supported Bank/Algorithm:");
     int i;
     for (i = 0; i < g_banks->count; i++) {
-        const char *alg_name = tpm2_alg_util_algtostr(g_banks->alg[i]);
+        const char *alg_name = tpm2_alg_util_algtostr(g_banks->alg[i], tpm2_alg_util_flags_hash);
         tpm2_tool_output(" %s(0x%04x)", alg_name, g_banks->alg[i]);
     }
     tpm2_tool_output("\n");
@@ -362,7 +363,7 @@ static bool on_option(char key, char *value) {
 
     switch (key) {
     case 'g':
-        ctx.selected_algorithm = tpm2_alg_util_from_optarg(value);
+        ctx.selected_algorithm = tpm2_alg_util_from_optarg(value, tpm2_alg_util_flags_hash);
         if (ctx.selected_algorithm == TPM2_ALG_ERROR) {
             LOG_ERR("Invalid algorithm, got: \"%s\"", value);
             return false;

--- a/tools/tpm2_quote.c
+++ b/tools/tpm2_quote.c
@@ -123,7 +123,7 @@ static int quote(TSS2_SYS_CONTEXT *sapi_context, TPM2_HANDLE akHandle, TPML_PCR_
     tpm2_tool_output( "quoted: " );
     tpm2_util_print_tpm2b((TPM2B *)&quoted);
     tpm2_tool_output("\nsignature:\n" );
-    tpm2_tool_output("  alg: %s\n", tpm2_alg_util_algtostr(signature.sigAlg));
+    tpm2_tool_output("  alg: %s\n", tpm2_alg_util_algtostr(signature.sigAlg, tpm2_alg_util_flags_sig));
 
     UINT16 size;
     BYTE *sig = tpm2_extract_plain_signature(&size, &signature);
@@ -189,7 +189,7 @@ static bool on_option(char key, char *value) {
          }
          break;
     case 'G':
-        ctx.sig_hash_algorithm = tpm2_alg_util_from_optarg(value);
+        ctx.sig_hash_algorithm = tpm2_alg_util_from_optarg(value, tpm2_alg_util_flags_sig);
         if(ctx.sig_hash_algorithm == TPM2_ALG_ERROR) {
             LOG_ERR("Could not convert signature hash algorithm selection, got: \"%s\"", value);
             return false;

--- a/tools/tpm2_readpublic.c
+++ b/tools/tpm2_readpublic.c
@@ -89,7 +89,7 @@ static int read_public_and_save(TSS2_SYS_CONTEXT *sapi_context) {
     }
     tpm2_tool_output("\n");
 
-    tpm2_util_public_to_yaml(&public);
+    tpm2_util_public_to_yaml(&public, NULL);
 
     return ctx.outFilePath ?
             tpm2_convert_pubkey_save(&public, ctx.format, ctx.outFilePath) : true;

--- a/tools/tpm2_sign.c
+++ b/tools/tpm2_sign.c
@@ -193,7 +193,7 @@ static bool on_option(char key, char *value) {
         ctx.key_auth_str = value;
         break;
     case 'G': {
-        ctx.halg = tpm2_alg_util_from_optarg(value);
+        ctx.halg = tpm2_alg_util_from_optarg(value, tpm2_alg_util_flags_hash);
         if (ctx.halg == TPM2_ALG_ERROR) {
             LOG_ERR("Could not convert to number or lookup algorithm, got: \"%s\"",
                     value);

--- a/tools/tpm2_startauthsession.c
+++ b/tools/tpm2_startauthsession.c
@@ -72,7 +72,7 @@ static bool on_option(char key, char *value) {
         ctx.session.type = TPM2_SE_POLICY;
         break;
     case 'g':
-        ctx.session.halg = tpm2_alg_util_from_optarg(value);
+        ctx.session.halg = tpm2_alg_util_from_optarg(value, tpm2_alg_util_flags_hash);
         if(ctx.session.halg == TPM2_ALG_ERROR) {
             LOG_ERR("Invalid choice for policy digest hash algorithm");
             return false;

--- a/tools/tpm2_verifysignature.c
+++ b/tools/tpm2_verifysignature.c
@@ -202,7 +202,7 @@ static bool on_option(char key, char *value) {
 	    ctx.context_arg = value;
 	    break;
 	case 'G': {
-		ctx.halg = tpm2_alg_util_from_optarg(value);
+		ctx.halg = tpm2_alg_util_from_optarg(value, tpm2_alg_util_flags_hash);
 		if (ctx.halg == TPM2_ALG_ERROR) {
 			LOG_ERR("Unable to convert algorithm, got: \"%s\"", value);
 			return false;
@@ -225,17 +225,12 @@ static bool on_option(char key, char *value) {
 	}
 		break;
 	case 'f': {
-		ctx.format = tpm2_alg_util_from_optarg(value);
+		ctx.format = tpm2_alg_util_from_optarg(value, tpm2_alg_util_flags_sig);
 		if (ctx.format == TPM2_ALG_ERROR) {
 		    LOG_ERR("Unknown signing scheme, got: \"%s\"", value);
 		    return false;
 		}
 
-		bool result = tpm2_alg_util_is_signing_scheme(ctx.format);
-		if (!result) {
-		    LOG_ERR("Algorithm is NOT a signing scheme, got: \"%s\"", value);
-		    return false;
-		}
 		ctx.flags.fmt = 1;
 	} break;
 	case 's':


### PR DESCRIPTION
The public structure for a tpm object needs many values set
when creating an object. Start to move away from the hardcodes,
while preserving the old defaults, and allow for more complex
algorithm specifications.

For instance to create an AES256 key, mode CBC:
tpm2_create -C context.out -G 'symcipher:symalg=aes,symkeybits=256,modesym=cbc' -u key.pub -r key.priv

TODO:
- [x] Tests
- [x] Docs
- [x] Create a ticket to come back and complete:
   a. Setting all the subordinate fields
   b. YAML outputting the right data

Signed-off-by: William Roberts <william.c.roberts@intel.com>