### PR TITLE
Capital options for parent, lower for current object

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## Changelog
 ### next
   * tpm2_activatecredential: -e becomes -E
+  * tpm2_activatecredential: -e becomes -E
   * tpm2_certify: -c and -C are swapped, -k becomes -K
   * tpm2_createprimary: -K becomes -k
   * tpm2_encryptdecrypt: supports input and output to stdin and stdout respectively.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## Changelog
 ### next
+  * tpm2_activatecredential: -e becomes -E
   * tpm2_certify: -c and -C are swapped, -k becomes -K
   * tpm2_createprimary: -K becomes -k
   * tpm2_encryptdecrypt: supports input and output to stdin and stdout respectively.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## Changelog
 ### next
+  * tpm2_createprimary: -K becomes -k
   * tpm2_encryptdecrypt: supports input and output to stdin and stdout respectively.
   * tpm2_create: -g/-G become optional options.
   * tpm2_createprimary: -g/-G become optional options.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## Changelog
 ### next
+  * tpm2_certify: -c and -C are swapped, -k becomes -K
   * tpm2_createprimary: -K becomes -k
   * tpm2_encryptdecrypt: supports input and output to stdin and stdout respectively.
   * tpm2_create: -g/-G become optional options.

--- a/man/tpm2_activatecredential.1.md
+++ b/man/tpm2_activatecredential.1.md
@@ -32,7 +32,8 @@ These options control the object verification:
     Either a file or a handle number. See section "Context Object Format".
 
   * **-P**, **--auth-key**=_AUTH\_VALUE_:
-    Use _AUTH\_VALUE_ for providing an authorization value for the _KEY\_HANDLE_.
+    Use _AUTH\_VALUE_ for providing an authorization value for the
+    _KEY\_CONTEXT\_OBJECT_.
     Passwords should follow the authorization formatting standards, see section
     "Authorization Formatting".
 

--- a/man/tpm2_activatecredential.1.md
+++ b/man/tpm2_activatecredential.1.md
@@ -37,15 +37,17 @@ These options control the object verification:
     Passwords should follow the authorization formatting standards, see section
     "Authorization Formatting".
 
-  * **-e**, **--endorse-password**=_ENDORSE\_PASSWORD_:
-    The endorsement password, optional. Follows the same formatting guidelines as the handle password option -P.
+  * **-E**, **--endorse-password**=_ENDORSE\_PASSWORD_:
+    The endorsement password, optional. Follows the same formatting guidelines
+    as the handle password option -P.
 
   * **-f**, **--in-file**=_INPUT\_FILE_:
-    Input file path, containing the two structures needed by tpm2_activatecredential function. This is created
-    via the tpm2_makecredential(1) command.
+    Input file path, containing the two structures needed by
+    tpm2_activatecredential function. This is created via the
+    tpm2_makecredential(1) command.
 
   * **-o**, **--out-file**=_OUTPUT\_FILE_:
-    Output file path, record the secret to decrypt  the certificate.
+    Output file path, record the secret to decrypt the certificate.
 
 [common options](common/options.md)
 
@@ -58,9 +60,9 @@ These options control the object verification:
 # EXAMPLES
 
 ```
-tpm2_activatecredential -c 0x81010002 -C 0x81010001 -P abc123 -e abc123 -f <filePath> -o <filePath>
-tpm2_activatecredential -c ak.dat -C ek.dat -P abc123 -e abc123 -f <filePath> -o <filePath>
-tpm2_activatecredential -c 0x81010002 -C 0x81010001 -P 123abc -e 1a1b1c -X -f <filePath> -o <filePath>
+tpm2_activatecredential -c 0x81010002 -C 0x81010001 -P abc123 -E abc123 -f <filePath> -o <filePath>
+tpm2_activatecredential -c ak.dat -C ek.dat -P abc123 -E abc123 -f <filePath> -o <filePath>
+tpm2_activatecredential -c 0x81010002 -C 0x81010001 -P 123abc -E 1a1b1c -X -f <filePath> -o <filePath>
 ```
 
 # RETURNS

--- a/man/tpm2_certify.1.md
+++ b/man/tpm2_certify.1.md
@@ -24,23 +24,23 @@ An object that only has its public area loaded cannot be certified.
 
 These options control the certification:
 
