### PR TITLE
help: update and correct help output

### DIFF
--- a/lib/tpm2_options.c
+++ b/lib/tpm2_options.c
@@ -35,11 +35,15 @@
 #include <stdlib.h>
 #include <string.h>
 
+#include <fcntl.h>
 #include <getopt.h>
 #include <unistd.h>
 
+#include <linux/limits.h>
+
 #include <sys/types.h>
 #include <sys/wait.h>
+#include <sys/stat.h>
 
 #include "log.h"
 #include "tpm2_options.h"
@@ -221,7 +225,7 @@ static tcti_conf tcti_get_config(const char *optstr) {
     return conf;
 }
 
-static bool execute_man(char *prog_name) {
+static bool execute_man(char *prog_name, bool show_errors) {
 
     pid_t  pid;
     int status;
@@ -233,6 +237,14 @@ static bool execute_man(char *prog_name) {
     }
 
     if (pid == 0) {
+
+        if (!show_errors) {
+            /* redirect manpager errors to stderr */
+            int fd = open("/dev/null", O_WRONLY);
+            dup2(fd, 2);
+            close(fd);
+        }
+
         char *manpage = basename(prog_name);
         execlp("man", "man", manpage, NULL);
     } else {
@@ -268,17 +280,22 @@ static void show_version (const char *name) {
 void tpm2_print_usage(const char *command, struct tpm2_options *tool_opts) {
     unsigned int i;
     bool indent = true;
-    char *command_copy;
 
-    if (!tool_opts || !(tool_opts->flags & TPM2_OPTIONS_SHOW_USAGE)) {
+    if (!tool_opts) {
         return;
     }
 
-    command_copy = strdup(command);
-    printf("Usage: %s%s%s\n", basename(command_copy),
+    char command_copy[PATH_MAX];
+    snprintf(command_copy, sizeof(command_copy), "%s", command);
+    char *name = basename(command_copy);
+    if (!tool_opts) {
+        printf("Usage: %s\n", name);
+        return;
+    }
+
+    printf("Usage: %s%s%s\n", name,
            tool_opts->callbacks.on_opt ? " [<options>]" : "",
            tool_opts->callbacks.on_arg ? " <arguments>" : "");
-    free(command_copy);
 
     if (tool_opts->callbacks.on_opt) {
         printf("Where <options> are:\n");
@@ -311,6 +328,8 @@ tpm2_option_code tpm2_handle_options (int argc, char **argv,
     tpm2_option_code rc = tpm2_option_code_err;
     bool result = false;
     bool show_help = false;
+    bool manpager = true;
+    bool explicit_manpager = false;
 
     /*
      * Handy way to *try* and find all used options:
@@ -318,7 +337,7 @@ tpm2_option_code tpm2_handle_options (int argc, char **argv,
      */
     struct option long_options [] = {
         { "tcti",          required_argument, NULL, 'T' },
-        { "help",          no_argument,       NULL, 'h' },
+        { "help",          optional_argument, NULL, 'h' },
         { "verbose",       no_argument,       NULL, 'V' },
         { "quiet",         no_argument,       NULL, 'Q' },
         { "version",       no_argument,       NULL, 'v' },
@@ -328,7 +347,7 @@ tpm2_option_code tpm2_handle_options (int argc, char **argv,
     const char *tcti_conf_option = NULL;
 
     /* handle any options */
-    const char* common_short_opts = "T:hvVQZ";
+    const char* common_short_opts = "T:h::vVQZ";
     tpm2_options *opts = tpm2_options_new(common_short_opts,
             ARRAY_LEN(long_options), long_options, NULL, NULL, true);
     if (!opts) {
@@ -359,6 +378,19 @@ tpm2_option_code tpm2_handle_options (int argc, char **argv,
             break;
         case 'h':
             show_help = true;
+            if (optarg) {
+                if (!strcmp(optarg, "man")) {
+                    manpager = true;
+                    explicit_manpager = true;
+                    optind++;
+                } else if (!strcmp(optarg, "no-man")) {
+                    manpager = false;
+                    optind++;
+                } else {
+                    LOG_ERR("Unknown help argument, got: \"%s\"", optarg);
+                }
+            }
+            goto out;
         break;
         case 'V':
             flags->verbose = 1;
@@ -392,6 +424,11 @@ tpm2_option_code tpm2_handle_options (int argc, char **argv,
     char **tool_args = &argv[optind];
     int tool_argc = argc - optind;
 
+    /*
+     * From here to out, anything that fails, just print output help
+     */
+    show_help = true;
+
     /* have args and no handler, error condition */
     if (tool_argc && (!tool_opts || !tool_opts->callbacks.on_arg)) {
         LOG_ERR("Got arguments but the tool takes no arguments");
@@ -420,18 +457,37 @@ tpm2_option_code tpm2_handle_options (int argc, char **argv,
         }
     }
 
+    /*
+     * We made it without error disable help output
+     */
+    show_help = false;
+
     rc = tpm2_option_code_continue;
 out:
 
+    /*
+     * If help output is selected via -h or indicated by an error that help output
+     * is desirable, show it.
+     *
+     * However, 3 conditions are possible:
+     * 1. Try manpager and success -- done, no need to show short help output.
+     * 2. Try manpager and failure -- show short help output.
+     * 3. Do not use manpager -- show short help output.
+     *
+     */
     if (show_help) {
-        bool did_manpager = execute_man(argv[0]);
+        bool did_manpager = false;
+        if (manpager) {
+            did_manpager = execute_man(argv[0], explicit_manpager);
+        }
+
         if (!did_manpager) {
             tpm2_print_usage(argv[0], tool_opts);
         }
 
         const TSS2_TCTI_INFO *info = tpm2_tcti_ldr_getinfo();
         if (info) {
-            printf("\ntcti-help: %s\n", info->config_help);
+            printf("\ntcti-help(%s): %s\n", info->name, info->config_help);
         }
         rc = tpm2_option_code_stop;
     }

--- a/lib/tpm2_options.h
+++ b/lib/tpm2_options.h
@@ -98,13 +98,10 @@ typedef bool (*tpm2_arg_handler)(int argc, char **argv);
 /**
  * TPM2_OPTIONS_* flags change default behavior of the argument parser
  *
- * TPM2_OPTIONS_SHOW_USAGE:
- *  Enable printing a short usage summary (I.e. help)
  * TPM2_OPTIONS_NO_SAPI:
  *  Skip SAPI initialization. Removes the "-T" common option.
  */
-#define TPM2_OPTIONS_SHOW_USAGE 0x1
-#define TPM2_OPTIONS_NO_SAPI 0x2
+#define TPM2_OPTIONS_NO_SAPI 0x1
 
 struct tpm2_options {
     struct {

--- a/man/common/options.md
+++ b/man/common/options.md
@@ -3,8 +3,14 @@
 This collection of options are common to many programs and provide
 information that many users may expect.
 
-  * **-h**, **--help**:
-    Display the tools manpage. This requires the manpages to be installed or on
+  * **-h**, **--help=[man|no-man]**:
+    Display the tools manpage. By default, it attempts to invoke the manpager for the tool,
+    however, on failure will output a short tool summary. This is the same behavior if the
+    "man" option argument is specified, however if explicit "man" is requested, the tool will
+    provide errors from man on stderr. If the "no-man" option if specified, or the manpager fails,
+    the short options will be output to stdout.
+
+    To successfully use the manpages feature requires the manpages to be installed or on
     _MANPATH_, See man(1) for more details.
 
   * **-v**, **--version**:

--- a/tools/aux/tpm2_print.c
+++ b/tools/aux/tpm2_print.c
@@ -377,7 +377,7 @@ bool tpm2_tool_onstart(tpm2_options **opts) {
     };
 
     *opts = tpm2_options_new("t:f:", ARRAY_LEN(topts), topts,
-        on_option, NULL, TPM2_OPTIONS_SHOW_USAGE|TPM2_OPTIONS_NO_SAPI);
+        on_option, NULL, TPM2_OPTIONS_NO_SAPI);
 
     return *opts != NULL;
 }

--- a/tools/aux/tpm2_rc_decode.c
+++ b/tools/aux/tpm2_rc_decode.c
@@ -74,7 +74,7 @@ static bool on_arg(int argc, char **argv) {
 bool tpm2_tool_onstart(tpm2_options **opts) {
 
     *opts = tpm2_options_new(NULL, 0, NULL, NULL, on_arg,
-            TPM2_OPTIONS_SHOW_USAGE|TPM2_OPTIONS_NO_SAPI);
+            TPM2_OPTIONS_NO_SAPI);
 
     return *opts != NULL;
 }

--- a/tools/tpm2_activatecredential.c
+++ b/tools/tpm2_activatecredential.c
@@ -265,7 +265,7 @@ bool tpm2_tool_onstart(tpm2_options **opts) {
     };
 
     *opts = tpm2_options_new("c:C:P:E:f:o:", ARRAY_LEN(topts), topts,
-                             on_option, NULL, TPM2_OPTIONS_SHOW_USAGE);
+                             on_option, NULL, 0);
 
     return *opts != NULL;
 }

--- a/tools/tpm2_certify.c
+++ b/tools/tpm2_certify.c
@@ -245,7 +245,7 @@ bool tpm2_tool_onstart(tpm2_options **opts) {
     };
 
     *opts = tpm2_options_new("P:k:g:a:s:c:C:f:", ARRAY_LEN(topts), topts,
-                             on_option, NULL, TPM2_OPTIONS_SHOW_USAGE);
+                             on_option, NULL, 0);
 
     return *opts != NULL;
 }

--- a/tools/tpm2_create.c
+++ b/tools/tpm2_create.c
@@ -244,7 +244,7 @@ bool tpm2_tool_onstart(tpm2_options **opts) {
     };
 
     *opts = tpm2_options_new("P:K:g:G:A:I:L:u:r:C:", ARRAY_LEN(topts), topts,
-                             on_option, NULL, TPM2_OPTIONS_SHOW_USAGE);
+                             on_option, NULL, 0);
 
     return *opts != NULL;
 }

--- a/tools/tpm2_createak.c
+++ b/tools/tpm2_createak.c
@@ -533,7 +533,7 @@ bool tpm2_tool_onstart(tpm2_options **opts) {
     };
 
     *opts = tpm2_options_new("o:C:E:k:g:D:s:P:f:n:p:c:r:", ARRAY_LEN(topts), topts,
-                             on_option, NULL, TPM2_OPTIONS_SHOW_USAGE);
+                             on_option, NULL, 0);
 
     return *opts != NULL;
 }

--- a/tools/tpm2_createpolicy.c
+++ b/tools/tpm2_createpolicy.c
@@ -193,7 +193,7 @@ bool tpm2_tool_onstart(tpm2_options **opts) {
     };
 
     *opts = tpm2_options_new("f:g:L:F:Pa", ARRAY_LEN(topts), topts, on_option,
-                             NULL, TPM2_OPTIONS_SHOW_USAGE);
+                             NULL, 0);
 
     return *opts != NULL;
 }

--- a/tools/tpm2_createprimary.c
+++ b/tools/tpm2_createprimary.c
@@ -156,7 +156,7 @@ bool tpm2_tool_onstart(tpm2_options **opts) {
     };
 
     *opts = tpm2_options_new("A:P:k:g:G:o:L:a:", ARRAY_LEN(topts), topts,
-            on_option, NULL, TPM2_OPTIONS_SHOW_USAGE);
+            on_option, NULL, 0);
 
     return *opts != NULL;
 }

--- a/tools/tpm2_dictionarylockout.c
+++ b/tools/tpm2_dictionarylockout.c
@@ -161,7 +161,7 @@ bool tpm2_tool_onstart(tpm2_options **opts) {
     };
 
     *opts = tpm2_options_new("n:t:l:P:cs", ARRAY_LEN(topts), topts, on_option,
-                             NULL, TPM2_OPTIONS_SHOW_USAGE);
+                             NULL, 0);
 
     return *opts != NULL;
 }

