### PR TITLE
options: fix broken -T option

### DIFF
--- a/lib/tpm2_options.c
+++ b/lib/tpm2_options.c
@@ -290,6 +290,8 @@ static tcti_conf tcti_get_config(const char *optstr) {
                 parse_env_tcti(optstr, &conf);
             }
         }
+    } else {
+        conf.name = strdup(optstr);
     }
 
     if (!conf.name) {


### PR DESCRIPTION
commit:
  - 175e47711c72 lib/tpm2_options: restore TCTI configuration environment variables

Broke the option handling, effectively ignoring the -T/--tcti input. Honor that input
if specified and don't just run the default TCTI search unless it's not specified.

Signed-off-by: William Roberts <william.c.roberts@intel.com>