-  * **-c**, **--obj-context**=_CONTEXT\_OBJECT_:
+  * **-C**, **--obj-context**=_CONTEXT\_OBJECT_:
     Context object for the object to be certified. Either a file or a handle number.
     See section "Context Object Format".
 
-  * **-C**, **--key-context**=_KEY\_CONTEXT_:
+  * **-c**, **--key-context**=_KEY\_CONTEXT_:
     Context object for the key used to sign the attestation structure.
     See section "Context Object Format".
 
   * **-P**, **--auth-object**=_OBJECT\_AUTH_:
     Use _OBJECT\_AUTH_ for providing an authorization value for the object specified
-    in _OBJECT\_HANDLE_.
+    in _CONTEXT\_OBJECT_.
     Authorization values should follow the "authorization formatting standards,
     see section "Authorization Formatting".
 
-  * **-K**, **--auth-key**=_KEY\_AUTH_:
+  * **-k**, **--auth-key**=_KEY\_AUTH_:
     Use _KEY\_AUTH_ for providing an authorization value for the key specified
-    in _KEY\_HANDLE_.
+    in _KEY\_CONTEXT_.
     Follows the same formatting guidelines as the object handle authorization or
     -P option.
 
@@ -67,9 +67,9 @@ These options control the certification:
 # EXAMPLES
 
 ```
-tpm2_certify -H 0x81010002 -k 0x81010001 -P 0x0011 -K 0x00FF -g 0x00B -a <fileName> -s <fileName>
-tpm2_certify -C obj.context -c key.context -P 0x0011 -K 0x00FF -g 0x00B -a <fileName> -s <fileName>
-tpm2_certify -H 0x81010002 -k 0x81010001 -P 0011 -K 00FF -X -g 0x00B -a <fileName> -s <fileName>
+tpm2_certify -H 0x81010002 -P 0x0011 -k 0x00FF -g 0x00B -a <fileName> -s <fileName>
+tpm2_certify -C obj.context -c key.context -P 0x0011 -k 0x00FF -g 0x00B -a <fileName> -s <fileName>
+tpm2_certify -H 0x81010002 -P 0011 -k 00FF -X -g 0x00B -a <fileName> -s <fileName>
 ```
 
 # RETURNS

--- a/man/tpm2_createak.1.md
+++ b/man/tpm2_createak.1.md
@@ -30,7 +30,7 @@ loaded-key:
 
 # OPTIONS
 
-  * **-e**, **--auth-endorse**=_ENDORSE\_AUTH_:
+  * **-E**, **--auth-endorse**=_ENDORSE\_AUTH_:
     Specifies current endorsement authorization.
     Authorizations should follow the "authorization formatting standards, see section
     "Authorization Formatting".

--- a/man/tpm2_createak.1.md
+++ b/man/tpm2_createak.1.md
@@ -32,7 +32,7 @@ loaded-key:
 
   * **-e**, **--auth-endorse**=_ENDORSE\_AUTH_:
     Specifies current endorsement authorization.
-    authorizations should follow the "authorization formatting standards, see section
+    Authorizations should follow the "authorization formatting standards, see section
     "Authorization Formatting".
 
   * **-P**, **--auth-ak**=_AK\_AUTH_

--- a/man/tpm2_createprimary.1.md
+++ b/man/tpm2_createprimary.1.md
@@ -36,7 +36,7 @@ will create and load a Primary Object. The sensitive area is not returned.
     values should follow the authorization formatting standards, see section
     "Authorization Formatting".
 
-  * **-K**, **--auth-object**=_OBJECT\_AUTH_:
+  * **-k**, **--auth-object**=_OBJECT\_AUTH_:
     Optional authorization password for the newly created object. Password
     values should follow the authorization formatting standards, see section
     "Authorization Formatting".

--- a/test/integration/tests/certify.sh
+++ b/test/integration/tests/certify.sh
@@ -55,6 +55,6 @@ tpm2_create -Q -g sha256 -G rsa -u certify.pub -r certify.priv  -C primary.ctx
 
 tpm2_load -Q -C primary.ctx -u certify.pub -r certify.priv -n certify.name -o certify.ctx
 
-tpm2_certify -Q -c primary.ctx -C certify.ctx -g sha256 -a attest.out -s sig.out
+tpm2_certify -Q -C primary.ctx -c certify.ctx -g sha256 -a attest.out -s sig.out
 
 exit 0