--- a/tools/tpm2_encryptdecrypt.c
+++ b/tools/tpm2_encryptdecrypt.c
@@ -157,7 +157,7 @@ bool tpm2_tool_onstart(tpm2_options **opts) {
     };
 
     *opts = tpm2_options_new("P:DI:o:c:", ARRAY_LEN(topts), topts, on_option,
-                             NULL, TPM2_OPTIONS_SHOW_USAGE);
+                             NULL, 0);
 
     return *opts != NULL;
 }

--- a/tools/tpm2_evictcontrol.c
+++ b/tools/tpm2_evictcontrol.c
@@ -117,7 +117,7 @@ bool tpm2_tool_onstart(tpm2_options **opts) {
     };
 
     *opts = tpm2_options_new("a:p:P:c:", ARRAY_LEN(topts), topts, on_option,
-                             NULL, TPM2_OPTIONS_SHOW_USAGE);
+                             NULL, 0);
 
     return *opts != NULL;
 }

--- a/tools/tpm2_flushcontext.c
+++ b/tools/tpm2_flushcontext.c
@@ -139,7 +139,7 @@ bool tpm2_tool_onstart(tpm2_options **opts) {
     };
 
     *opts = tpm2_options_new("c:tlsS:", ARRAY_LEN(topts), topts,
-                             on_option, NULL, TPM2_OPTIONS_SHOW_USAGE);
+                             on_option, NULL, 0);
 
     return *opts != NULL;
 }

