### PR TITLE
Enhancments to tpm2-import

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## Changelog
 ### next
+  * tpm2_import: support RSA1024 keys.
   * tpm2_import: -q changes to -u to align with tpm2_loads public/private output arguments.
   * tpm2_import: Supports setting object name algorithm via -g.
   * tpm2_unseal: -P becomes -p

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## Changelog
 ### next
+  * tpm2_import: -q changes to -u to align with tpm2_loads public/private output arguments.
   * tpm2_import: Supports setting object name algorithm via -g.
   * tpm2_unseal: -P becomes -p
   * tpm2_sign: -P becomes -p

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 ## Changelog
 ### next
-  * tpm2_import: support RSA1024 keys.
+  * tpm2_import: support additional import key types:
+    * RSA1024/2048
+    * AES128/192/256
   * tpm2_import: -q changes to -u to align with tpm2_loads public/private output arguments.
   * tpm2_import: Supports setting object name algorithm via -g.
   * tpm2_unseal: -P becomes -p

--- a/lib/tpm2_util.c
+++ b/lib/tpm2_util.c
@@ -491,6 +491,10 @@ bool tpm2_util_object_load(TSS2_SYS_CONTEXT *sapi_ctx,
     result = files_load_tpm_context_from_path(sapi_ctx, &outobject->handle,
                 outobject->path);
 
+    if (!result) {
+        LOG_ERR("Could not load object, got: \"%s\"", objectstr);
+    }
+
     return result;
 }
 

--- a/man/tpm2_import.1.md
+++ b/man/tpm2_import.1.md
@@ -3,7 +3,7 @@ tpm2_import 1 "SEPTEMBER 2017" tpm2-tools
 
 # NAME
 
-tpm2_import(8) - imports an external key (AES-128) into the tpm as a TPM managed key object.
+tpm2_import(8) - imports an external key into the tpm as a TPM managed key object.
 
 # SYNOPSIS
 
@@ -11,8 +11,8 @@ tpm2_import(8) - imports an external key (AES-128) into the tpm as a TPM managed
 
 # DESCRIPTION
 
-This tool imports an external key either, a symmetric AES-128 or an RSA2K as TPM managed key object.
-It requires the parent handle be persistent and an object of type RSA key.
+This tool imports an external generated key as TPM managed key object.
+It requires that the parent key object be of type RSA key.
 
 # OPTIONS
 
@@ -21,7 +21,7 @@ These options control the key importation process:
   * **-G**, **--import-key-alg**=_ALGORITHM_:
     The algorithm used by the key to be imported. Supports:
     * aes - AES 128 key.
-    * rsa - RSA 2048 key.
+    * rsa - RSA 1024 or 2048 key.
 
   * **-g**, **--halg**=_ALGORITHM_:
     The hash algorithm for generating the objects name. This is optional

--- a/man/tpm2_import.1.md
+++ b/man/tpm2_import.1.md
@@ -48,7 +48,7 @@ These options control the key importation process:
     Specifies the file path required to save the encrypted private portion of
     the object imported as key.
 
-  * **-q**, **--import-key-public**=_FILE_:
+  * **-u**, **--import-key-public**=_FILE_:
     Specifies the file path required to save the public portion of the object imported as key
 
   * **-A**, **--object-attributes**=_ATTRIBUTES_:
@@ -68,7 +68,7 @@ These options control the key importation process:
 tpm2_import -k sym.key -C 0x81010001 -f parent.pub -q import_key.pub -r import_key.priv
 
 tpm2_import -Q -G rsa -k private.pem -C 0x81010005 -f parent.pub \
