### PR TITLE
tpm2_createek: don't segfault if -c isn't passed

### DIFF
--- a/test/integration/tests/createek.sh
+++ b/test/integration/tests/createek.sh
@@ -58,4 +58,6 @@ tpm2_createek -c - -G rsa -p ek.pub > ek.log
 phandle=`yaml_get_kv ek.log \"persistent\-handle\"`
 tpm2_evictcontrol -Q -a o -c $phandle
 
+tpm2_createek -G rsa -p ek.pub
+
 exit 0

--- a/tools/tpm2_createek.c
+++ b/tools/tpm2_createek.c
@@ -304,7 +304,7 @@ int tpm2_tool_onrun(TSS2_SYS_CONTEXT *sapi_context, tpm2_option_flags flags) {
     }
 
     bool ret;
-    if (!strcmp(ctx.context_arg, "-")) {
+    if (ctx.context_arg && !strcmp(ctx.context_arg, "-")) {
         /* If user passes a handle of '-' we try and find a vacant slot for
          * to use and tell them what it is.
          */
@@ -316,7 +316,7 @@ int tpm2_tool_onrun(TSS2_SYS_CONTEXT *sapi_context, tpm2_option_flags flags) {
             goto out;
         }
         tpm2_tool_output("persistent-handle: 0x%x\n", ctx.ctx_obj.handle);
-    } else {
+    } else if (ctx.context_arg) {
         ret = tpm2_util_object_load(sapi_context, ctx.context_arg, &ctx.ctx_obj);
         if (!ret) {
             goto out;


### PR DESCRIPTION
-c/--context is optional, therefore don't assume the argument is passed
(and segfault trying to access an unallocated variable).

Fixes #1169

Signed-off-by: Joshua Lock <joshua.g.lock@intel.com>