--- a/test/integration/tests/output_formats.sh
+++ b/test/integration/tests/output_formats.sh
@@ -115,7 +115,7 @@ done
 
 for fmt in tss plain; do
     this_sig="${file_quote_sig_base}.${fmt}"
-    tpm2_quote -Q -C $handle_ak -l 0 -g "$alg_hash" -f $fmt -m "$file_quote_msg" -s "$this_sig"
+    tpm2_quote -Q -C $handle_ak -l 0 -L "$alg_hash":0 -f $fmt -m "$file_quote_msg" -s "$this_sig"
 
     if [ "$fmt" = plain ]; then
         openssl dgst -verify "$file_pubak_pem" -keyform pem -${alg_hash} -signature "$this_sig" "$file_quote_msg" > /dev/null

--- a/test/integration/tests/quote.sh
+++ b/test/integration/tests/quote.sh
@@ -90,7 +90,7 @@ tpm2_create -Q -g $alg_create_obj -G $alg_create_key -u $file_quote_key_pub -r $
 
 tpm2_load -Q -C $file_primary_key_ctx  -u $file_quote_key_pub  -r $file_quote_key_priv -n $file_quote_key_name -o $file_quote_key_ctx
 
-tpm2_quote -C $file_quote_key_ctx  -g $alg_quote -l 16,17,18 -q $nonce > $out
+tpm2_quote -C $file_quote_key_ctx  -L $alg_quote:16,17,18 -q $nonce > $out
 
 yaml_verify $out
 
@@ -99,7 +99,7 @@ tpm2_quote -Q -C $file_quote_key_ctx  -L $alg_quote:16,17,18+$alg_quote1:16,17,1
 #####handle testing
 tpm2_evictcontrol -Q -a o -c $file_quote_key_ctx -p $Handle_ak_quote
 
-tpm2_quote -Q -C $Handle_ak_quote  -g $alg_quote -l 16,17,18 -q $nonce
+tpm2_quote -Q -C $Handle_ak_quote -L $alg_quote:16,17,18 -q $nonce
 
 tpm2_quote -Q -C $Handle_ak_quote  -L $alg_quote:16,17,18+$alg_quote1:16,17,18 -q $nonce
 
@@ -108,6 +108,6 @@ tpm2_createek -Q -c $Handle_ek_quote -g 0x01 -p ek.pub2
 
 tpm2_createak -Q -C $Handle_ek_quote -k  $Handle_ak_quote2 -p ak.pub2 -n ak.name_2
 
-tpm2_quote -Q -C $Handle_ak_quote -g $alg_quote -l 16,17,18 -q $nonce
+tpm2_quote -Q -C $Handle_ak_quote -L $alg_quote:16,17,18 -l 16,17,18 -q $nonce
 
 exit 0

--- a/tools/tpm2_activatecredential.c
+++ b/tools/tpm2_activatecredential.c
@@ -57,7 +57,7 @@ struct tpm_activatecred_ctx {
         UINT8 f : 1;
         UINT8 o : 1;
         UINT8 P : 1;
-        UINT8 e : 1;
+        UINT8 E : 1;
     } flags;
 
     char *passwd_auth_str;
