### PR TITLE
configure: ensure POSIX compatibility

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -12,7 +12,7 @@ AX_CODE_COVERAGE
 AC_CONFIG_FILES([Makefile])
 AC_CHECK_PROG([PANDOC],[pandoc],[yes])
 AS_IF(
-    [test "x${PANDOC}" == x"yes"],
+    [test "x${PANDOC}" = x"yes"],
     [],
     [AC_MSG_WARN([Required executable pandoc not found, man pages will not be built])])
 AM_CONDITIONAL([HAVE_PANDOC],[test "x${PANDOC}" = "xyes"])
@@ -98,13 +98,13 @@ AC_DEFUN([unit_test_checks],[
 
     AC_CHECK_PROG([BASH_SHELL],[bash],[yes])
     AS_IF(
-        [test "x${BASH_SHELL}" == x"yes"],
+        [test "x${BASH_SHELL}" = x"yes"],
         [],
         [AC_MSG_WARN([Required executable bash not found, system tests require a bash shell!])])
 
     AC_CHECK_PROG([PYTHON],[python],[yes])
     AS_IF(
-        [test "x${PYTHON}" == x"yes"],
+        [test "x${PYTHON}" = x"yes"],
         [],
         [AC_MSG_WARN([Required executable python not found, some system tests will fail!])])
 
@@ -112,7 +112,7 @@ AC_DEFUN([unit_test_checks],[
 
     AC_CHECK_PROG([XXD],[xxd],[yes])
     AS_IF(
-        [test "x${XXD}" == x"yes"],
+        [test "x${XXD}" = x"yes"],
         [],
         [AC_MSG_WARN([Required executable xxd not found, some system tests will fail!])])
 ])
@@ -208,11 +208,11 @@ add_c_flag([-Wduplicated-cond])
 
 # Best attempt, strip unused stuff from the binary to reduce size.
 # Rather than nesting these and making them ugly just use a counter.
-AX_CHECK_COMPILE_FLAG([-fdata-sections], [strip+="y"])
-AX_CHECK_COMPILE_FLAG([-ffunction-sections], [strip+="y"])
-AX_CHECK_LINK_FLAG([[-Wl,--gc-sections]], [strip+="y"])
+AX_CHECK_COMPILE_FLAG([-fdata-sections], [strip="${strip}y"])
+AX_CHECK_COMPILE_FLAG([-ffunction-sections], [strip="${strip}y"])
+AX_CHECK_LINK_FLAG([[-Wl,--gc-sections]], [strip="${strip}y"])
 
-AS_IF([test x"$strip" == x"yyy"], [
+AS_IF([test x"$strip" = x"yyy"], [
   EXTRA_CFLAGS="$EXTRA_CFLAGS -fdata-sections -ffunction-sections"
   EXTRA_LDFLAGS="$EXTRA_LDFLAGS -Wl,--gc-sections"
 ],


### PR DESCRIPTION
`configure.ac` uses non-portable syntax:
- String comparison in `test` with a double `==` instead of a single `=`.
- `+=` for string concatenation of variables.

This can be problematic if `/bin/sh` is not `bash`, but e.g. `dash`.