### PR TITLE
default: dial back AES256 default to AES128

### DIFF
--- a/lib/tpm2_alg_util.c
+++ b/lib/tpm2_alg_util.c
@@ -329,7 +329,7 @@ static bool handle_asym_scheme_common(const char *ext, TPM2B_PUBLIC *public) {
         ext = scheme;
     } else {
         if (!next || *(next + 1) == '\0') {
-            next = is_restricted ? ":aes256cfb" : ":null";
+            next = is_restricted ? ":aes128cfb" : ":null";
         }
 
         // Go past next :
@@ -357,8 +357,8 @@ static bool handle_rsa(const char *ext, TPM2B_PUBLIC *public) {
     /*
      * Deal with normalizing the input strings.
      *
-     * "rsa --> maps to rsa2048:aes256cbc
-     * "rsa:aes --> maps to rsa2048:aes256cbc
+     * "rsa --> maps to rsa2048:aes128cbc
+     * "rsa:aes --> maps to rsa2048:aes128cbc
      * "rsa:null" -- maps to rsa2048:null
      *
      * This function is invoked with rsa removed.
@@ -386,7 +386,7 @@ static bool handle_rsa(const char *ext, TPM2B_PUBLIC *public) {
     ext += 4;
 
     if (*ext != ':' || *ext + 1 == '\0') {
-        ext = is_restricted ? ":null:aes256cfb" : ":null:null";
+        ext = is_restricted ? ":null:aes128cfb" : ":null:null";
     }
 
     // go past the colon separator
@@ -428,7 +428,7 @@ static bool handle_ecc(const char *ext, TPM2B_PUBLIC *public) {
     ext += 3;
 
     if (*ext != ':' || *ext + 1 == '\0') {
-        ext = is_restricted ? ":null:aes256cfb" : ":null:null";
+        ext = is_restricted ? ":null:aes128cfb" : ":null:null";
     }
 
     // go past the colon separator

--- a/man/common/alg.md
+++ b/man/common/alg.md
@@ -90,6 +90,7 @@ arguments.
 
 #### Hash Optional Scheme Specifiers
 These scheme specifiers are followed immediately by a valid hash algorithm, For example: `oaepsha256`.
+
   * oaep
   * ecdh
   * rsassa
@@ -107,11 +108,12 @@ This scheme specifier takes NO arguments.
 
 ### Symmetric Details Specifiers
 This field is optional, and defaults based on the *type* of object being created and it's attributes.
-Generally, any valid **Symmetric** specifier from the **Type Scpefiers** list should work.
+Generally, any valid **Symmetric** specifier from the **Type Specifiers** list should work. If not
+specified, an asymmetric objects symmetric details defaults to *aes128cfb*.
 
 ## Examples:
 
-Create an rsa2048 key with an rsaes assymmetric encryption scheme:
+Create an rsa2048 key with an rsaes asymmetric encryption scheme:
 `tpm2_create -C parent.ctx -G rsa2048:rsaes -u key.pub -r key.priv`
 
 Create an ecc256 key with an ecdaa signing scheme with a count of 4 and sha384 hash:


### PR DESCRIPTION
All TPMs support AES128CFB, but not many seem to support
AES128. Numerous bug reports have surfaced on switching
the default to AES256, dial it back so it just works.

Fixes: #1166 
References initial bug: #1142

Signed-off-by: William Roberts <william.c.roberts@intel.com>