### PR TITLE
tpm2_import: support specifying parent key via context file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Changelog
 ### next
+  * tpm2_import: support specifying parent key with a context file,
+    --parent-key-handle/-H becomes --parent-key/-C
   * tpm2_nvwrite and tpm2_nvread: when -P is "index" -a is optional and defaults to
     the NV_INDEX value passed to -x.
   * Load TCTI's by SONAME, not raw .so file

--- a/man/tpm2_activatecredential.1.md
+++ b/man/tpm2_activatecredential.1.md
@@ -34,8 +34,8 @@ These options control the object verification:
   * **-P**, **--auth-key**=_AUTH\_VALUE_:
     Use _AUTH\_VALUE_ for providing an authorization value for the
     _KEY\_CONTEXT\_OBJECT_.
-    Passwords should follow the authorization formatting standards, see section
-    "Authorization Formatting".
+    Passwords should follow the "authorization formatting standards", see
+    section "Authorization Formatting".
 
   * **-E**, **--endorse-password**=_ENDORSE\_PASSWORD_:
     The endorsement password, optional. Follows the same formatting guidelines

--- a/man/tpm2_certify.1.md
+++ b/man/tpm2_certify.1.md
@@ -35,7 +35,7 @@ These options control the certification:
   * **-P**, **--auth-object**=_OBJECT\_AUTH_:
     Use _OBJECT\_AUTH_ for providing an authorization value for the object specified
     in _CONTEXT\_OBJECT_.
-    Authorization values should follow the "authorization formatting standards,
+    Authorization values should follow the "authorization formatting standards",
     see section "Authorization Formatting".
 
   * **-k**, **--auth-key**=_KEY\_AUTH_:

--- a/man/tpm2_changeauth.1.md
+++ b/man/tpm2_changeauth.1.md
@@ -21,7 +21,7 @@ authorization values.
   * **-o**, **--owner-passwd**=_OWNER\_PASSWORD_:
     The new owner authorization value.
 
-    Passwords should follow the password authorization formatting standards,
+    Passwords should follow the "password authorization formatting standards",
     see section "Authorization Formatting".
 
   * **-e**, **--endorse-passwd**=_ENDORSE\_PASSWORD_:

--- a/man/tpm2_clear.1.md
+++ b/man/tpm2_clear.1.md
@@ -24,7 +24,7 @@ values. If the lockout password option is missing, assume NULL.
   * **-L**, **--auth-lockout**=_LOCKOUT\_AUTH_:
     The lockout authorization value.
 
-    Authorization values should follow the authorization formatting standards,
+    Authorization values should follow the "authorization formatting standards",
     see section "Authorization Formatting".
 
 [common options](common/options.md)

--- a/man/tpm2_clearlock.1.md
+++ b/man/tpm2_clearlock.1.md
@@ -29,7 +29,7 @@ is missing, assume NULL.
   * **-L**, **--auth-lockout**=_LOCKOUT\_PASSWORD_:
     The lockout authorization value.
 
-    Authorization values should follow the authorization formatting standards,
+    Authorization values should follow the "authorization formatting standards",
     see section "Authorization Formatting".
     This tool only respects the *Password* and *HMAC* options.
 

--- a/man/tpm2_create.1.md
+++ b/man/tpm2_create.1.md
@@ -26,7 +26,7 @@ These options for creating the tpm entity:
 
   * **-P**, **--auth-parent**=_PARENT\_KEY\_AUTH_:
     The authorization value for using the parent key, optional.
-    Authorization values should follow the authorization formatting standards,
+    Authorization values should follow the "authorization formatting standards",
     see section "Authorization Formatting".
 
   * **-K**, **--auth-key**=_KEY\_AUTH_:
@@ -37,7 +37,7 @@ These options for creating the tpm entity:
   * **-g**, **--halg**=_ALGORITHM_:
     The hash algorithm for generating the objects name. This is optional
     and defaults to sha256 when not specified. Algorithms should follow the
-    " formatting standards, see section "Algorithm Specifiers".
+    "formatting standards", see section "Algorithm Specifiers".
     Also, see section "Supported Hash Algorithms" for a list of supported
     hash algorithms.
 

