### PR TITLE
tpm2_changeauth: only change hierachy specified

### DIFF
--- a/.ci/docker.run
+++ b/.ci/docker.run
@@ -39,6 +39,10 @@ if [ -e /var/run/dbus/pid ]; then
   rm /var/run/dbus/pid
 fi
 
+if [ -e /var/run/dbus/system_bus_socket ]; then
+  rm /var/run/dbus/system_bus_socket
+fi
+
 # start dbus
 dbus-daemon --fork --system
 echo "dbus started"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
   addition to supporting the new unified TPM2TOOLS_ENV_TCTI
   * Fix tpm2_getcap to print properties with the TPM_PT prefix, rather than
   TPM2_PT
+  * Fix tpm2_takeownership to only attempt to change the specified hierarchies
 
 ### 3.1.2 - 2018-08-14
   * Revert the change to use user supplied object attributes exclusively. This is an inappropriate behavioural change for a MINOR version number increment.


### PR DESCRIPTION
Backport of the change in 7ace0ea to the 3.X branch.

Only send a changeauth command if the hiearchy is specified.
This corrects behavior of attempting to change a non-specified hierarchy.

Fixes #1183

Signed-off-by: Joshua Lock <joshua.g.lock@intel.com>