--- a/tools/tpm2_getcap.c
+++ b/tools/tpm2_getcap.c
@@ -947,7 +947,7 @@ bool tpm2_tool_onstart(tpm2_options **opts) {
     };
 
     *opts = tpm2_options_new("c:l", ARRAY_LEN(topts), topts, on_option, NULL,
-                             TPM2_OPTIONS_SHOW_USAGE);
+                             0);
 
     return *opts != NULL;
 }

--- a/tools/tpm2_getmanufec.c
+++ b/tools/tpm2_getmanufec.c
@@ -525,7 +525,7 @@ bool tpm2_tool_onstart(tpm2_options **opts) {
     };
 
     *opts = tpm2_options_new("e:o:H:P:g:f:NO:E:i:U", ARRAY_LEN(topts), topts,
-                             on_option, on_args, TPM2_OPTIONS_SHOW_USAGE);
+                             on_option, on_args, 0);
 
     return *opts != NULL;
 }

--- a/tools/tpm2_getrandom.c
+++ b/tools/tpm2_getrandom.c
@@ -110,7 +110,7 @@ bool tpm2_tool_onstart(tpm2_options **opts) {
     };
 
     *opts = tpm2_options_new("o:", ARRAY_LEN(topts), topts, on_option, on_args,
-                             TPM2_OPTIONS_SHOW_USAGE);
+                             0);
 
     return *opts != NULL;
 }

