### PR TITLE
tpm2_policyauthorize: New tool to enable authorizing policy digests using PolicyAuthorize

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -85,6 +85,7 @@ bin_PROGRAMS = \
     tools/tpm2_pcrextend \
     tools/tpm2_pcrlist \
     tools/tpm2_policypcr \
+    tools/tpm2_policyauthorize \
     tools/tpm2_policyrestart \
     tools/tpm2_quote \
     tools/tpm2_readpublic \
@@ -150,6 +151,7 @@ tools_tpm2_import_SOURCES = tools/tpm2_import.c $(TOOL_SRC)
 tools_tpm2_flushcontext_SOURCES = tools/tpm2_flushcontext.c $(TOOL_SRC)
 tools_tpm2_startauthsession_SOURCES = tools/tpm2_startauthsession.c $(TOOL_SRC)
 tools_tpm2_policypcr_SOURCES = tools/tpm2_policypcr.c $(TOOL_SRC)
+tools_tpm2_policyauthorize_SOURCES = tools/tpm2_policyauthorize.c $(TOOL_SRC)
 tools_tpm2_policyrestart_SOURCES = tools/tpm2_policyrestart.c $(TOOL_SRC)
 
 if UNIT
@@ -297,6 +299,7 @@ if HAVE_MAN_PAGES
     man/man1/tpm2_pcrlist.1 \
     man/man1/tpm2_policypcr.1 \
     man/man1/tpm2_policyrestart.1 \
+    man/man1/tpm2_policyauthorize.1 \
     man/man1/tpm2_quote.1 \
     man/man1/tpm2_rc_decode.1 \
     man/man1/tpm2_readpublic.1 \

--- a/lib/tpm2_policy.h
+++ b/lib/tpm2_policy.h
@@ -58,6 +58,32 @@ bool tpm2_policy_build_pcr(TSS2_SYS_CONTEXT *sapi_context,
         const char *raw_pcrs_file,
         TPML_PCR_SELECTION *pcr_selections);
 
+
+/**
+ * Enables a signing authority to authorize policies
+ * @param sapi_context
+ *   The system api context
+ * @param policy_session
+ *   The policy session that has the policy digest to be authorized
+ * @param policy_digest_path
+ *   The policy digest file that needs to be authorized by signing authority
+ * @param policy_qualifier_path
+ *   The policy qualifier data that concatenates with approved policies
+ * @param verifying_pubkey_name_path
+ *   The name of the public key that verifies the signature of the signer
+ * @param ticket_path
+ *   The verification ticket generated when TPM verifies the signature
+ * @return
+ *   true on success, false otherwise.
+ */
+bool tpm2_policy_build_policyauthorize(
+    TSS2_SYS_CONTEXT *sapi_context,
+    tpm2_session *policy_session,
+    const char *policy_digest_path,
+    const char *policy_qualifier_path,
+    const char *verifying_pubkey_name_path,
+    const char *ticket_path);
+
 /**
  * Retrieves the policy digest for a session via Tss2_Sys_PolicyGetDigest.
  * @param sapi_context
@@ -71,6 +97,6 @@ bool tpm2_policy_build_pcr(TSS2_SYS_CONTEXT *sapi_context,
  */
 bool tpm2_policy_get_digest(TSS2_SYS_CONTEXT *sapi_context,
         tpm2_session *session,
-        TPM2B_DIGEST *policy_digest);
+        TPM2B_DIGEST *policy_digest_path);
 
 #endif /* TPM2_POLICY_H_ */

