### PR TITLE
Print usage information when incorrect options are passed to tools

### DIFF
--- a/test/integration/tests/getcap.sh
+++ b/test/integration/tests/getcap.sh
@@ -75,7 +75,7 @@ trap - ERR
 
 # Regression test, ensure that getcap -c never accepts prefix matches
 tpm2_getcap -Q --capability="comma" 2>/dev/null
-if [ $? -eq 0 ]; then
+if [ $? -eq -1 ]; then
   echo "Expected \"tpm2_getcap -Q --capability=\"comma\"\" to fail."
   exit 1
 fi

--- a/tools/tpm2_activatecredential.c
+++ b/tools/tpm2_activatecredential.c
@@ -278,8 +278,8 @@ int tpm2_tool_onrun(TSS2_SYS_CONTEXT *sapi_context, tpm2_option_flags flags) {
     if ((!ctx.ctx_arg)
             && (!ctx.key_ctx_arg)
             && !ctx.flags.f && !ctx.flags.o) {
-        LOG_ERR("Expected options c and C and f and o");
-        return 1;
+        LOG_ERR("Expected options c and C and f and o.");
+        return -1;
     }
 
     bool res = tpm2_util_object_load(sapi_context, ctx.ctx_arg, &ctx.ctx_obj);

--- a/tools/tpm2_certify.c
+++ b/tools/tpm2_certify.c
@@ -235,7 +235,7 @@ bool tpm2_tool_onstart(tpm2_options **opts) {
       { "sig-file",      required_argument, NULL, 's' },
       { "obj-context",   required_argument, NULL, 'C' },
       { "key-context",   required_argument, NULL, 'c' },
-      {  "format",       required_argument, NULL, 'f' },
+      { "format",        required_argument, NULL, 'f' },
     };
 
     *opts = tpm2_options_new("P:p:g:a:s:c:C:f:", ARRAY_LEN(topts), topts,
@@ -256,7 +256,7 @@ int tpm2_tool_onrun(TSS2_SYS_CONTEXT *sapi_context, tpm2_option_flags flags) {
         && (!ctx.key_context_arg)
         && (ctx.flags.g) && (ctx.flags.a)
         && (ctx.flags.s)) {
-        goto out;
+        return -1;
     }
 
     /* Load input files */

--- a/tools/tpm2_create.c
+++ b/tools/tpm2_create.c
@@ -228,14 +228,19 @@ int tpm2_tool_onrun(TSS2_SYS_CONTEXT *sapi_context, tpm2_option_flags flags) {
 
     TPMA_OBJECT attrs = DEFAULT_ATTRS;
 
-    if (ctx.flags.I) {
-        bool res = load_sensitive();
-        if (!res) {
-            goto out;
-        }
+    if(!ctx.context_arg) {
+        LOG_ERR("Must specify parent object via -C.");
+        return -1;
+    }
 
+    if (ctx.flags.I) {
         if (ctx.flags.G) {
             LOG_ERR("Cannot specify -G and -I together.");
+            return -1;
+        }
+
+        bool res = load_sensitive();
+        if (!res) {
             goto out;
         }
 
@@ -258,11 +263,6 @@ int tpm2_tool_onrun(TSS2_SYS_CONTEXT *sapi_context, tpm2_option_flags flags) {
 
     if (ctx.flags.I && ctx.in_public.publicArea.type != TPM2_ALG_KEYEDHASH) {
         LOG_ERR("Only TPM2_ALG_KEYEDHASH algorithm is allowed when sealing data");
-        goto out;
-    }
-
-    if(!ctx.context_arg) {
-        LOG_ERR("Must specify parent object via -C");
         goto out;
     }
 

--- a/tools/tpm2_createak.c
+++ b/tools/tpm2_createak.c
@@ -545,7 +545,7 @@ int tpm2_tool_onrun(TSS2_SYS_CONTEXT *sapi_context, tpm2_option_flags flags) {
 
     if (ctx.flags.f && !ctx.ak.out.pub_file) {
         LOG_ERR("Please specify an output file name when specifying a format");
-        return 1;
+        return -1;
     }
 
     if (ctx.find_persistent_ak) {

--- a/tools/tpm2_createek.c
+++ b/tools/tpm2_createek.c
@@ -300,7 +300,7 @@ int tpm2_tool_onrun(TSS2_SYS_CONTEXT *sapi_context, tpm2_option_flags flags) {
 
     if (ctx.flags.f && !ctx.out_file_path) {
         LOG_ERR("Please specify an output file name when specifying a format");
-        goto out;
+        return -1;
     }
 
     bool ret;

--- a/tools/tpm2_dictionarylockout.c
+++ b/tools/tpm2_dictionarylockout.c
@@ -175,7 +175,7 @@ int tpm2_tool_onrun(TSS2_SYS_CONTEXT *sapi_context, tpm2_option_flags flags) {
 
     if (!ctx.clear_lockout && !ctx.setup_parameters) {
         LOG_ERR( "Invalid operational input: Neither Setup nor Clear lockout requested.");
-        goto out;
+        return -1;
     }
 
     if (ctx.flags.p) {

--- a/tools/tpm2_encryptdecrypt.c
+++ b/tools/tpm2_encryptdecrypt.c
@@ -215,8 +215,8 @@ int tpm2_tool_onrun(TSS2_SYS_CONTEXT *sapi_context, tpm2_option_flags flags) {
     int rc = 1;
 
     if (!ctx.context_arg) {
-        LOG_ERR("Expected a context file or handle, got none");
-        goto out;
+        LOG_ERR("Expected a context file or handle, got none.");
+        return -1;
     }
 
     ctx.data.size = sizeof(ctx.data.buffer);

--- a/tools/tpm2_getcap.c
+++ b/tools/tpm2_getcap.c
@@ -957,8 +957,8 @@ int tpm2_tool_onrun(TSS2_SYS_CONTEXT *sapi_context, tpm2_option_flags flags) {
     UNUSED(flags);
 
     if (options.list && options.capability_string) {
-        LOG_ERR("Cannot specify -l with -c");
-        return 1;
+        LOG_ERR("Cannot specify -l with -c.");
+        return -1;
     }
 
     /* list known capabilities, ie -l option */
@@ -974,7 +974,7 @@ int tpm2_tool_onrun(TSS2_SYS_CONTEXT *sapi_context, tpm2_option_flags flags) {
     ret = sanity_check_capability_opts();
     if (ret == 1) {
         LOG_ERR("Invalid capability string. See --help.\n");
-        return 1;
+        return -1;
     }
     /* get requested capability from TPM, dump it to stdout */
     if (!get_tpm_capability_all(sapi_context, &capability_data))

--- a/tools/tpm2_hmac.c
+++ b/tools/tpm2_hmac.c
@@ -261,11 +261,11 @@ int tpm2_tool_onrun(TSS2_SYS_CONTEXT *sapi_context, tpm2_option_flags flags) {
     bool result;
 
     /*
-     * Options k or c must be specified.
+     * Option C must be specified.
      */
     if (!ctx.context_arg) {
-        LOG_ERR("Must specify options C");
-        return rc;
+        LOG_ERR("Must specify options C.");
+        return -1;
     }
 
     if (ctx.flags.P) {

--- a/tools/tpm2_load.c
+++ b/tools/tpm2_load.c
@@ -171,8 +171,8 @@ int tpm2_tool_onrun(TSS2_SYS_CONTEXT *sapi_context, tpm2_option_flags flags) {
     bool result;
 
     if ((!ctx.context_arg) || (!ctx.flags.u || !ctx.flags.r)) {
-        LOG_ERR("Expected options C, u and r");
-        goto out;
+        LOG_ERR("Expected options C, u and r.");
+        return -1;
     }
 
     if(ctx.flags.P) {

--- a/tools/tpm2_makecredential.c
+++ b/tools/tpm2_makecredential.c
@@ -206,8 +206,8 @@ int tpm2_tool_onrun(TSS2_SYS_CONTEXT *sapi_context, tpm2_option_flags flags) {
     UNUSED(flags);
 
     if (!ctx.flags.e || !ctx.flags.n || !ctx.flags.o || !ctx.flags.s) {
-        LOG_ERR("Expected options e, n, o and s");
-        return 1;
+        LOG_ERR("Expected options e, n, o and s.");
+        return -11;
     }
 
     return make_credential_and_save(sapi_context) != true;

--- a/tools/tpm2_pcrlist.c
+++ b/tools/tpm2_pcrlist.c
@@ -419,7 +419,7 @@ int tpm2_tool_onrun(TSS2_SYS_CONTEXT *sapi_context, tpm2_option_flags flags) {
                 ctx.flags.L ? "-L" : "",
                 ctx.flags.s ? "-s" : ""
         );
-        goto error;
+        return -1;
     }
 
     if (ctx.flags.o) {

--- a/tools/tpm2_policypcr.c
+++ b/tools/tpm2_policypcr.c
@@ -104,17 +104,17 @@ int tpm2_tool_onrun(TSS2_SYS_CONTEXT *sapi_context, tpm2_option_flags flags) {
 
     bool fail = false;
     if (!ctx.session_path) {
-        LOG_ERR("Must specify -S session file");
+        LOG_ERR("Must specify -S session file.");
         fail = true;
     }
 
     if (!ctx.pcr_selection.count) {
-        LOG_ERR("Must specify -L pcr selection list");
+        LOG_ERR("Must specify -L pcr selection list.");
         fail = true;
     }
 
     if (fail) {
-        return rc;
+        return -1;
     }
 
     s = tpm2_session_restore(sapi_context, ctx.session_path);

--- a/tools/tpm2_quote.c
+++ b/tools/tpm2_quote.c
@@ -230,8 +230,8 @@ int tpm2_tool_onrun(TSS2_SYS_CONTEXT *sapi_context, tpm2_option_flags flags) {
 
     /* TODO this whole file needs to be re-done, especially the option validation */
     if (!ctx.flags.l && !ctx.flags.L) {
-        LOG_ERR("Expected either -l or -L to be specified");
-        goto out;
+        LOG_ERR("Expected either -l or -L to be specified.");
+        return -1;
     }
 
     if (ctx.flags.P) {

--- a/tools/tpm2_rsadecrypt.c
+++ b/tools/tpm2_rsadecrypt.c
@@ -138,8 +138,8 @@ static bool init(TSS2_SYS_CONTEXT *sapi_context) {
 
 
     if (!(ctx.context_arg && ctx.flags.I && ctx.flags.o)) {
-        LOG_ERR("Expected arguments I, o and C");
-        return false;
+        LOG_ERR("Expected arguments I, o and c.");
+        return -1;
     }
 
     bool result = tpm2_util_object_load(sapi_context, ctx.context_arg,

--- a/tools/tpm2_tool.c
+++ b/tools/tpm2_tool.c
@@ -157,10 +157,16 @@ int main(int argc, char *argv[]) {
     /*
      * Call the specific tool, all tools implement this function instead of
      * 'main'.
+     * rc 1 = failure
+     * rc 0 = success
+     * rc -1 = show usage
      */
-    ret = tpm2_tool_onrun(sapi_context, flags) ? 1 : 0;
-    if (ret != 0) {
+    ret = tpm2_tool_onrun(sapi_context, flags);
+    if (ret > 0) {
         LOG_ERR("Unable to run %s", argv[0]);
+    } else if (ret < 0) {
+        tpm2_print_usage(argv[0], tool_opts);
+        ret = 0;
     }
 
     /*

--- a/tools/tpm2_tool.h
+++ b/tools/tpm2_tool.h
@@ -59,7 +59,9 @@ bool tpm2_tool_onstart(tpm2_options **opts) __attribute__((weak));
  * @param flags
  *  Flags that tools may wish to respect.
  * @return
- *  0 on success.
+ *  0 on success
+ *  1 on failure
+ * -1 to show usage
  */
 int tpm2_tool_onrun (TSS2_SYS_CONTEXT *sapi_context, tpm2_option_flags flags) __attribute__((weak));
 


### PR DESCRIPTION
This PR updates the tpm2_tools tpm2_tool_onrun() method, the main interface for tools, such that if -1 is returned the tools usage will be printed.

Addresses #1099