--- a/man/tpm2_createak.1.md
+++ b/man/tpm2_createak.1.md
@@ -32,7 +32,7 @@ loaded-key:
 
   * **-E**, **--auth-endorse**=_ENDORSE\_AUTH_:
     Specifies current endorsement authorization.
-    Authorizations should follow the "authorization formatting standards, see section
+    Authorizations should follow the "authorization formatting standards", see section
     "Authorization Formatting".
 
   * **-P**, **--auth-ak**=_AK\_AUTH_

--- a/man/tpm2_createek.1.md
+++ b/man/tpm2_createek.1.md
@@ -22,7 +22,7 @@ Refer to:
 
   * **-e**, **--auth-endorse**=_ENDORSE\_AUTH_:
     Specifies current endorsement authorization.
-    authorizations should follow the "authorization formatting standards, see section
+    authorizations should follow the "authorization formatting standards", see section
     "Authorization Formatting".
 
   * **-P**, **--auth-ek**=_EK\_AUTH_

--- a/man/tpm2_createpolicy.1.md
+++ b/man/tpm2_createpolicy.1.md
@@ -28,7 +28,7 @@ These options control creating the policy authorization session:
 
   * **-g**, **--policy-digest-alg**=_HASH\_ALGORITHM_:
     The hash algorithm used in computation of the policy digest. Algorithms
-    should follow the "formatting standards, see section "Algorithm Specifiers".
+    should follow the "formatting standards", see section "Algorithm Specifiers".
     Also, see section "Supported Hash Algorithms" for a list of supported hash
     algorithms.
 

--- a/man/tpm2_createprimary.1.md
+++ b/man/tpm2_createprimary.1.md
@@ -21,8 +21,9 @@ will create and load a Primary Object. The sensitive area is not returned.
 # OPTIONS
 
   * **-a**, **--hierarchy**=_HIERARCHY_:
-    Specify the hierarchy under which the object is created. This will also dictate which authorization secret (if any) must be supplied.
-    Defaults to **o**, **TPM_RH_OWNER**, when no value specified.
+    Specify the hierarchy under which the object is created. This will also
+    dictate which authorization secret (if any) must be supplied. Defaults to
+    **o**, **TPM_RH_OWNER**, when no value specified.
     Supported options are:
       * **o** for **TPM_RH_OWNER**
       * **p** for **TPM_RH_PLATFORM**
@@ -33,18 +34,18 @@ will create and load a Primary Object. The sensitive area is not returned.
   * **-P**, **--auth-hierarchy**=_HIERARCHY\_\_AUTH\_VALUE_:
     Optional authorization value when authorization is required to create object
     under the specified hierarchy given via the **-a** option. Authorization
-    values should follow the authorization formatting standards, see section
+    values should follow the "authorization formatting standards", see section
     "Authorization Formatting".
 
   * **-k**, **--auth-object**=_OBJECT\_AUTH_:
     Optional authorization password for the newly created object. Password
-    values should follow the authorization formatting standards, see section
+    values should follow the "authorization formatting standards", see section
     "Authorization Formatting".
 
   * **-g**, **--halg**=_ALGORITHM_:
     The hash algorithm to use for generating the objects name.
     If not specified, the default name algorithm is SHA256.
-    Algorithms should follow the "formatting standards, see section
+    Algorithms should follow the "formatting standards", see section
     "Algorithm Specifiers". Also, see section
     "Supported Hash Algorithms" for a list of supported hash algorithms.
 

--- a/man/tpm2_dictionarylockout.1.md
+++ b/man/tpm2_dictionarylockout.1.md
@@ -40,7 +40,7 @@ dictionary-attack-lockout state, if any passwd option is missing, assume NULL.
   * **-P**, **--auth-lockout**=_LOCKOUT\_AUTH_:
     The lockout authorization value.
 
-    Authorization values should follow the authorization formatting standards,
+    Authorization values should follow the "authorization formatting standards",
     see section "Authorization Formatting".
 
 [common options](common/options.md)

