### PR TITLE
Object auth short-form unification

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## Changelog
 ### next
+  * tpm2_unseal: -P becomes -p
   * tpm2_sign: -P becomes -p
   * tpm2_nvreadlock: long form for -P is now --auth-hierarchy
   * tpm2_rsadecrypt: -P becomes -p

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## Changelog
 ### next
+  * tpm2_nvdefine: -I becomes -p
   * tpm2_encryptdecrypt: -P becomes -p
   * tpm2_dictionarylockout: -P becomes -p
   * tpm2_createprimary: -K becomes -p

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## Changelog
 ### next
+  * tpm2_sign: -P becomes -p
   * tpm2_nvreadlock: long form for -P is now --auth-hierarchy
   * tpm2_rsadecrypt: -P becomes -p
   * tpm2_nvrelease: long-form of -P becomes --auth-hierarchy

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## Changelog
 ### next
+  * tpm2_dictionarylockout: -P becomes -p
   * tpm2_createprimary: -K becomes -p
   * tpm2_createak: -E becomes -e
   * tpm2_certify: -k becomes -p

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## Changelog
 ### next
+  * tpm2_nvreadlocK: long form for -P is now --auth-hierarchy
   * tpm2_nvdefine: -I becomes -p
   * tpm2_encryptdecrypt: -P becomes -p
   * tpm2_dictionarylockout: -P becomes -p

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## Changelog
 ### next
-  * tpm2_nvreadlocK: long form for -P is now --auth-hierarchy
+  * tpm2_nvreadlock: long form for -P is now --auth-hierarchy
+  * tpm2_nvrelease: long-form of -P becomes --auth-hierarchy
   * tpm2_nvdefine: -I becomes -p
   * tpm2_encryptdecrypt: -P becomes -p
   * tpm2_dictionarylockout: -P becomes -p

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## Changelog
 ### next
+  * tpm2_certify: -k becomes -p
   * tpm2_hash: -g changes to -G
   * tpm2_encryptdecrypt: Support IVs via -i and algorithm modes via -G.
   * tpm2_hmac: drop -g, just use the algorithm associated with the object.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## Changelog
 ### next
+  * tpm2_encryptdecrypt: -P becomes -p
   * tpm2_dictionarylockout: -P becomes -p
   * tpm2_createprimary: -K becomes -p
   * tpm2_createak: -E becomes -e

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## Changelog
 ### next
   * tpm2_nvreadlock: long form for -P is now --auth-hierarchy
+  * tpm2_rsadecrypt: -P becomes -p
   * tpm2_nvrelease: long-form of -P becomes --auth-hierarchy
   * tpm2_nvdefine: -I becomes -p
   * tpm2_encryptdecrypt: -P becomes -p

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## Changelog
 ### next
+  * tpm2_createprimary: -K becomes -p
   * tpm2_createak: -E becomes -e
   * tpm2_certify: -k becomes -p
   * tpm2_hash: -g changes to -G

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## Changelog
 ### next
+  * tpm2_createak: -E becomes -e
   * tpm2_certify: -k becomes -p
   * tpm2_hash: -g changes to -G
   * tpm2_encryptdecrypt: Support IVs via -i and algorithm modes via -G.

--- a/man/tpm2_certify.1.md
+++ b/man/tpm2_certify.1.md
@@ -38,7 +38,7 @@ These options control the certification:
     Authorization values should follow the "authorization formatting standards",
     see section "Authorization Formatting".
 
-  * **-k**, **--auth-key**=_KEY\_AUTH_:
+  * **-p**, **--auth-key**=_KEY\_AUTH_:
     Use _KEY\_AUTH_ for providing an authorization value for the key specified
     in _KEY\_CONTEXT_.
     Follows the same formatting guidelines as the object handle authorization or
@@ -67,9 +67,9 @@ These options control the certification:
 # EXAMPLES
 
 ```
-tpm2_certify -H 0x81010002 -P 0x0011 -k 0x00FF -g 0x00B -a <fileName> -s <fileName>
-tpm2_certify -C obj.context -c key.context -P 0x0011 -k 0x00FF -g 0x00B -a <fileName> -s <fileName>
-tpm2_certify -H 0x81010002 -P 0011 -k 00FF -X -g 0x00B -a <fileName> -s <fileName>
+tpm2_certify -H 0x81010002 -P 0x0011 -p 0x00FF -g 0x00B -a <fileName> -s <fileName>
+tpm2_certify -C obj.context -c key.context -P 0x0011 -p 0x00FF -g 0x00B -a <fileName> -s <fileName>
+tpm2_certify -H 0x81010002 -P 0011 -p 00FF -X -g 0x00B -a <fileName> -s <fileName>
 ```
 
 # RETURNS

--- a/man/tpm2_create.1.md
+++ b/man/tpm2_create.1.md
@@ -29,7 +29,7 @@ These options for creating the tpm entity:
     Authorization values should follow the "authorization formatting standards",
     see section "Authorization Formatting".
 
-  * **-K**, **--auth-key**=_KEY\_AUTH_:
+  * **-p**, **--auth-key**=_KEY\_AUTH_:
     The authorization value for the key, optional.
     Follows the authorization formatting of the
     "password for parent key" option: **-P**.
@@ -97,7 +97,7 @@ These options for creating the tpm entity:
 
 ```
 tpm2_create -C 0x81010001 -P abc123 -K def456 -g sha256 -G keyedhash-I data.File -o opu.File
-tpm2_create -C file:parent.context -P abc123 -K def456 -g sha256 -G keyedhash -I data.File -o opu.File
+tpm2_create -C file:parent.context -P abc123 -p def456 -g sha256 -G keyedhash -I data.File -o opu.File
 tpm2_create -C 0x81010001 -P 123abc -K 456def -X -g sha256 -G keyedhash -I data.File -o opu.File
 ```
 

