### PR TITLE
add more ECC support

### DIFF
--- a/lib/tpm2_alg_util.h
+++ b/lib/tpm2_alg_util.h
@@ -153,20 +153,6 @@ bool pcr_parse_digest_list(char **argv, int len,
 UINT16 tpm2_alg_util_get_hash_size(TPMI_ALG_HASH id);
 
 /**
- * Extracts the plain signature data without any headers
- *
- * Communicates errors via LOG_ERR.
- *
- * @param size
- *  Will receive the number of bytes stored in buffer.
- * @signature The actual signature struct to extract the plain signature from.
- * @return
- *  Returns a buffer filled with the extracted signature or NULL on error.
- *  Needs to be free()'d by the caller.
- */
-UINT8* tpm2_extract_plain_signature(UINT16 *size, TPMT_SIGNATURE *signature);
-
-/**
  * Retrieves an appropriate signature scheme (scheme) signable by
  * specified key (keyHandle) and hash algorithm (halg).
  * @param sapi_context

--- a/lib/tpm2_convert.h
+++ b/lib/tpm2_convert.h
@@ -84,8 +84,21 @@ tpm2_convert_sig_fmt tpm2_convert_sig_fmt_from_optarg(const char *label);
  *
  * LOG_ERR is used to communicate errors.
  */
-bool tpm2_convert_sig(TPMT_SIGNATURE *signature, tpm2_convert_sig_fmt format,
+bool tpm2_convert_sig_save(TPMT_SIGNATURE *signature, tpm2_convert_sig_fmt format,
         const char *path);
+
+/**
+ * Like tpm2_convert_save with the "plain" signature option.
+ *
+ * @param size
+ *  The size of the signature buffer.
+ * @param signature
+ *  The signature to convert.
+ * @return
+ *  NULL on error or a buffer of size bytes to be freed by the caller
+ *  via free(2).
+ */
+UINT8 *tpm2_convert_sig(UINT16 *size, TPMT_SIGNATURE *signature);
 
 /**
  * Load a signature from path and convert the format

--- a/lib/tpm2_openssl.c
+++ b/lib/tpm2_openssl.c
@@ -258,7 +258,7 @@ static bool load_public_RSA_from_pem(FILE *f, const char *path, TPM2B_PUBLIC *pu
     if (!k) {
         k = PEM_read_RSAPublicKey(f, NULL, NULL, NULL);
     }
-    fclose(f);
+
     if (!k) {
          ERR_print_errors_fp (stderr);
          LOG_ERR("Reading public PEM file \"%s\" failed", path);

--- a/man/tpm2_loadexternal.1.md
+++ b/man/tpm2_loadexternal.1.md
@@ -36,12 +36,15 @@ scalar.
     The algorithm used by the key to be imported. Supports:
     * aes - AES 128,192 or 256 key.
     * rsa - RSA 1024 or 2048 key.
+    * ecc - ECC NIST P192, P224, P256, P384 or P521 public and private key.
 
   * **-u**, **--pubfile**=_PUBLIC\_FILE_:
     The public portion of the object, this can be one of the following file formats:
       * TSS - The TSS/TPm format. For example from option `-u` of command `tpm2_create`.
       * RSA - OSSL PEM formats. For example `public.pem` from the command
         `openssl rsa -in private.pem -out public.pem -pubout`
+      * ECC - OSSL PEM formats. For example `public.pem` from the command
+        `openssl ec -in private.ecc.pem -out public.ecc.pem -pubout`
 
   * **-r**, **--privfile**=_PRIVATE\_FILE_:
     The sensitive portion of the object, optional. If one wishes to use the private portion

--- a/man/tpm2_sign.1.md
+++ b/man/tpm2_sign.1.md
@@ -57,7 +57,7 @@ data and validation shall indicate that hashed data did not start with
 
     The ticket file, containing the validation structure, optional.
 
-  * **-s**, **--sig**=_TICKET\_FILE_:
+  * **-s**, **--sig**=_SIGNATURE\_FILE_:
 
     The signature file, records the signature structure.
 
@@ -81,10 +81,32 @@ data and validation shall indicate that hashed data did not start with
 
 # EXAMPLES
 
-
+Sign and verify with the TPM using the *endorsement* hierarchy
 ```
-tpm2_sign -c 0x81010001 -p abc123 -g sha256 -m <filePath> -s <filePath> -t <filePath>
-tpm2_sign -c key.context -p abc123 -g sha256 -m <filePath> -s <filePath> -t <filePath>
+tpm2_createprimary -a e -o primary.ctx
+tpm2_create -G rsa -u rsa.pub -r rsa.priv -C primary.ctx
+tpm2_load -C primary.ctx -u rsa.pub -r rsa.priv -o rsa.ctx
+
+echo "my message > message.dat
+tpm2_sign -c rsa.ctx -G sha256 -m message.dat -s sig.rssa
+tpm2_verifysignature -c rsa.ctx -G sha256 -m message.dat -s sig.rssa
+```
+
+Sign with the TPM and verify with OSSL
+```
+openssl ecparam -name prime256v1 -genkey -noout -out private.ecc.pem
+openssl ec -in private.ecc.pem -out public.ecc.pem -pubout
+
+# Generate a hash to sign
+echo "data to sign" > data.in.raw
+sha256sum data.in.raw | awk '{ print "000000 " $1 }' | xxd -r -c 32 > data.in.digest
+
+# Load the private key for signing
+tpm2_loadexternal -Q -G ecc -r private.ecc.pem -o key.ctx
+
+# Sign in the TPM and verify with OSSL
+tpm2_sign -Q -c key.ctx -G sha256 -D data.in.digest -f plain -s data.out.signed
+openssl dgst -verify public.ecc.pem -keyform pem -sha256 -signature data.out.signed data.in.raw
 ```
 
 # RETURNS

--- a/man/tpm2_verifysignature.1.md
+++ b/man/tpm2_verifysignature.1.md
@@ -63,10 +63,6 @@ symmetric key, both the public and private portions need to be loaded.
 
     The ticket file to record the validation structure.
 
-  * **-S**, **--input-session-handle**=_SESSION\_HANDLE_:
-
-    Optional Input session handle from a policy session for authorization.
-
 [common options](common/options.md)
 
 [common tcti options](common/tcti.md)
@@ -83,10 +79,37 @@ symmetric key, both the public and private portions need to be loaded.
 
 # EXAMPLES
 
+Sign and verify with the TPM using the *endorsement* hierarchy
 ```
-tpm2_verifysignature -C 0x81010001 -g sha256 -m <filePath> -s <filePath> -t <filePath>
-tpm2_verifysignature -C 0x81010001 -D <filePath> -s <filePath> -t <filePath>
-tpm2_verifysignature -C key.context -g sha256 -m <filePath> -s <filePath> -t <filePath>
+tpm2_createprimary -a e -o primary.ctx
+tpm2_create -G rsa -u rsa.pub -r rsa.priv -C primary.ctx
+tpm2_load -C primary.ctx -u rsa.pub -r rsa.priv -o rsa.ctx
+
+echo "my message > message.dat
+tpm2_sign -c rsa.ctx -G sha256 -m message.dat -s sig.rssa
+tpm2_verifysignature -c rsa.ctx -G sha256 -m message.dat -s sig.rssa
+```
+
+Sign with openssl and verify with the TPM
+```
+# Generate an ECC key
+openssl ecparam -name prime256v1 -genkey -noout -out private.ecc.pem
+openssl ec -in private.ecc.pem -out public.ecc.pem -pubout
+
+# Generate a hash to sign (OSSL needs the hash of the message)
+echo "data to sign" > data.in.raw
+sha256sum data.in.raw | awk '{ print "000000 " $1 }' | xxd -r -c 32 > data.in.digest
+
+# Load the private key for signing
+tpm2_loadexternal -Q -G ecc -r private.ecc.pem -o key.ctx
+
+# Sign in the TPM and verify with OSSL
+tpm2_sign -Q -c key.ctx -G sha256 -D data.in.digest -f plain -s data.out.signed
+openssl dgst -verify public.ecc.pem -keyform pem -sha256 -signature data.out.signed data.in.raw
+
+# Sign with openssl and verify with TPM
+openssl dgst -sha256 -sign private.ecc.pem -out data.out.signed data.in.raw
+tpm2_verifysignature -Q -c key.ctx -G sha256 -m data.in.raw -f ecdsa -s data.out.signed
 ```
 
 # RETURNS

--- a/test/integration/tests/loadexternal.sh
+++ b/test/integration/tests/loadexternal.sh
@@ -161,7 +161,8 @@ run_ecc_test() {
 	tpm2_sign -Q -c key.ctx -G sha256 -D data.in.digest -f plain -s data.out.signed
 	openssl dgst -verify public.ecc.pem -keyform pem -sha256 -signature data.out.signed data.in.raw
 
-	# Sign with openssl and verify with TPM
+	# Sign with openssl and verify with TPM but only with the public portion of an object loaded
+	tpm2_loadexternal -Q -G ecc -u public.ecc.pem -o key.ctx
 	openssl dgst -sha256 -sign private.ecc.pem -out data.out.signed data.in.raw
 	tpm2_verifysignature -Q -c key.ctx -G sha256 -m data.in.raw -f ecdsa -s data.out.signed
 }

--- a/test/integration/tests/loadexternal.sh
+++ b/test/integration/tests/loadexternal.sh
@@ -149,14 +149,8 @@ run_ecc_test() {
     tpm2_loadexternal -Q -G ecc -r private.ecc.pem -o key.ctx
 
 	# Sign in the TPM and verify with OSSL
-	#
-	# XXX
-	# Verify fails..
-	# 139777493120664:error:0D0680A8:asn1 encoding routines:ASN1_CHECK_TLEN:wrong tag:tasn_dec.c:1217:
-    #139777493120664:error:0D07803A:asn1 encoding routines:ASN1_ITEM_EX_D2I:nested asn1 error:tasn_dec.c:386:Type=ECDSA_SIG
-    #
 	tpm2_sign -Q -c key.ctx -G sha256 -D data.in.digest -f plain -s data.out.signed
-	# openssl dgst -verify public.ecc.pem -keyform pem -sha256 -signature data.out.signed data.in.raw
+	openssl dgst -verify public.ecc.pem -keyform pem -sha256 -signature data.out.signed data.in.raw
 
 	# Sign with openssl and verify with TPM
 	openssl dgst -sha256 -sign private.ecc.pem -out data.out.signed data.in.raw

--- a/test/integration/tests/loadexternal.sh
+++ b/test/integration/tests/loadexternal.sh
@@ -111,6 +111,15 @@ run_rsa_test() {
     tpm2_rsadecrypt -c key.ctx -p foo -I plain.rsa.enc -o plain.rsa.dec
 
     diff plain.txt plain.rsa.dec
+
+    # try encrypting with the public key and decrypting with the private
+    tpm2_loadexternal -G rsa -a n -p foo -u public.pem -o key.ctx
+
+    tpm2_rsaencrypt -Tmssim -c key.ctx plain.txt -o plain.rsa.enc
+
+    openssl rsautl -decrypt -inkey private.pem -in plain.rsa.enc -out plain.rsa.dec
+
+    diff plain.txt plain.rsa.dec
 }
 
 run_aes_test() {

--- a/test/integration/tests/loadexternal.sh
+++ b/test/integration/tests/loadexternal.sh
@@ -159,13 +159,8 @@ run_ecc_test() {
 	# openssl dgst -verify public.ecc.pem -keyform pem -sha256 -signature data.out.signed data.in.raw
 
 	# Sign with openssl and verify with TPM
-	#
-	# Verify in the TPM fails:
-	# ERROR: Unsupported signature input format.
-    # ERROR: Tss2_Sys_VerifySignature(0x1D5) - tpm:parameter(1):structure is the wrong size
-    # ERROR: Verify signature failed!
 	openssl dgst -sha256 -sign private.ecc.pem -out data.out.signed data.in.raw
-	# tpm2_verifysignature -Q -c key.ctx -G sha256 -m data.in.raw -f plain -s data.out.signed -t ticket.out
+	tpm2_verifysignature -Q -c key.ctx -G sha256 -m data.in.raw -f ecdsa -s data.out.signed
 }
 
 run_tss_test

--- a/tools/tpm2_certify.c
+++ b/tools/tpm2_certify.c
@@ -177,7 +177,7 @@ static bool certify_and_save_data(TSS2_SYS_CONTEXT *sapi_context) {
         return false;
     }
 
-    return tpm2_convert_sig(&signature, ctx.sig_fmt, ctx.file_path.sig);
+    return tpm2_convert_sig_save(&signature, ctx.sig_fmt, ctx.file_path.sig);
 }
 
 static bool on_option(char key, char *value) {

--- a/tools/tpm2_quote.c
+++ b/tools/tpm2_quote.c
@@ -82,7 +82,7 @@ static bool write_output_files(TPM2B_ATTEST *quoted, TPMT_SIGNATURE *signature) 
 
     bool res = true;
     if (ctx.signature_path) {
-        res &= tpm2_convert_sig(signature, ctx.sig_format, ctx.signature_path);
+        res &= tpm2_convert_sig_save(signature, ctx.sig_format, ctx.signature_path);
     }
 
     if (ctx.message_path) {
@@ -126,7 +126,7 @@ static int quote(TSS2_SYS_CONTEXT *sapi_context, TPM2_HANDLE akHandle, TPML_PCR_
     tpm2_tool_output("  alg: %s\n", tpm2_alg_util_algtostr(signature.sigAlg, tpm2_alg_util_flags_sig));
 
     UINT16 size;
-    BYTE *sig = tpm2_extract_plain_signature(&size, &signature);
+    BYTE *sig = tpm2_convert_sig(&size, &signature);
     tpm2_tool_output("  sig: ");
     tpm2_util_hexdump(sig, size);
     tpm2_tool_output("\n");

--- a/tools/tpm2_sign.c
+++ b/tools/tpm2_sign.c
@@ -113,7 +113,7 @@ static bool sign_and_save(TSS2_SYS_CONTEXT *sapi_context) {
         return false;
     }
 
-    return tpm2_convert_sig(&signature, ctx.sig_format, ctx.outFilePath);
+    return tpm2_convert_sig_save(&signature, ctx.sig_format, ctx.outFilePath);
 }
 
 static bool init(TSS2_SYS_CONTEXT *sapi_context) {

--- a/tools/tpm2_verifysignature.c
+++ b/tools/tpm2_verifysignature.c
@@ -150,8 +150,8 @@ static bool init(TSS2_SYS_CONTEXT *sapi_context) {
     TPM2B *msg = NULL;
     bool return_value = false;
 
-    return_value = tpm2_util_object_load(sapi_context, ctx.context_arg, &ctx.key_context_object);
-    if (!return_value) {
+    bool tmp = tpm2_util_object_load(sapi_context, ctx.context_arg, &ctx.key_context_object);
+    if (!tmp) {
         return false;
     }
 


### PR DESCRIPTION
Add:
1. Support to loadexternal for ECC keys (which bled into verifying them)
2. Support for tpm2_verifysignature for loading OSSL produced signatures (ASN1 ECDSA sigs)
3. Support for tpm2_sign for outputting ASN1 ECDSA signatures for OSSL

Test that this all works, ie can load an external ECC key, sign and verify to/from OSSL and TPM.

Update man pages with better examples, fix some typos.