### PR TITLE
lib/files: rm extra fopen() in library path

### DIFF
--- a/lib/files.c
+++ b/lib/files.c
@@ -555,8 +555,8 @@ bool files_load_bytes_from_file_or_stdin(const char *path, UINT16 *size, BYTE *b
     }
 
     UINT16 original_size = *size;
-    bool res = files_load_bytes_from_path(path, buf,
-            size);
+    bool res = read_bytes_from_file(file, buf,
+            size, path);
     if (!res) {
         res = true;
         *size = fread(buf, 1,


### PR DESCRIPTION
Routine files_load_bytes_from_file_or_stdin() calls
files_load_bytes_from_path() when it already has an open FILE pointer, just
re-use that FILE * rather than invoking another fopen() call via
read_bytes_from_file().

Signed-off-by: William Roberts <william.c.roberts@intel.com>