--- a/man/tpm2_createak.1.md
+++ b/man/tpm2_createak.1.md
@@ -30,7 +30,7 @@ loaded-key:
 
 # OPTIONS
 
-  * **-E**, **--auth-endorse**=_ENDORSE\_AUTH_:
+  * **-e**, **--auth-endorse**=_ENDORSE\_AUTH_:
     Specifies current endorsement authorization.
     Authorizations should follow the "authorization formatting standards", see section
     "Authorization Formatting".

--- a/man/tpm2_createprimary.1.md
+++ b/man/tpm2_createprimary.1.md
@@ -37,7 +37,7 @@ will create and load a Primary Object. The sensitive area is not returned.
     values should follow the "authorization formatting standards", see section
     "Authorization Formatting".
 
-  * **-k**, **--auth-object**=_OBJECT\_AUTH_:
+  * **-p**, **--auth-object**=_OBJECT\_AUTH_:
     Optional authorization password for the newly created object. Password
     values should follow the "authorization formatting standards", see section
     "Authorization Formatting".

--- a/man/tpm2_dictionarylockout.1.md
+++ b/man/tpm2_dictionarylockout.1.md
@@ -37,7 +37,7 @@ dictionary-attack-lockout state, if any passwd option is missing, assume NULL.
     specifies the maximum number of allowed authentication attempts on
     DA-protected-object; after which DA is activated.
 
-  * **-P**, **--auth-lockout**=_LOCKOUT\_AUTH_:
+  * **-p**, **--auth-lockout**=_LOCKOUT\_AUTH_:
     The lockout authorization value.
 
     Authorization values should follow the "authorization formatting standards",

--- a/man/tpm2_encryptdecrypt.1.md
+++ b/man/tpm2_encryptdecrypt.1.md
@@ -22,9 +22,9 @@ specified symmetric key.
     Name of the key context object to be used for the  operation. Either a file
     or a handle number. See section "Context Object Format".
 
-  * **-P**, **--auth-key**=_KEY\_AUTH_:
+  * **-p**, **--auth-key**=_KEY\_AUTH_:
 
-    Optional authorization value to use the key specified by **-k**.
+    Optional authorization value to use the key specified by **-c**.
     Authorization values should follow the "authorization formatting standards",
     see section "Authorization Formatting".
 
@@ -74,9 +74,9 @@ specified symmetric key.
 # EXAMPLES
 
 ```
-tpm2_encryptdecrypt -C 0x81010001 -P abc123 -I <filePath> -o <filePath>
-tpm2_encryptdecrypt -C key.dat -P abc123 -I <filePath> -o <filePath>
-tpm2_encryptdecrypt -C 0x81010001 -P 123abca -X -I <filePath> -o <filePath>
+tpm2_encryptdecrypt -C 0x81010001 -p abc123 -I <filePath> -o <filePath>
+tpm2_encryptdecrypt -C key.dat -p abc123 -I <filePath> -o <filePath>
+tpm2_encryptdecrypt -C 0x81010001 -p 123abca -X -I <filePath> -o <filePath>
 ```
 
 # RETURNS

--- a/man/tpm2_hmac.1.md
+++ b/man/tpm2_hmac.1.md
@@ -17,7 +17,7 @@ _FILE_ is not specified, then data is read from stdin.
 
 # OPTIONS
 
- * **-C**, **--key-context**=_KEY\_CONTEXT\_OBJECT_:
+  * **-C**, **--key-context**=_KEY\_CONTEXT\_OBJECT_:
     The context object of the symmetric signing key providing the HMAC key.
     Either a file or a handle number. See section "Context Object Format".
 

--- a/man/tpm2_nvdefine.1.md
+++ b/man/tpm2_nvdefine.1.md
@@ -41,7 +41,7 @@
     should follow the "authorization formatting standards", see section
     "Authorization Formatting".
 
-  * **-I**, **--auth-index**=_INDEX\_PASSWORD_:
+  * **-p**, **--auth-index**=_INDEX\_PASSWORD_:
     Specifies the password of NV Index when created.
     HMAC and Password authorization values should follow the "authorization
     formatting standards", see section "Authorization Formatting".
@@ -61,7 +61,7 @@
 
 ```
 tpm2_nvdefine -x 0x1500016 -a 0x40000001 -s 32 -t 0x2000A
-tpm2_nvdefine -x 0x1500016 -a 0x40000001 -s 32 -t ownerread|ownerwrite|policywrite -I 1a1b1c
+tpm2_nvdefine -x 0x1500016 -a 0x40000001 -s 32 -t ownerread|ownerwrite|policywrite -p 1a1b1c
 ```
 
 # RETURNS

--- a/man/tpm2_nvread.1.md
+++ b/man/tpm2_nvread.1.md
@@ -19,8 +19,8 @@
   * **-x**, **--index**=_NV\_INDEX_:
     Specifies the index to define the space at.
 
-  * **-a**, **--auth-handle**=_AUTH_:
-    specifies the handle used to authorize. Defaults to **o**, **TPM_RH_OWNER**,
+  * **-a**, **--hierarchy**=_AUTH_:
+    specifies the hierarchy used to authorize. Defaults to **o**, **TPM_RH_OWNER**,
     when no value has been specified.
     Supported options are:
       * **o** for **TPM_RH_OWNER**
