### PR TITLE
Updated tpm2_unseal and authorizations pages.

### DIFF
--- a/man/common/authorizations.md
+++ b/man/common/authorizations.md
@@ -10,7 +10,7 @@ Authorization for use of an object in TPM2.0 can come in 3 different forms:
 ## Passwords
 
 Passwords are interpreted in two forms, string and hex-string. A string password is not
-interpreted, and is directly used for authorization. A hex-string, is converted from
+interpreted, and is directly used for authorization. A hex-string password is converted from
 a hexidecimal form into a byte array form, thus allowing passwords with non-printable
 and/or terminal un-friendly characters.
 
@@ -27,6 +27,6 @@ HMAC tickets can be presented as hex escaped passwords.
 
 ## Sessions
 
-When using a policy session to authorize the use of an object, one prefixes the option argument
-with the *session* keyword. You then indicate a path to a session file that was created
+When using a policy session to authorize the use of an object, prefixe the option argument
+with the *session* keyword.  Then indicate a path to a session file that was created
 with tpm2_startauthsession(1).

--- a/man/common/authorizations.md
+++ b/man/common/authorizations.md
@@ -27,6 +27,6 @@ HMAC tickets can be presented as hex escaped passwords.
 
 ## Sessions
 
-When using a policy session to authorize the use of an object, prefixe the option argument
+When using a policy session to authorize the use of an object, prefix the option argument
 with the *session* keyword.  Then indicate a path to a session file that was created
 with tpm2_startauthsession(1).

--- a/man/tpm2_unseal.1.md
+++ b/man/tpm2_unseal.1.md
@@ -16,7 +16,7 @@
 
 **NOTE**: The **--set-list** and **--pcr-input-file** options should only be
 used for simple PCR authentication policies. For more complex policies the
-tools should be ran in an execution environment that keeps the session context
+tools should be run in an execution environment that keeps the session context
 alive and pass that session using the **--input-session-handle** option.
 
 # OPTIONS


### PR DESCRIPTION
- Changed 'ran' to 'run' in the description paragraph for tpm2_unseal.
- Changed 'hex-string,' to 'hex-string password' in authorizations.
- Cleaned up the Sessions paragraph in authorizations.