--- a/man/tpm2_encryptdecrypt.1.md
+++ b/man/tpm2_encryptdecrypt.1.md
@@ -25,7 +25,7 @@ specified symmetric key.
   * **-P**, **--auth-key**=_KEY\_AUTH_:
 
     Optional authorization value to use the key specified by **-k**.
-    Authorization values should follow the authorization formatting standards,
+    Authorization values should follow the "authorization formatting standards",
     see section "Authorization Formatting".
 
   * **-D**, **--decrypt**:

--- a/man/tpm2_evictcontrol.1.md
+++ b/man/tpm2_evictcontrol.1.md
@@ -44,7 +44,7 @@ be evicted.
   * **-P**, **--auth-hierarchy**=_AUTH\_HIERARCHY_\VALUE_:
 
     Optional authorization value. Authorization values should follow the
-    authorization formatting standards, see section "Authorization Formatting".
+    "authorization formatting standards", see section "Authorization Formatting".
 
   * **-S**, **--session**=_SESSION\_FILE_:
 

--- a/man/tpm2_getmanufec.1.md
+++ b/man/tpm2_getmanufec.1.md
@@ -22,8 +22,8 @@ server.
 
   * **-e**, **--auth-endorse**=_ENDORSE\_AUTH_:
     Specifies current endorsement authorization.
-    authorizations should follow the "authorization formatting standards, see section
-    "Authorization Formatting".
+    Authorizations should follow the "authorization formatting standards", see
+    section "Authorization Formatting".
 
   * **-P**, **--auth-ek**=_EK\_AUTH_
     Specifies the EK authorization when created.

--- a/man/tpm2_hash.1.md
+++ b/man/tpm2_hash.1.md
@@ -31,7 +31,7 @@ sign.
 
   * **-g**, **--halg**=_HASH\_ALGORITHM_:
     The hash algorithm to use.
-    Algorithms should follow the "formatting standards, see section
+    Algorithms should follow the "formatting standards", see section
     "Algorithm Specifiers".
     Also, see section "Supported Hash Algorithms" for a list of supported hash
     algorithms.

--- a/man/tpm2_hmac.1.md
+++ b/man/tpm2_hmac.1.md
@@ -24,7 +24,7 @@ _FILE_ is not specified, then data is read from stdin.
   * **-P**, **--auth-key**=_KEY\_AUTH_:
 
     Optional authorization value to use the key specified by **-k**.
-    Authorization values should follow the authorization formatting standards,
+    Authorization values should follow the "authorization formatting standards",
     see section "Authorization Formatting".
 
   * **-g**, **--halg**=_HASH\_ALGORITHM_:

--- a/man/tpm2_import.1.md
+++ b/man/tpm2_import.1.md
@@ -21,30 +21,30 @@ OPTIONS
 
 These options control the key importation process:
 
-  * `-G`, **--import-key-alg**=_ALGORITHM_:
-    The hash algorithm to use. Algorithms should follow the
-    " formatting standards, see section "Algorithm Specifiers".
-    Also, see section "Supported Hash Algorithms" for a list of supported
-    hash algorithms.
+  * **-G**, **--import-key-alg**=_ALGORITHM_:
+    The algorithm used by the key to be imported, AES and RSA keys are supported.
+    Algorithms should follow the "formatting standards", see section
+    "Algorithm Specifiers".
 
-  * `-k`, `--input-key-file`=_FILE_:
+  * **-k**, **--input-key-file**=_FILE_:
     Specifies the filename of symmetric key (128 bit data) to be imported. OR,
     Specifies the filename for the RSA2K private key file in PEM and PKCS#1
     format. A typical file is generated with openssl genrsa.
 
-  * `-H`, `--parent-key-handle`=_HANDLE_:
-    Specifies the persistent parent key handle.
+  * **-C**, **--parent-key**=_PARENT_CONTEXT_:
+    Specifies the context object for the parent key. Either a file or a handle number.
+    See section "Context Object Format".
 
