### PR TITLE
[for master] tpm2_create: Use better object attributes defaults for authentication

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -18,6 +18,32 @@ When a release is cut, the process is the same as an rc, with the exception that
 not marked as "pre-release" on github. The release notes should include everything from
 the last release to the latest release.
 
+### Updating the CHANGELOG for release candidates and final releases
+
+When a first release candidate is cut, a new entry will be added to the CHANGELOG file. This
+entry will have the release candiate version and the date on which the release candidate was
+released. The entry will list all the changes that happened between the latest final release
+and the first release candidate.
+
+The commit that made the change will be tagged with a release version and a -rc0 suffix as an
+indication that is not a final release but a first release candidate. If after a week the -rc
+has no changes, then a final release can be made as explained above. But if changes are made,
+then a new releases candidate will be released and the -rc suffix will be incremented.
+
+For each release candidate, the changes that happened between the previous release candidate
+will be appended to the CHANGELOG entry, and both the release candidate version and the date
+of the release will be updated to reflect the latest release candidate.
+
+The commit that updated the CHANGELOG entry will be tagged as the latest release candidate.
+
+When a final version will be released, there will not be changes to append to the CHANGELOG
+entry since otherwise a new release candidate should be cut. So only the release version and
+date should be updated in the CHANGELOG.
+
+The commit that updated the CHANGELOG entry will be tagged as the final release.
+
+For a final release, change the version to the final release version (i.e: 3.0.5-rc3 -> 3.0.5) and update the date. The commit for this change will be tagged as $version.
+
 ### Version Information
 
 Releases shall be tagged following semantic version guidelines found at:


### PR DESCRIPTION
The tpm2_create tool allows to define a policy session or a password for
authentication. By default no policy session is used and the password is
empty, which means that this empty password is used for authentication.

So the default object attribute flag userWithAuth is set in order to use
the empty password. This isn't a good default though if a policy is set,
since in this case the policy session has to be used for authentication
instead of an empty password.

If a policy is defined, the userWithAuth bit has to be clear unless the
user defines a password so in that case authentication would happen only
using the policy session or the defined password.

Also add these cases in the integration test to detect regressions.

Fixes: #1123

Signed-off-by: Javier Martinez Canillas <javierm@redhat.com>