### PR TITLE
tools: stop checking if output file already exists

### DIFF
--- a/lib/files.c
+++ b/lib/files.c
@@ -352,23 +352,6 @@ bool files_load_tpm_context_from_path(TSS2_SYS_CONTEXT *sapi_context,
     return result;
 }
 
-bool files_does_file_exist(const char *path) {
-
-    if (!path) {
-        LOG_ERR("Path cannot be NULL");
-        return false;
-    }
-
-    FILE *fp = fopen(path,"rb");
-    if (fp) {
-        fclose(fp);
-        LOG_ERR("Path: %s already exists. Please rename or delete the file!",
-                path);
-        return true;
-    }
-    return false;
-}
-
 bool files_get_file_size_path(const char *path, unsigned long *file_size) {
 
     bool result = false;

--- a/lib/files.h
+++ b/lib/files.h
@@ -269,16 +269,6 @@ bool files_save_private(TPM2B_PRIVATE *private, const char *path);
 bool files_load_private(const char *path, TPM2B_PRIVATE *private);
 
 /**
- * Checks a file for existence.
- * @param path
- *  The file to check for existence.
- * @return
- * true if a file exists with read permissions, false if it doesn't exist or an error occurs.
- *
- */
-bool files_does_file_exist(const char *path);
-
-/**
  * Retrieves a files size given a file path.
  * @param path
  *  The path of the file to retrieve the size of.

--- a/test/unit/test_files.c
+++ b/test/unit/test_files.c
@@ -244,25 +244,6 @@ static void test_file_size_bad_args(void **state) {
     assert_false(res);
 }
 
-static void test_file_exists(void **state) {
-
-    test_file *tf = test_file_from_state(state);
-
-    bool res = files_does_file_exist(tf->path);
-    assert_true(res);
-}
-
-static void test_file_exists_bad_args(void **state) {
-
-    (void) state;
-
-    bool res = files_does_file_exist("this_should_be_a_bad_path");
-    assert_false(res);
-
-    res = files_does_file_exist(NULL);
-    assert_false(res);
-}
-
 int main(int argc, char* argv[]) {
     (void)argc;
     (void)argv;
@@ -293,11 +274,6 @@ int main(int argc, char* argv[]) {
         cmocka_unit_test_setup_teardown(test_file_size,
                 test_setup, test_teardown),
         cmocka_unit_test_setup_teardown(test_file_size_bad_args,
-                test_setup, test_teardown),
-
-        cmocka_unit_test_setup_teardown(test_file_exists,
-                test_setup, test_teardown),
-        cmocka_unit_test_setup_teardown(test_file_exists_bad_args,
                 test_setup, test_teardown),
     };
 

--- a/tools/tpm2_certify.c
+++ b/tools/tpm2_certify.c
@@ -206,16 +206,10 @@ static bool on_option(char key, char *value) {
         ctx.flags.g = 1;
         break;
     case 'a':
-        if (files_does_file_exist(value)) {
-            return false;
-        }
         ctx.file_path.attest = value;
         ctx.flags.a = 1;
         break;
     case 's':
-        if (files_does_file_exist(value)) {
-            return false;
-        }
         ctx.file_path.sig = value;
         ctx.flags.s = 1;
         break;

--- a/tools/tpm2_rsadecrypt.c
+++ b/tools/tpm2_rsadecrypt.c
@@ -111,10 +111,6 @@ static bool on_option(char key, char *value) {
     }
         break;
     case 'o': {
-        bool result = files_does_file_exist(value);
-        if (result) {
-            return false;
-        }
         ctx.output_file_path = value;
         ctx.flags.o = 1;
         break;

--- a/tools/tpm2_sign.c
+++ b/tools/tpm2_sign.c
@@ -224,10 +224,6 @@ static bool on_option(char key, char *value) {
     }
         break;
     case 's': {
-        bool result = files_does_file_exist(value);
-        if (result) {
-            return false;
-        }
         ctx.outFilePath = value;
         ctx.flags.s = 1;
     }

--- a/tools/tpm2_verifysignature.c
+++ b/tools/tpm2_verifysignature.c
@@ -239,10 +239,6 @@ static bool on_option(char key, char *value) {
 		break;
 	case 't':
 		ctx.out_file_path = value;
-
-		if (files_does_file_exist(ctx.out_file_path)) {
-			return false;
-		}
 		ctx.flags.ticket = 1;
 		break;
 		/* no default */


### PR DESCRIPTION
Almost no tool checks to see if the user specified output
file already exists, and if so, aborts operation with an
error. Just clobber the output file.

Signed-off-by: William Roberts <william.c.roberts@intel.com>