-  * `-K`, `--parent-key-public`=_FILE_:
+  * **-K**, **--parent-key-public**=_FILE_:
     Optional. Specifies the parent key public data file input. This can be read with
     tpm2_readpublic tool. If not specified, the tool invokes a tpm2_readpublic on the parent
     object.
 
-  * `-r`, `--import-key-private`=_FILE_:
+  * **-r**, **--import-key-private**=_FILE_:
     Specifies the file path required to save the encrypted private portion of
     the object imported as key.
 
-  * `-q`, `--import-key-public`=_FILE_:
+  * **-q**, **--import-key-public**=_FILE_:
     Specifies the file path required to save the public portion of the object imported as key
 
   * **-A**, **--object-attributes**=_ATTRIBUTES_:
@@ -54,12 +54,16 @@ These options control the key importation process:
 
 [common tcti options](common/tcti.md)
 
+[context object format](commmon/ctxobj.md)
+
+[algorithm specifiers](common/alg.md)
+
 EXAMPLES
 --------
 
-tpm2_import -k sym.key -H 0x81010001 -f parent.pub -q import_key.pub -r import_key.priv
+tpm2_import -k sym.key -C 0x81010001 -f parent.pub -q import_key.pub -r import_key.priv
 
-tpm2_import -Q -G rsa -k private.pem -H 0x81010005 -f parent.pub \
+tpm2_import -Q -G rsa -k private.pem -C 0x81010005 -f parent.pub \
 -q import_rsa_key.pub -r import_rsa_key.priv
 
 RETURNS

--- a/man/tpm2_listpersistent.1.md
+++ b/man/tpm2_listpersistent.1.md
@@ -20,7 +20,7 @@ These options for listing the persistent objects:
 
   * **-g**, **--halg**=_ALGORITHM_:
     Only display persistent objects using this hash algorithm. Algorithms should
-    follow the " formatting standards, see section "Algorithm Specifiers".
+    follow the "formatting standards", see section "Algorithm Specifiers".
     Also, see section "Supported Hash Algorithms" for a list of supported
     hash algorithms.
 

--- a/man/tpm2_load.1.md
+++ b/man/tpm2_load.1.md
@@ -23,7 +23,7 @@ into the TPM.
 
   * **-P**, **--auth-parent**=_KEY\_AUTH_:
     Optional authorization value to use the parent object specified by **-H**.
-    Authorization values should follow the authorization formatting standards,
+    Authorization values should follow the "authorization formatting standards",
     see section "Authorization Formatting".
 
   * **-u**, **--pubfile**=_PUBLIC\_OBJECT\_DATA\_FILE_:

--- a/man/tpm2_nvdefine.1.md
+++ b/man/tpm2_nvdefine.1.md
@@ -38,14 +38,13 @@
 
   * **-P**, **--auth-hierarchy**=_AUTH\_HIERARCHY\_VALUE_:
     Specifies the authorization value for the hierarchy. Authorization values
-    should follow the authorization formatting standards, see section
+    should follow the "authorization formatting standards", see section
     "Authorization Formatting".
 
   * **-I**, **--auth-index**=_INDEX\_PASSWORD_:
     Specifies the password of NV Index when created.
-    HMAC and Password authorization values should follow
-    the authorization formatting standards, see section
-    "Authorization Formatting".
+    HMAC and Password authorization values should follow the "authorization
+    formatting standards", see section "Authorization Formatting".
 
   * **-L**, **--policy-file**=_POLICY\_FILE_:
     Specifies the policy digest file for policy based authorizations.

--- a/man/tpm2_nvread.1.md
+++ b/man/tpm2_nvread.1.md
@@ -36,7 +36,7 @@
 
   * **-P**, **--auth-hierarchy**=_AUTH\_HIERARCHY\_VALUE__:
     Specifies the authorization value for the hierarchy. Authorization values
-    should follow the authorization formatting standards, see section
+    should follow the "authorization formatting standards", see section
     "Authorization Formatting".
 
   * **-s**, **--size**=_SIZE_:

