### PR TITLE
Revert "objectattrs: clear before or'ing in values"

### DIFF
--- a/lib/tpm2_attr_util.c
+++ b/lib/tpm2_attr_util.c
@@ -501,7 +501,6 @@ bool tpm2_attr_util_nv_strtoattr(char *attribute_list, TPMA_NV *nvattrs) {
 
 bool tpm2_attr_util_obj_strtoattr(char *attribute_list, TPMA_OBJECT *objattrs) {
 
-    memset(objattrs, 0, sizeof(*objattrs));
     return common_strtoattr(attribute_list, objattrs, obj_attr_table, ARRAY_LEN(obj_attr_table));
 }
 


### PR DESCRIPTION
This reverts commit e103bbf5117b0b62b358fd15f18f848854fcb0ee.

The tpm2-tools 3.1.0 release contains a backward incompatible change that
was introduced by commit e103bbf5117 ("objectattrs: clear before or'ing
in values"), that changed the way that object attributes were specified.

Before there were a set of default attributes and the user could specify
additional attributes to be used, but after the mentioned commit the user
must specify all attributes.

This is a user visible change that changes the tools semantics, so is not
a suitable change for a MINOR version number increment, according to the
Semantic Versioning document (https://semver.org) since it breaks rule 2:

2.MINOR version when you add functionality in a backwards-compatible manner

Fixes: #1097

Signed-off-by: Javier Martinez Canillas <javierm@redhat.com>