@@ -29,7 +29,7 @@
 
     When **-a** isn't explicitly passed the index handle will be used to
     authorize against the index. The index auth value is set via the
-    **-I** option to tpm2_nvdefine(1).
+    **-p** option to tpm2_nvdefine(1).
 
   * **-f**, **--out-file**=_FILE_:
     file to write data

--- a/man/tpm2_nvreadlock.1.md
+++ b/man/tpm2_nvreadlock.1.md
@@ -20,16 +20,17 @@ is released on subsequent restart of the machine.
   * **-x**, **--index**=_NV\_INDEX_:
     Specifies the index to define the space at.
 
-  * **-a**, **--auth-handle**=_SECRET\_DATA\_FILE_:
-    specifies the handle used to authorize:
+  * **-a**, **--hierarchy**=_AUTH_:
+    specifies the hierarchy used to authorize:
     * **o** for **TPM_RH_OWNER**
     * **p** for **TPM_RH_PLATFORM**
     Defaults to **o**, **TPM_RH_OWNER**, when no value has been
     specified.
 
-  * **-P**, **--handle-passwd**=_HANDLE\_PASSWORD_:
-    specifies the password of authHandle. Passwords should follow the
-    "authorization formatting standards", see section "Authorization Formatting".
+  * **-P**, **--auth-hierarchy**=_AUTH\_HIERARCHY\_VALUE_:
+    Specifies the authorization value for the hierarchy. Authorization values
+    should follow the "authorization formatting standards", see section
+    "Authorization Formatting".
 
   * **-S**, **--input-session-handle**=_SESSION\_FILE_:
     Optional, a session file from **tpm2_startauthsession**(1)'s **-S** option.

--- a/man/tpm2_nvrelease.1.md
+++ b/man/tpm2_nvrelease.1.md
@@ -20,8 +20,8 @@ defined with tpm2_nvdefine(1).
   * **-x**, **--index**=_NV\_INDEX_:
     Specifies the index to release.
 
-  * **-a**, **--auth-handle**=_AUTH_:
-    specifies the handle used to authorize.
+  * **-a**, **--hierarchy**=_AUTH_:
+    specifies the hierarchy used to authorize.
     Supported options are:
       * **o** for **TPM_RH_OWNER**
       * **p** for **TPM_RH_PLATFORM**
@@ -30,9 +30,10 @@ defined with tpm2_nvdefine(1).
   * **-s**, **--size**=_SIZE_:
     specifies the size of data area in bytes.
 
-  * **-P**, **--handle-passwd**=_HANDLE\_PASSWORD_:
-    specifies the password of authHandle. Passwords should follow the
-    "authorization formatting standards", see section "Authorization Formatting".
+  * **-P**, **--auth-hierarchy**=_AUTH\_HIERARCHY\_VALUE_:
+    Specifies the authorization value for the hierarchy. Authorization values
+    should follow the "authorization formatting standards", see section
+    "Authorization Formatting".
 
   * **-S**, **--session**=_SESSION\_FILE_:
 

--- a/man/tpm2_nvwrite.1.md
+++ b/man/tpm2_nvwrite.1.md
@@ -23,7 +23,7 @@ If _FILE_ is not specified, it defaults to stdin.
   * **-o**, **--offset**=_OFFSET_:
     The offset within the NV index to start writing at.
 
-  * **-a**, **--auth-handle**=_AUTH_:
+  * **-a**, **--hierarchy**=_AUTH_:
     specifies the handle used to authorize. Defaults to **o**, **TPM_RH_OWNER**,
     when no value has been specified.
     Supported options are:
@@ -33,7 +33,7 @@ If _FILE_ is not specified, it defaults to stdin.
 
     When **-a** isn't explicitly passed the index handle will be used to
     authorize against the index. The index auth value is set via the
-    **-I** option to tpm2_nvdefine(1).
+    **-p** option to tpm2_nvdefine(1).
 
   * **-P**, **--auth-hierarchy**=_HIERARCHY\_AUTH_:
     Specifies the authorization value for the hierarchy. Authorization values

--- a/man/tpm2_rsadecrypt.1.md
+++ b/man/tpm2_rsadecrypt.1.md
@@ -28,7 +28,7 @@ The key referenced by key-context is **required** to be:
     decryption. Either a file or a handle number.
     See section "Context Object Format".
 
-  * **-P**, **--auth-key**=_KEY\_AUTH_:
+  * **-p**, **--auth-key**=_KEY\_AUTH_:
 
     Optional authorization value to use the key specified by **-k**.
     Authorization values should follow the "authorization formatting standards",

--- a/man/tpm2_rsaencrypt.1.md
+++ b/man/tpm2_rsaencrypt.1.md
@@ -29,11 +29,6 @@ The key referenced by key-context is **required** to be:
     encryption. Either a file or a handle number.
     See section "Context Object Format".
 
-  * **-P**, **--pwdk**=_KEY\_PASSWORD_:
-
-    Specifies the password of _KEY\_HANDLE_. Passwords should follow the
-    "authorization formatting standards", see section "Authorization Formatting".
-
   * **-o**, **--out-file**=_OUTPUT\_FILE_:
 
     Output file path, record the decrypted data. The default is to print an
@@ -46,12 +41,10 @@ The key referenced by key-context is **required** to be:
 
 [context object format](commmon/ctxobj.md)
 
-[authorization formatting](common/password.md)
-
 # EXAMPLES
 
 ```
-tpm2_rsaencrypt -C 0x81010001 -I plain.in -o encrypted.out
+tpm2_rsaencrypt -C 0x81010001 -o encrypted.out
 ```
 
 # RETURNS