--- a/tools/tpm2_hmac.c
+++ b/tools/tpm2_hmac.c
@@ -266,7 +266,7 @@ bool tpm2_tool_onstart(tpm2_options **opts) {
     ctx.input = stdin;
 
     *opts = tpm2_options_new("C:P:g:o:", ARRAY_LEN(topts), topts, on_option,
-                             on_args, TPM2_OPTIONS_SHOW_USAGE);
+                             on_args, 0);
 
     return *opts != NULL;
 }

--- a/tools/tpm2_import.c
+++ b/tools/tpm2_import.c
@@ -652,7 +652,7 @@ bool tpm2_tool_onstart(tpm2_options **opts) {
     };
 
     *opts = tpm2_options_new("G:k:C:K:q:r:A:", ARRAY_LEN(topts), topts, on_option,
-                             NULL, TPM2_OPTIONS_SHOW_USAGE);
+                             NULL, 0);
 
     return *opts != NULL;
 }

--- a/tools/tpm2_load.c
+++ b/tools/tpm2_load.c
@@ -158,7 +158,7 @@ bool tpm2_tool_onstart(tpm2_options **opts) {
     };
 
     *opts = tpm2_options_new("P:u:r:n:C:o:", ARRAY_LEN(topts), topts,
-                             on_option, NULL, TPM2_OPTIONS_SHOW_USAGE);
+                             on_option, NULL, 0);
 
     return *opts != NULL;
 }

