### PR TITLE
bash-completion: move to recommended directory

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -391,3 +391,15 @@ CLEANFILES = $(man1_MANS)
 
 bashcompdir=@bashcompdir@
 dist_bashcomp_DATA=dist/bash-completion/tpm2-tools/tpm2_completion.bash
+
+install-data-hook:
+	cd $(DESTDIR)$(bashcompdir) && \
+	for tool in $(bin_PROGRAMS); do \
+		$(LN_S) -f tpm2_completion.bash $${tool##*/}; \
+	done
+
+uninstall-hook:
+	cd $(DESTDIR)$(bashcompdir) && \
+	for tool in $(bin_PROGRAMS); do \
+		[ -L $${tool##*/} ] && rm -f $${tool##*/}; \
+	done

--- a/configure.ac
+++ b/configure.ac
@@ -2,6 +2,7 @@ AC_INIT([tpm2-tools],
     [m4_esyscmd_s([git describe --tags --always --dirty])])
 AC_CONFIG_MACRO_DIR([m4])
 AC_PROG_CC
+AC_PROG_LN_S
 LT_INIT
 AM_INIT_AUTOMAKE([foreign
                   subdir-objects])
@@ -39,8 +40,8 @@ AS_VAR_COPY([$1], [pkg_cv_][$1])
 AS_VAR_IF([$1], [""], [$5], [$4])dnl
 ])# PKG_CHECK_VAR
 ])
-PKG_CHECK_VAR(bashcompdir, [bash-completion], [compatdir], ,
-  bashcompdir="${sysconfdir}/bash_completion.d")
+PKG_CHECK_VAR(bashcompdir, [bash-completion], [completionsdir], ,
+  bashcompdir="${datarootdir}/bash-completion/completions")
 AC_SUBST(bashcompdir)
 
 AC_CANONICAL_HOST

--- a/dist/bash-completion/tpm2-tools/tpm2_completion.bash
+++ b/dist/bash-completion/tpm2-tools/tpm2_completion.bash
@@ -132,14 +132,9 @@ _tpm2_tools()
 
     COMPREPLY=( $( compgen -W '$( echo ${suggestions[@]} )' -- "$cur" ) )
 
-} &&
-  #to obtain the installation path of the tools, it is necessary to know just one of them, tpm2_import was choose ramdomly
-  #and then assign the completion function to all the tools
-  tools_for_completions=( $(find $( dirname $(which tpm2_import) ) -type f -printf '%f\n' | grep 'tpm2_') )
-  for i in "${tools_for_completions[@]}"
-  do
-   complete -F _tpm2_tools $i
-  done
+}
+
+complete -F _tpm2_tools ${COMP_WORDS[0]##*/}
 
 #function used to exlude the already completed options from the suggested completions
 _exclude_completed_opts() {


### PR DESCRIPTION
According to the [bash-completion FAQ](https://github.com/scop/bash-completion#faq), `/etc/bash_completion.d` (pkgconfig variable `compatdir`) is deprecated in favour of `/usr/share/bash-completion/completions` (pkgconfig variable `completionsdir`). As the completion file is loaded on demand based on its filename, we need to create symlinks for every tool during installation.

Using the on demand loading allows to replace the somewhat awkward [`find`-based loop to setup completion for all tools in `tpm2_completion.bash`](https://github.com/tpm2-software/tpm2-tools/blob/5d4cc4ee0f5ccc2ea84f7266a446373d602a188a/dist/bash-completion/tpm2-tools/tpm2_completion.bash#L136) with a simpler approach based on the currently requested completion.