### PR TITLE
Make option short forms consistent

### DIFF
--- a/.ci/travis.run
+++ b/.ci/travis.run
@@ -16,6 +16,8 @@ if [ "$TRAVIS_BRANCH" != "coverity_scan" ]; then
     -v `pwd`:/workspace/tpm2-tools tpm2software/tpm2-tss \
     /bin/bash -c '/workspace/tpm2-tools/.ci/docker.run'
 
+  # check to ensure change hasn't introduced conflicting short options
+  scripts/utils/analyze.py tools
 else
 
   if [[ "$CC" == clang* ]]; then

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## Changelog
 ### next
+  * tpm2_verifysignature: -g becomes -G
   * tpm2_sign: -g becomes -G
   * tpm2_verifysignature: -f/--format becomes -i/--input-format
   * tpm2_import: support specifying parent key with a context file,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## Changelog
 ### next
+  * tpm2_verifysignature: -f/--format becomes -i/--input-format
   * tpm2_import: support specifying parent key with a context file,
     --parent-key-handle/-H becomes --parent-key/-C
   * tpm2_nvwrite and tpm2_nvread: when -P is "index" -a is optional and defaults to

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## Changelog
 ### next
+  * tpm2_sign: -g becomes -G
   * tpm2_verifysignature: -f/--format becomes -i/--input-format
   * tpm2_import: support specifying parent key with a context file,
     --parent-key-handle/-H becomes --parent-key/-C

--- a/man/common/signschemes.md
+++ b/man/common/signschemes.md
@@ -1,6 +1,6 @@
 # Supported Signing Schemes
 
-Supported hash algorithms are:
+Supported signing algorithms are:
 
   * **0x5**  or **hmac** for **TPM_ALG_HMAC**
   * **0x14** or **rsassa** for **TPM_ALG_RSASSA**

--- a/man/tpm2_sign.1.md
+++ b/man/tpm2_sign.1.md
@@ -31,7 +31,7 @@ data and validation shall indicate that hashed data did not start with
     Authorization values should follow the "authorization formatting standards",
     see section "Authorization Formatting".
 
-  * **-g**, **--halg**=_HASH\_ALGORITHM_:
+  * **-G**, **--halg**=_HASH\_ALGORITHM_:
 
     The hash algorithm used to digest the message.
     Algorithms should follow the "formatting standards", see section

--- a/man/tpm2_verifysignature.1.md
+++ b/man/tpm2_verifysignature.1.md
@@ -26,7 +26,7 @@ symmetric key, both the public and private portions need to be loaded.
     Context object for the key context used for the operation. Either a file
     or a handle number. See section "Context Object Format".
 
-  * **-g**, **--halg**=_HASH\_ALGORITHM_:
+  * **-G**, **--halg**=_HASH\_ALGORITHM_:
 
     The hash algorithm used to digest the message.
     Algorithms should follow the "formatting standards", see section

--- a/man/tpm2_verifysignature.1.md
+++ b/man/tpm2_verifysignature.1.md
@@ -48,7 +48,7 @@ symmetric key, both the public and private portions need to be loaded.
 
     The input signature file of the signature to be validated.
 
-  * **-f**, **--format**:
+  * **-i**, **--input-format**=_INPUT\_FORMAT_:
 
     Set the input signature file to a specified format. The default is the tpm2.0 TPMT_SIGNATURE
     data format, however different schemes can be selected if the data came from an external

--- a/scripts/utils/analyze.py
+++ b/scripts/utils/analyze.py
@@ -44,7 +44,8 @@ class ToolConflictor(object):
 
     _ignore = ["tpm2_tool"]
 
-    def __init__(self, tools):
+    def __init__(self, tools, full=False):
+        self.full = full
 
         # Using the command summary here:
         # https://trustedcomputinggroup.org/wp-content/uploads/TPM-Rev-2.0-Part-3-Commands-01.38.pdf
@@ -242,6 +243,9 @@ class ToolConflictor(object):
             if conflicts is None:
                 continue
 
+            if not self.full and gname == "custom":
+                continue
+
             has_conflicts = True
             print "group: %s:" % (gname)
             print "\ttools: %s" % str([t.name for t in tools])
@@ -291,16 +295,18 @@ class Parser(object):
 
 
 def main():
-    '''main entry point to program'''
+    import argparse
+    parser = argparse.ArgumentParser()
+    parser.add_argument("path", help="path to directory of c files to analyze")
+    parser.add_argument("-c", "--custom",
+                        help="include custom tools in the report",
+                        action="store_true")
+    args = parser.parse_args()
 
