### PR TITLE
tpm2_changeauth: only change hierachy specified

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## Changelog
 ### next
+  * tpm2_create: -K becomes -k
   * tpm2_hash: -g changes to -G
   * tpm2_encryptdecrypt: Support IVs via -i and algorithm modes via -G.
   * tpm2_hmac: drop -g, just use the algorithm associated with the object.

--- a/man/tpm2_create.1.md
+++ b/man/tpm2_create.1.md
@@ -29,7 +29,7 @@ These options for creating the tpm entity:
     Authorization values should follow the "authorization formatting standards",
     see section "Authorization Formatting".
 
-  * **-K**, **--auth-key**=_KEY\_AUTH_:
+  * **-k**, **--auth-key**=_KEY\_AUTH_:
     The authorization value for the key, optional.
     Follows the authorization formatting of the
     "password for parent key" option: **-P**.

--- a/tools/tpm2_changeauth.c
+++ b/tools/tpm2_changeauth.c
@@ -119,12 +119,23 @@ static bool change_auth(TSS2_SYS_CONTEXT *sapi_context,
 static bool change_hierarchy_auth(TSS2_SYS_CONTEXT *sapi_context) {
 
     // change owner, endorsement and lockout auth.
-    return change_auth(sapi_context, &ctx.auths.owner,
-                "Owner", TPM2_RH_OWNER)
-        && change_auth(sapi_context, &ctx.auths.endorse,
-                "Endorsement", TPM2_RH_ENDORSEMENT)
-        && change_auth(sapi_context, &ctx.auths.lockout,
+    bool result = true;
+    if (ctx.flags.o || ctx.flags.O) {
+        result &= change_auth(sapi_context, &ctx.auths.owner,
+                "Owner", TPM2_RH_OWNER);
+    }
+
+    if (ctx.flags.e || ctx.flags.E) {
+        result &= change_auth(sapi_context, &ctx.auths.endorse,
+                "Endorsement", TPM2_RH_ENDORSEMENT);
+    }
+
+    if (ctx.flags.l || ctx.flags.L) {
+        result &= change_auth(sapi_context, &ctx.auths.lockout,
                 "Lockout", TPM2_RH_LOCKOUT);
+    }
+
+    return result;
 }
 
 static bool on_option(char key, char *value) {

--- a/tools/tpm2_create.c
+++ b/tools/tpm2_create.c
@@ -105,18 +105,13 @@ static bool create(TSS2_SYS_CONTEXT *sapi_context) {
     TSS2L_SYS_AUTH_RESPONSE sessionsDataOut;
 
     TPM2B_DATA              outsideInfo = TPM2B_EMPTY_INIT;
-    TPML_PCR_SELECTION      creationPCR;
+    TPML_PCR_SELECTION      creationPCR = { .count = 0 };
     TPM2B_PUBLIC            outPublic = TPM2B_EMPTY_INIT;
     TPM2B_PRIVATE           outPrivate = TPM2B_TYPE_INIT(TPM2B_PRIVATE, buffer);
 
     TPM2B_CREATION_DATA     creationData = TPM2B_EMPTY_INIT;
     TPM2B_DIGEST            creationHash = TPM2B_TYPE_INIT(TPM2B_DIGEST, buffer);
     TPMT_TK_CREATION        creationTicket = TPMT_TK_CREATION_EMPTY_INIT;
-
-
-    ctx.in_sensitive.size = ctx.in_sensitive.sensitive.userAuth.size + 2;
-
-    creationPCR.count = 0;
 
     rval = TSS2_RETRY_EXP(Tss2_Sys_Create(sapi_context, ctx.context_object.handle, &sessionsData, &ctx.in_sensitive,
                            &ctx.in_public, &outsideInfo, &creationPCR, &outPrivate,&outPublic,

--- a/tools/tpm2_create.c
+++ b/tools/tpm2_create.c
@@ -200,7 +200,7 @@ bool tpm2_tool_onstart(tpm2_options **opts) {
 
     static struct option topts[] = {
       { "auth-parent",          required_argument, NULL, 'P' },
-      { "auth-key",             required_argument, NULL, 'K' },
+      { "auth-key",             required_argument, NULL, 'k' },
       { "halg",                 required_argument, NULL, 'g' },
       { "kalg",                 required_argument, NULL, 'G' },
       { "object-attributes",    required_argument, NULL, 'A' },
@@ -211,7 +211,7 @@ bool tpm2_tool_onstart(tpm2_options **opts) {
       { "context-parent",       required_argument, NULL, 'C' },
     };
 
-    *opts = tpm2_options_new("P:K:g:G:A:I:L:u:r:C:", ARRAY_LEN(topts), topts,
+    *opts = tpm2_options_new("P:k:g:G:A:I:L:u:r:C:", ARRAY_LEN(topts), topts,
                              on_option, NULL, 0);
 
     return *opts != NULL;

--- a/tools/tpm2_create.c
+++ b/tools/tpm2_create.c
@@ -79,7 +79,7 @@ struct tpm_create_ctx {
 
     struct {
         UINT16 P : 1;
-        UINT16 K : 1;
+        UINT16 k : 1;
         UINT16 A : 1;
         UINT16 I : 1;
         UINT16 L : 1;
@@ -157,8 +157,8 @@ static bool on_option(char key, char *value) {
         ctx.flags.P = 1;
         ctx.parent_auth_str = value;
         break;
-    case 'K':
-        ctx.flags.K = 1;
+    case 'k':
+        ctx.flags.k = 1;
         ctx.key_auth_str = value;
     break;
     case 'g':
@@ -279,7 +279,7 @@ int tpm2_tool_onrun(TSS2_SYS_CONTEXT *sapi_context, tpm2_option_flags flags) {
         goto out;
     }
 
-    if (ctx.flags.K) {
+    if (ctx.flags.k) {
         TPMS_AUTH_COMMAND tmp;
         result = tpm2_auth_util_from_optarg(sapi_context, ctx.key_auth_str, &tmp, NULL);
         if (!result) {

--- a/tools/tpm2_createprimary.c
+++ b/tools/tpm2_createprimary.c
@@ -146,7 +146,7 @@ bool tpm2_tool_onstart(tpm2_options **opts) {
         { "object-attributes",    required_argument, NULL, 'A' },
     };
 
-    *opts = tpm2_options_new("A:P:K:g:G:o:L:a:", ARRAY_LEN(topts), topts,
+    *opts = tpm2_options_new("A:P:k:g:G:o:L:a:", ARRAY_LEN(topts), topts,
             on_option, NULL, 0);
 
     return *opts != NULL;


### PR DESCRIPTION
Only send a changeauth command if the hiearchy is specified.
This corrects behavior of attempting to change a non-specified
hierarchy.

Signed-off-by: William Roberts <william.c.roberts@intel.com>