### PR TITLE
Issue 1217 passin ossl

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Changelog
 ### next
+  * tpm2_loadexternal: support OSSL style -passin argument as --passin for PEM file passwords.
+  * tpm2_import: support OSSL style -passin argument as --passin for PEM file passwords.
   * tpm2_readpublic: supports ECC pem and der file generation.
   * tpm2_activatecredential: Option `--endorse-passwd` changes to `--auth-endorse`.
   * tpm2_loadexternal: name output to file and stdout. Changes YAML stdout output.

--- a/lib/files.c
+++ b/lib/files.c
@@ -562,12 +562,12 @@ bool files_load_bytes_from_file_or_stdin(const char *path, UINT16 *size, BYTE *b
         *size = fread(buf, 1,
                 *size, file);
         if (!feof(file)) {
-            LOG_ERR("Data to be sealed larger than expected. Got %u expected %u",
+            LOG_ERR("Data larger than expected. Got %u expected %u",
                     original_size, res);
             res = false;
         }
         else if (ferror(file)) {
-            LOG_ERR("Error reading sealed data from \"<stdin>\"");
+            LOG_ERR("Error reading data from \"<stdin>\"");
             res = false;
         }
     }

--- a/lib/tpm2_convert.c
+++ b/lib/tpm2_convert.c
@@ -283,8 +283,6 @@ static bool tpm2_convert_pubkey_ssl(TPMT_PUBLIC *public, tpm2_convert_pubkey_fmt
 
     bool result = false;
 
-    ERR_load_crypto_strings();
-
     FILE *fp = fopen(path, "wb");
     if (!fp) {
         LOG_ERR("Failed to open public key output file '%s': %s",

--- a/lib/tpm2_openssl.c
+++ b/lib/tpm2_openssl.c
@@ -643,11 +643,12 @@ static tpm2_openssl_load_rc load_private_RSA_from_pem(FILE *f, const char *path,
 
     bool loaded_pub = load_public_RSA_from_key(k, pub);
     if (!loaded_pub) {
-        return lprc_error;
+        goto out;
     } else {
         rc |= lprc_public;
     }
-
+out:
+    RSA_free(k);
     return rc;
 }
 

--- a/lib/tpm2_openssl.h
+++ b/lib/tpm2_openssl.h
@@ -141,12 +141,14 @@ static inline bool tpm2_openssl_did_load_public(tpm2_openssl_load_rc load_status
  * For symmetric keys, the file type is raw. For asymmetric keys, the
  * file type is a PEM file.
  *
- * This ONLY supports AES and RSA.
+ * This ONLY supports AES, ECC and RSA.
  *
  * It populates the sensitive seed with a random value for symmetric keys.
  *
  * @param path
  *  The path to load from.
+ * @param path
+ *  The passphrase for the input file.
  * @param alg
  *  algorithm type to import.
  * @param pub
@@ -157,8 +159,8 @@ static inline bool tpm2_openssl_did_load_public(tpm2_openssl_load_rc load_status
  * @returns
  *  A private object loading status
  */
-tpm2_openssl_load_rc tpm2_openssl_load_private(const char *path, TPMI_ALG_PUBLIC alg,
-        TPM2B_PUBLIC *pub, TPM2B_SENSITIVE *priv);
+tpm2_openssl_load_rc tpm2_openssl_load_private(const char *path, const char *pass,
+        TPMI_ALG_PUBLIC alg, TPM2B_PUBLIC *pub, TPM2B_SENSITIVE *priv);
 
 /**
  * Loads a public portion of a key from a file. Files can be the raw key, in the case

--- a/man/tpm2_import.1.md
+++ b/man/tpm2_import.1.md
@@ -56,6 +56,11 @@ These options control the key importation process:
   * **-A**, **--object-attributes**=_ATTRIBUTES_:
     The object attributes, optional.
 
+  * **--passin**=_OSSL\_PEM\_FILE\_PASSWORD_
+    An optional password for an Open SSL (OSSL) provided input file. It mirrors the -passin option of
+    OSSL and is known to support the pass, file, env, fd and plain password formats of openssl.
+    (see *man(1) openssl*) for more.
+
 [common options](common/options.md)
 
 [common tcti options](common/tcti.md)

--- a/man/tpm2_loadexternal.1.md
+++ b/man/tpm2_loadexternal.1.md
@@ -99,6 +99,11 @@ name: 0x000b44e59fa5658ab443834a069a488ecc1f6d7deb47c40c6ec49871ef57d7036b43
     An optional file to save the object name, which is in a binary hash format. The size of the hash is
     based on name algorithm or the **-g** option.
 
+  * **--passin**=_OSSL\_PEM\_FILE\_PASSWORD_
+    An optional password for an Open SSL (OSSL) provided input file. It mirrors the -passin option of
+    OSSL and is known to support the pass, file, env, fd and plain password formats of openssl.
+    (see *man(1) openssl*) for more.
+
 # Notes
 
 * If the hierarchy is *null* or the name hashing algorithm is *null*, tickets produced using the object

--- a/test/integration/tests/loadexternal.sh
+++ b/test/integration/tests/loadexternal.sh
@@ -115,7 +115,7 @@ run_rsa_test() {
     # try encrypting with the public key and decrypting with the private
     tpm2_loadexternal -G rsa -a n -p foo -u public.pem -o key.ctx
 
-    tpm2_rsaencrypt -Tmssim -c key.ctx plain.txt -o plain.rsa.enc
+    tpm2_rsaencrypt -c key.ctx plain.txt -o plain.rsa.enc
 
     openssl rsautl -decrypt -inkey private.pem -in plain.rsa.enc -out plain.rsa.dec
 

--- a/test/integration/tests/loadexternal.sh
+++ b/test/integration/tests/loadexternal.sh
@@ -52,7 +52,8 @@ cleanup() {
          $file_loadexternal_key_name $file_loadexternal_key_ctx \
          $file_loadexternal_output private.pem public.pem plain.txt \
          plain.rsa.dec key.ctx public.ecc.pem private.ecc.pem \
-         data.in.digest data.out.signed ticket.out name.bin stdout.yaml
+         data.in.digest data.out.signed ticket.out name.bin stdout.yaml \
+         passfile private.pem
 
   ina "$@" "keep_handle"
   if [ $? -ne 0 ]; then
@@ -179,6 +180,17 @@ run_ecc_test() {
 	tpm2_verifysignature -Q -c key.ctx -G sha256 -m data.in.raw -f ecdsa -s data.out.signed
 }
 
+run_rsa_passin_test() {
+
+    if [ "$2" != "stdin" ]; then
+        cmd="tpm2_loadexternal -Q -G rsa -r $1 -o key.ctx --passin $2"
+    else
+        cmd="tpm2_loadexternal -Q -G rsa -r $1 -o key.ctx --passin $2 < $3"
+    fi;
+
+    eval $cmd
+}
+
 run_tss_test
 
 run_rsa_test 1024
@@ -188,5 +200,24 @@ run_aes_test 128
 run_aes_test 256
 
 run_ecc_test prime256v1
+
+#
+# Test loadexternal passin option
+#
+openssl genrsa -aes128 -passout "pass:mypassword" -out "private.pem" 1024
+
+run_rsa_passin_test "private.pem" "pass:mypassword"
+
+export envvar="mypassword"
+run_rsa_passin_test "private.pem" "env:envvar"
+
+echo -n "mypassword" > "passfile"
+run_rsa_passin_test "private.pem" "file:passfile"
+
+exec 42<> passfile
+run_rsa_passin_test "private.pem" "fd:42"
+
+run_rsa_passin_test "private.pem" "stdin" "passfile"
+
 
 exit 0

--- a/tools/tpm2_import.c
+++ b/tools/tpm2_import.c
@@ -725,10 +725,6 @@ int tpm2_tool_onrun(TSS2_SYS_CONTEXT *sapi_context, tpm2_option_flags flags) {
     int rc = 1;
     bool result;
 
-    OpenSSL_add_all_algorithms();
-    OpenSSL_add_all_ciphers();
-    ERR_load_crypto_strings();
-
     tpm2_loaded_object parent_ctx;
 
     rc = check_options();

--- a/tools/tpm2_import.c
+++ b/tools/tpm2_import.c
@@ -709,6 +709,12 @@ static int check_options(void) {
         rc = -1;
     }
 
+    if (!ctx.parent_ctx_arg) {
+        LOG_ERR("Expected parent key to be specified via \"-C\","
+                " missing option.");
+        rc = -1;
+    }
+
     return rc;
 }
 

--- a/tools/tpm2_tool.c
+++ b/tools/tpm2_tool.c
@@ -33,6 +33,9 @@
 
 #include <unistd.h>
 
+#include <openssl/evp.h>
+#include <openssl/err.h>
+
 #include "log.h"
 #include "tpm2_tcti_ldr.h"
 #include "tpm2_options.h"
@@ -153,6 +156,14 @@ int main(int argc, char *argv[]) {
     if (flags.enable_errata) {
         tpm2_errata_init(sapi_context);
     }
+
+    /*
+     * Load the openssl error strings and algorithms
+     * so library routines work as expected.
+     */
+    OpenSSL_add_all_algorithms();
+    OpenSSL_add_all_ciphers();
+    ERR_load_crypto_strings();
 
     /*
      * Call the specific tool, all tools implement this function instead of


### PR DESCRIPTION
* cleanups and fixes
* Allow encrypted PEM passwords via --passin similair to OSSLs -passin option.

Fixes: #1217