### PR TITLE
autotools: allow man page installation without pandoc being available

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -241,8 +241,7 @@ EXTRA_DIST = $(top_srcdir)/man \
 	     README.md \
 	     RELEASE.md \
 	     test/system
-
-if HAVE_PANDOC
+if HAVE_MAN_PAGES
     man1_MANS := \
     man/man1/tpm2_activatecredential.1 \
     man/man1/tpm2_certify.1 \
@@ -283,7 +282,9 @@ if HAVE_PANDOC
     man/man1/tpm2_takeownership.1 \
     man/man1/tpm2_unseal.1 \
     man/man1/tpm2_verifysignature.1
+endif
 
+if HAVE_PANDOC
 # If pandoc is enabled, we want to generate the manpages for the dist tarball
 EXTRA_DIST += $(man1_MANS)
 else

--- a/configure.ac
+++ b/configure.ac
@@ -15,6 +15,9 @@ AS_IF(
     [],
     [AC_MSG_WARN([Required executable pandoc not found, man pages will not be built])])
 AM_CONDITIONAL([HAVE_PANDOC],[test "x${PANDOC}" = "xyes"])
+AM_CONDITIONAL(
+    [HAVE_MAN_PAGES],
+    [test -d "${srcdir}/man/man1" -o "x${PANDOC}" = "xyes"])
 PKG_CHECK_MODULES([SAPI],[tss2-sys >= 2.0 tss2-sys < 3.0])
 PKG_CHECK_MODULES([SAPI],[tss2-mu >= 2.0 tss2-sys < 3.0])
 PKG_CHECK_MODULES([CRYPTO], [libcrypto >= 1.0.2g])


### PR DESCRIPTION
Backport patch to fix installing man pages without pandoc installed.

Fixes #1091