--- a/tools/tpm2_loadexternal.c
+++ b/tools/tpm2_loadexternal.c
@@ -122,7 +122,7 @@ bool tpm2_tool_onstart(tpm2_options **opts) {
     };
 
     *opts = tpm2_options_new("a:u:r:o:", ARRAY_LEN(topts), topts, on_option,
-                             NULL, TPM2_OPTIONS_SHOW_USAGE);
+                             NULL, 0);
 
     return *opts != NULL;
 }

--- a/tools/tpm2_makecredential.c
+++ b/tools/tpm2_makecredential.c
@@ -196,7 +196,7 @@ bool tpm2_tool_onstart(tpm2_options **opts) {
     };
 
     *opts = tpm2_options_new("e:s:n:o:", ARRAY_LEN(topts), topts, on_option,
-                             NULL, TPM2_OPTIONS_SHOW_USAGE);
+                             NULL, 0);
 
     return *opts != NULL;
 }

--- a/tools/tpm2_nvdefine.c
+++ b/tools/tpm2_nvdefine.c
@@ -193,7 +193,7 @@ bool tpm2_tool_onstart(tpm2_options **opts) {
     };
 
     *opts = tpm2_options_new("x:a:s:t:P:I:L:", ARRAY_LEN(topts), topts,
-                             on_option, NULL, TPM2_OPTIONS_SHOW_USAGE);
+                             on_option, NULL, 0);
 
     return *opts != NULL;
 }

--- a/tools/tpm2_nvread.c
+++ b/tools/tpm2_nvread.c
@@ -253,7 +253,7 @@ bool tpm2_tool_onstart(tpm2_options **opts) {
     };
 
     *opts = tpm2_options_new("x:a:f:s:o:P:L:F:", ARRAY_LEN(topts),
-                             topts, on_option, NULL, TPM2_OPTIONS_SHOW_USAGE);
+                             topts, on_option, NULL, 0);
 
     return *opts != NULL;
 }

--- a/tools/tpm2_nvreadlock.c
+++ b/tools/tpm2_nvreadlock.c
@@ -130,7 +130,7 @@ bool tpm2_tool_onstart(tpm2_options **opts) {
     };
 
     *opts = tpm2_options_new("x:a:P:", ARRAY_LEN(topts), topts,
-                             on_option, NULL, TPM2_OPTIONS_SHOW_USAGE);
+                             on_option, NULL, 0);
 
     return *opts != NULL;
 }

--- a/tools/tpm2_nvrelease.c
+++ b/tools/tpm2_nvrelease.c
@@ -125,7 +125,7 @@ bool tpm2_tool_onstart(tpm2_options **opts) {
     };
 
     *opts = tpm2_options_new("x:a:P:", ARRAY_LEN(topts), topts, on_option,
-                             NULL, TPM2_OPTIONS_SHOW_USAGE);
+                             NULL, 0);
 
     return *opts != NULL;
 }

--- a/tools/tpm2_quote.c
+++ b/tools/tpm2_quote.c
@@ -216,7 +216,7 @@ bool tpm2_tool_onstart(tpm2_options **opts) {
     };
 
     *opts = tpm2_options_new("C:P:l:L:q:s:m:f:G:", ARRAY_LEN(topts), topts,
-                             on_option, NULL, TPM2_OPTIONS_SHOW_USAGE);
+                             on_option, NULL, 0);
 
     return *opts != NULL;
 }

