### PR TITLE
tpm2_rsaencrypt: fix example in man page

### DIFF
--- a/man/tpm2_rsaencrypt.1.md
+++ b/man/tpm2_rsaencrypt.1.md
@@ -55,7 +55,7 @@ The key referenced by keyHandle is **required** to be:
 # EXAMPLES
 
 ```
-tpm2_rsaencrypt -k 0x81010001 -I plain.in -o encrypted.out
+tpm2_rsaencrypt -k 0x81010001 -o encrypted.out plain.in
 ```
 
 # RETURNS


### PR DESCRIPTION
The -I option was removed and became an argument

Signed-off-by: Joshua Lock <joshua.g.lock@intel.com>