-    if len(sys.argv) != 2:
-        sys.exit("Expected file path argument, got %d arguments" %
-                 (len(sys.argv)))
-
-    parser = Parser(sys.argv[1])
+    parser = Parser(args.path)
     tools = parser.parse()
 
-    conflictor = ToolConflictor(tools)
+    conflictor = ToolConflictor(tools, full=args.custom)
     conflictor.process()
 
     has_conflicts = conflictor.report()

--- a/test/integration/tests/import.sh
+++ b/test/integration/tests/import.sh
@@ -97,7 +97,7 @@ echo "data to sign" > data.in.raw
 
 sha256sum data.in.raw | awk '{ print "000000 " $1 }' | xxd -r -c 32 > data.in.digest
 
-tpm2_sign -Q -c import_rsa_key.ctx -g sha256 -D data.in.digest -f plain -s data.out.signed
+tpm2_sign -Q -c import_rsa_key.ctx -G sha256 -D data.in.digest -f plain -s data.out.signed
 
 openssl dgst -verify public.pem -keyform pem -sha256 -signature data.out.signed data.in.raw
 

--- a/test/integration/tests/import.sh
+++ b/test/integration/tests/import.sh
@@ -105,6 +105,6 @@ openssl dgst -verify public.pem -keyform pem -sha256 -signature data.out.signed 
 openssl dgst -sha256 -sign private.pem -out data.out.signed data.in.raw
 
 # Verify with the TPM
-tpm2_verifysignature -Q -c import_rsa_key.ctx -g sha256 -m data.in.raw -f rsassa -s data.out.signed -t ticket.out
+tpm2_verifysignature -Q -c import_rsa_key.ctx -g sha256 -m data.in.raw -i rsassa -s data.out.signed -t ticket.out
 
 exit 0

--- a/test/integration/tests/import.sh
+++ b/test/integration/tests/import.sh
@@ -105,6 +105,6 @@ openssl dgst -verify public.pem -keyform pem -sha256 -signature data.out.signed 
 openssl dgst -sha256 -sign private.pem -out data.out.signed data.in.raw
 
 # Verify with the TPM
-tpm2_verifysignature -Q -c import_rsa_key.ctx -g sha256 -m data.in.raw -i rsassa -s data.out.signed -t ticket.out
+tpm2_verifysignature -Q -c import_rsa_key.ctx -G sha256 -m data.in.raw -i rsassa -s data.out.signed -t ticket.out
 
 exit 0

--- a/test/integration/tests/output_formats.sh
+++ b/test/integration/tests/output_formats.sh
@@ -106,7 +106,7 @@ tpm2_hash -Q -a e -g $alg_hash -t "$file_hash_ticket" -o "$file_hash_result" "$f
 
 for fmt in tss plain; do
     this_sig="${file_sig_base}.${fmt}"
-    tpm2_sign -Q -c $handle_ak -g $alg_hash -m "${file_hash_input}" -f $fmt -s "${this_sig}" -t "${file_hash_ticket}"
+    tpm2_sign -Q -c $handle_ak -G $alg_hash -m "${file_hash_input}" -f $fmt -s "${this_sig}" -t "${file_hash_ticket}"
 
     if [ "$fmt" = plain ]; then
         openssl dgst -verify "$file_pubak_pem" -keyform pem -${alg_hash} -signature "$this_sig" "$file_hash_input" > /dev/null

--- a/test/integration/tests/sign.sh
+++ b/test/integration/tests/sign.sh
@@ -78,13 +78,13 @@ tpm2_create -Q -g $alg_hash -G $alg_signing_key -u $file_signing_key_pub -r $fil
 
 tpm2_load -Q -C $file_primary_key_ctx  -u $file_signing_key_pub  -r $file_signing_key_priv -n $file_signing_key_name -o $file_signing_key_ctx
 
-tpm2_sign -Q -c $file_signing_key_ctx -g $alg_hash -m $file_input_data -s $file_output_data
+tpm2_sign -Q -c $file_signing_key_ctx -G $alg_hash -m $file_input_data -s $file_output_data
 
 rm -f $file_output_data
 
 tpm2_evictcontrol -Q -a o -c $file_signing_key_ctx -p $handle_signing_key
 
-tpm2_sign -Q -c $handle_signing_key -g $alg_hash -m $file_input_data -s $file_output_data
+tpm2_sign -Q -c $handle_signing_key -G $alg_hash -m $file_input_data -s $file_output_data
 
 rm -f $file_output_data
 
