### PR TITLE
tpm2_rsadecrypt: fix -p option

### DIFF
--- a/test/integration/tests/rsadecrypt.sh
+++ b/test/integration/tests/rsadecrypt.sh
@@ -70,14 +70,14 @@ tpm2_clear
 
 tpm2_createprimary -Q -a e -g $alg_hash -G $alg_primary_key -o $file_primary_key_ctx
 
-tpm2_create -Q -g $alg_hash -G $alg_rsaencrypt_key -u $file_rsaencrypt_key_pub -r $file_rsaencrypt_key_priv  -C $file_primary_key_ctx
+tpm2_create -Q -g $alg_hash -p foo -G $alg_rsaencrypt_key -u $file_rsaencrypt_key_pub -r $file_rsaencrypt_key_priv  -C $file_primary_key_ctx
 
-tpm2_loadexternal -Q -a n   -u $file_rsaencrypt_key_pub  -o $file_rsaencrypt_key_ctx
+tpm2_loadexternal -Q -a n -u $file_rsaencrypt_key_pub -o $file_rsaencrypt_key_ctx
 
 tpm2_rsaencrypt -Q -c $file_rsaencrypt_key_ctx -o $file_rsa_en_output_data < $file_input_data
 
 tpm2_load -Q -C $file_primary_key_ctx -u $file_rsaencrypt_key_pub -r $file_rsaencrypt_key_priv  -n $file_rsaencrypt_key_name  -o $file_rsadecrypt_key_ctx
 
-tpm2_rsadecrypt -Q -c $file_rsadecrypt_key_ctx  -I  $file_rsa_en_output_data -o  $file_rsa_de_output_data
+tpm2_rsadecrypt -Q -c $file_rsadecrypt_key_ctx -p foo -I  $file_rsa_en_output_data -o  $file_rsa_de_output_data
 
 exit 0

--- a/tools/tpm2_rsadecrypt.c
+++ b/tools/tpm2_rsadecrypt.c
@@ -128,7 +128,7 @@ bool tpm2_tool_onstart(tpm2_options **opts) {
       { "key-context",  required_argument, NULL, 'c' },
     };
 
-    *opts = tpm2_options_new("P:I:o:c:", ARRAY_LEN(topts), topts,
+    *opts = tpm2_options_new("p:I:o:c:", ARRAY_LEN(topts), topts,
                              on_option, NULL, 0);
 
     return *opts != NULL;


### PR DESCRIPTION
In the getopt short option string, a capital P was in place
for lowercase p resulting in the password option not being
processed. Fix this and add passwords to the tests to prevent
regressions.

Signed-off-by: William Roberts <william.c.roberts@intel.com>