### PR TITLE
test: make test_tpm2_activecredential python3 compatible

### DIFF
--- a/test/system/test_tpm2_activecredential.sh
+++ b/test/system/test_tpm2_activecredential.sh
@@ -57,10 +57,12 @@ tpm2_getpubak -E 0x81010009 -k 0x8101000a -g rsa -D sha256 -s rsassa -f ak.pub -
 
 # Capture the yaml output and verify that its the same as the name output
 loaded_key_name_yaml=`python << pyscript
+from __future__ import print_function
 import yaml
+
 with open('ak.out', 'r') as f:
     doc = yaml.load(f)
-    print doc['loaded-key']['name']
+    print(doc['loaded-key']['name'])
 pyscript`
 
 # Use -c in xxd so there is no line wrapping


### PR DESCRIPTION
Use the print function, not the print keyword, so that the code is
compatible with python3.

Fixes #1178

Signed-off-by: Joshua Lock <joshua.g.lock@intel.com>