### PR TITLE
Add bash completion support for all the tools

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -374,3 +374,6 @@ man/man1/%.1 : man/%.1.md $(MARKDOWN_COMMON_DEPS)
 	    < $< | pandoc -s -t man > $@
 
 CLEANFILES = $(man1_MANS)
+
+bashcompdir=@bashcompdir@
+dist_bashcomp_DATA=dist/bash-completion/tpm2-tools/tpm2_completion.bash

--- a/configure.ac
+++ b/configure.ac
@@ -22,6 +22,10 @@ PKG_CHECK_MODULES([TSS2_SYS], [tss2-sys >= 2.0.0])
 PKG_CHECK_MODULES([CRYPTO], [libcrypto >= 1.0.2g])
 PKG_CHECK_MODULES([CURL], [libcurl])
 
+PKG_CHECK_VAR(bashcompdir, [bash-completion], [compatdir], ,
+  bashcompdir="${sysconfdir}/bash_completion.d")
+AC_SUBST(bashcompdir)
+
 AC_ARG_ENABLE([unit],
             [AS_HELP_STRING([--enable-unit],
                             [build cmocka unit tests (default is no)])],

--- a/dist/bash-completion/tpm2-tools/tpm2_completion.bash
+++ b/dist/bash-completion/tpm2-tools/tpm2_completion.bash
@@ -1,0 +1,155 @@
+#!/bin/sh
+# bash completion for tmp2-tools                                 -*- shell-script -*-
+
+
+_tpm2_tools()
+{
+
+
+
+    local cur prev words cword
+    _init_completion || return
+    local common_options=(-h --help -v --version -V --verbose -Q --quiet -Z --enable-errata -T --tcti=)
+    local aux1=$( ${COMP_WORDS[0]} -h no-man 2>/dev/null )
+    local aux2=$( echo "${aux1}" | tr "[]|" " " | awk '{if(NR>2)print}' | tr " " "\n" | sed 's/=<value>//')
+    suggestions=("${aux2[@]}" "${common_options[@]}") #generate all the opts for the tool
+    local halg=(sha1 sha256 sha384 sha512 sm3_256)
+    local public_object_alg=(rsa keyedhash ecc 0x25 symcipher)
+    local signing_alg=(hmac rsassa rsapss ecdsa ecdaa sm2 ecschnorr)
+    local signing_schemes=(hmac rsassa rsaes rsapss oeap)
+    local tcti_opts=(device: mssim: abrmd:)
+
+
+    case $prev in
+      -g | --halg)
+          if [[ "${COMP_WORDS[0]}" != "tpm2_createek" && "${COMP_WORDS[0]}" != "tpm2_getmanufec" && "${COMP_WORDS[0]}" != "tpm2_createak" ]]; then
+            suggestions=( $( compgen -W "${halg[*]}" -- "$cur" ) )
+            COMPREPLY=("${suggestions[@]}")
+          else
+            suggestions=( $( compgen -W "${public_object_alg[*]}" -- "$cur" ) )
+            COMPREPLY=("${suggestions[@]}")
+          fi
+          return;;
+      -G | --kalg)
+          if [[  "${COMP_WORDS[0]}" != "tpm2_import"  && "${COMP_WORDS[0]}" != "tpm2_quote" ]]; then
+            suggestions=( $( compgen -W "${public_object_alg[*]}" -- "$cur" ) )
+            COMPREPLY=("${suggestions[@]}")
+          else
+            suggestions=( $( compgen -W "${halg[*]}" -- "$cur" ) )
+            COMPREPLY=("${suggestions[@]}")
+          fi
+          return;;
+      -D | --digest-alg)
+          if [[  "${COMP_WORDS[0]}" == "tpm2_createak" ]]; then
+            suggestions=( $( compgen -W "${halg[*]}" -- "$cur" ) )
+            COMPREPLY=("${suggestions[@]}")
+          else
+            _filedir
+          fi
+          return;;
+
+      -h | --help)
+          suggestions=( $( compgen -W 'summary manpage' -- "$cur" ) )
+          COMPREPLY=("${suggestions[@]}")
+          return;;
+      -T | --tcti)
+          suggestions=( $( compgen -W "${tcti_opts[*]}" -- "$cur" ) )
+          COMPREPLY=("${suggestions[@]}")
+          [[ $COMPREPLY == *: ]] && compopt -o nospace
+          return;;
+      -f)
+          if [[ "${COMP_WORDS[0]}" == "tpm2_activatecredential" || "${COMP_WORDS[0]}" == "print" ]]; then
+            _filedir
+          elif [[ "${COMP_WORDS[0]}" == "tpm2_quote" || "${COMP_WORDS[0]}" == "tpm2_sign" ]]; then
+            suggestions=( $( compgen -W 'plain tss' -- "$cur" ) )
+            COMPREPLY=("${suggestions[@]}")
+          elif [[ "${COMP_WORDS[0]}" == "tpm2_verifysignature" ]]; then
+            suggestions=( $( compgen -W "${signing_schemes[*]}" -- "$cur" ) )
+            COMPREPLY=("${suggestions[@]}")
+          fi
+          return;;
+      -s)
+          if [[ "${COMP_WORDS[0]}" == "tpm2_createak" ]]; then
+            suggestions=( $( compgen -W "${signing_alg[*]}" -- "$cur" ) )
+            COMPREPLY=("${suggestions[@]}")
+          elif [["${COMP_WORDS[0]}" == "tpm2_verifysignature" ]];then
+            _filedir
+          fi
+          return;;
+      -u | -r)
+          if [[ "${COMP_WORDS[0]}" == "tpm2_load" || "${COMP_WORDS[0]}" == "tpm2_loadexternal" ]]; then
+            _filedir
+          fi
+          return;;
+      -I)
+          if [[ "${COMP_WORDS[0]}" != "tpm2_nvdefine" ]]; then
+            _filedir
+          fi
+          return;;
+      -k | -K)
+          if [[ "${COMP_WORDS[0]}" == "tpm2_import" ]]; then
+            _filedir
+          fi
+          return;;
+      -i)
+          if [[ "${COMP_WORDS[0]}" == "tpm2_send" ]]; then
+            _filedir
+          fi
+          return;;
+      -m)
+          if [[ "${COMP_WORDS[0]}" != "tpm2_quote" ]]; then
+            _filedir
+          fi
+          return;;
+      -t)
+          if [[ "${COMP_WORDS[0]}" == "tpm2_sign" ]]; then
+            _filedir
+          fi
+          return;;
+      -L)
+          if [[ "${COMP_WORDS[0]}" == "tpm2_create" || "${COMP_WORDS[0]}" == "tpm2_createprimary" || "${COMP_WORDS[0]}" == "tpm2_nvdefine" ]]; then
+            _filedir
+          fi
+          return;;
+      -e)
+          if [[ "${COMP_WORDS[0]}" == "tpm2_makecredential" ]]; then
+            _filedir
+          fi
+          return;;
+
+      -S | F | C)
+         _filedir
+         return;;
+
+    esac
+
+    if [[ "$cur" == -* ]]; then #start completion
+        _exclude_completed_opts
+        COMPREPLY=( $( compgen -W '$( echo ${suggestions[@]} )' -- "$cur" ) )
+        [[ $COMPREPLY == *= ]] && compopt -o nospace
+        return
+    fi
+
+    COMPREPLY=( $( compgen -W '$( echo ${suggestions[@]} )' -- "$cur" ) )
+
+} &&
+  #to obtain the installation path of the tools, it is necessary to know just one of them, tpm2_import was choose ramdomly
+  #and then assign the completion function to all the tools
+  tools_for_completions=( $(find $( dirname $(which tpm2_import) ) -type f -printf '%f\n' | grep 'tpm2_') )
+  for i in "${tools_for_completions[@]}"
+  do
+   complete -F _tpm2_tools $i
+  done
+
+#function used to exlude the already completed options from the suggested completions
+_exclude_completed_opts() {
+  local len=$(($COMP_CWORD - 1))
+  local i
+  for ((i=1 ; i<=len; i++)) ; do
+      local aux="${COMP_WORDS[$i]}"
+      if [[ $aux == -* ]] ; then
+          (( i<len )) && [[ ${COMP_WORDS[$(( i + 1))]} == '=' ]] && aux="$aux="
+          suggestions=( "${suggestions[@]/$aux}" )
+      fi
+  done
+}

