### PR TITLE
Fix CI for 3.X branch

### DIFF
--- a/.ci/download-deps.sh
+++ b/.ci/download-deps.sh
@@ -47,8 +47,10 @@ function get_deps() {
 	echo "pwd done tss: `pwd`"
 
 	echo "pwd clone abrmd: `pwd`"
-	git clone -b master https://github.com/tpm2-software/tpm2-abrmd.git
+	git clone https://github.com/tpm2-software/tpm2-abrmd.git --depth=1
 	pushd tpm2-abrmd
+	git fetch --tags
+	git checkout 2.0.1 -b release-2.0.1
 	echo "pwd build abrmd: `pwd`"
 	./bootstrap
 	./configure

--- a/.ci/download-deps.sh
+++ b/.ci/download-deps.sh
@@ -36,8 +36,10 @@ function get_deps() {
 	echo "pwd starting: `pwd`"
 	pushd "$1"
 	echo "pwd clone tss: `pwd`"
-	git clone -b 2.0.0 https://github.com/tpm2-software/tpm2-tss.git
+	git clone https://github.com/tpm2-software/tpm2-tss.git --depth=1
 	pushd tpm2-tss
+	git fetch --tags
+	git checkout 2.0.0 -b release-2.0.0
 	echo "pwd build tss: `pwd`"
 	./bootstrap
 	./configure


### PR DESCRIPTION
Recent changes in tpm2-tss and tpm2-abrmd broke our CI for the 3.X branch. 