--- a/man/tpm2_sign.1.md
+++ b/man/tpm2_sign.1.md
@@ -25,9 +25,9 @@ data and validation shall indicate that hashed data did not start with
     Context object pointing to the the key used for signing. Either a file or a
     handle number. See section "Context Object Format".
 
-  * **-P**, **--auth-key**=_KEY\_AUTH_:
+  * **-p**, **--auth-key**=_KEY\_AUTH_:
 
-    Optional authorization value to use the key specified by **-k**.
+    Optional authorization value to use the key specified by **-c**.
     Authorization values should follow the "authorization formatting standards",
     see section "Authorization Formatting".
 
@@ -83,8 +83,8 @@ data and validation shall indicate that hashed data did not start with
 
 
 ```
-tpm2_sign -C 0x81010001 -P abc123 -g sha256 -m <filePath> -s <filePath> -t <filePath>
-tpm2_sign -C key.context -P abc123 -g sha256 -m <filePath> -s <filePath> -t <filePath>
+tpm2_sign -c 0x81010001 -p abc123 -g sha256 -m <filePath> -s <filePath> -t <filePath>
+tpm2_sign -c key.context -p abc123 -g sha256 -m <filePath> -s <filePath> -t <filePath>
 ```
 
 # RETURNS

--- a/man/tpm2_unseal.1.md
+++ b/man/tpm2_unseal.1.md
@@ -12,7 +12,7 @@
 
 # DESCRIPTION
 
-**tpm2_unseal**(1) - -returns the data in a loaded Sealed Data Object.
+**tpm2_unseal**(1) - returns the data in a loaded Sealed Data Object.
 
 **NOTE**: The **--set-list** and **--pcr-input-file** options should only be
 used for simple PCR authentication policies. For more complex policies the
@@ -26,9 +26,9 @@ alive and pass that session using the **--input-session-handle** option.
     Context object for the loaded object. Either a file or a handle number.
     See section "Context Object Format".
 
-  * **-P**, **--auth-key**=_KEY\_AUTH_:
+  * **-p**, **--auth-key**=_KEY\_AUTH_:
 
-    Optional authorization value to use the key specified by **-k**.
+    Optional authorization value to use the key specified by **-c**.
     Authorization values should follow the "authorization formatting standards",
     see section "Authorization Formatting".
 
@@ -66,9 +66,9 @@ alive and pass that session using the **--input-session-handle** option.
 # EXAMPLES
 
 ```
-tpm2_unseal -H 0x81010001 -P abc123 -o out.dat
-tpm2_unseal -c item.context -P abc123 -o out.dat
-tpm2_unseal -c 0x81010001 -P "hex:123abc" -o out.dat
+tpm2_unseal -c 0x81010001 -p abc123 -o out.dat
+tpm2_unseal -c item.context -p abc123 -o out.dat
+tpm2_unseal -c 0x81010001 -p "hex:123abc" -o out.dat
 tpm2_unseal -c item.context -L sha1:0,1,2 -F out.dat
 ```
 

--- a/test/integration/tests/nv.sh
+++ b/test/integration/tests/nv.sh
@@ -192,7 +192,7 @@ tpm2_changeauth -o owner
 
 tpm2_nvdefine -x 0x1500015 -a 0x40000001 -s 32 \
   -t "policyread|policywrite|authread|authwrite|ownerwrite|ownerread" \
-  -I "index" -P "owner"
+  -p "index" -P "owner"
 
 # Use index password write/read, implicit -a
 tpm2_nvwrite -Q -x 0x1500015 -P "index" nv.test_w

--- a/test/integration/tests/tcti/abrmd/extended-sessions.sh
+++ b/test/integration/tests/tcti/abrmd/extended-sessions.sh
@@ -113,7 +113,7 @@ handle=`tpm2_startauthsession -a -S $file_session_file | cut -d' ' -f 2-2`
 
 tpm2_policypcr -Q -S $file_session_file -L ${alg_pcr_policy}:${pcr_ids} -F $file_pcr_value -f $file_policy
 
-unsealed=`tpm2_unseal -P"session:$file_session_file" -c $file_unseal_key_ctx`
+unsealed=`tpm2_unseal -p"session:$file_session_file" -c $file_unseal_key_ctx`
 
 test "$unsealed" == "$secret"
 
@@ -123,7 +123,7 @@ tpm2_policyrestart -S $file_session_file
 # negative test, clear the error handler
 trap - ERR
 
-tpm2_unseal -P"session:$file_session_file" -c $file_unseal_key_ctx 2>/dev/null
+tpm2_unseal -p"session:$file_session_file" -c $file_unseal_key_ctx 2>/dev/null
 rc=$?
 
 # restore the error handler

