### PR TITLE
Fixes for building on CentOS 7

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -22,6 +22,23 @@ PKG_CHECK_MODULES([TSS2_SYS], [tss2-sys >= 2.0.0])
 PKG_CHECK_MODULES([CRYPTO], [libcrypto >= 1.0.2g])
 PKG_CHECK_MODULES([CURL], [libcurl])
 
+# backwards compat with older pkg-config
+# - pull in AC_DEFUN from pkg.m4
+m4_ifndef([PKG_CHECK_VAR], [
+# PKG_CHECK_VAR(VARIABLE, MODULE, CONFIG-VARIABLE,
+# [ACTION-IF-FOUND], [ACTION-IF-NOT-FOUND])
+# -------------------------------------------
+# Retrieves the value of the pkg-config variable for the given module.
+AC_DEFUN([PKG_CHECK_VAR],
+[AC_REQUIRE([PKG_PROG_PKG_CONFIG])dnl
+AC_ARG_VAR([$1], [value of $3 for $2, overriding pkg-config])dnl
+
+_PKG_CONFIG([$1], [variable="][$3]["], [$2])
+AS_VAR_COPY([$1], [pkg_cv_][$1])
+
+AS_VAR_IF([$1], [""], [$5], [$4])dnl
+])# PKG_CHECK_VAR
+])
 PKG_CHECK_VAR(bashcompdir, [bash-completion], [compatdir], ,
   bashcompdir="${sysconfdir}/bash_completion.d")
 AC_SUBST(bashcompdir)

--- a/tools/tpm2_rsaencrypt.c
+++ b/tools/tpm2_rsaencrypt.c
@@ -51,7 +51,9 @@ struct tpm_rsaencrypt_ctx {
     char *input_path;
 };
 
-static tpm_rsaencrypt_ctx ctx = {};
+static tpm_rsaencrypt_ctx ctx = {
+    .context_arg = NULL
+};
 
 static bool rsa_encrypt_and_save(TSS2_SYS_CONTEXT *sapi_context) {
 


### PR DESCRIPTION
Whilst trying to replicate #1089 I have build both the 3.X and master branches on CentOS 7. The following two patches were required to build master on CentOS 7.