### PR TITLE
tpm2_alg_util: remove scheme check

### DIFF
--- a/lib/tpm2_alg_util.c
+++ b/lib/tpm2_alg_util.c
@@ -302,12 +302,6 @@ static bool handle_asym_scheme_common(const char *ext, TPM2B_PUBLIC *public) {
         }
     }
 
-    if (is_restricted && s->scheme.scheme != TPM2_ALG_NULL) {
-        LOG_ERR("Restricted objects require a NULL scheme");
-        /* don't print another error message */
-        return false;
-    }
-
     /*
      * If the scheme is set, both the encrypt and decrypt attributes cannot be set,
      * check to see if this is the case, and turn down:


### PR DESCRIPTION
    tpm2_alg_util: remove scheme check
    
    Remove an incorrect scheme check and allow NULL schemes
    on restricted objects.
    
    These checks are better enforced by the TPM, as the algorithm, scheme, object
    attributes and symmetric details behave in a complex fashion. Also, revisions
    of TPM software change how this matrix behaves, like revision 101 of:
      - https://trustedcomputinggroup.org/wp-content/uploads/TPM-Rev-2.0-Part-1-Architecture-01.38.pdf
    
    This allows for:
    tpm2_createprimary -o primary.ctx
    tpm2_create -C primary.ctx -g sha256 -G ecc256:ecdsa:null -u child.pub -r child.priv \
      -A "fixedtpm|fixedparent|sensitivedataorigin|userwithauth|restricted|sign"
    
    Signed-off-by: William Roberts <william.c.roberts@intel.com>