--- a/man/tpm2_policyauthorize.1.md
+++ b/man/tpm2_policyauthorize.1.md
@@ -1,0 +1,104 @@
+% tpm2_policyauthorize(1) tpm2-tools | General Commands Manual
+%
+% AUGUST 2018
+
+# NAME
+
+**tpm2_policyauthorize**(1) - Generates/Creates a policy event that authorizes
+a policy digest from TPM policy events.
+
+# SYNOPSIS
+
+**tpm2_policyauthorize** [*OPTIONS*]
+
+# DESCRIPTION
+
+**tpm2_policyauthorize**(1) Generates a policy_authorize event with the TPM. It
+expects a session to be already established via **tpm2_startauthsession**(1). If
+the input session is a trial session this tool generates a policy digest that
+associates a signing authority's public key name with the policy being
+authorized. If the input session is real policy session **tpm2_policyauthorize**
+looks for a verification ticket from the TPM to attest that the TPM has verified
+the signature on the policy digest.
+
+# OPTIONS
+
+  * **-o**, **--policy-file**=_POLICY\_FILE_:
+
+    File to save the policy digest.
+
+  * **-S**, **--session**=_SESSION_FILE_:
+
+    The policy session file generated via the **-S** option to
+    **tpm2_startauthsession**(1).
+
+  * **-f**, **--input-policy-file**=_POLICY\_FILE_:
+
+    The policy digest that has to be authorized.
+
+  * **-q**, **--qualifier**=_DATA_FILE_:
+
+    The policy qualifier data signed in conjunction with the input policy digest.
+    This is a unique data that the signer can choose to include in the signature.
+
+  * **-n**, **--name**=_NAME\_DATA\_FILE_:
+
+    File containing the name of the verifying public key. This ties the final
+    policy digest with a signer. This can be retrieved with **tpm2_readpublic**
+
+  * **-t**, **--ticket**=_TICKET\_FILE_:
+
+    The ticket file to record the validation structure. This is generated with
+    **tpm2_verifysignature**.
+
+[common options](common/options.md)
+
+[common tcti options](common/tcti.md)
+
+[supported hash algorithms](common/hash.md)
+
+[algorithm specifiers](common/alg.md)
+
+# EXAMPLES
+
+Starts a *trial* session, builds a PCR policy. This pcr policy digest is then
+an input to the **tpm2_policyauthorize** along with policy qualifier data and a
+signer public. The resultant policy digest is then used in creation of objects.
+Subsequently when the PCR change and so does the pcr policy digest, the actual
+policy digest from the **tpm2_policyauthorize** used in creation of the object
+will not change. At runtime the new pcr policy needs to be satisfied along with
+verification of the signature on the pcr policy digest using **tpm2_policyauthorize**
+```
+(1) Create a policy to be authorized like pcr policy:
+tpm2_pcrlist  -L sha256:0 -o file_pcr_value
+tpm2_startauthsession  -S file_session_file
+tpm2_policypcr  -S file_session_file -L sha256:0 -F file_pcr_value -f pcr_policy
+tpm2_flushcontext -S file_session_file
+
+(2)Generate an authorized policy for the policy:
+tpm2_startauthsession  -S file_session_file
+tpm2_policyauthorize  -S file_session_file -o final_policy -f pcr_policy \
+  -q policy_qualifier -n verifying_public_key_name
+tpm2_flushcontext -S file_session_file
+
+(3)Create a sealing object with policyauthorize as the sealing auth policy:
+tpm2_createprimary -Q -a o -g sha256 -G rsa -o prim.ctx
+tpm2_create -Q -g sha256 -u sealing_key.pub -r sealing_key.pub -I- -C prim.ctx \
+  -L final_policy -A 'fixedtpm|fixedparent' <<< "secret to seal"
+
+(4)Satisfy policy and unseal secret data:
+tpm2_startauthsession -a -S real_policy_session_policyAuthorize
+tpm2_policypcr -Q -S real_policy_session_policyAuthorize -L sha256:0 \
+  -F file_pcr_value -f pcr_policy
+tpm2_policyauthorize  -S file_session_file -o final_policy -f pcr_policy \
+  -q policy_qualifier -n verifying_public_key_name -t verification_ticket
+unsealed=`tpm2_unseal -p"session:real_policy_session_policyAuthorize" \
+  -c sealing_key.ctx
+tpm2_flushcontext -S file_session_file
+```
+
+# RETURNS
+
+0 on success or 1 on failure.
+
+[footer](common/footer.md)

--- a/scripts/utils/analyze.py
+++ b/scripts/utils/analyze.py
@@ -134,10 +134,10 @@ class ToolConflictor(object):
             },
             {
                 "gname": "ea",
-                "tools-in-group": ["tpm2_policypcr", "tpm2_createpolicy"],
+                "tools-in-group": ["tpm2_policypcr", "tpm2_createpolicy", "tpm2_policyauthorize"],
                 "tools": [],
                 "conflict": None,
-                "ignore": set(['S', 'session'])
+                "ignore": set(['S', 'session', 'q', 'qualifier', 'n', 'name', 't', 'ticket'])
             },
             {
                 "gname": "hierarchy",

--- a/test/integration/tests/tcti/abrmd/policyauthorize.sh
+++ b/test/integration/tests/tcti/abrmd/policyauthorize.sh
@@ -1,0 +1,99 @@
+#!/bin/bash
+#;**********************************************************************;
+#
+# Copyright (c) 2018, Intel Corporation
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# 1. Redistributions of source code must retain the above copyright notice,
+# this list of conditions and the following disclaimer.
+#
+# 2. Redistributions in binary form must reproduce the above copyright notice,
+# this list of conditions and the following disclaimer in the documentation
+# and/or other materials provided with the distribution.
+#
+# 3. Neither the name of Intel Corporation nor the names of its contributors
+# may be used to endorse or promote products derived from this software without
+# specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+# THE POSSIBILITY OF SUCH DAMAGE.
+#;**********************************************************************;
+
+source helpers.sh
+
+pcr_ids="0"
+alg_pcr_policy=sha256
+file_pcr_value=pcr.bin
+file_policy=policy.data
+file_authorized_policy_1=auth_policy_1.data
+file_authorized_policy_2=auth_policy_2.data
+file_session_file="session.dat"
+file_private_key="private.pem"
+file_public_key="public.pem"
+file_verifying_key_public="verifying_key_public"
+file_verifying_key_name="verifying_key_name"
+file_verifying_key_ctx="verifying_key_ctx"
+file_policyref="policyref"
+
+cleanup() {
+  rm -f  $file_pcr_value $file_policy $file_session_file $file_private_key \
+    $file_public_key $file_verifying_key_public $file_verifying_key_name \
+    $file_verifying_key_ctx $file_policyref $file_authorized_policy_1 \
+    $file_authorized_policy_2
+
+  tpm2_flushcontext -S $file_session_file 2>/dev/null || true
+}
+trap cleanup EXIT
+
+start_up
+
+cleanup
+
+generate_policy_authorize () {
+
+  tpm2_startauthsession -Q -S $file_session_file
+  tpm2_policyauthorize -Q -S $file_session_file  -o $3 -f $1 -q $2 -n $4
+  tpm2_flushcontext -S $file_session_file
+}
+
+openssl genrsa -out $file_private_key 2048 2>/dev/null
+openssl rsa -in $file_private_key -out $file_public_key -pubout 2>/dev/null
+tpm2_loadexternal -G rsa -a n -u $file_public_key -o $file_verifying_key_ctx \
+  -n $file_verifying_key_name
+
+dd if=/dev/urandom of=$file_policyref bs=1 count=32 2>/dev/null
+
+tpm2_pcrlist -Q -L ${alg_pcr_policy}:${pcr_ids} -o $file_pcr_value
+tpm2_startauthsession -Q -S $file_session_file
+tpm2_policypcr -Q -S $file_session_file -L ${alg_pcr_policy}:${pcr_ids} -F $file_pcr_value -f $file_policy
+tpm2_flushcontext -S $file_session_file
+
+generate_policy_authorize $file_policy $file_policyref $file_authorized_policy_1 \
+  $file_verifying_key_name
+
+tpm2_pcrextend  \
+  0:sha256=e7011b851ee967e2d24e035ae41b0ada2decb182e4f7ad8411f2bf564c56fd6f
+
+tpm2_pcrlist -Q -L ${alg_pcr_policy}:${pcr_ids} -o $file_pcr_value
+tpm2_startauthsession -Q -S $file_session_file
+tpm2_policypcr -Q -S $file_session_file -L ${alg_pcr_policy}:${pcr_ids} -F $file_pcr_value -f $file_policy
+tpm2_flushcontext -S $file_session_file
+
+generate_policy_authorize $file_policy $file_policyref $file_authorized_policy_2 \
+  $file_verifying_key_name
+
+diff $file_authorized_policy_1 $file_authorized_policy_2
+
+exit 0

--- a/tools/tpm2_policyauthorize.c
+++ b/tools/tpm2_policyauthorize.c
@@ -1,0 +1,173 @@
+//**********************************************************************;
+// Copyright (c) 2018, Intel Corporation
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+// 1. Redistributions of source code must retain the above copyright notice,
+// this list of conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright notice,
+// this list of conditions and the following disclaimer in the documentation
+// and/or other materials provided with the distribution.
+//
+// 3. Neither the name of Intel Corporation nor the names of its contributors
+// may be used to endorse or promote products derived from this software without
+// specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+// THE POSSIBILITY OF SUCH DAMAGE.
+//**********************************************************************;
+
+#include <tss2/tss2_sys.h>
+
+#include "files.h"
+#include "log.h"
+#include "tpm2_options.h"
+#include "tpm2_policy.h"
+#include "tpm2_session.h"
+#include "tpm2_tool.h"
+#include "tpm2_util.h"
+
+typedef struct tpm2_startauthsession_ctx tpm2_startauthsession_ctx;
+struct tpm2_startauthsession_ctx {
+   //File path for the session context data
+   const char *session_path;
+   //File path for the policy digest that will be authorized
+   const char *policy_digest_path;
+   //File path for the policy qualifier data
+   const char *qualifier_data_path;
+   //File path for the verifying public key name
+   const char *verifying_pubkey_path;
+   //File path for the verification ticket
+   const char *ticket_path;
+   //File path for storing the policy digest output
+   const char *out_policy_dgst_path;
+};
+
+static tpm2_startauthsession_ctx ctx;
+
+static bool on_option(char key, char *value) {
+
+    switch (key) {
+    case 'o':
+        ctx.out_policy_dgst_path = value;
+        break;
+    case 'S':
+        ctx.session_path = value;
+        break;
+    case 'f':
+        ctx.policy_digest_path = value;
+        break;
+    case 'q':
+        ctx.qualifier_data_path = value;
+        break;
+    case 'n':
+        ctx.verifying_pubkey_path = value;
+        break;
+    case 't':
+        ctx.ticket_path = value;
+        break;
+    }
+    return true;
+}
+
+bool tpm2_tool_onstart(tpm2_options **opts) {
+
+    static struct option topts[] = {
+        { "policy-file",       required_argument, NULL, 'o' },
+        { "session",           required_argument, NULL, 'S' },
+        { "input-policy-file", required_argument, NULL, 'f' },
+        { "qualifier",         required_argument, NULL, 'q' },
+        { "name",              required_argument, NULL, 'n' },
+        { "ticket",            required_argument, NULL, 't' },
+    };
+
+    *opts = tpm2_options_new("o:S:f:q:n:t:", ARRAY_LEN(topts), topts, on_option,
+                             NULL, 0);
+
+    return *opts != NULL;
+}
+
+bool is_check_input_options_ok(void) {
+
+    if (!ctx.session_path) {
+        LOG_ERR("Must specify -S session file.");
+        return false;
+    }
+
+    if (!ctx.policy_digest_path) {
+        LOG_ERR("Must specify -a p name.");
+        return false;
+    }
+
+    if (!ctx.verifying_pubkey_path) {
+        LOG_ERR("Must specify -c u name.");
+        return false;
+    }
+
+    return true;
+}
+
+int tpm2_tool_onrun(TSS2_SYS_CONTEXT *sapi_context, tpm2_option_flags flags) {
+
+    UNUSED(flags);
+
+    if (!is_check_input_options_ok()) {
+        return -1;
+    }
+
+    int rc = 1;
+
+    tpm2_session *s = tpm2_session_restore(sapi_context, ctx.session_path);
+    if (!s) {
+        return rc;
+    }
+
+    bool result = tpm2_policy_build_policyauthorize(sapi_context, s, ctx.policy_digest_path,
+                        ctx.qualifier_data_path, ctx.verifying_pubkey_path, ctx.ticket_path);
+    if (!result) {
+        LOG_ERR("Could not build tpm authorized policy");
+        goto out;
+    }
+
+    TPM2B_DIGEST policy_digest = TPM2B_EMPTY_INIT;
+    result = tpm2_policy_get_digest(sapi_context, s, &policy_digest);
+    if (!result) {
+        LOG_ERR("Could not build tpm policy");
+        goto out;
+    }
+
+    tpm2_util_hexdump(policy_digest.buffer, policy_digest.size);
+
+    if (ctx.out_policy_dgst_path) {
+        result = files_save_bytes_to_file(ctx.out_policy_dgst_path, policy_digest.buffer,
+                    policy_digest.size);
+        if (!result) {
+            LOG_ERR("Failed to save policy digest into file \"%s\"",
+                    ctx.out_policy_dgst_path);
+            goto out;
+        }
+    }
+    result = tpm2_session_save(sapi_context, s, ctx.session_path);
+    if (!result) {
+        LOG_ERR("Failed to save policy to file \"%s\"", ctx.session_path);
+        goto out;
+    }
+
+    rc = 0;
+
+out:
+    tpm2_session_free(&s);
+    return rc;
+}


### PR DESCRIPTION
This tool enables creating policy that authorizes policy digests. 
Amongst other uses of this tool, This tool also helps address a very specific problem with sealing secrets to raw PCR values. Since the PCRs are reflective of a software (preboot) state, PCRs are susceptible to frequent changes as software is updated. This results in PCR-brittleness, in that, one loses the ability to unseal the secrets tied to a specific set of PCR with specific values. This tool can address this issue by generating a policy by authorizing the pcr policy digest.

PS: 
There is a need to augment the existing tpm2_loadexternal tool to directly load an external public key file in pem format. This is required when verifying the signatures created with the signing authority when using the this tpm2_policyauthorize tool.

Closes #854