### PR TITLE
Ensure Python 3 compatibility of print function

### DIFF
--- a/scripts/utils/analyze.py
+++ b/scripts/utils/analyze.py
@@ -12,6 +12,7 @@ a human will need to make a plan of action to correct the tools so they conform.
 The tool exits with a status of non-zero on error, making this useful for checking
 PRs and can thus be added to travis.
 '''
+from __future__ import print_function
 
 import glob
 import os
@@ -247,9 +248,9 @@ class ToolConflictor(object):
                 continue
 
             has_conflicts = True
-            print "group: %s:" % (gname)
-            print "\ttools: %s" % str([t.name for t in tools])
-            print "\tconflicts: %s" % (str(conflicts))
+            print("group: %s:" % (gname))
+            print("\ttools: %s" % str([t.name for t in tools]))
+            print("\tconflicts: %s" % (str(conflicts)))
 
         return has_conflicts
 

--- a/test/integration/tests/activecredential.sh
+++ b/test/integration/tests/activecredential.sh
@@ -59,10 +59,13 @@ tpm2_createak -C 0x81010009 -k 0x8101000a -G rsa -D sha256 -s rsassa -p ak.pub -
 
 # Capture the yaml output and verify that its the same as the name output
 loaded_key_name_yaml=`python << pyscript
+from __future__ import print_function
+
 import yaml
+
 with open('ak.out', 'r') as f:
     doc = yaml.load(f)
-    print doc['loaded-key']['name']
+    print(doc['loaded-key']['name'])
 pyscript`
 
 # Use -c in xxd so there is no line wrapping


### PR DESCRIPTION
This is just an extremely trivial pull request to add parentheses to the Python `print` function so that it works with Python 3 as well as Python 2. This is necessary to run the integration tests e.g. on Arch Linux, which uses Python 3 as the default interpreter. I think I found all instances where the old syntax was still used, while some scripts like [test/integration/tests/getcap.sh](https://github.com/tpm2-software/tpm2-tools/blob/master/test/integration/tests/getcap.sh#L58) already used the new syntax anyway.

With this change, the test suite compiles and runs successfully on Arch Linux. The resulting files still work with Python 2 as well.