@@ -231,8 +231,8 @@ static bool on_option(char key, char *value) {
         ctx.flags.P = 1;
         ctx.passwd_auth_str = value;
         break;
-    case 'e':
-        ctx.flags.e = 1;
+    case 'E':
+        ctx.flags.E = 1;
         ctx.endorse_auth_str = value;
         break;
     case 'f':
@@ -259,12 +259,12 @@ bool tpm2_tool_onstart(tpm2_options **opts) {
          {"context",        required_argument, NULL, 'c'},
          {"key-context",    required_argument, NULL, 'C'},
          {"auth-key",       required_argument, NULL, 'P'},
-         {"endorse-passwd", required_argument, NULL, 'e'},
+         {"endorse-passwd", required_argument, NULL, 'E'},
          {"in-file",        required_argument, NULL, 'f'},
          {"out-file",       required_argument, NULL, 'o'},
     };
 
-    *opts = tpm2_options_new("c:C:P:e:f:o:", ARRAY_LEN(topts), topts,
+    *opts = tpm2_options_new("c:C:P:E:f:o:", ARRAY_LEN(topts), topts,
                              on_option, NULL, TPM2_OPTIONS_SHOW_USAGE);
 
     return *opts != NULL;
@@ -306,7 +306,7 @@ int tpm2_tool_onrun(TSS2_SYS_CONTEXT *sapi_context, tpm2_option_flags flags) {
         }
     }
 
-    if (ctx.flags.e) {
+    if (ctx.flags.E) {
         bool res = tpm2_auth_util_from_optarg(sapi_context, ctx.endorse_auth_str,
                 &ctx.endorse_auth, &ctx.endorse_session);
         if (!res) {

--- a/tools/tpm2_certify.c
+++ b/tools/tpm2_certify.c
@@ -58,7 +58,7 @@ struct tpm_certify_ctx {
     } file_path;
     struct {
         UINT16 P : 1;
-        UINT16 K : 1;
+        UINT16 k : 1;
         UINT16 g : 1;
         UINT16 a : 1;
         UINT16 s : 1;
@@ -183,18 +183,18 @@ static bool certify_and_save_data(TSS2_SYS_CONTEXT *sapi_context) {
 static bool on_option(char key, char *value) {
 
     switch (key) {
-    case 'c':
+    case 'C':
         ctx.context_arg = value;
         break;
-    case 'C':
+    case 'c':
         ctx.key_context_arg = value;
         break;
     case 'P':
         ctx.flags.P = 1;
         ctx.object_auth_str = value;
         break;
-    case 'K':
-        ctx.flags.K = 1;
+    case 'k':
+        ctx.flags.k = 1;
         ctx.key_auth_str = value;
         break;
     case 'g':
@@ -235,16 +235,16 @@ bool tpm2_tool_onstart(tpm2_options **opts) {
 
     const struct option topts[] = {
       { "auth-object",   required_argument, NULL, 'P' },
-      { "auth-key",      required_argument, NULL, 'K' },
+      { "auth-key",      required_argument, NULL, 'k' },
       { "halg",          required_argument, NULL, 'g' },
       { "attest-file",   required_argument, NULL, 'a' },
       { "sig-file",      required_argument, NULL, 's' },
-      { "obj-context",   required_argument, NULL, 'c' },
-      { "key-context",   required_argument, NULL, 'C' },
+      { "obj-context",   required_argument, NULL, 'C' },
+      { "key-context",   required_argument, NULL, 'c' },
       {  "format",       required_argument, NULL, 'f' },
     };
 
-    *opts = tpm2_options_new("P:K:g:a:s:c:C:f:", ARRAY_LEN(topts), topts,
+    *opts = tpm2_options_new("P:k:g:a:s:c:C:f:", ARRAY_LEN(topts), topts,
                              on_option, NULL, TPM2_OPTIONS_SHOW_USAGE);
 
     return *opts != NULL;
@@ -291,7 +291,7 @@ int tpm2_tool_onrun(TSS2_SYS_CONTEXT *sapi_context, tpm2_option_flags flags) {
         }
     }
 
-    if (ctx.flags.K) {
+    if (ctx.flags.k) {
         result = tpm2_auth_util_from_optarg(sapi_context, ctx.key_auth_str,
                 &ctx.cmd_auth[1], &ctx.session[1]);
         if (!result) {

--- a/tools/tpm2_createak.c
+++ b/tools/tpm2_createak.c
@@ -86,7 +86,7 @@ struct createak_context {
     struct {
         UINT8 f : 1;
         UINT8 o : 1;
-        UINT8 e : 1;
+        UINT8 E : 1;
         UINT8 P : 1;
         UINT8 unused : 4;
     } flags;
@@ -482,8 +482,8 @@ static bool on_option(char key, char *value) {
         ctx.flags.o = 1;
         ctx.owner_auth_str = value;
         break;
-    case 'e':
-        ctx.flags.e = 1;
+    case 'E':
+        ctx.flags.E = 1;
         ctx.endorse_auth_str = value;
         break;
     case 'P': 
@@ -518,7 +518,7 @@ bool tpm2_tool_onstart(tpm2_options **opts) {
 
     const struct option topts[] = {
         { "auth-owner",     required_argument, NULL, 'o' },
-        { "auth-endorse",   required_argument, NULL, 'e' },
+        { "auth-endorse",   required_argument, NULL, 'E' },
         { "auth-ak",        required_argument, NULL, 'P' },
         { "ek-context",     required_argument, NULL, 'C' },
         { "ak-handle",      required_argument, NULL, 'k' },
@@ -532,7 +532,7 @@ bool tpm2_tool_onstart(tpm2_options **opts) {
         { "privfile",       required_argument, NULL, 'r'},
     };
 
-    *opts = tpm2_options_new("o:C:e:k:g:D:s:P:f:n:p:c:r:", ARRAY_LEN(topts), topts,
+    *opts = tpm2_options_new("o:C:E:k:g:D:s:P:f:n:p:c:r:", ARRAY_LEN(topts), topts,
                              on_option, NULL, TPM2_OPTIONS_SHOW_USAGE);
 
     return *opts != NULL;
@@ -574,7 +574,7 @@ int tpm2_tool_onrun(TSS2_SYS_CONTEXT *sapi_context, tpm2_option_flags flags) {
         }
     }
 
-    if (ctx.flags.e) {
+    if (ctx.flags.E) {
         bool res = tpm2_auth_util_from_optarg(sapi_context, ctx.endorse_auth_str,
                 &ctx.ek.auth2.session_data, &ctx.ek.auth2.session);
         if (!res) {

--- a/tools/tpm2_createprimary.c
+++ b/tools/tpm2_createprimary.c
@@ -60,7 +60,7 @@ struct tpm_createprimary_ctx {
     char *context_file;
     struct {
         UINT8 P :1;
-        UINT8 K :1;
+        UINT8 k :1;
     } flags;
     char *parent_auth_str;
     char *key_auth_str;
@@ -87,8 +87,8 @@ static bool on_option(char key, char *value) {
         ctx.flags.P = 1;
         ctx.parent_auth_str = value;
         break;
-    case 'K': {
-        ctx.flags.K = 1;
+    case 'k': {
+        ctx.flags.k = 1;
         ctx.key_auth_str = value;
     } break;
     case 'g': {
@@ -147,7 +147,7 @@ bool tpm2_tool_onstart(tpm2_options **opts) {
     const struct option topts[] = {
         { "hierarchy",            required_argument, NULL, 'a' },
         { "auth-hierarchy",       required_argument, NULL, 'P' },
-        { "auth-object",          required_argument, NULL, 'K' },
+        { "auth-object",          required_argument, NULL, 'k' },
         { "halg",                 required_argument, NULL, 'g' },
         { "kalg",                 required_argument, NULL, 'G' },
         { "out-context",          required_argument, NULL, 'o' },
@@ -155,7 +155,7 @@ bool tpm2_tool_onstart(tpm2_options **opts) {
         { "object-attributes",    required_argument, NULL, 'A' },
     };
 
-    *opts = tpm2_options_new("A:P:K:g:G:o:L:a:", ARRAY_LEN(topts), topts,
+    *opts = tpm2_options_new("A:P:k:g:G:o:L:a:", ARRAY_LEN(topts), topts,
             on_option, NULL, TPM2_OPTIONS_SHOW_USAGE);
 
     return *opts != NULL;
@@ -175,7 +175,7 @@ int tpm2_tool_onrun(TSS2_SYS_CONTEXT *sapi_context, tpm2_option_flags flags) {
         }
     }
 
-    if (ctx.flags.K) {
+    if (ctx.flags.k) {
         TPMS_AUTH_COMMAND tmp;
         result = tpm2_auth_util_from_optarg(sapi_context, ctx.key_auth_str, &tmp, NULL);
         if (!result) {

--- a/tools/tpm2_quote.c
+++ b/tools/tpm2_quote.c
@@ -215,7 +215,7 @@ bool tpm2_tool_onstart(tpm2_options **opts) {
         { "sig-hash-algorithm",   required_argument, NULL, 'G' }
     };
 
-    *opts = tpm2_options_new("C:P:l:g:L:q:s:m:f:G:", ARRAY_LEN(topts), topts,
+    *opts = tpm2_options_new("C:P:l:L:q:s:m:f:G:", ARRAY_LEN(topts), topts,
                              on_option, NULL, TPM2_OPTIONS_SHOW_USAGE);
 
     return *opts != NULL;


### PR DESCRIPTION
Fix issues noted in #1039 where the incorrect case is used for short options.