--- a/man/tpm2_nvreadlock.1.md
+++ b/man/tpm2_nvreadlock.1.md
@@ -29,7 +29,7 @@ is released on subsequent restart of the machine.
 
   * **-P**, **--handle-passwd**=_HANDLE\_PASSWORD_:
     specifies the password of authHandle. Passwords should follow the
-    "authorization formatting standards, see section "Authorization Formatting".
+    "authorization formatting standards", see section "Authorization Formatting".
 
   * **-S**, **--input-session-handle**=_SESSION\_FILE_:
     Optional, a session file from **tpm2_startauthsession**(1)'s **-S** option.

--- a/man/tpm2_nvrelease.1.md
+++ b/man/tpm2_nvrelease.1.md
@@ -32,7 +32,7 @@ defined with tpm2_nvdefine(1).
 
   * **-P**, **--handle-passwd**=_HANDLE\_PASSWORD_:
     specifies the password of authHandle. Passwords should follow the
-    "authorization formatting standards, see section "Authorization Formatting".
+    "authorization formatting standards", see section "Authorization Formatting".
 
   * **-S**, **--session**=_SESSION\_FILE_:
 

--- a/man/tpm2_nvwrite.1.md
+++ b/man/tpm2_nvwrite.1.md
@@ -37,7 +37,7 @@ If _FILE_ is not specified, it defaults to stdin.
 
   * **-P**, **--auth-hierarchy**=_HIERARCHY\_AUTH_:
     Specifies the authorization value for the hierarchy. Authorization values
-    should follow the authorization formatting standards, see section
+    should follow the "authorization formatting standards", see section
     "Authorization Formatting".
 
   * **-L**, **--set-list**==_PCR\_SELECTION\_LIST_:

--- a/man/tpm2_pcrevent.1.md
+++ b/man/tpm2_pcrevent.1.md
@@ -35,7 +35,7 @@ These options control extending the pcr:
 
   * **-P**, **--auth-pcr**=_PCR\_AUTH_:
     Specifies the authorization value for PCR. Authorization values
-    should follow the authorization formatting standards, see section
+    should follow the "authorization formatting standards", see section
     "Authorization Formatting".
 
 [common options](common/options.md)

--- a/man/tpm2_pcrlist.1.md
+++ b/man/tpm2_pcrlist.1.md
@@ -31,7 +31,7 @@ sha256 :
 
   * **-g**, **--halg**=_HASH\_ALGORITHM_:
     Only output PCR banks with the given algorithm.
-    Algorithms should follow the "formatting standards, see section
+    Algorithms should follow the "formatting standards", see section
     "Algorithm Specifiers".
     Also, see section "Supported Hash Algorithms" for a list of supported hash
     algorithms.

--- a/man/tpm2_quote.1.md
+++ b/man/tpm2_quote.1.md
@@ -22,8 +22,9 @@
     See section "Context Object Format".
 
   * **-P**, **--auth-ak**=_AK\_AUTH_:
+
     Specifies the authorization value for AK specified by option **-C**.
-    Authorization values should follow the authorization formatting standards,
+    Authorization values should follow the "authorization formatting standards",
     see section "Authorization Formatting".
 
   * **-l**, **--id-list**=_PCR\_ID\_LIST_

--- a/man/tpm2_rsadecrypt.1.md
+++ b/man/tpm2_rsadecrypt.1.md
@@ -31,7 +31,7 @@ The key referenced by key-context is **required** to be:
   * **-P**, **--auth-key**=_KEY\_AUTH_:
 
     Optional authorization value to use the key specified by **-k**.
-    Authorization values should follow the authorization formatting standards,
+    Authorization values should follow the "authorization formatting standards",
     see section "Authorization Formatting".
 
   * **-I**, **--in-file**=_INPUT\FILE_:

--- a/man/tpm2_rsaencrypt.1.md
+++ b/man/tpm2_rsaencrypt.1.md
@@ -31,8 +31,8 @@ The key referenced by key-context is **required** to be:
 
   * **-P**, **--pwdk**=_KEY\_PASSWORD_:
 
