### PR TITLE
Minimum fixes to import

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -171,8 +171,6 @@ check_PROGRAMS = \
 
 TESTS += $(ALL_SYSTEM_TESTS)
 
-XFAIL_TESTS = test/integration/tests/import.sh
-
 test_unit_test_string_bytes_CFLAGS   = $(AM_CFLAGS) $(CMOCKA_CFLAGS)
 test_unit_test_string_bytes_LDADD    = $(CMOCKA_LIBS) $(LIB_COMMON) $(LDADD)
 test_unit_test_string_bytes_SOURCES  = test/unit/test_string_bytes.c


### PR DESCRIPTION
This is the minimum set of fixes for tpm2-import. It still requires a lot of hardcoded values. Future work needs to be done to make this tool much more robust in the face of different parents, as well as configurable parameters for the object being created.

This makes progress towards #1079 