### PR TITLE
[for 3.X] tpm2_create: Use better object attributes defaults for authentication

### DIFF
--- a/test/system/test_tpm2_unseal.sh
+++ b/test/system/test_tpm2_unseal.sh
@@ -109,4 +109,55 @@ unsealed=`tpm2_unseal -c $file_unseal_key_ctx -L ${alg_pcr_policy}:${pcr_ids} -F
 
 test "$unsealed" == "$secret"
 
+# Test that unseal fails if a PCR policy isn't provided
+
+trap - ERR
+
+tpm2_unseal -c $file_unseal_key_ctx 2> /dev/null
+if [ $? != 1 ]; then
+  echo "tpm2_unseal didn't fail without a PCR policy!"
+  exit 1
+fi
+
+# Test that unseal fails if PCR state isn't the same as the defined PCR policy
+
+pcr_extend=$(echo $pcr_ids | cut -d ',' -f1)
+
+tpm2_pcrextend $pcr_extend:sha1=6c10289a8da7f774cf67bd2fc8502cd4b585346a
+
+tpm2_unseal -c $file_unseal_key_ctx -L ${alg_pcr_policy}:${pcr_ids} -F $file_pcr_value 2> /dev/null
+if [ $? != 1 ]; then
+  echo "tpm2_unseal didn't fail with a PCR state different than the policy!"
+  exit 1
+fi
+
+# Test that the object can be unsealed without a policy but a password
+
+trap onerror ERR
+
+rm $file_unseal_key_pub $file_unseal_key_priv $file_unseal_key_name
+
+tpm2_pcrlist -Q -L ${alg_pcr_policy}:${pcr_ids} -o $file_pcr_value
+
+tpm2_createpolicy -Q -P -L ${alg_pcr_policy}:${pcr_ids} -F $file_pcr_value -f $file_policy
+
+tpm2_create -Q -g $alg_create_obj -G $alg_create_key -u $file_unseal_key_pub -r $file_unseal_key_priv -I- -c $file_primary_key_ctx -L $file_policy -K secretpass\
+  -A 'sign|fixedtpm|fixedparent|sensitivedataorigin' <<< $secret
+
+tpm2_load -Q -c $file_primary_key_ctx  -u $file_unseal_key_pub  -r $file_unseal_key_priv -n $file_unseal_key_name -C $file_unseal_key_ctx
+
+unsealed=`tpm2_unseal -c $file_unseal_key_ctx -P secretpass`
+
+test "$unsealed" == "$secret"
+
+# Test that unseal fails when using a wrong password
+
+trap - ERR
+
+tpm2_unseal -c $file_unseal_key_ctx -P wrongpass 2> /dev/null
+if [ $? != 1 ]; then
+  echo "tpm2_unseal didn't fail when using a wrong object password!"
+  exit 1
+fi
+
 exit 0

--- a/tools/tpm2_create.c
+++ b/tools/tpm2_create.c
@@ -243,6 +243,7 @@ static bool on_option(char key, char *value) {
             return false;
         }
         ctx.flags.K = 1;
+        ctx.in_public.publicArea.objectAttributes |= TPMA_OBJECT_USERWITHAUTH;
         break;
     case 'g':
         ctx.nameAlg = tpm2_alg_util_from_optarg(value);
@@ -281,6 +282,9 @@ static bool on_option(char key, char *value) {
             return false;
         }
         ctx.flags.L = 1;
+        if (!ctx.flags.K) {
+             ctx.in_public.publicArea.objectAttributes &= ~TPMA_OBJECT_USERWITHAUTH;
+        }
         break;
     case 'S':
         if (!tpm2_util_string_to_uint32(value, &ctx.session_data.sessionHandle)) {


### PR DESCRIPTION
The tpm2_create tool allows to define a policy session or a password for
authentication. By default no policy session is used and the password is
empty, which means that this empty password is used for authentication.

So the default object attribute flag userWithAuth is set in order to use
the empty password. This isn't a good default though if a policy is set,
since in this case the policy session has to be used for authentication
instead of an empty password.

If a policy is defined, the userWithAuth bit has to be clear unless the
user defines a password so in that case authentication would happen only
using the policy session or the defined password.

Signed-off-by: Javier Martinez Canillas <javierm@redhat.com>