### PR TITLE
[for master] tpm2_create: Use better object attributes defaults for authentication

### DIFF
--- a/tools/tpm2_create.c
+++ b/tools/tpm2_create.c
@@ -261,6 +261,10 @@ int tpm2_tool_onrun(TSS2_SYS_CONTEXT *sapi_context, tpm2_option_flags flags) {
         goto out;
     }
 
+    if (ctx.flags.L && !ctx.flags.p) {
+        ctx.in_public.publicArea.objectAttributes &= ~TPMA_OBJECT_USERWITHAUTH;
+    }
+
     if (ctx.flags.I && ctx.in_public.publicArea.type != TPM2_ALG_KEYEDHASH) {
         LOG_ERR("Only TPM2_ALG_KEYEDHASH algorithm is allowed when sealing data");
         goto out;


### PR DESCRIPTION
As explained in https://github.com/tpm2-software/tpm2-tools/pull/1127#issuecomment-418175796, the handling of the `userwithauth` object attribute has been improved on the 3.X branch in https://github.com/tpm2-software/tpm2-tools/pull/1126, but these changes have not been merged to master yet. There was a pull request for that (https://github.com/tpm2-software/tpm2-tools/pull/1127), but it has been overwritten by other changes, so I reconstructed the original state of that pull request from https://github.com/tpm2-software/tpm2-tools/pull/1126 and the still available diffs in https://github.com/tpm2-software/tpm2-tools/pull/1127. The resulting code matches the behaviour of `tpm2_create` on the 3.X branch, as described in https://github.com/tpm2-software/tpm2-tools/pull/1126#issuecomment-408918917.

As this is not really my own work, but a reproduction of @martinezjavier's code, feel free to change the author of this commit or to reopen https://github.com/tpm2-software/tpm2-tools/pull/1127 instead of this PR.