--q import_rsa_key.pub -r import_rsa_key.priv
+-u import_rsa_key.pub -r import_rsa_key.priv
 ```
 
 # LIMITATIONS

--- a/man/tpm2_import.1.md
+++ b/man/tpm2_import.1.md
@@ -20,7 +20,7 @@ These options control the key importation process:
 
   * **-G**, **--import-key-alg**=_ALGORITHM_:
     The algorithm used by the key to be imported. Supports:
-    * aes - AES 128 key.
+    * aes - AES 128,192 or 256 key.
     * rsa - RSA 1024 or 2048 key.
 
   * **-g**, **--halg**=_ALGORITHM_:

--- a/test/integration/tests/import.sh
+++ b/test/integration/tests/import.sh
@@ -61,9 +61,9 @@ run_test() {
 	dd if=/dev/urandom of=sym.key bs=1 count=16 2>/dev/null
 
 	#Symmetric Key Import Test
-	echo "tpm2_import -Q -G aes -g "$name_alg" -k sym.key -C parent.ctx -q import_key.pub -r import_key.priv"
+	echo "tpm2_import -Q -G aes -g "$name_alg" -k sym.key -C parent.ctx -u import_key.pub -r import_key.priv"
 	
-	tpm2_import -Q -G aes -g "$name_alg" -k sym.key -C parent.ctx -q import_key.pub \
+	tpm2_import -Q -G aes -g "$name_alg" -k sym.key -C parent.ctx -u import_key.pub \
 	-r import_key.priv
 
 	tpm2_load -Q -C parent.ctx -u import_key.pub -r import_key.priv -n import_key.name \
@@ -84,7 +84,7 @@ run_test() {
 
 	# Test an import without the parent public info data to force a readpublic
 	tpm2_import -Q -G rsa -g "$name_alg" -k private.pem -C parent.ctx \
-	-q import_rsa_key.pub -r import_rsa_key.priv
+	-u import_rsa_key.pub -r import_rsa_key.priv
 
 	tpm2_load -Q -C parent.ctx -u import_rsa_key.pub -r import_rsa_key.priv \
 	-n import_rsa_key.name -o import_rsa_key.ctx

--- a/test/integration/tests/import.sh
+++ b/test/integration/tests/import.sh
@@ -121,6 +121,8 @@ run_test() {
 
 	# 128 bit AES is 16 bytes
 	run_aes_import_test 16
+	# 256 bit AES is 32 bytes
+	run_aes_import_test 32
 
 	run_rsa_import_test parent.ctx 1024
     run_rsa_import_test parent.ctx 2048

--- a/tools/tpm2_activatecredential.c
+++ b/tools/tpm2_activatecredential.c
@@ -284,16 +284,11 @@ int tpm2_tool_onrun(TSS2_SYS_CONTEXT *sapi_context, tpm2_option_flags flags) {
 
     bool res = tpm2_util_object_load(sapi_context, ctx.ctx_arg, &ctx.ctx_obj);
     if (!res) {
-        tpm2_tool_output(
-                "Failed to load context object (handle: 0x%x, path: %s).\n",
-                ctx.ctx_obj.handle, ctx.ctx_obj.path);
         return 1;
     }
 
     res = tpm2_util_object_load(sapi_context, ctx.key_ctx_arg, &ctx.key_ctx_obj);
     if (!res) {
-        tpm2_tool_output("Failed to load context object for key (handle: 0x%x, path: %s).\n",
-                ctx.key_ctx_obj.handle, ctx.key_ctx_obj.path);
         return 1;
     }
 

--- a/tools/tpm2_create.c
+++ b/tools/tpm2_create.c
@@ -269,8 +269,6 @@ int tpm2_tool_onrun(TSS2_SYS_CONTEXT *sapi_context, tpm2_option_flags flags) {
     result = tpm2_util_object_load(sapi_context, ctx.context_arg,
             &ctx.context_object);
     if (!result) {
-        tpm2_tool_output("Failed to load context object (handle: 0x%x, path: %s).\n",
-                ctx.context_object.handle, ctx.context_object.path);
         goto out;
     }
 

--- a/tools/tpm2_createak.c
+++ b/tools/tpm2_createak.c
@@ -561,7 +561,6 @@ int tpm2_tool_onrun(TSS2_SYS_CONTEXT *sapi_context, tpm2_option_flags flags) {
 
     ret = tpm2_util_object_load(sapi_context, ctx.ek.ctx_arg, &ctx.ek.ek_ctx);
     if (!ret) {
-        LOG_ERR("Could not load EK context from passed object: %s", ctx.ek.ctx_arg);
         return 1;
     }
 

--- a/tools/tpm2_createek.c
+++ b/tools/tpm2_createek.c
@@ -319,8 +319,6 @@ int tpm2_tool_onrun(TSS2_SYS_CONTEXT *sapi_context, tpm2_option_flags flags) {
     } else {
         ret = tpm2_util_object_load(sapi_context, ctx.context_arg, &ctx.ctx_obj);
         if (!ret) {
-            tpm2_tool_output("Failed to load context object (handle: 0x%x, path: %s).\n",
-                            ctx.ctx_obj.handle, ctx.ctx_obj.path);
             goto out;
         }
     }

--- a/tools/tpm2_encryptdecrypt.c
+++ b/tools/tpm2_encryptdecrypt.c
@@ -228,8 +228,6 @@ int tpm2_tool_onrun(TSS2_SYS_CONTEXT *sapi_context, tpm2_option_flags flags) {
     result = tpm2_util_object_load(sapi_context, ctx.context_arg,
             &ctx.key_context_object);
     if (!result) {
-        tpm2_tool_output("Failed to load context object for key (handle: 0x%x, path: %s).\n",
-                ctx.key_context_object.handle, ctx.key_context_object.path);
         goto out;
     }
 

--- a/tools/tpm2_evictcontrol.c
+++ b/tools/tpm2_evictcontrol.c
@@ -132,8 +132,6 @@ int tpm2_tool_onrun(TSS2_SYS_CONTEXT *sapi_context, tpm2_option_flags flags) {
     result = tpm2_util_object_load(sapi_context, ctx.context_arg,
             &ctx.context_object);
     if (!result) {
-        tpm2_tool_output("Failed to load context object (handle: 0x%x, path: %s).\n",
-                ctx.context_object.handle, ctx.context_object.path);
         goto out;
     }
 

--- a/tools/tpm2_flushcontext.c
+++ b/tools/tpm2_flushcontext.c
@@ -176,8 +176,6 @@ int tpm2_tool_onrun(TSS2_SYS_CONTEXT *sapi_context, tpm2_option_flags flags) {
             result = tpm2_util_object_load(sapi_context, ctx.context_arg,
                     &ctx.context_object);
             if (!result) {
-                tpm2_tool_output("Failed to load context object (handle: 0x%x, path: %s).\n",
-                        ctx.context_object.handle, ctx.context_object.path);
                 return 1;
             }
         }

--- a/tools/tpm2_hmac.c
+++ b/tools/tpm2_hmac.c
@@ -281,8 +281,6 @@ int tpm2_tool_onrun(TSS2_SYS_CONTEXT *sapi_context, tpm2_option_flags flags) {
     result = tpm2_util_object_load(sapi_context, ctx.context_arg,
             &ctx.key_context_object);
     if (!result) {
-        tpm2_tool_output("Failed to load context object for key (handle: 0x%x, path: %s).\n",
-                ctx.key_context_object.handle, ctx.key_context_object.path);
         goto out;
     }
 

--- a/tools/tpm2_import.c
+++ b/tools/tpm2_import.c
@@ -912,12 +912,14 @@ static bool load_rsa_key(const char *private_path,
     RSA_get0_key(k, &n, NULL, NULL);
 #endif
 
-    int priv_bytes = BN_num_bytes(p);
-    if (priv_bytes > priv->size) {
-        LOG_ERR("Expected prime \"p\" to be less than or equal to %u,"
-                " got: %d", priv->size, priv_bytes);
+    unsigned priv_bytes = BN_num_bytes(p);
+    if (priv_bytes > sizeof(priv->buffer)) {
+        LOG_ERR("Expected prime \"p\" to be less than or equal to %lu,"
+                " got: %u", sizeof(priv->buffer), priv_bytes);
         goto out;
     }
+
+    priv->size = priv_bytes;
 
     int success = BN_bn2bin(p, priv->buffer);
     if (!success) {
@@ -960,7 +962,6 @@ static bool load_key(
             private->size = TPM2_MAX_SYM_BLOCK_SIZE;
             break;
         case TPM2_ALG_RSA:
-            private->size = 128;
             break;
         default:
             LOG_ERR("Invalid/ unsupported key algorithm for import, got\"0x%x\"",

--- a/tools/tpm2_import.c
+++ b/tools/tpm2_import.c
@@ -1034,9 +1034,6 @@ int tpm2_tool_onrun(TSS2_SYS_CONTEXT *sapi_context, tpm2_option_flags flags) {
     result = tpm2_util_object_load(sapi_context, ctx.parent_ctx_arg,
                     &parent_ctx);
     if (!result) {
-        tpm2_tool_output(
-            "Failed to load context object (handle: 0x%x, path: %s).\n",
-            parent_ctx.handle, parent_ctx.path);
       goto out;
     }
 

--- a/tools/tpm2_import.c
+++ b/tools/tpm2_import.c
@@ -835,7 +835,7 @@ static bool on_option(char key, char *value) {
     case 'K':
         ctx.parent_key_public_file = value;
         break;
-    case 'q':
+    case 'u':
         ctx.import_key_public_file = value;
         break;
     case 'r':
@@ -870,12 +870,12 @@ bool tpm2_tool_onstart(tpm2_options **opts) {
       { "parent-key",         required_argument, NULL, 'C'},
       { "parent-key-public",  required_argument, NULL, 'K'},
       { "import-key-private", required_argument, NULL, 'r'},
-      { "import-key-public",  required_argument, NULL, 'q'},
+      { "import-key-public",  required_argument, NULL, 'u'},
       { "object-attributes",  required_argument, NULL, 'A'},
       { "halg",               required_argument, NULL, 'g'},
     };
 
-    *opts = tpm2_options_new("G:k:C:K:q:r:A:g:", ARRAY_LEN(topts), topts, on_option,
+    *opts = tpm2_options_new("G:k:C:K:u:r:A:g:", ARRAY_LEN(topts), topts, on_option,
                              NULL, 0);
 
     return *opts != NULL;

--- a/tools/tpm2_import.c
+++ b/tools/tpm2_import.c
@@ -982,6 +982,42 @@ static bool load_key(
     return true;
 }
 
+/**
+ * Check all options and report as many errors as possible via LOG_ERR.
+ * @return
+ *  0 on success, -1 on failure.
+ */
+static int check_options(void) {
+
+    int rc = 0;
+
+    if (!ctx.input_key_file) {
+        LOG_ERR("Expected to be imported key data to be specified via \"-k\","
+                " missing option.");
+        rc = -1;
+    }
+
+    if (!ctx.import_key_public_file) {
+        LOG_ERR("Expected output public file missing, specify \"-u\","
+                " missing option.");
+        rc = -1;
+    }
+
+    if (!ctx.import_key_public_file) {
+        LOG_ERR("Expected output private file missing, specify \"-r\","
+                " missing option.");
+        rc = -1;
+    }
+
+    if (!ctx.key_type) {
+        LOG_ERR("Expected key type to be specified via \"-G\","
+                " missing option.");
+        rc = -1;
+    }
+
+    return rc;
+}
+
 int tpm2_tool_onrun(TSS2_SYS_CONTEXT *sapi_context, tpm2_option_flags flags) {
 
     UNUSED(flags);
@@ -1004,13 +1040,9 @@ int tpm2_tool_onrun(TSS2_SYS_CONTEXT *sapi_context, tpm2_option_flags flags) {
       goto out;
     }
 
-    if (!ctx.input_key_file || !parent_ctx.handle
-            || !ctx.import_key_public_file || !ctx.import_key_private_file
-            || !ctx.key_type) {
-        LOG_ERR("tpm2_import tool missing arguments: %s\n %08X\n %s\n %s",
-             ctx.input_key_file, parent_ctx.handle,
-             ctx.import_key_public_file, ctx.import_key_private_file);
-        return 1;
+    rc = check_options();
+    if (rc) {
+        goto out;
     }
 
     TPM2B_MAX_BUFFER private = TPM2B_EMPTY_INIT;

--- a/tools/tpm2_import.c
+++ b/tools/tpm2_import.c
@@ -959,8 +959,7 @@ static bool load_key(
 
     switch(key_type) {
         case TPM2_ALG_AES:
-            private->size = TPM2_MAX_SYM_BLOCK_SIZE;
-            break;
+            /* falls through */
         case TPM2_ALG_RSA:
             break;
         default:
@@ -973,6 +972,7 @@ static bool load_key(
         return load_rsa_key(private_path, private, public);
     }
 
+    private->size = sizeof(private->buffer);
     bool res = files_load_bytes_from_path(ctx.input_key_file,
         private->buffer, &private->size);
     if (!res) {

--- a/tools/tpm2_load.c
+++ b/tools/tpm2_load.c
@@ -187,8 +187,6 @@ int tpm2_tool_onrun(TSS2_SYS_CONTEXT *sapi_context, tpm2_option_flags flags) {
     result = tpm2_util_object_load(sapi_context,
             ctx.context_arg, &ctx.context_object);
     if (!result) {
-        tpm2_tool_output("Failed to load context object (handle: 0x%x, path: %s).\n",
-                ctx.context_object.handle, ctx.context_object.path);
         goto out;
     }
 

--- a/tools/tpm2_quote.c
+++ b/tools/tpm2_quote.c
@@ -245,9 +245,6 @@ int tpm2_tool_onrun(TSS2_SYS_CONTEXT *sapi_context, tpm2_option_flags flags) {
 
     result = tpm2_util_object_load(sapi_context, ctx.context_arg, &ctx.context_object);
     if (!result) {
-        tpm2_tool_output(
-                "Failed to load context object (handle: 0x%x, path: %s).\n",
-                ctx.context_object.handle, ctx.context_object.path);
         goto out;
     }
 

--- a/tools/tpm2_readpublic.c
+++ b/tools/tpm2_readpublic.c
@@ -135,8 +135,6 @@ static bool init(TSS2_SYS_CONTEXT *sapi_context) {
     bool result = tpm2_util_object_load(sapi_context,
             ctx.context_arg, &ctx.context_object);
     if (!result) {
-        tpm2_tool_output("Failed to load context object (handle: 0x%x, path: %s).\n",
-                ctx.context_object.handle, ctx.context_object.path);
         return false;
     }
 

--- a/tools/tpm2_rsadecrypt.c
+++ b/tools/tpm2_rsadecrypt.c
@@ -145,9 +145,6 @@ static bool init(TSS2_SYS_CONTEXT *sapi_context) {
     bool result = tpm2_util_object_load(sapi_context, ctx.context_arg,
             &ctx.key_context_object);
     if (!result) {
-        tpm2_tool_output(
-                "Failed to load contest object for key (handle: 0x%x, path: %s).\n",
-                ctx.key_context_object.handle, ctx.key_context_object.path);
         return false;
     }
 

--- a/tools/tpm2_rsaencrypt.c
+++ b/tools/tpm2_rsaencrypt.c
@@ -133,9 +133,6 @@ static bool init(TSS2_SYS_CONTEXT *sapi_context) {
     bool result = tpm2_util_object_load(sapi_context, ctx.context_arg,
             &ctx.key_context);
     if (!result) {
-        tpm2_tool_output(
-                "Failed to load contest object for key (handle: 0x%x, path: %s).\n",
-                ctx.key_context.handle, ctx.key_context.path);
         return false;
     }
 

--- a/tools/tpm2_sign.c
+++ b/tools/tpm2_sign.c
@@ -138,9 +138,6 @@ static bool init(TSS2_SYS_CONTEXT *sapi_context) {
      */
     bool result = tpm2_util_object_load(sapi_context, ctx.context_arg, &ctx.key_context);
     if (!result) {
-        tpm2_tool_output(
-                "Failed to load contest object for key (handle: 0x%x, path: %s).\n",
-                ctx.key_context.handle, ctx.key_context.path);
         return false;
     }
 

--- a/tools/tpm2_unseal.c
+++ b/tools/tpm2_unseal.c
@@ -131,9 +131,6 @@ static bool init(TSS2_SYS_CONTEXT *sapi_context) {
 
     bool retval = tpm2_util_object_load(sapi_context, ctx.context_arg, &ctx.context_object);
     if (!retval) {
-        tpm2_tool_output(
-                "Failed to load contest object for key (handle: 0x%x, path: %s).\n",
-                ctx.context_object.handle, ctx.context_object.path);
         return false;
     }
 

--- a/tools/tpm2_verifysignature.c
+++ b/tools/tpm2_verifysignature.c
@@ -147,9 +147,6 @@ static bool init(TSS2_SYS_CONTEXT *sapi_context) {
 
     return_value = tpm2_util_object_load(sapi_context, ctx.context_arg, &ctx.key_context_object);
     if (!return_value) {
-        tpm2_tool_output(
-                "Failed to load contest object for key (handle: 0x%x, path: %s).\n",
-                ctx.key_context_object.handle, ctx.key_context_object.path);
         return false;
     }
 


### PR DESCRIPTION
Enhance tpm2-import:
1. Internal refactoring to reduce usages of globals.
2. Support setting name hash algorithm via -g.
3. Support varying parent name-alg and symmetric parameters.
4. Support importation of RSA 1024 keys (likely works for 4096 but needs testing)
5. Support importation of AES 128/192/256 keys

This makes progress on #1079, but doesn't resolve everything. Issues #1129 and #1128 have been opened to address adding in missing ECC support.

It might be awhile before I can get back to tpm2_import, but this makes major progress and should be included in master.