### PR TITLE
tpm2_getmanufec: fix memory leak in OpenSSL usage

### DIFF
--- a/test/integration/tests/getmanufec.sh
+++ b/test/integration/tests/getmanufec.sh
@@ -33,19 +33,6 @@
 
 source helpers.sh
 
-# Building with asan on clang, the leak sanitizer
-# portion (lsan) on ancient versions is:
-# 1. Detecting a leak that (maybe) doesn't exist.
-#    OpenSSL is hard...
-# 2. The suppression option via ASAN_OPTIONS doesn't
-#    exist for 3.6.
-# TODO When this is fixed, remove it.
-# Bug: https://github.com/tpm2-software/tpm2-tools/issues/390
-if [ "$ASAN_ENABLED" == "true" ]; then
-  echo "Skipping ASAN_ENABLED is true"
-  exit 0
-fi
-
 handle=0x81000000
 opass=abc123
 epass=abc123

--- a/tools/tpm2_getmanufec.c
+++ b/tools/tpm2_getmanufec.c
@@ -305,7 +305,6 @@ char *Base64Encode(const unsigned char* buffer)
     BIO_write(bio, buffer, SHA256_DIGEST_LENGTH);
     BIO_flush(bio);
     BIO_get_mem_ptr(bio, &bufferPtr);
-    BIO_set_close(bio, BIO_NOCLOSE);
 
     /* these are not NULL terminated */
     char *b64text = bufferPtr->data;


### PR DESCRIPTION
BIO_NOCLOSE prevents BIO_free() from freeing the underlying BUF_MEM
structure, however we don't need that as we do all of our work with
underlying buffer before we call BIO_free_all().

Fixes #390

Signed-off-by: Joshua Lock <joshua.g.lock@intel.com>