--- a/tools/tpm2_readpublic.c
+++ b/tools/tpm2_readpublic.c
@@ -125,7 +125,7 @@ bool tpm2_tool_onstart(tpm2_options **opts) {
     };
 
     *opts = tpm2_options_new("o:c:f:", ARRAY_LEN(topts), topts,
-                             on_option, NULL, TPM2_OPTIONS_SHOW_USAGE);
+                             on_option, NULL, 0);
 
     return *opts != NULL;
 }

--- a/tools/tpm2_rsadecrypt.c
+++ b/tools/tpm2_rsadecrypt.c
@@ -133,7 +133,7 @@ bool tpm2_tool_onstart(tpm2_options **opts) {
     };
 
     *opts = tpm2_options_new("P:I:o:c:", ARRAY_LEN(topts), topts,
-                             on_option, NULL, TPM2_OPTIONS_SHOW_USAGE);
+                             on_option, NULL, 0);
 
     return *opts != NULL;
 }

--- a/tools/tpm2_rsaencrypt.c
+++ b/tools/tpm2_rsaencrypt.c
@@ -116,7 +116,7 @@ bool tpm2_tool_onstart(tpm2_options **opts) {
     };
 
     *opts = tpm2_options_new("o:c:", ARRAY_LEN(topts), topts,
-                             on_option, on_args, TPM2_OPTIONS_SHOW_USAGE);
+                             on_option, on_args, 0);
 
     return *opts != NULL;
 }

--- a/tools/tpm2_sign.c
+++ b/tools/tpm2_sign.c
@@ -259,7 +259,7 @@ bool tpm2_tool_onstart(tpm2_options **opts) {
     };
 
     *opts = tpm2_options_new("P:g:m:D:t:s:c:f:", ARRAY_LEN(topts), topts,
-                             on_option, NULL, TPM2_OPTIONS_SHOW_USAGE);
+                             on_option, NULL, 0);
 
     return *opts != NULL;
 }

--- a/tools/tpm2_tool.c
+++ b/tools/tpm2_tool.c
@@ -116,11 +116,6 @@ int main(int argc, char *argv[]) {
         }
     }
 
-    if (argc == 1 && tool_opts && (tool_opts->flags & TPM2_OPTIONS_SHOW_USAGE)) {
-        tpm2_print_usage(argv[0], tool_opts);
-        return ret;
-    }
-
     tpm2_option_flags flags = { .all = 0 };
     TSS2_TCTI_CONTEXT *tcti = NULL;
     tpm2_option_code rc = tpm2_handle_options(argc, argv, tool_opts, &flags, &tcti);

--- a/tools/tpm2_unseal.c
+++ b/tools/tpm2_unseal.c
@@ -187,7 +187,7 @@ bool tpm2_tool_onstart(tpm2_options **opts) {
     };
 
     *opts = tpm2_options_new("P:o:c:L:F:", ARRAY_LEN(topts), topts,
-                             on_option, NULL, TPM2_OPTIONS_SHOW_USAGE);
+                             on_option, NULL, 0);
 
     return *opts != NULL;
 }

--- a/tools/tpm2_verifysignature.c
+++ b/tools/tpm2_verifysignature.c
@@ -270,7 +270,7 @@ bool tpm2_tool_onstart(tpm2_options **opts) {
 
 
     *opts = tpm2_options_new("g:m:D:f:s:t:c:", ARRAY_LEN(topts), topts,
-                             on_option, NULL, TPM2_OPTIONS_SHOW_USAGE);
+                             on_option, NULL, 0);
 
     return *opts != NULL;
 }


### PR DESCRIPTION
1. Drop the help flag. Either we show help based on -h|--help option
   or if a tool fails along the way in option handling.

2. Add man and no-man options to the help argument so that folks can
   skip invoking the manpager. Leave it as the default.

3. Re-direct stderr to /dev/null from man so that we can avoid the
   messgae "Man page not found for xxx" and just dump the short
   help summary.

4. Drop the dynamic allocation of the command name in help and use PATH_MAX.

Signed-off-by: William Roberts <william.c.roberts@intel.com>