### PR TITLE
Algorithms: Enhance scheme support

### DIFF
--- a/lib/tpm2_alg_util.c
+++ b/lib/tpm2_alg_util.c
@@ -511,7 +511,6 @@ static bool handle_keyedhash(TPM2B_PUBLIC *public) {
 
         public->publicArea.type = TPM2_ALG_KEYEDHASH;
         public->publicArea.parameters.keyedHashDetail.scheme.scheme = TPM2_ALG_NULL;
-
         return true;
 }
 
@@ -972,4 +971,28 @@ bool tpm2_alg_util_public_init(char *alg_details, char *name_halg, char *attrs, 
     *public = tmp;
 
     return true;
+}
+
+const char *tpm2_alg_util_ecc_to_str(TPM2_ECC_CURVE curve_id) {
+
+    switch(curve_id) {
+    case TPM2_ECC_NIST_P192:
+        return "NIST p192";
+    case TPM2_ECC_NIST_P224:
+        return "NIST p224";
+    case TPM2_ECC_NIST_P256:
+        return "NIST p256";
+    case TPM2_ECC_NIST_P384:
+        return "NIST p384";
+    case TPM2_ECC_NIST_P521:
+        return "NIST 521";
+    case TPM2_ECC_BN_P256:
+        return "BN P256";
+    case TPM2_ECC_BN_P638:
+        return "BN P638";
+    case TPM2_ECC_SM2_P256:
+        return "SM2 p256";
+        /* no default */
+    }
+    return NULL;
 }

