### PR TITLE
tpm2_import: fix private file option check

### DIFF
--- a/tools/tpm2_import.c
+++ b/tools/tpm2_import.c
@@ -823,7 +823,7 @@ static int check_options(void) {
         rc = -1;
     }
 
-    if (!ctx.import_key_public_file) {
+    if (!ctx.import_key_private_file) {
         LOG_ERR("Expected output private file missing, specify \"-r\","
                 " missing option.");
         rc = -1;


### PR DESCRIPTION
The code was checking if the public file was specified twice, when
it wanted ot verify public once and private once. Correct this.

Signed-off-by: William Roberts <william.c.roberts@intel.com>