### PR TITLE
Reduce need for duplicate args in tpm2_nvwrite/tpm2_nvread

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## Changelog
 ### next
+  * tpm2_nvwrite and tpm2_nvread: when -P is "index" -a is optional and defaults to
+    the NV_INDEX value passed to -x.
+  * Load TCTI's by SONAME, not raw .so file
   * tpm2_encryptdecrypt: supports input and output to stdin and stdout respectively.
   * tpm2_create: -g/-G become optional options.
   * tpm2_createprimary: -g/-G become optional options.

--- a/man/tpm2_nvread.1.md
+++ b/man/tpm2_nvread.1.md
@@ -27,8 +27,8 @@
       * **p** for **TPM_RH_PLATFORM**
       * **`<num>`** where a raw number can be used.
 
-    **NOTE**: To authorize against the index, specify the index handle as
-    the argument to option **-a**. The index auth value is set via the
+    When **-a** isn't explicitly passed the index handle will be used to
+    authorize against the index. The index auth value is set via the
     **-I** option to tpm2_nvdefine(1).
 
   * **-f**, **--out-file**=_FILE_:

--- a/man/tpm2_nvwrite.1.md
+++ b/man/tpm2_nvwrite.1.md
@@ -31,8 +31,8 @@ If _FILE_ is not specified, it defaults to stdin.
       * **p** for **TPM_RH_PLATFORM**
       * **`<num>`** where a raw number can be used.
 
-    **NOTE**: To authorize against the index, specify the index handle as
-    the argument to option **-a**. The index auth value is set via the
+    When **-a** isn't explicitly passed the index handle will be used to
+    authorize against the index. The index auth value is set via the
     **-I** option to tpm2_nvdefine(1).
 
   * **-P**, **--auth-hierarchy**=_HIERARCHY\_AUTH_:
@@ -62,7 +62,7 @@ If _FILE_ is not specified, it defaults to stdin.
 To write the file nv.data to index 0x150016:
 
 ```
-tpm2_nvwrite -x 0x1500016 -a 0x40000001 -f nv.data
+tpm2_nvwrite -x 0x1500016 -P "index" -f nv.data
 ```
 
 # RETURNS

--- a/test/integration/tests/nv.sh
+++ b/test/integration/tests/nv.sh
@@ -196,7 +196,7 @@ tpm2_nvdefine -x 0x1500015 -a 0x40000001 -s 32 \
 
 # Use index password write/read
 tpm2_nvwrite -Q -x 0x1500015 -P "index" nv.test_w
-tpm2_nvread -Q -x 0x1500015 -a 0x1500015 -P "index"
+tpm2_nvread -Q -x 0x1500015 -P "index"
 
 # use owner password
 tpm2_nvwrite -Q -x 0x1500015 -a 0x40000001 -P "owner" nv.test_w

--- a/test/integration/tests/nv.sh
+++ b/test/integration/tests/nv.sh
@@ -194,9 +194,13 @@ tpm2_nvdefine -x 0x1500015 -a 0x40000001 -s 32 \
   -t "policyread|policywrite|authread|authwrite|ownerwrite|ownerread" \
   -I "index" -P "owner"
 
-# Use index password write/read
+# Use index password write/read, implicit -a
 tpm2_nvwrite -Q -x 0x1500015 -P "index" nv.test_w
 tpm2_nvread -Q -x 0x1500015 -P "index"
+
+# Use index password write/read, explicit -a
+tpm2_nvwrite -Q -x 0x1500015 -a 0x1500015 -P "index" nv.test_w
+tpm2_nvread -Q -x 0x1500015 -a 0x1500015 -P "index"
 
 # use owner password
 tpm2_nvwrite -Q -x 0x1500015 -a 0x40000001 -P "owner" nv.test_w

--- a/test/integration/tests/nv.sh
+++ b/test/integration/tests/nv.sh
@@ -195,7 +195,7 @@ tpm2_nvdefine -x 0x1500015 -a 0x40000001 -s 32 \
   -I "index" -P "owner"
 
 # Use index password write/read
-tpm2_nvwrite -Q -x 0x1500015 -a 0x1500015 -P "index" nv.test_w
+tpm2_nvwrite -Q -x 0x1500015 -P "index" nv.test_w
 tpm2_nvread -Q -x 0x1500015 -a 0x1500015 -P "index"
 
 # use owner password

--- a/tools/tpm2_nvread.c
+++ b/tools/tpm2_nvread.c
@@ -64,6 +64,7 @@ struct tpm_nvread_ctx {
     struct {
         UINT8 L : 1;
         UINT8 P : 1;
+        UINT8 a : 1;
     } flags;
     char *hierarchy_auth_str;
 };
@@ -199,6 +200,7 @@ static bool on_option(char key, char *value) {
         if (!result) {
             return false;
         }
+        ctx.flags.a = 1;
         break;
     case 'f':
         ctx.output_file = value;
@@ -305,6 +307,7 @@ int tpm2_tool_onrun(TSS2_SYS_CONTEXT *sapi_context, tpm2_option_flags flags) {
             goto out;
         }
     }
+
     if (ctx.flags.P) {
         result = tpm2_auth_util_from_optarg(sapi_context, ctx.hierarchy_auth_str,
                 &ctx.auth.session_data, &ctx.auth.session);
@@ -313,6 +316,13 @@ int tpm2_tool_onrun(TSS2_SYS_CONTEXT *sapi_context, tpm2_option_flags flags) {
                 ctx.hierarchy_auth_str);
             return false;
         }
+    }
+
+    /* If the users doesn't specify an auth-hierarchy use the index passed to
+     * -x/--index for the authorisation index.
+     */
+    if (!ctx.flags.a) {
+        ctx.auth.hierarchy = ctx.nv_index;
     }
 
     result = nv_read(sapi_context, flags);


### PR DESCRIPTION
Update tpm2_nvwrite and tpm2_nvread such that when -x is specified and -a is empty we try and authorise using the NV_INDEX value passed to -x. Fixes #941