--- a/lib/tpm2_alg_util.h
+++ b/lib/tpm2_alg_util.h
@@ -199,4 +199,13 @@ bool get_signature_scheme(TSS2_SYS_CONTEXT *sapi_context,
 bool tpm2_alg_util_public_init(char *alg_details, char *name_halg, char *attrs, char *auth_policy, TPMA_OBJECT def_attrs,
        TPM2B_PUBLIC *public);
 
+/**
+ * Returns an ECC curve as a friendly name.
+ * @param curve_id
+ *  The curve to look up a friendly string for.
+ * @return
+ *  The friendly string or NULL if not found.
+ */
+const char *tpm2_alg_util_ecc_to_str(TPM2_ECC_CURVE curve_id);
+
 #endif /* LIB_TPM2_ALG_UTIL_H_ */

--- a/man/common/alg.md
+++ b/man/common/alg.md
@@ -1,9 +1,123 @@
 # Algorithm Specifiers
 
-Options that take algorithms support "nice-names". Nice names, like sha1 can be
-used in place of the raw hex for sha1: 0x4. The nice names are converted by
-stripping the leading **TPM_ALG_** from the Algorithm Name field and converting
-it to lower case. For instance **TPM_ALG_SHA3_256** becomes **sha3_256**.
+Options that take algorithms support "nice-names".
 
-The algorithms can be found at:
-<https://trustedcomputinggroup.org/wp-content/uploads/TCG_Algorithm_Registry_Rev_1.24.pdf>
+There are two major algorithm specification string classes, simple and complex.
+Only certain algorithms will be accepted by the TPM, based on usage and conditions.
+
+## Simple specifiers
+These are strings with no additional specification data. When creating objects,
+non-specified portions of an object are assumed to defaults. You can find the
+list of known "Simple Specifiers Below".
+
+### Asymmetric
+  * rsa
+  * ecc
+
+### Symmetric
+  * aes
+  * camellia
+
+### Hashing Algorithms:
+  * sha1
+  * sha256
+  * sha384
+  * sha512
+  * sm3_256
+  * sha3_256
+  * sha3_384
+  * sha3_512
+
+### Keyed Hash
+ * hmac
+ * xor
+
+### Signing Schemes
+  * rsassa
+  * rsapss
+  * ecdsa
+  * ecdaa
+  * ecschnorr
+
+### Asymmetric Encryption Schemes
+  * oaep
+  * rsaes
+  * ecdh
+
+### Modes
+  * ctr
+  * ofb
+  * cbc
+  * cfb
+  * ecb
+
+### Misc
+  * null
+
+## Complex Specifiers
+Objects, when specified for creation by the TPM, have numerous algorithms to populate in the
+public data. Things like type, scheme and asymmetric details, key size, etc. Below is the
+general format for specifying this data:
+`<type>:<scheme>:<symmetric-details>`
+
+### Type Specifiers
+
+   This portion of the complex algorithm specifier is required. The remaining scheme and symmetric details
+   will default based on the type specified and the type of the object being created.
+
+  * aes - Default AES: aes128cfb
+  * aes128`<mode>` - 128 bit AES with optional mode (*ctr*|*ofb*|*cbc*|*cfb*|*ecb*). If mode is not
+      specified, defaults to *cfb*.
+  * aes256`<mode>` - Same as aes128`<mode>`, except for a 256 bit key size.
+  * ecc - Elliptical Curve, defaults to ecc256.
+  * ecc192 - 192 bit ECC
+  * ecc224 - 224 bit ECC
+  * ecc256 - 256 bit ECC
+  * ecc384 - 384 bit ECC
+  * ecc521 - 521 bit ECC
+  * rsa - Default RSA: rsa2048
+  * rsa1024 - RSA with 1024 bit keysize.
+  * rsa2048 - RSA with 2048 bit keysize.
+  * rsa4096 - RSA with 4096 bit keysize.
+
+### Scheme Specifiers
+Next, is an optional field, it can be skipped.
+
+Schemes are usually **Signing Schemes** or **Asymmetric Encryption Schemes**.
+Most signing schemes take a hash algorithm directly following the signing scheme. If the hash
+algorithm is missing, it defaults to *sha256*. Some take no arguments, and some take multiple
+arguments.
+
+#### Hash Optional Scheme Specifiers
+These scheme specifiers are followed immediately by a valid hash algorithm, For example: `oaepsha256`.
+  * oaep
+  * ecdh
+  * rsassa
+  * rsapss
+  * ecdsa
+  * ecschnorr
+
+#### Multiple Option Scheme Specifiers
+This scheme specifier is followed by a count (max size UINT16) a dash(-) and a valid hash algorithm.
+  * ecdaa
+
+#### No Option Scheme Specifiers
+This scheme specifier takes NO arguments.
+  * rsaes
+
+### Symmetric Details Specifiers
+This field is optional, and defaults based on the *type* of object being created and it's attributes.
+Generally, any valid **Symmetric** specifier from the **Type Scpefiers** list should work.
+
+## Examples:
+
+Create an rsa2048 key with an rsaes assymmetric encryption scheme:
+`tpm2_create -C parent.ctx -G rsa2048:rsaes -u key.pub -r key.priv`
+
+Create an ecc256 key with an ecdaa signing scheme with a count of 4 and sha384 hash:
+`/tpm2_create -C parent.ctx -G ecc256:ecdaa4-sha384 -u key.pub -r key.priv`
+
+
+**DEPRECATED**
+The old numerical arguments are deprecated, and use is discouraged and will not be officially supported
+going forward.

--- a/test/integration/tests/create.sh
+++ b/test/integration/tests/create.sh
@@ -84,16 +84,16 @@ test "$policy_orig" == "$policy_new"
 tpm2_create -Q -C context.out -g sha256 -G aes256cbc -u key.pub -r key.priv
 tpm2_load -Q -C context.out -u key.pub -r key.priv -o key.ctx
 tpm2_readpublic -c key.ctx > out.yaml
-keybits=$(yaml_get_kv out.yaml \"keybits\")
-mode=$(yaml_get_kv out.yaml \"mode\" \"value\")
+keybits=$(yaml_get_kv out.yaml \"sym-keybits\")
+mode=$(yaml_get_kv out.yaml \"sym-mode\" \"value\")
 test "$keybits" -eq "256"
 test "$mode" == "cbc"
 
 tpm2_create -Q -C context.out -g sha256 -G aes128ofb -u key.pub -r key.priv
 tpm2_load -Q -C context.out -u key.pub -r key.priv -o key.ctx
 tpm2_readpublic -c key.ctx > out.yaml
-keybits=$(yaml_get_kv out.yaml \"keybits\")
-mode=$(yaml_get_kv out.yaml \"mode\" \"value\")
+keybits=$(yaml_get_kv out.yaml \"sym-keybits\")
+mode=$(yaml_get_kv out.yaml \"sym-mode\" \"value\")
 test "$keybits" -eq "128"
 test "$mode" == "ofb"
 

--- a/test/integration/tests/create.sh
+++ b/test/integration/tests/create.sh
@@ -97,5 +97,12 @@ mode=$(yaml_get_kv out.yaml \"mode\" \"value\")
 test "$keybits" -eq "128"
 test "$mode" == "ofb"
 
+#
+# Test scheme support
+#
+
+for alg in "rsa1024:rsaes" "ecc384:ecdaa4-sha256"; do
+  tpm2_create -Q -C context.out -g sha256 -G "$alg" -u key.pub -r key.priv
+done
 
 exit 0

--- a/tools/tpm2_createprimary.c
+++ b/tools/tpm2_createprimary.c
@@ -187,7 +187,8 @@ int tpm2_tool_onrun(TSS2_SYS_CONTEXT *sapi_context, tpm2_option_flags flags) {
         goto out;
     }
 
-    tpm2_util_tpma_object_to_yaml(ctx.objdata.in.public.publicArea.objectAttributes, NULL);
+    tpm2_util_public_to_yaml(&ctx.objdata.out.public, NULL);
+
     tpm2_tool_output("handle: 0x%X\n", ctx.objdata.out.handle);
 
     if (ctx.context_file) {


### PR DESCRIPTION
Support specifying meaningful data in the scheme field of complex
algorithm specifiers. This allows for one to create keys for signing,
etc.

For instance things like this are now possible via -G:

- ecc256:ecdaa4-sha256

Signed-off-by: William Roberts <william.c.roberts@intel.com>