### PR TITLE
tpm2_rsaencrypt: fix example in man page

### DIFF
--- a/.ci/docker.run
+++ b/.ci/docker.run
@@ -55,6 +55,10 @@ if [ -e /var/run/dbus/pid ]; then
   rm /var/run/dbus/pid
 fi
 
+if [ -e /var/run/dbus/system_bus_socket ]; then
+  rm /var/run/dbus/system_bus_socket
+fi
+
 # start dbus
 dbus-daemon --fork --system
 echo "dbus started"


### PR DESCRIPTION
The -I option was removed and became an argument

Signed-off-by: Joshua Lock <joshua.g.lock@intel.com>