--- a/lib/tpm2_options.c
+++ b/lib/tpm2_options.c
@@ -280,22 +280,17 @@ static void show_version (const char *name) {
 void tpm2_print_usage(const char *command, struct tpm2_options *tool_opts) {
     unsigned int i;
     bool indent = true;
+    char *command_copy;
 
     if (!tool_opts) {
         return;
     }
 
-    char command_copy[PATH_MAX];
-    snprintf(command_copy, sizeof(command_copy), "%s", command);
-    char *name = basename(command_copy);
-    if (!tool_opts) {
-        printf("Usage: %s\n", name);
-        return;
-    }
-
-    printf("Usage: %s%s%s\n", name,
+    command_copy = strdup(command);
+    printf("Usage: %s%s%s\n", basename(command_copy),
            tool_opts->callbacks.on_opt ? " [<options>]" : "",
            tool_opts->callbacks.on_arg ? " <arguments>" : "");
+    free(command_copy);
 
     if (tool_opts->callbacks.on_opt) {
         printf("Where <options> are:\n");
@@ -346,6 +341,7 @@ tpm2_option_code tpm2_handle_options (int argc, char **argv,
 
     const char *tcti_conf_option = NULL;
 
+
     /* handle any options */
     const char* common_short_opts = "T:h::vVQZ";
     tpm2_options *opts = tpm2_options_new(common_short_opts,
@@ -378,16 +374,17 @@ tpm2_option_code tpm2_handle_options (int argc, char **argv,
             break;
         case 'h':
             show_help = true;
-            if (optarg) {
-                if (!strcmp(optarg, "man")) {
+            if (argv[optind]) {
+                if (!strcmp(argv[optind], "man")) {
                     manpager = true;
                     explicit_manpager = true;
                     optind++;
-                } else if (!strcmp(optarg, "no-man")) {
+                } else if (!strcmp(argv[optind], "no-man")) {
                     manpager = false;
                     optind++;
                 } else {
-                    LOG_ERR("Unknown help argument, got: \"%s\"", optarg);
+                    show_help=false;
+                    LOG_ERR("Unknown help argument, got: \"%s\"", argv[optind]);
                 }
             }
             goto out;
@@ -438,19 +435,21 @@ tpm2_option_code tpm2_handle_options (int argc, char **argv,
         }
 	}
 
-    /* Only init a TCTI if the tool needs it */
-    if (!tool_opts || !(tool_opts->flags & TPM2_OPTIONS_NO_SAPI)) {
-        tcti_conf conf = tcti_get_config(tcti_conf_option);
+    /* Only init a TCTI if the tool needs it and if the -h/--help option isn't present */
+    if (show_help){
+      if (!tool_opts || !(tool_opts->flags & TPM2_OPTIONS_NO_SAPI)) {
+          tcti_conf conf = tcti_get_config(tcti_conf_option);
 
-        *tcti = tpm2_tcti_ldr_load(conf.name, conf.opts);
-        if (!*tcti) {
-            LOG_ERR("Could not load tcti, got: \"%s\"", conf.name);
-            goto out;
-        }
+          *tcti = tpm2_tcti_ldr_load(conf.name, conf.opts);
+          if (!*tcti) {
+              LOG_ERR("Could not load tcti, got: \"%s\"", conf.name);
+              goto out;
+          }
 
-        if (!flags->enable_errata) {
-            flags->enable_errata = !!getenv (TPM2TOOLS_ENV_ENABLE_ERRATA);
-        }
+          if (!flags->enable_errata) {
+              flags->enable_errata = !!getenv (TPM2TOOLS_ENV_ENABLE_ERRATA);
+          }
+      }
     }
 
     rc = tpm2_option_code_continue;


### PR DESCRIPTION
This pull-request contains @kaiserkyu patch from PR #1068, plus some fixes from issues I pointed out in the review.

The changes from his original commit are:

1. Install bash completion file in compatdir (/etc/bash_completion.d) instead of completionsdir(/usr/share/bash-completion/completions).
2. Only show the pretty names instead of the hexadecimal values for option arguments.
3. Don't show long options as `--option=` but instead just as `--option` and also allow to autocomplete the arguments for long options.
4. Remove some unnecessary blank lines that were introduced in the patch.

@williamcroberts I've tested his patch and it works for me, basically what I do is:

```
$ ./bootstrap
$ ./configure --prefix=/usr
$ make -j5 && sudo make install
```

Then I open a new terminal and type:

```
$ tpm2_create
```

Then I press a space and tab, the first tab would autocomplete to:

```
$ tpm2_create -
```

And then pressing tab again I see the following:

```
$ tpm2_create -
-A                   --context-parent     -h                   --in-file            -p                   --pubfile            -T                   -V                   
--auth-key           --enable-errata      --halg               --kalg               -P                   -Q                   --tcti=              --verbose            
--auth-parent        -g                   --help               -L                   --policy-file        --quiet              -u                   --version            
-C                   -G
```

Then I can choose an option, i.e: (-g) and then pressing some tabs again I see:

```
$ tpm2_create -g s
sha1     sha256   sha384   sha512   sm3_256
```

Same for the long options:

```
$ tpm2_create --halg s
sha1     sha256   sha384   sha512   sm3_256
```

@kaiserkyu works great, thanks a lot for working on this!