### PR TITLE
man: remove mentioned but unused -S options

### DIFF
--- a/man/tpm2_create.1.md
+++ b/man/tpm2_create.1.md
@@ -72,11 +72,6 @@ These options for creating the tpm entity:
   * **-r**, **--privfile**=_OUTPUT\_PRIVATE\_FILE_:
     The output file which contains the sensitive portion of the object, optional.
 
-  * **-S**, **--session**=_SESSION\_FILE_:
-
-    Optional, A session file from **tpm2_startauthsession**(1)'s **-S** option. This session
-    is used in lieu of starting a session and using the PCR policy options.
-
 [common options](common/options.md)
 
 [common tcti options](common/tcti.md)

--- a/man/tpm2_createek.1.md
+++ b/man/tpm2_createek.1.md
@@ -56,10 +56,6 @@ Refer to:
     specification. Using the **--format** option allows one to change this
     behavior.
 
-  * **-S**, **--session**=_SESSION\_FILE_:
-
-    Optional, A session file from **tpm2_startauthsession**(1)'s **-S** option.
-
 [pubkey options](common/pubkey.md)
 
 [common options](common/options.md)

--- a/man/tpm2_createprimary.1.md
+++ b/man/tpm2_createprimary.1.md
@@ -66,10 +66,6 @@ will create and load a Primary Object. The sensitive area is not returned.
 
     `TPMA_OBJECT_RESTRICTED|TPMA_OBJECT_DECRYPT|TPMA_OBJECT_FIXEDTPM|TPMA_OBJECT_FIXEDPARENT|TPMA_OBJECT_SENSITIVEDATAORIGIN|TPMA_OBJECT_USERWITHAUTH`
 
-  * **-S**, **--session**=_SESSION\_FILE_:
-
-    Optional, A session file from **tpm2_startauthsession**(1)'s **-S** option.
-
 [common options](common/options.md)
 
 [common tcti options](common/tcti.md)

--- a/man/tpm2_encryptdecrypt.1.md
+++ b/man/tpm2_encryptdecrypt.1.md
@@ -37,11 +37,6 @@ specified symmetric key.
     Optional. Specifies the input file path for either the encrypted or decrypted
     data, depending on option **-D**. If not specified, defaults to **stdin**.
 
-  * **-S**, **--session**=_SESSION\_FILE_:
-
-    Optional, a session file from **tpm2_startauthsession**(1)'s **-S** option. This session
-    is used in lieu of starting a session and using the PCR policy options.
-
   * **-o**, **--out-file**=_OUT\_FILE_:
 
     Optional. Specifies the output file path for either the encrypted or decrypted

--- a/man/tpm2_evictcontrol.1.md
+++ b/man/tpm2_evictcontrol.1.md
@@ -46,10 +46,6 @@ be evicted.
     Optional authorization value. Authorization values should follow the
     "authorization formatting standards", see section "Authorization Formatting".
 
-  * **-S**, **--session**=_SESSION\_FILE_:
-
-    Optional, A session file from **tpm2_startauthsession**(1)'s **-S** option.
-
 [common options](common/options.md)
 
 [common tcti options](common/tcti.md)

--- a/man/tpm2_getmanufec.1.md
+++ b/man/tpm2_getmanufec.1.md
@@ -63,11 +63,6 @@ server.
     specifies to attempt connecting with the  TPM manufacturer provisioning server
     with SSL_NO_VERIFY option.
 
-  * **-S**, **--session**=_SESSION\_FILE_:
-
-    Optional, A session file from **tpm2_startauthsession**(1)'s **-S** option.
-
-
 [common options](common/options.md)
 
 [common tcti options](common/tcti.md)

--- a/man/tpm2_hmac.1.md
+++ b/man/tpm2_hmac.1.md
@@ -30,10 +30,6 @@ _FILE_ is not specified, then data is read from stdin.
   * **-o**, **--out-file**=_OUT\_FILE_
     Optional file record of the HMAC result. Defaults to stdout.
 
-  * **-S**, **--session**=_SESSION\_FILE_:
-
-    Optional, A session file from **tpm2_startauthsession**(1)'s **-S** option.
-
 [common options](common/options.md)
 
 [common tcti options](common/tcti.md)

--- a/man/tpm2_load.1.md
+++ b/man/tpm2_load.1.md
@@ -38,10 +38,6 @@ into the TPM.
   * **-o**, **--out-context**=_CONTEXT\_FILE_:
     An optional file to save the object context to.
 
-  * **-S**, **--session**=_SESSION\_FILE_:
-
-    Optional, A session file from **tpm2_startauthsession**(1)'s **-S** option.
-
 [common options](common/options.md)
 
 [common tcti options](common/tcti.md)

--- a/man/tpm2_nvrelease.1.md
+++ b/man/tpm2_nvrelease.1.md
@@ -35,10 +35,6 @@ defined with tpm2_nvdefine(1).
     should follow the "authorization formatting standards", see section
     "Authorization Formatting".
 
-  * **-S**, **--session**=_SESSION\_FILE_:
-
-    Optional, A session file from **tpm2_startauthsession**(1)'s **-S** option.
-
 [common options](common/options.md)
 
 [common tcti options](common/tcti.md)

--- a/man/tpm2_quote.1.md
+++ b/man/tpm2_quote.1.md
@@ -56,10 +56,6 @@
     Data given as a Hex string to qualify the  quote, optional. This is typically
     used to add a nonce against replay attacks.
 
-  * **-S**, **--session**=_SESSION\_FILE_:
-
-    Optional, A session file from **tpm2_startauthsession**(1)'s **-S** option.
-
   * **-G**, **--sig-hash-algorithm**:
 
     Hash algorithm for signature.

--- a/man/tpm2_rsadecrypt.1.md
+++ b/man/tpm2_rsadecrypt.1.md
@@ -42,10 +42,6 @@ The key referenced by key-context is **required** to be:
 
     Output file path, record the decrypted data.
 
-  * **-S**, **--session**=_SESSION\_FILE_:
-
-    Optional, A session file from **tpm2_startauthsession**(1)'s **-S** option.
-
 [common options](common/options.md)
 
 [common tcti options](common/tcti.md)


### PR DESCRIPTION
-S is no longer used in tools, it's supported as a password
option, thus remove the mentions from the manpage.

Signed-off-by: William Roberts <william.c.roberts@intel.com>