@@ -92,7 +92,7 @@ rm -f $file_output_data
 
 tpm2_hash -Q -a e -g $alg_hash -o $file_output_hash -t $file_output_ticket $file_input_data
 
-tpm2_sign -Q -c $handle_signing_key -g $alg_hash -s $file_output_data -m $file_input_data -t $file_output_ticket
+tpm2_sign -Q -c $handle_signing_key -G $alg_hash -s $file_output_data -m $file_input_data -t $file_output_ticket
 
 rm -f $file_output_data
 
@@ -100,12 +100,12 @@ rm -f $file_output_data
 
 sha256sum $file_input_data | awk '{ print "000000 " $1 }' | xxd -r -c 32 > $file_input_digest
 
-tpm2_sign -Q -c $handle_signing_key -g $alg_hash -D $file_input_digest -s $file_output_data
+tpm2_sign -Q -c $handle_signing_key -G $alg_hash -D $file_input_digest -s $file_output_data
 
 rm -f $file_output_data
 
 # test with digest + message/validation (warning generated)
 
-tpm2_sign -Q -c $handle_signing_key -g $alg_hash -D $file_input_digest -s $file_output_data -m $file_input_data -t $file_output_ticket |& grep -q ^WARN
+tpm2_sign -Q -c $handle_signing_key -G $alg_hash -D $file_input_digest -s $file_output_data -m $file_input_data -t $file_output_ticket |& grep -q ^WARN
 
 exit 0

--- a/test/integration/tests/verifysignature.sh
+++ b/test/integration/tests/verifysignature.sh
@@ -79,7 +79,7 @@ tpm2_load -Q -C $file_primary_key_ctx  -u $file_signing_key_pub  -r $file_signin
 
 tpm2_sign -Q -c $file_signing_key_ctx -G $alg_hash -m $file_input_data -s $file_output_data
 
-tpm2_verifysignature -Q -c $file_signing_key_ctx  -g $alg_hash -m $file_input_data  -s $file_output_data -t $file_verify_tk_data
+tpm2_verifysignature -Q -c $file_signing_key_ctx  -G $alg_hash -m $file_input_data  -s $file_output_data -t $file_verify_tk_data
 
 tpm2_hash -Q -a n -g $alg_hash -o $file_input_data_hash -t $file_input_data_hash_tk $file_input_data
 
@@ -89,6 +89,6 @@ tpm2_verifysignature -Q -c $file_signing_key_ctx  -D  $file_input_data_hash -s $
 rm -f $file_verify_tk_data $file_signing_key_ctx  -rf
 tpm2_loadexternal -Q -a n -u $file_signing_key_pub -o  $file_signing_key_ctx
 
-tpm2_verifysignature -Q -c $file_signing_key_ctx  -g $alg_hash -m $file_input_data  -s $file_output_data -t $file_verify_tk_data
+tpm2_verifysignature -Q -c $file_signing_key_ctx  -G $alg_hash -m $file_input_data  -s $file_output_data -t $file_verify_tk_data
 
 exit 0

--- a/test/integration/tests/verifysignature.sh
+++ b/test/integration/tests/verifysignature.sh
@@ -77,7 +77,7 @@ tpm2_create -Q -g $alg_hash -G $alg_signing_key -u $file_signing_key_pub -r $fil
 
 tpm2_load -Q -C $file_primary_key_ctx  -u $file_signing_key_pub  -r $file_signing_key_priv -n $file_signing_key_name -o $file_signing_key_ctx
 
-tpm2_sign -Q -c $file_signing_key_ctx -g $alg_hash -m $file_input_data -s $file_output_data
+tpm2_sign -Q -c $file_signing_key_ctx -G $alg_hash -m $file_input_data -s $file_output_data
 
 tpm2_verifysignature -Q -c $file_signing_key_ctx  -g $alg_hash -m $file_input_data  -s $file_output_data -t $file_verify_tk_data
 

