### PR TITLE
Added support for QNX build

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -45,7 +45,7 @@ AM_CFLAGS := \
 AM_LDFLAGS   := $(EXTRA_LDFLAGS) $(CODE_COVERAGE_LIBS)
 
 LDADD = \
-    $(LIB_COMMON) $(TSS2_SYS_LIBS) $(CRYPTO_LIBS) -ldl
+    $(LIB_COMMON) $(TSS2_SYS_LIBS) $(CRYPTO_LIBS) $(LIBDL_LDFLAGS)
 
 # keep me sorted
 bin_PROGRAMS = \
@@ -99,6 +99,7 @@ bin_PROGRAMS = \
     tools/tpm2_startup \
     tools/tpm2_unseal \
     tools/tpm2_verifysignature
+
 
 noinst_LIBRARIES = $(LIB_COMMON)
 lib_libcommon_a_SOURCES = $(LIB_SRC)

--- a/configure.ac
+++ b/configure.ac
@@ -43,6 +43,20 @@ PKG_CHECK_VAR(bashcompdir, [bash-completion], [compatdir], ,
   bashcompdir="${sysconfdir}/bash_completion.d")
 AC_SUBST(bashcompdir)
 
+AC_CANONICAL_HOST
+
+# Check OS and set library and compile flags accordingly
+case "${host_os}" in
+    *nto-qnx*)
+        EXTRA_CFLAGS="$EXTRA_CFLAGS -D_QNX_SOURCE"
+        LIBDL_LDFLAGS=""
+        ;;
+    *)
+        LIBDL_LDFLAGS="-ldl"
+        ;;
+esac
+AC_SUBST([LIBDL_LDFLAGS])
+
 AC_ARG_ENABLE([unit],
             [AS_HELP_STRING([--enable-unit],
                             [build cmocka unit tests (default is no)])],

--- a/lib/tpm2_hash.c
+++ b/lib/tpm2_hash.c
@@ -206,14 +206,14 @@ bool tpm2_hash_compute_data(TSS2_SYS_CONTEXT    *sapi_context,
                             TPM2B_DIGEST        *result,
                             TPMT_TK_HASHCHECK   *validation)
 {
-    return tpm2_hash_common(    sapi_context,
-                                halg,
-                                hierarchy,
-                                NULL,
-                                buffer,
-                                length,
-                                result,
-                                validation);
+    return (!!buffer) && tpm2_hash_common( sapi_context,
+                                            halg,
+                                            hierarchy,
+                                            NULL,
+                                            buffer,
+                                            length,
+                                            result,
+                                            validation);
 }
 
 bool tpm2_hash_file(TSS2_SYS_CONTEXT    *sapi_context,
@@ -223,12 +223,12 @@ bool tpm2_hash_file(TSS2_SYS_CONTEXT    *sapi_context,
                     TPM2B_DIGEST        *result,
                     TPMT_TK_HASHCHECK   *validation)
 {
-    return tpm2_hash_common(    sapi_context,
-                                halg,
-                                hierarchy,
-                                input,
-                                NULL,
-                                0,
-                                result,
-                                validation);
+    return (!!input) && tpm2_hash_common( sapi_context,
+                                            halg,
+                                            hierarchy,
+                                            input,
+                                            NULL,
+                                            0,
+                                            result,
+                                            validation);
 }

--- a/lib/tpm2_hash.c
+++ b/lib/tpm2_hash.c
@@ -38,125 +38,197 @@
 #include "tpm2_hash.h"
 #include "tpm2_util.h"
 
-bool tpm2_hash_compute_data(TSS2_SYS_CONTEXT *sapi_context, TPMI_ALG_HASH halg,
-        TPMI_RH_HIERARCHY hierarchy, BYTE *buffer, UINT16 length,
-        TPM2B_DIGEST *result, TPMT_TK_HASHCHECK *validation) {
-
-    FILE *mem = fmemopen(buffer, length, "rb");
-    if (!mem) {
-        LOG_ERR("Error converting buffer to memory stream: %s",
-                strerror(errno));
-        return false;
-    }
-
-    return tpm2_hash_file(sapi_context, halg, hierarchy, mem, result, validation);
-}
-
-bool tpm2_hash_file(TSS2_SYS_CONTEXT *sapi_context, TPMI_ALG_HASH halg,
-        TPMI_RH_HIERARCHY hierarchy, FILE *input, TPM2B_DIGEST *result,
-        TPMT_TK_HASHCHECK *validation) {
-
+static bool tpm2_hash_common(   TSS2_SYS_CONTEXT    *sapi_context,
+                                TPMI_ALG_HASH       halg,
+                                TPMI_RH_HIERARCHY   hierarchy,
+                                FILE                *infilep,
+                                BYTE                *inbuffer,
+                                UINT16              inbuffer_len,
+                                TPM2B_DIGEST        *result,
+                                TPMT_TK_HASHCHECK   *validation)
+{
+    bool res, use_left, done;
+    size_t left, bytes_read;
+    TSS2_RC rval;
     TPM2B_AUTH nullAuth = TPM2B_EMPTY_INIT;
     TPMI_DH_OBJECT sequenceHandle;
+    TSS2L_SYS_AUTH_COMMAND cmdAuthArray = { 1, { {  .sessionHandle = TPM2_RS_PW,
+                                                    .nonce = TPM2B_EMPTY_INIT,
+                                                    .hmac = TPM2B_EMPTY_INIT,
+                                                    .sessionAttributes = 0, }}};
+    TPM2B_MAX_BUFFER buffer;
 
-    TSS2L_SYS_AUTH_COMMAND cmdAuthArray = { 1, {{.sessionHandle = TPM2_RS_PW, 
-            .nonce = TPM2B_EMPTY_INIT, .hmac = TPM2B_EMPTY_INIT,
-            .sessionAttributes = 0, }}};
-    unsigned long file_size = 0;
-
-    /* Suppress error reporting with NULL path */
-    bool res = files_get_file_size(input, &file_size, NULL);
-
-    /* If we can get the file size and its less than 1024, just do it in one hash invocation */
-    if (res && file_size <= TPM2_MAX_DIGEST_BUFFER) {
-
-        TPM2B_MAX_BUFFER buffer = { .size = file_size };
-
-        res = files_read_bytes(input, buffer.buffer, buffer.size);
-        if (!res) {
-            LOG_ERR("Error reading input file!");
-            return false;
-        }
-
-        TSS2_RC rval = TSS2_RETRY_EXP(Tss2_Sys_Hash(sapi_context, NULL, &buffer, halg,
-            hierarchy, result, validation, NULL));
-        if (rval != TSS2_RC_SUCCESS) {
-            LOG_PERR(Tss2_Sys_Hash, rval);
-            return false;
-        }
-
-        return true;
+    /*  if we're using infilep, get file size */
+    if (!!infilep) {
+        /* Suppress error reporting with NULL path */
+        use_left = files_get_file_size(infilep, &left, NULL);
+    } else {
+        /*  if we're using inbuffer, inbuffer_len is valid*/
+        left = inbuffer_len;
+        use_left = true;
     }
 
-    /*
-     * Size is either unknown because the FILE * is a fifo, or it's too big
-     * to do in a single hash call. Based on the size figure out the chunks
-     * to loop over, if possible. This way we can call Complete with data.
-     */
-    TSS2_RC rval = TSS2_RETRY_EXP(Tss2_Sys_HashSequenceStart(sapi_context, NULL, &nullAuth,
-            halg, &sequenceHandle, NULL));
-    if (rval != TPM2_RC_SUCCESS) {
-        LOG_PERR(Tss2_Sys_HashSequenceStart, rval);
-        return rval;
-    }
-
-    /* If we know the file size, we decrement the amount read and terminate the loop
-     * when 1 block is left, else we go till feof.
-     */
-    size_t left = file_size;
-    bool use_left = !!res;
-
-    TPM2B_MAX_BUFFER data;
-
-    bool done = false;
-    while (!done) {
-
-        size_t bytes_read = fread(data.buffer, 1,
-                BUFFER_SIZE(typeof(data), buffer), input);
-        if (ferror(input)) {
-            LOG_ERR("Error reading from input file");
-            return false;
-        }
-
-        data.size = bytes_read;
-
-        /* if data was read, update the sequence */
-        rval = TSS2_RETRY_EXP(Tss2_Sys_SequenceUpdate(sapi_context, sequenceHandle,
-                &cmdAuthArray, &data, NULL));
-        if (rval != TPM2_RC_SUCCESS) {
-            LOG_PERR(Tss2_Sys_SequenceUpdate, rval);
-            return false;
-        }
-
-        if (use_left) {
-            left -= bytes_read;
-            if (left <= TPM2_MAX_DIGEST_BUFFER) {
-                done = true;
-                continue;
+    /* if data length is non-zero (valid) and less than 1024, just do it in one
+       hash invocation */
+    if (use_left && left <= TPM2_MAX_DIGEST_BUFFER) {
+        buffer.size = left;
+        if (!!infilep) {
+            res = files_read_bytes(infilep, buffer.buffer, buffer.size);
+            if (!res) {
+                LOG_ERR("Error reading input file!");
             }
-        } else if (feof(input)) {
-            done = true;
+        } else {
+            memcpy(buffer.buffer, inbuffer, buffer.size);
+            res = true;
         }
-    } /* end file read/hash update loop */
 
-    if (use_left) {
-        data.size = left;
-        bool res = files_read_bytes(input, data.buffer, left);
-        if (!res) {
-            LOG_ERR("Error reading from input file.");
-            return false;
+        if (res) {
+            rval = TSS2_RETRY_EXP( Tss2_Sys_Hash(   sapi_context,
+                                                    NULL,
+                                                    &buffer,
+                                                    halg,
+                                                    hierarchy,
+                                                    result,
+                                                    validation,
+                                                    NULL));
+            if (rval != TSS2_RC_SUCCESS) {
+                LOG_PERR(Tss2_Sys_Hash, rval);
+                res = false;
+            } else {
+                res = true;
+            }
         }
     } else {
-        data.size = 0;
-    }
+        /*
+         * length is either unknown because the FILE * is a fifo, or it's too
+         * big to do in a single hash call. Based on the size figure out the
+         * chunks to loop over, if possible. This way we can call Complete with
+         * data.
+         */
+        rval = TSS2_RETRY_EXP( Tss2_Sys_HashSequenceStart( sapi_context,
+                                                            NULL,
+                                                            &nullAuth,
+                                                            halg,
+                                                            &sequenceHandle,
+                                                            NULL) );
+        if (rval != TSS2_RC_SUCCESS) {
+            LOG_PERR(Tss2_Sys_HashSequenceStart, rval);
+            res = false;
+        } else {
+            res = true;
+        }
 
-    rval = TSS2_RETRY_EXP(Tss2_Sys_SequenceComplete(sapi_context, sequenceHandle,
-            &cmdAuthArray, &data, hierarchy, result, validation,
-            NULL));
-    if (rval != TSS2_RC_SUCCESS) {
-        LOG_PERR(Tss2_Sys_SequenceComplete, rval);
-        return false;
-    }
+        /* If we know the file size, we decrement the amount read and terminate
+         * the loop when 1 block is left, else we go till feof.
+         */
+        done = false;
+        while (res && !done) {
+            /*  if we're using infilep, read the file. Otherwise, directly
+                copy into our local buffer. */
+            buffer.size = BUFFER_SIZE(typeof(buffer), buffer);
+            if(!!infilep){
+                bytes_read = fread( buffer.buffer, 1, buffer.size, infilep);
+                if (ferror(infilep)) {
+                    LOG_ERR("Error reading from input file");
+                    res = false;
+                } else {
+                    buffer.size = bytes_read;
+                    res = true;
+                }
+            } else {
+                memcpy(buffer.buffer, inbuffer, buffer.size);
+                inbuffer = inbuffer + buffer.size;
+                res = true;
+            }
 
-    return true;
+            if (res) {
+                rval = TSS2_RETRY_EXP( Tss2_Sys_SequenceUpdate( sapi_context,
+                                                                sequenceHandle,
+                                                                &cmdAuthArray,
+                                                                &buffer,
+                                                                NULL) );
+                if (rval != TPM2_RC_SUCCESS) {
+                    LOG_PERR(Tss2_Sys_SequenceUpdate, rval);
+                    res = false;
+                } else {
+                    if (use_left) {
+                        left -= buffer.size;
+                        if (left <= TPM2_MAX_DIGEST_BUFFER) {
+                            done = true;
+                            continue;
+                        }
+                    } else if (!!infilep && feof(infilep)) {
+                        done = true;
+                    }
+                }
+            }
+        } /* end file read/hash update loop */
+
+        /*  if there is data left, get the last bit of data from the file or
+            buffer or set the size to zero */
+        if (res && use_left) {
+            buffer.size = left;
+            if(!!infilep){
+                res = files_read_bytes(infilep, buffer.buffer, buffer.size);
+                if (!res) {
+                    LOG_ERR("Error reading from input file.");
+                }
+            } else {
+                memcpy(buffer.buffer, inbuffer, buffer.size);
+            }
+        } else {
+            buffer.size = 0;
+        }
+
+        if (res) {
+            rval = TSS2_RETRY_EXP( Tss2_Sys_SequenceComplete( sapi_context,
+                                                                sequenceHandle,
+                                                                &cmdAuthArray,
+                                                                &buffer,
+                                                                hierarchy,
+                                                                result,
+                                                                validation,
+                                                                NULL) );
+            if (rval != TSS2_RC_SUCCESS) {
+                LOG_PERR(Tss2_Sys_SequenceComplete, rval);
+                res = false;
+            }
+        }
+    } /* end of start-update-complete hash branch */
+    return res;
+}
+
+bool tpm2_hash_compute_data(TSS2_SYS_CONTEXT    *sapi_context,
+                            TPMI_ALG_HASH       halg,
+                            TPMI_RH_HIERARCHY   hierarchy,
+                            BYTE                *buffer,
+                            UINT16              length,
+                            TPM2B_DIGEST        *result,
+                            TPMT_TK_HASHCHECK   *validation)
+{
+    return tpm2_hash_common(    sapi_context,
+                                halg,
+                                hierarchy,
+                                NULL,
+                                buffer,
+                                length,
+                                result,
+                                validation);
+}
+
+bool tpm2_hash_file(TSS2_SYS_CONTEXT    *sapi_context,
+                    TPMI_ALG_HASH       halg,
+                    TPMI_RH_HIERARCHY   hierarchy,
+                    FILE                *input,
+                    TPM2B_DIGEST        *result,
+                    TPMT_TK_HASHCHECK   *validation)
+{
+    return tpm2_hash_common(    sapi_context,
+                                halg,
+                                hierarchy,
+                                input,
+                                NULL,
+                                0,
+                                result,
+                                validation);
 }

--- a/lib/tpm2_options.c
+++ b/lib/tpm2_options.c
@@ -38,8 +38,9 @@
 #include <fcntl.h>
 #include <getopt.h>
 #include <unistd.h>
+#include <libgen.h>
 
-#include <linux/limits.h>
+#include <limits.h>
 
 #include <sys/types.h>
 #include <sys/wait.h>


### PR DESCRIPTION
Differences on QNX:

*   Have to define `_QNX_SOURCE` to enable parts of the API.

*   Dynamic-library API (e.g. `dl_open`) is a part of libc. There is no `libdl`.

*   There is no `fmemopen`, `open_memstream`, or equivalent functionality

`Makefile.am`:
Replaced hard-coded `LDFLAGS`, "`-ldl`", with variable, `LIBDL_LDFLAGS`.

`configure.ac`:
Added `$host_os` case statement to detect QNX targets and modify `CFLAGS` and set `LIBDL_LDFLAGS`.

`lib/tpm2_options.c`:
Added `#include <libgen.h>` explicitly for `basename`.
Replaced `linux/limits.h` with `limits.h`. Appears to be a valid change in Ubuntu, Alpine, MinGW64, and QNX.

`lib/tpm2_hash.c`: Modified code to work without `fmemopen`.
- Most of the code previously in `tpm2_hash_file` is now in `tpm2_hash_common` with additional changes.
- `tpm2_hash_common` has the same function header as `tpm2_hash_compute_data`, and an additional `infilep` argument.
- `tpm2_hash_common` uses the`infilep` argument as the data source if non-NULL or uses `inbuffer` and `inbuffer_len`.
- Both `tpm2_hash_file` and `tpm2_hash_compute_data` wrap `tpm2_hash_common`, setting `inbuffer` and `inbuffer_len` to zero, or setting `infilep` to zero, respectively.

Signed-off-by: Safayet Ahmed <safayet.ahmed@ge.com>