### PR TITLE
options: fix broken -T option when passing additional arguments

### DIFF
--- a/lib/tpm2_options.c
+++ b/lib/tpm2_options.c
@@ -291,7 +291,7 @@ static tcti_conf tcti_get_config(const char *optstr) {
             }
         }
     } else {
-        conf.name = strdup(optstr);
+        parse_env_tcti(optstr, &conf);
     }
 
     if (!conf.name) {


### PR DESCRIPTION
The commit 175e47711c7 ("lib/tpm2_options: restore TCTI configuration
environment variables") restored how the TCTI configuration was setup
for the 3.X releases, but this broke the -T,--tcti option since was
ignored.

Commit 554a13f45c0 ("options: fix broken -T option") partially fixed
this, but only when additional TCTI arguments were not used.

For example when specifying the -T device:/dev/tpmrm0 TCTI option:

$ tpm2_pcrlist -T device:/dev/tpmrm0
...
ERROR: Could not dlopen library: "device:/dev/tpmrm0"
ERROR: Could not load tcti, got: "device:/dev/tpmrm0"

Signed-off-by: Javier Martinez Canillas <javierm@redhat.com>