### PR TITLE
Add Docker manifest to repo

### DIFF
--- a/.ci/Dockerfile
+++ b/.ci/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:18.04
+FROM debian:stable
 
 RUN apt-get update && \
     apt-get install -y \
@@ -23,8 +23,7 @@ RUN apt-get update && \
     doxygen \
     libdbus-1-dev \
     libglib2.0-dev \
-    clang-6.0 \
-    clang-tools-6.0 \
+    clang-4.0 \
     pandoc \
     lcov \
     libcurl4-openssl-dev \
@@ -32,7 +31,7 @@ RUN apt-get update && \
     python-yaml \
     xxd
 
-RUN update-alternatives --install /usr/bin/clang clang /usr/bin/clang-6.0 100
+RUN update-alternatives --install /usr/bin/clang clang /usr/bin/clang-4.0 100
 
 ARG ibmtpm_name=ibmtpm1119
 WORKDIR /tmp

--- a/.ci/Dockerfile
+++ b/.ci/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:16.04
+FROM ubuntu:18.04
 
 RUN apt-get update && \
     apt-get install -y \
@@ -30,18 +30,9 @@ RUN apt-get update && \
     libcurl4-openssl-dev \
     dbus-x11 \
     python-yaml \
-    vim-common
+    xxd
 
 RUN update-alternatives --install /usr/bin/clang clang /usr/bin/clang-6.0 100
-
-ARG autoconf_archive=autoconf-archive-2018.03.13
-WORKDIR /tmp 
-RUN wget --quiet --show-progress --progress=dot:giga "http://mirror.kumi.systems/gnu/autoconf-archive/$autoconf_archive.tar.xz" \
-		&& tar -xf $autoconf_archive.tar.xz \
-        && rm $autoconf_archive.tar.xz \
-        && cd $autoconf_archive \
-        && ./configure --prefix=/usr \
-        && make -j $(nproc) && make install
 
 ARG ibmtpm_name=ibmtpm1119
 WORKDIR /tmp

--- a/.ci/Dockerfile
+++ b/.ci/Dockerfile
@@ -1,0 +1,55 @@
+FROM ubuntu:16.04
+
+RUN apt-get update && \
+    apt-get install -y \
+    autoconf-archive \
+    libcmocka0 \
+    libcmocka-dev \
+    net-tools \
+    build-essential \
+    git \
+    pkg-config \
+    gcc \
+    g++ \
+    m4 \
+    libtool \
+    automake \
+    libgcrypt20-dev \
+    libssl-dev \
+    uthash-dev \
+    autoconf \
+    gnulib \
+    wget \
+    doxygen \
+    libdbus-1-dev \
+    libglib2.0-dev \
+    clang-6.0 \
+    clang-tools-6.0 \
+    pandoc \
+    lcov \
+    libcurl4-openssl-dev \
+    dbus-x11 \
+    python-yaml \
+    vim-common
+
+RUN update-alternatives --install /usr/bin/clang clang /usr/bin/clang-6.0 100
+
+ARG autoconf_archive=autoconf-archive-2018.03.13
+WORKDIR /tmp 
+RUN wget --quiet --show-progress --progress=dot:giga "http://mirror.kumi.systems/gnu/autoconf-archive/$autoconf_archive.tar.xz" \
+		&& tar -xf $autoconf_archive.tar.xz \
+        && rm $autoconf_archive.tar.xz \
+        && cd $autoconf_archive \
+        && ./configure --prefix=/usr \
+        && make -j $(nproc) && make install
+
+ARG ibmtpm_name=ibmtpm1119
+WORKDIR /tmp
+RUN wget --quiet --show-progress --progress=dot:giga "https://downloads.sourceforge.net/project/ibmswtpm2/$ibmtpm_name.tar.gz" \
+	&& sha256sum $ibmtpm_name.tar.gz | grep ^b9eef79904e276aeaed2a6b9e4021442ef4d7dfae4adde2473bef1a6a4cd10fb \
+	&& mkdir -p $ibmtpm_name \
+	&& tar xvf $ibmtpm_name.tar.gz -C $ibmtpm_name \
+	&& rm $ibmtpm_name.tar.gz
+WORKDIR $ibmtpm_name/src
+RUN CFLAGS="-I/usr/local/openssl/include" make -j$(nproc) \
+&& cp tpm_server /usr/local/bin

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,4 +15,4 @@ script:
   - ./.ci/travis.run
 
 after_failure:
-  - cat build/test-suite.log
+  - find . -name test-suite.log | xargs cat


### PR DESCRIPTION
This series adds a Dockerfile to our repo that should replace the image at tpm2-software/tpm2tss on Dockerhub.

This series shows my working:
0. Make the after_failure command more robust
1. Mimic the current hand-crafted image Ubuntu 16.04 with a Dockerfile
2. Update to latest Ubuntu LTS (in order to get newer libssl without leaks)
3. Switch to Debian stable to avoid a weird test failure on Ubuntu 18:04

I'd be happy to squash patches 1-3 into an "Add a Dockerfile" commit.

If we like the direction we need to update the image on Dockerhub with that generated by the Dockerfile.