### PR TITLE
Fix no TCTI initialized and correct travis

### DIFF
--- a/.ci/docker.run
+++ b/.ci/docker.run
@@ -31,6 +31,8 @@
 # THE POSSIBILITY OF SUCH DAMAGE.
 #;**********************************************************************;
 
+set -e
+
 source $TRAVIS_BUILD_DIR/.ci/docker-prelude.sh
 
 echo "starting dbus"

--- a/.ci/travis.run
+++ b/.ci/travis.run
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 
+set -e
+
 if [ "$TRAVIS_BRANCH" != "coverity_scan" ]; then
 
   docker pull tpm2software/tpm2-tss

--- a/lib/tpm2_options.c
+++ b/lib/tpm2_options.c
@@ -436,7 +436,7 @@ tpm2_option_code tpm2_handle_options (int argc, char **argv,
 	}
 
     /* Only init a TCTI if the tool needs it and if the -h/--help option isn't present */
-    if (show_help){
+    if (!show_help){
       if (!tool_opts || !(tool_opts->flags & TPM2_OPTIONS_NO_SAPI)) {
           tcti_conf conf = tcti_get_config(tcti_conf_option);
 


### PR DESCRIPTION
The following commit:
https://github.com/tpm2-software/tpm2-tools/commit/2fb68758e01bca412f9001ad53374beb862c752f

Introduced in a bug in TCTI initialization, which then skips providing a SAPI context
to the tools. Correct the check so TCTI initialization occurs.

Also, it looks like Travis stopped getting the exit code propagated back, fix this with some set -e in the scripts.

Signed-off-by: William Roberts <william.c.roberts@intel.com>