-    specifies the password of _KEY\_HANDLE_. Passwords should follow the
-    authorization formatting standards, see section "Authorization Formatting".
+    Specifies the password of _KEY\_HANDLE_. Passwords should follow the
+    "authorization formatting standards", see section "Authorization Formatting".
 
   * **-o**, **--out-file**=_OUTPUT\_FILE_:
 

--- a/man/tpm2_sign.1.md
+++ b/man/tpm2_sign.1.md
@@ -28,13 +28,13 @@ data and validation shall indicate that hashed data did not start with
   * **-P**, **--auth-key**=_KEY\_AUTH_:
 
     Optional authorization value to use the key specified by **-k**.
-    Authorization values should follow the authorization formatting standards,
+    Authorization values should follow the "authorization formatting standards",
     see section "Authorization Formatting".
 
   * **-g**, **--halg**=_HASH\_ALGORITHM_:
 
     The hash algorithm used to digest the message.
-    Algorithms should follow the "formatting standards, see section
+    Algorithms should follow the "formatting standards", see section
     "Algorithm Specifiers".
     Also, see section "Supported Hash Algorithms" for a list of supported hash
     algorithms.

--- a/man/tpm2_unseal.1.md
+++ b/man/tpm2_unseal.1.md
@@ -29,7 +29,7 @@ alive and pass that session using the **--input-session-handle** option.
   * **-P**, **--auth-key**=_KEY\_AUTH_:
 
     Optional authorization value to use the key specified by **-k**.
-    Authorization values should follow the authorization formatting standards,
+    Authorization values should follow the "authorization formatting standards",
     see section "Authorization Formatting".
 
   * **-o**, **--out-file**=_OUT\_FILE_:

--- a/man/tpm2_verifysignature.1.md
+++ b/man/tpm2_verifysignature.1.md
@@ -29,7 +29,7 @@ symmetric key, both the public and private portions need to be loaded.
   * **-g**, **--halg**=_HASH\_ALGORITHM_:
 
     The hash algorithm used to digest the message.
-    Algorithms should follow the "formatting standards, see section
+    Algorithms should follow the "formatting standards", see section
     "Algorithm Specifiers".
     Also, see section "Supported Hash Algorithms" for a list of supported hash
     algorithms.
@@ -54,7 +54,7 @@ symmetric key, both the public and private portions need to be loaded.
     data format, however different schemes can be selected if the data came from an external
     source like OpenSSL. The tool currently only supports rsassa.
 
-    Algorithms should follow the "formatting standards, see section
+    Algorithms should follow the "formatting standards", see section
     "Algorithm Specifiers".
     Also, see section "Supported Signing Schemes" for a list of supported hash
     algorithms.

--- a/test/integration/tests/import.sh
+++ b/test/integration/tests/import.sh
@@ -59,7 +59,7 @@ dd if=/dev/urandom of=sym.key bs=1 count=16 2>/dev/null
 tpm2_readpublic -Q -c 0x81010005 --out-file parent.pub
 
 #Symmetric Key Import Test
-tpm2_import -Q -G aes -k sym.key -H 0x81010005 -K parent.pub -q import_key.pub \
+tpm2_import -Q -G aes -k sym.key -C 0x81010005 -K parent.pub -q import_key.pub \
 -r import_key.priv
 
 tpm2_load -Q -C 0x81010005 -u import_key.pub -r import_key.priv -n import_key.name \
@@ -79,7 +79,7 @@ openssl genrsa -out private.pem 2048
 openssl rsa -in private.pem -pubout > public.pem
 
 # Test an import without the parent public info data to force a readpublic
-tpm2_import -Q -G rsa -k private.pem -H 0x81010005 \
+tpm2_import -Q -G rsa -k private.pem -C 0x81010005 \
 -q import_rsa_key.pub -r import_rsa_key.priv
 
 tpm2_load -Q -C 0x81010005 -u import_rsa_key.pub -r import_rsa_key.priv \


### PR DESCRIPTION
Update to support specifying the parent key as either a handle *or* a context file. Change the option long and short forms:
-H -> -C
--parent-key-handle -> --parent-key-context

Fixes #1023