### PR TITLE
tests/output_formats.sh: use /dev/urandom

### DIFF
--- a/test/integration/tests/output_formats.sh
+++ b/test/integration/tests/output_formats.sh
@@ -81,7 +81,7 @@ trap cleanup EXIT
 
 start_up
 
-head -c 4096 /dev/random > $file_hash_input
+head -c 4096 /dev/urandom > $file_hash_input
 
 tpm2_createek -Q -G $alg_ek -p "$file_pubek_orig" -c $handle_ek
 


### PR DESCRIPTION
The integration test `output_formats.sh` uses `/dev/random` to retrieve 4096 random bytes. As `/dev/random` blocks if there is not enough entropy available, this can take a very long time one some systems. Using the non-blocking `/dev/urandom` [is perfectly adequate](https://unix.stackexchange.com/questions/324209/when-to-use-dev-random-vs-dev-urandom) and [already done by all other integration tests](https://github.com/tpm2-software/tpm2-tools/blob/5505dc9893406ba6297f3b1711616f5ee5687760/test/integration/tests/encryptdecrypt.sh#L86).