### PR TITLE
man: fix inclusion of common object attribute specifiers section

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## Changelog
 ### Next - TBD
   * Revert the change to use user supplied object attributes exclusively. This is an inappropriate behavioural change for a MINOR version number increment.
+  * Fix inclusion of object attribute specifiers section in tpm2_create and tpm2_createprimary man pages.
 
 ### 3.1.1 - 2018-07-09
   * Allow man page installation without pandoc being available

--- a/man/tpm2_create.1.md
+++ b/man/tpm2_create.1.md
@@ -79,7 +79,7 @@ These options for creating the tpm entity:
 
 [algorithm specifiers](common/alg.md)
 
-[object attribute specifiers](common/object-attrs.md)
+[object attribute specifiers](common/obj-attrs.md)
 
 # EXAMPLES
 

--- a/man/tpm2_createprimary.1.md
+++ b/man/tpm2_createprimary.1.md
@@ -74,7 +74,7 @@ will create and load a Primary Object. The sensitive area is not returned.
 
 [algorithm specifiers](common/alg.md)
 
-[object attribute specifiers](common/object-attrs.md)
+[object attribute specifiers](common/obj-attrs.md)
 
 # EXAMPLES
 


### PR DESCRIPTION
The filename is obj-attrs.md not object-attrs.md

Signed-off-by: Joshua Lock <joshua.g.lock@intel.com>