--- a/tools/tpm2_sign.c
+++ b/tools/tpm2_sign.c
@@ -192,7 +192,7 @@ static bool on_option(char key, char *value) {
         ctx.flags.P = 1;
         ctx.key_auth_str = value;
         break;
-    case 'g': {
+    case 'G': {
         ctx.halg = tpm2_alg_util_from_optarg(value);
         if (ctx.halg == TPM2_ALG_ERROR) {
             LOG_ERR("Could not convert to number or lookup algorithm, got: \"%s\"",
@@ -249,7 +249,7 @@ bool tpm2_tool_onstart(tpm2_options **opts) {
 
     static const struct option topts[] = {
       { "auth-key",             required_argument, NULL, 'P' },
-      { "halg",                 required_argument, NULL, 'g' },
+      { "halg",                 required_argument, NULL, 'G' },
       { "message",              required_argument, NULL, 'm' },
       { "digest",               required_argument, NULL, 'D' },
       { "sig",                  required_argument, NULL, 's' },
@@ -258,7 +258,7 @@ bool tpm2_tool_onstart(tpm2_options **opts) {
       { "format",               required_argument, NULL, 'f' }
     };
 
-    *opts = tpm2_options_new("P:g:m:D:t:s:c:f:", ARRAY_LEN(topts), topts,
+    *opts = tpm2_options_new("P:G:m:D:t:s:c:f:", ARRAY_LEN(topts), topts,
                              on_option, NULL, TPM2_OPTIONS_SHOW_USAGE);
 
     return *opts != NULL;

--- a/tools/tpm2_verifysignature.c
+++ b/tools/tpm2_verifysignature.c
@@ -201,7 +201,7 @@ static bool on_option(char key, char *value) {
 	case 'c':
 	    ctx.context_arg = value;
 	    break;
-	case 'g': {
+	case 'G': {
 		ctx.halg = tpm2_alg_util_from_optarg(value);
 		if (ctx.halg == TPM2_ALG_ERROR) {
 			LOG_ERR("Unable to convert algorithm, got: \"%s\"", value);
@@ -260,7 +260,7 @@ bool tpm2_tool_onstart(tpm2_options **opts) {
 
     const struct option topts[] = {
             { "digest",       required_argument, NULL, 'D' },
-            { "halg",         required_argument, NULL, 'g' },
+            { "halg",         required_argument, NULL, 'G' },
             { "message",      required_argument, NULL, 'm' },
             { "input-format", required_argument, NULL, 'i' },
             { "sig",          required_argument, NULL, 's' },
@@ -269,7 +269,7 @@ bool tpm2_tool_onstart(tpm2_options **opts) {
     };
 
 
-    *opts = tpm2_options_new("g:m:D:i:s:t:c:", ARRAY_LEN(topts), topts,
+    *opts = tpm2_options_new("G:m:D:i:s:t:c:", ARRAY_LEN(topts), topts,
                              on_option, NULL, TPM2_OPTIONS_SHOW_USAGE);
 
     return *opts != NULL;

--- a/tools/tpm2_verifysignature.c
+++ b/tools/tpm2_verifysignature.c
@@ -224,7 +224,7 @@ static bool on_option(char key, char *value) {
 		ctx.flags.digest = 1;
 	}
 		break;
-	case 'f': {
+	case 'i': {
 		ctx.format = tpm2_alg_util_from_optarg(value);
 		if (ctx.format == TPM2_ALG_ERROR) {
 		    LOG_ERR("Unknown signing scheme, got: \"%s\"", value);
@@ -259,17 +259,17 @@ static bool on_option(char key, char *value) {
 bool tpm2_tool_onstart(tpm2_options **opts) {
 
     const struct option topts[] = {
-            { "digest",      required_argument, NULL, 'D' },
-            { "halg",        required_argument, NULL, 'g' },
-            { "message",     required_argument, NULL, 'm' },
-            { "format",      required_argument, NULL, 'f' },
-            { "sig",         required_argument, NULL, 's' },
-            { "ticket",      required_argument, NULL, 't' },
-            { "key-context", required_argument, NULL, 'c' },
+            { "digest",       required_argument, NULL, 'D' },
+            { "halg",         required_argument, NULL, 'g' },
+            { "message",      required_argument, NULL, 'm' },
+            { "input-format", required_argument, NULL, 'i' },
+            { "sig",          required_argument, NULL, 's' },
+            { "ticket",       required_argument, NULL, 't' },
+            { "key-context",  required_argument, NULL, 'c' },
     };
 
 
-    *opts = tpm2_options_new("g:m:D:f:s:t:c:", ARRAY_LEN(topts), topts,
+    *opts = tpm2_options_new("g:m:D:i:s:t:c:", ARRAY_LEN(topts), topts,
                              on_option, NULL, TPM2_OPTIONS_SHOW_USAGE);
 
     return *opts != NULL;


### PR DESCRIPTION
This pull request should resolve the remaining items to resolve/fix #957:

- change **-f** to **-i** in `tpm2_verifysignature`
- change **-g** to **-G** in `tpm2_sign` and `tpm2_verifysignature`
- updates `scripts/utils/analyze.py` to only print the report for the custom group when the **-c** option is passed
- integrates `scripts/utils/analyze.py` into the CI loop so that introduction of conflicting short options causes a CI failure