--- a/tools/tpm2_certify.c
+++ b/tools/tpm2_certify.c
@@ -58,7 +58,7 @@ struct tpm_certify_ctx {
     } file_path;
     struct {
         UINT16 P : 1;
-        UINT16 k : 1;
+        UINT16 p : 1;
         UINT16 g : 1;
         UINT16 a : 1;
         UINT16 s : 1;
@@ -193,8 +193,8 @@ static bool on_option(char key, char *value) {
         ctx.flags.P = 1;
         ctx.object_auth_str = value;
         break;
-    case 'k':
-        ctx.flags.k = 1;
+    case 'p':
+        ctx.flags.p = 1;
         ctx.key_auth_str = value;
         break;
     case 'g':
@@ -235,7 +235,7 @@ bool tpm2_tool_onstart(tpm2_options **opts) {
 
     const struct option topts[] = {
       { "auth-object",   required_argument, NULL, 'P' },
-      { "auth-key",      required_argument, NULL, 'k' },
+      { "auth-key",      required_argument, NULL, 'p' },
       { "halg",          required_argument, NULL, 'g' },
       { "attest-file",   required_argument, NULL, 'a' },
       { "sig-file",      required_argument, NULL, 's' },
@@ -244,7 +244,7 @@ bool tpm2_tool_onstart(tpm2_options **opts) {
       {  "format",       required_argument, NULL, 'f' },
     };
 
-    *opts = tpm2_options_new("P:k:g:a:s:c:C:f:", ARRAY_LEN(topts), topts,
+    *opts = tpm2_options_new("P:p:g:a:s:c:C:f:", ARRAY_LEN(topts), topts,
                              on_option, NULL, 0);
 
     return *opts != NULL;
@@ -291,7 +291,7 @@ int tpm2_tool_onrun(TSS2_SYS_CONTEXT *sapi_context, tpm2_option_flags flags) {
         }
     }
 
-    if (ctx.flags.k) {
+    if (ctx.flags.p) {
         result = tpm2_auth_util_from_optarg(sapi_context, ctx.key_auth_str,
                 &ctx.cmd_auth[1], &ctx.session[1]);
         if (!result) {

--- a/tools/tpm2_create.c
+++ b/tools/tpm2_create.c
@@ -79,7 +79,7 @@ struct tpm_create_ctx {
 
     struct {
         UINT16 P : 1;
-        UINT16 K : 1;
+        UINT16 p : 1;
         UINT16 A : 1;
         UINT16 I : 1;
         UINT16 L : 1;
@@ -157,8 +157,8 @@ static bool on_option(char key, char *value) {
         ctx.flags.P = 1;
         ctx.parent_auth_str = value;
         break;
-    case 'K':
-        ctx.flags.K = 1;
+    case 'p':
+        ctx.flags.p = 1;
         ctx.key_auth_str = value;
     break;
     case 'g':
@@ -200,7 +200,7 @@ bool tpm2_tool_onstart(tpm2_options **opts) {
 
     static struct option topts[] = {
       { "auth-parent",          required_argument, NULL, 'P' },
-      { "auth-key",             required_argument, NULL, 'K' },
+      { "auth-key",             required_argument, NULL, 'p' },
       { "halg",                 required_argument, NULL, 'g' },
       { "kalg",                 required_argument, NULL, 'G' },
       { "object-attributes",    required_argument, NULL, 'A' },
@@ -211,7 +211,7 @@ bool tpm2_tool_onstart(tpm2_options **opts) {
       { "context-parent",       required_argument, NULL, 'C' },
     };
 
-    *opts = tpm2_options_new("P:K:g:G:A:I:L:u:r:C:", ARRAY_LEN(topts), topts,
+    *opts = tpm2_options_new("P:p:g:G:A:I:L:u:r:C:", ARRAY_LEN(topts), topts,
                              on_option, NULL, 0);
 
     return *opts != NULL;
@@ -279,7 +279,7 @@ int tpm2_tool_onrun(TSS2_SYS_CONTEXT *sapi_context, tpm2_option_flags flags) {
         goto out;
     }
 
-    if (ctx.flags.K) {
+    if (ctx.flags.p) {
         TPMS_AUTH_COMMAND tmp;
         result = tpm2_auth_util_from_optarg(sapi_context, ctx.key_auth_str, &tmp, NULL);
         if (!result) {

--- a/tools/tpm2_createak.c
+++ b/tools/tpm2_createak.c
@@ -86,7 +86,7 @@ struct createak_context {
     struct {
         UINT8 f : 1;
         UINT8 o : 1;
-        UINT8 E : 1;
+        UINT8 e : 1;
         UINT8 P : 1;
         UINT8 unused : 4;
     } flags;
@@ -482,8 +482,8 @@ static bool on_option(char key, char *value) {
         ctx.flags.o = 1;
         ctx.owner_auth_str = value;
         break;
-    case 'E':
-        ctx.flags.E = 1;
+    case 'e':
+        ctx.flags.e = 1;
         ctx.endorse_auth_str = value;
         break;
     case 'P': 
@@ -518,7 +518,7 @@ bool tpm2_tool_onstart(tpm2_options **opts) {
 
     const struct option topts[] = {
         { "auth-owner",     required_argument, NULL, 'o' },
-        { "auth-endorse",   required_argument, NULL, 'E' },
+        { "auth-endorse",   required_argument, NULL, 'e' },
         { "auth-ak",        required_argument, NULL, 'P' },
         { "ek-context",     required_argument, NULL, 'C' },
         { "ak-handle",      required_argument, NULL, 'k' },
@@ -532,7 +532,7 @@ bool tpm2_tool_onstart(tpm2_options **opts) {
         { "privfile",       required_argument, NULL, 'r'},
     };
 
-    *opts = tpm2_options_new("o:C:E:k:G:D:s:P:f:n:p:c:r:", ARRAY_LEN(topts), topts,
+    *opts = tpm2_options_new("o:C:e:k:G:D:s:P:f:n:p:c:r:", ARRAY_LEN(topts), topts,
                              on_option, NULL, 0);
 
     return *opts != NULL;
@@ -574,7 +574,7 @@ int tpm2_tool_onrun(TSS2_SYS_CONTEXT *sapi_context, tpm2_option_flags flags) {
         }
     }
 
-    if (ctx.flags.E) {
+    if (ctx.flags.e) {
         bool res = tpm2_auth_util_from_optarg(sapi_context, ctx.endorse_auth_str,
                 &ctx.ek.auth2.session_data, &ctx.ek.auth2.session);
         if (!res) {

--- a/tools/tpm2_createprimary.c
+++ b/tools/tpm2_createprimary.c
@@ -67,7 +67,7 @@ struct tpm_createprimary_ctx {
     char *context_file;
     struct {
         UINT8 P :1;
-        UINT8 K :1;
+        UINT8 p :1;
     } flags;
     char *parent_auth_str;
     char *key_auth_str;
@@ -105,8 +105,8 @@ static bool on_option(char key, char *value) {
         ctx.flags.P = 1;
         ctx.parent_auth_str = value;
         break;
-    case 'k':
-        ctx.flags.K = 1;
+    case 'p':
+        ctx.flags.p = 1;
         ctx.key_auth_str = value;
         break;
     case 'g':
@@ -138,7 +138,7 @@ bool tpm2_tool_onstart(tpm2_options **opts) {
     const struct option topts[] = {
         { "hierarchy",            required_argument, NULL, 'a' },
         { "auth-hierarchy",       required_argument, NULL, 'P' },
-        { "auth-object",          required_argument, NULL, 'K' },
+        { "auth-object",          required_argument, NULL, 'p' },
         { "halg",                 required_argument, NULL, 'g' },
         { "kalg",                 required_argument, NULL, 'G' },
         { "out-context",          required_argument, NULL, 'o' },
@@ -146,7 +146,7 @@ bool tpm2_tool_onstart(tpm2_options **opts) {
         { "object-attributes",    required_argument, NULL, 'A' },
     };
 
-    *opts = tpm2_options_new("A:P:K:g:G:o:L:a:", ARRAY_LEN(topts), topts,
+    *opts = tpm2_options_new("A:P:p:g:G:o:L:a:", ARRAY_LEN(topts), topts,
             on_option, NULL, 0);
 
     return *opts != NULL;
@@ -166,7 +166,7 @@ int tpm2_tool_onrun(TSS2_SYS_CONTEXT *sapi_context, tpm2_option_flags flags) {
         }
     }
 
-    if (ctx.flags.K) {
+    if (ctx.flags.p) {
         TPMS_AUTH_COMMAND tmp;
         result = tpm2_auth_util_from_optarg(sapi_context, ctx.key_auth_str, &tmp, NULL);
         if (!result) {

--- a/tools/tpm2_dictionarylockout.c
+++ b/tools/tpm2_dictionarylockout.c
@@ -55,7 +55,7 @@ struct dictionarylockout_ctx {
         tpm2_session *session;
     } auth;
     struct {
-        UINT8 P : 1;
+        UINT8 p : 1;
         UINT8 unused : 7;
     } flags;
     char *lockout_auth_str;
@@ -112,8 +112,8 @@ static bool on_option(char key, char *value) {
     case 's':
         ctx.setup_parameters = true;
         break;
-    case 'P':
-        ctx.flags.P = 1;
+    case 'p':
+        ctx.flags.p = 1;
         ctx.lockout_auth_str = value;
         break;
     case 'n':
@@ -155,12 +155,12 @@ bool tpm2_tool_onstart(tpm2_options **opts) {
         { "max-tries",             required_argument, NULL, 'n' },
         { "recovery-time",         required_argument, NULL, 't' },
         { "lockout-recovery-time", required_argument, NULL, 'l' },
-        { "auth-lockout",          required_argument, NULL, 'P' },
+        { "auth-lockout",          required_argument, NULL, 'p' },
         { "clear-lockout",         no_argument,       NULL, 'c' },
         { "setup-parameters",      no_argument,       NULL, 's' },
     };
 
-    *opts = tpm2_options_new("n:t:l:P:cs", ARRAY_LEN(topts), topts, on_option,
+    *opts = tpm2_options_new("n:t:l:p:cs", ARRAY_LEN(topts), topts, on_option,
                              NULL, 0);
 
     return *opts != NULL;
@@ -178,7 +178,7 @@ int tpm2_tool_onrun(TSS2_SYS_CONTEXT *sapi_context, tpm2_option_flags flags) {
         goto out;
     }
 
-    if (ctx.flags.P) {
+    if (ctx.flags.p) {
         result = tpm2_auth_util_from_optarg(sapi_context, ctx.lockout_auth_str,
                 &ctx.auth.session_data, &ctx.auth.session);
         if (!result) {

--- a/tools/tpm2_encryptdecrypt.c
+++ b/tools/tpm2_encryptdecrypt.c
@@ -66,7 +66,7 @@ struct tpm_encrypt_decrypt_ctx {
         char *out;
     } iv;
     struct {
-        UINT8 P : 1;
+        UINT8 p : 1;
         UINT8 D : 1;
         UINT8 I : 1;
         UINT8 X : 1;
@@ -160,8 +160,8 @@ static bool on_option(char key, char *value) {
     case 'c':
         ctx.context_arg = value;
         break;
-    case 'P':
-        ctx.flags.P = 1;
+    case 'p':
+        ctx.flags.p = 1;
         ctx.key_auth_str = value;
         break;
     case 'D':
@@ -192,7 +192,7 @@ static bool on_option(char key, char *value) {
 bool tpm2_tool_onstart(tpm2_options **opts) {
 
     const struct option topts[] = {
-        { "auth-key",             required_argument, NULL, 'P' },
+        { "auth-key",             required_argument, NULL, 'p' },
         { "decrypt",              no_argument,       NULL, 'D' },
         { "in-file",              required_argument, NULL, 'I' },
         { "iv",                   required_argument, NULL, 'i' },
@@ -201,7 +201,7 @@ bool tpm2_tool_onstart(tpm2_options **opts) {
         { "key-context",          required_argument, NULL, 'c' },
     };
 
-    *opts = tpm2_options_new("P:DI:o:c:i:G:", ARRAY_LEN(topts), topts, on_option,
+    *opts = tpm2_options_new("p:DI:o:c:i:G:", ARRAY_LEN(topts), topts, on_option,
                              NULL, 0);
 
     return *opts != NULL;
@@ -233,7 +233,7 @@ int tpm2_tool_onrun(TSS2_SYS_CONTEXT *sapi_context, tpm2_option_flags flags) {
         goto out;
     }
 
-    if (ctx.flags.P) {
+    if (ctx.flags.p) {
         result = tpm2_auth_util_from_optarg(sapi_context, ctx.key_auth_str,
                 &ctx.auth.session_data, &ctx.auth.session);
         if (!result) {

--- a/tools/tpm2_nvdefine.c
+++ b/tools/tpm2_nvdefine.c
@@ -61,7 +61,7 @@ struct tpm_nvdefine_ctx {
     char *policy_file;
     struct {
         UINT8 P : 1;
-        UINT8 I : 1;
+        UINT8 p : 1;
         UINT8 unused : 6;
     } flags;
     char *hierarchy_auth_str;
@@ -167,8 +167,8 @@ static bool on_option(char key, char *value) {
                 }
             }
             break;
-        case 'I':
-            ctx.flags.I = 1;
+        case 'p':
+            ctx.flags.p = 1;
             ctx.index_auth_str = value;
             break;
         case 'L':
@@ -187,12 +187,12 @@ bool tpm2_tool_onstart(tpm2_options **opts) {
         { "size",                   required_argument,  NULL,   's' },
         { "attributes",             required_argument,  NULL,   't' },
         { "auth-hierarchy",         required_argument,  NULL,   'P' },
-        { "auth-index",             required_argument,  NULL,   'I' },
+        { "auth-index",             required_argument,  NULL,   'p' },
         { "policy-file",            required_argument,  NULL,   'L' },
         { "session",                required_argument,  NULL,   'S' },
     };
 
-    *opts = tpm2_options_new("x:a:s:t:P:I:L:", ARRAY_LEN(topts), topts,
+    *opts = tpm2_options_new("x:a:s:t:P:Ip:L:", ARRAY_LEN(topts), topts,
                              on_option, NULL, 0);
 
     return *opts != NULL;
@@ -214,7 +214,7 @@ int tpm2_tool_onrun(TSS2_SYS_CONTEXT *sapi_context, tpm2_option_flags flags) {
         }
     }
 
-    if (ctx.flags.I) {
+    if (ctx.flags.p) {
         TPMS_AUTH_COMMAND tmp;
         result = tpm2_auth_util_from_optarg(sapi_context, ctx.index_auth_str,
                 &tmp, NULL);

--- a/tools/tpm2_nvreadlock.c
+++ b/tools/tpm2_nvreadlock.c
@@ -125,8 +125,8 @@ bool tpm2_tool_onstart(tpm2_options **opts) {
 
     const struct option topts[] = {
         { "index",                required_argument, NULL, 'x' },
-        { "hierarchy",       required_argument, NULL, 'a' },
-        { "handle-passwd",        required_argument, NULL, 'P' },
+        { "hierarchy",            required_argument, NULL, 'a' },
+        { "auth-hierarchy",       required_argument, NULL, 'P' },
     };
 
     *opts = tpm2_options_new("x:a:P:", ARRAY_LEN(topts), topts,

--- a/tools/tpm2_nvrelease.c
+++ b/tools/tpm2_nvrelease.c
@@ -119,9 +119,9 @@ static bool on_option(char key, char *value) {
 bool tpm2_tool_onstart(tpm2_options **opts) {
 
     const struct option topts[] = {
-        { "index",                required_argument, NULL, 'x' },
-        { "hierarchy",       required_argument, NULL, 'a' },
-        { "handle-passwd",        required_argument, NULL, 'P' },
+        { "index",          required_argument, NULL, 'x' },
+        { "hierarchy",      required_argument, NULL, 'a' },
+        { "auth-hierarchy", required_argument, NULL, 'P' },
     };
 
     *opts = tpm2_options_new("x:a:P:", ARRAY_LEN(topts), topts, on_option,

--- a/tools/tpm2_rsadecrypt.c
+++ b/tools/tpm2_rsadecrypt.c
@@ -46,7 +46,7 @@
 typedef struct tpm_rsadecrypt_ctx tpm_rsadecrypt_ctx;
 struct tpm_rsadecrypt_ctx {
     struct {
-        UINT8 P : 1;
+        UINT8 p : 1;
         UINT8 I : 1;
         UINT8 o : 1;
         UINT8 unused : 3;
@@ -96,8 +96,8 @@ static bool on_option(char key, char *value) {
     case 'c':
         ctx.context_arg = value;
         break;
-    case 'P':
-        ctx.flags.P = 1;
+    case 'p':
+        ctx.flags.p = 1;
         ctx.key_auth_str = value;
         break;
     case 'I': {
@@ -126,7 +126,7 @@ static bool on_option(char key, char *value) {
 bool tpm2_tool_onstart(tpm2_options **opts) {
 
     static struct option topts[] = {
-      { "auth-key",     required_argument, NULL, 'P' },
+      { "auth-key",     required_argument, NULL, 'p' },
       { "in-file",      required_argument, NULL, 'I' },
       { "out-file",     required_argument, NULL, 'o' },
       { "key-context",  required_argument, NULL, 'c' },
@@ -168,7 +168,7 @@ int tpm2_tool_onrun(TSS2_SYS_CONTEXT *sapi_context, tpm2_option_flags flags) {
         goto out;
     }
 
-    if (ctx.flags.P) {
+    if (ctx.flags.p) {
         result = tpm2_auth_util_from_optarg(sapi_context, ctx.key_auth_str,
                 &ctx.auth.session_data, &ctx.auth.session);
         if (!result) {

--- a/tools/tpm2_sign.c
+++ b/tools/tpm2_sign.c
@@ -66,7 +66,7 @@ struct tpm_sign_ctx {
     char *inMsgFileName;
     tpm2_convert_sig_fmt sig_format;
     struct {
-        UINT16 P : 1;
+        UINT16 p : 1;
         UINT16 g : 1;
         UINT16 m : 1;
         UINT16 t : 1;
@@ -188,8 +188,8 @@ static bool on_option(char key, char *value) {
     case 'c':
         ctx.context_arg = value;
         break;
-    case 'P':
-        ctx.flags.P = 1;
+    case 'p':
+        ctx.flags.p = 1;
         ctx.key_auth_str = value;
         break;
     case 'G': {
@@ -248,7 +248,7 @@ static bool on_option(char key, char *value) {
 bool tpm2_tool_onstart(tpm2_options **opts) {
 
     static const struct option topts[] = {
-      { "auth-key",             required_argument, NULL, 'P' },
+      { "auth-key",             required_argument, NULL, 'p' },
       { "halg",                 required_argument, NULL, 'G' },
       { "message",              required_argument, NULL, 'm' },
       { "digest",               required_argument, NULL, 'D' },
@@ -258,7 +258,7 @@ bool tpm2_tool_onstart(tpm2_options **opts) {
       { "format",               required_argument, NULL, 'f' }
     };
 
-    *opts = tpm2_options_new("P:G:m:D:t:s:c:f:", ARRAY_LEN(topts), topts,
+    *opts = tpm2_options_new("p:G:m:D:t:s:c:f:", ARRAY_LEN(topts), topts,
                              on_option, NULL, 0);
 
     return *opts != NULL;
@@ -274,7 +274,7 @@ int tpm2_tool_onrun(TSS2_SYS_CONTEXT *sapi_context, tpm2_option_flags flags) {
         goto out;
     }
 
-    if (ctx.flags.P) {
+    if (ctx.flags.p) {
         result = tpm2_auth_util_from_optarg(sapi_context, ctx.key_auth_str,
                 &ctx.auth.session_data, &ctx.auth.session);
         if (!result) {

--- a/tools/tpm2_unseal.c
+++ b/tools/tpm2_unseal.c
@@ -60,7 +60,7 @@ struct tpm_unseal_ctx {
     const char *context_arg;
     tpm2_loaded_object context_object;
     struct {
-        UINT8 P : 1;
+        UINT8 p : 1;
         UINT8 L : 1;
     } flags;
 };
@@ -125,7 +125,7 @@ static bool start_auth_session(TSS2_SYS_CONTEXT *sapi_context) {
 static bool init(TSS2_SYS_CONTEXT *sapi_context) {
 
     if (!ctx.context_arg) {
-        LOG_ERR("Expected option C");
+        LOG_ERR("Expected option c");
         return false;
     }
 
@@ -153,8 +153,8 @@ static bool on_option(char key, char *value) {
     case 'c':
         ctx.context_arg = value;
         break;
-    case 'P': {
-        ctx.flags.P = 1;
+    case 'p': {
+        ctx.flags.p = 1;
         ctx.parent_auth_str = value;
     }
         break;
@@ -179,14 +179,14 @@ static bool on_option(char key, char *value) {
 bool tpm2_tool_onstart(tpm2_options **opts) {
 
     static const struct option topts[] = {
-      { "auth-key",             required_argument, NULL, 'P' },
+      { "auth-key",             required_argument, NULL, 'p' },
       { "out-file",             required_argument, NULL, 'o' },
       { "item-context",         required_argument, NULL, 'c' },
       { "set-list",             required_argument, NULL, 'L' },
       { "pcr-input-file",       required_argument, NULL, 'F' },
     };
 
-    *opts = tpm2_options_new("P:o:c:L:F:", ARRAY_LEN(topts), topts,
+    *opts = tpm2_options_new("p:o:c:L:F:", ARRAY_LEN(topts), topts,
                              on_option, NULL, 0);
 
     return *opts != NULL;
@@ -202,7 +202,7 @@ int tpm2_tool_onrun(TSS2_SYS_CONTEXT *sapi_context, tpm2_option_flags flags) {
         goto out;
     }
 
-    if (ctx.flags.P) {
+    if (ctx.flags.p) {
         result = tpm2_auth_util_from_optarg(sapi_context, ctx.parent_auth_str,
                 &ctx.auth.session_data, &ctx.auth.session);
         if (!result) {


### PR DESCRIPTION
Switch to consistently using -p as short option for current/child object authorisation and -P for parent object authorisation, much as we have standardised around the -c/-C short options for current/parent object specification.

Option unification wiki page has been updated to reflect this series: https://github.com/tpm2-software/tpm2-tools/wiki/Option-unification#object-authorization

Fixes #1082 