### PR TITLE
tpm2_verifysignature enhancmeents

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## Changelog
 ### next
+  * tpm2_verifysignature: make -t optional.
   * tpm2_import: support additional import key types:
     * RSA1024/2048
     * AES128/192/256

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## Changelog
 ### next
+  * tpm2_verifysignature: stop outputting message hash.
   * tpm2_verifysignature: issues a warning when ticket is specified for a NULL hierarchy.
   * tpm2_verifysignature: make -t optional.
   * tpm2_import: support additional import key types:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## Changelog
 ### next
+  * tpm2_verifysignature: issues a warning when ticket is specified for a NULL hierarchy.
   * tpm2_verifysignature: make -t optional.
   * tpm2_import: support additional import key types:
     * RSA1024/2048

--- a/tools/tpm2_verifysignature.c
+++ b/tools/tpm2_verifysignature.c
@@ -96,7 +96,20 @@ static bool verify_signature(TSS2_SYS_CONTEXT *sapi_context) {
         return false;
     }
 
-    return ctx.out_file_path ? files_save_ticket(&validation, ctx.out_file_path) : true;
+    /*
+     * NULL Hierarchies don't produce validation data, so let the user know
+     * by issuing a warning.
+     */
+    if (ctx.out_file_path) {
+        if (validation.hierarchy == TPM2_RH_NULL) {
+            LOG_WARN("The NULL hierarchy doesn't produce a validation ticket,"
+                    " not outputting ticket");
+        } else {
+            return files_save_ticket(&validation, ctx.out_file_path);
+        }
+    }
+
+    return true;
 }
 
 static TPM2B *message_from_file(const char *msg_file_path) {

--- a/tools/tpm2_verifysignature.c
+++ b/tools/tpm2_verifysignature.c
@@ -96,7 +96,7 @@ static bool verify_signature(TSS2_SYS_CONTEXT *sapi_context) {
         return false;
     }
 
-    return files_save_ticket(&validation, ctx.out_file_path);
+    return ctx.out_file_path ? files_save_ticket(&validation, ctx.out_file_path) : true;
 }
 
 static TPM2B *message_from_file(const char *msg_file_path) {
@@ -136,9 +136,9 @@ static bool init(TSS2_SYS_CONTEXT *sapi_context) {
         return false;
     }
 
-    if (!(ctx.context_arg && ctx.flags.sig && ctx.flags.ticket)) {
+    if (!(ctx.context_arg && ctx.flags.sig)) {
         LOG_ERR(
-                "--keyHandle (-k) or --keyContext (-c) and --sig (-s) and --ticket (-t) must be specified");
+                "--key-context (-c) and --sig (-s) are required");
         return false;
     }
 

--- a/tools/tpm2_verifysignature.c
+++ b/tools/tpm2_verifysignature.c
@@ -78,18 +78,10 @@ tpm2_verifysig_ctx ctx = {
 static bool verify_signature(TSS2_SYS_CONTEXT *sapi_context) {
 
 
-    UINT32 rval;
     TPMT_TK_VERIFIED validation;
-
     TSS2L_SYS_AUTH_RESPONSE sessionsDataOut;
 
-    UINT16 i;
-    for (i = 0; i < ctx.msgHash.size; i++) {
-        tpm2_tool_output("%02x ", ctx.msgHash.buffer[i]);
-    }
-    tpm2_tool_output("\n");
-
-    rval = TSS2_RETRY_EXP(Tss2_Sys_VerifySignature(sapi_context, ctx.key_context_object.handle, NULL,
+    TSS2_RC rval = TSS2_RETRY_EXP(Tss2_Sys_VerifySignature(sapi_context, ctx.key_context_object.handle, NULL,
             &ctx.msgHash, &ctx.signature, &validation, &sessionsDataOut));
     if (rval != TPM2_RC_SUCCESS) {
         LOG_PERR(Tss2_Sys_VerifySignature, rval);


### PR DESCRIPTION
* Stop outputting the message bytes
* Make -t optional
* Issue a warning when -t is specified and the object hierarchy is NULL.