### PR TITLE
test/unit: fix undefined reference to external variable

### DIFF
--- a/test/unit/test_files.c
+++ b/test/unit/test_files.c
@@ -301,6 +301,11 @@ static void test_files_get_unique_name(void **state) {
     assert_null(unique);
 }
 
+/* link required symbol, but tpm2_tool.c declares it AND main, which
+ * we have a main below for cmocka tests.
+ */
+bool output_enabled = true;
+
 int main(int argc, char* argv[]) {
     (void)argc;
     (void)argv;

--- a/test/unit/test_pcr.c
+++ b/test/unit/test_pcr.c
@@ -57,6 +57,11 @@ static void test_pcr_alg_nice_names(void **state) {
             sizeof(raw_pcr_selections));
 }
 
+/* link required symbol, but tpm2_tool.c declares it AND main, which
+ * we have a main below for cmocka tests.
+ */
+bool output_enabled = true;
+
 int main(int argc, char* argv[]) {
     (void) argc;
     (void) argv;

--- a/test/unit/test_string_bytes.c
+++ b/test/unit/test_string_bytes.c
@@ -101,6 +101,11 @@ TEST_ENDIAN_NTOH(16, 0xFF00, 0x00FF)
 TEST_ENDIAN_NTOH(32, 0xAABBCCDD, 0xDDCCBBAA)
 TEST_ENDIAN_NTOH(64, 0x0011223344556677, 0x7766554433221100)
 
+/* link required symbol, but tpm2_tool.c declares it AND main, which
+ * we have a main below for cmocka tests.
+ */
+bool output_enabled = true;
+
 int main(int argc, char* argv[]) {
     (void)argc;
     (void)argv;

--- a/test/unit/test_tpm2_alg_util.c
+++ b/test/unit/test_tpm2_alg_util.c
@@ -415,6 +415,11 @@ static void test_tpm2_alg_util_flags_hash(void **state) {
     assert_null(name);
 }
 
+/* link required symbol, but tpm2_tool.c declares it AND main, which
+ * we have a main below for cmocka tests.
+ */
+bool output_enabled = true;
+
 int main(int argc, char* argv[]) {
     (void) argc;
     (void) argv;

--- a/test/unit/test_tpm2_attr_util.c
+++ b/test/unit/test_tpm2_attr_util.c
@@ -367,6 +367,11 @@ static void test_tpm2_attr_util_obj_from_optarg_good(void **state) {
     assert_int_equal(TPMA_OBJECT_FIXEDTPM, objattrs);
 }
 
+/* link required symbol, but tpm2_tool.c declares it AND main, which
+ * we have a main below for cmocka tests.
+ */
+bool output_enabled = true;
+
 int main(int argc, char* argv[]) {
     (void) argc;
     (void) argv;

--- a/test/unit/test_tpm2_errata.c
+++ b/test/unit/test_tpm2_errata.c
@@ -174,6 +174,11 @@ static void test_tpm2_errata_init_no_match_and_apply(void **state) {
                     TPMA_OBJECT_SIGN_ENCRYPT);
 }
 
+/* link required symbol, but tpm2_tool.c declares it AND main, which
+ * we have a main below for cmocka tests.
+ */
+bool output_enabled = true;
+
 int main(int argc, char *argv[]) {
     UNUSED(argc);
     UNUSED(argv);

--- a/test/unit/test_tpm2_error.c
+++ b/test/unit/test_tpm2_error.c
@@ -258,6 +258,11 @@ static void test_tcti(void **state) {
     assert_string_equal(e, "tcti:Fails to connect to next lower layer");
 }
 
+/* link required symbol, but tpm2_tool.c declares it AND main, which
+ * we have a main below for cmocka tests.
+ */
+bool output_enabled = true;
+
 int main(int argc, char* argv[]) {
     (void) argc;
     (void) argv;

--- a/test/unit/test_tpm2_header.c
+++ b/test/unit/test_tpm2_header.c
@@ -140,6 +140,11 @@ static void test_tpm_response_header(void **state) {
     assert_true(rc == 0x00);
 }
 
+/* link required symbol, but tpm2_tool.c declares it AND main, which
+ * we have a main below for cmocka tests.
+ */
+bool output_enabled = true;
+
 int main(int argc, char* argv[]) {
     (void)argc;
     (void)argv;

--- a/test/unit/test_tpm2_hierarchy.c
+++ b/test/unit/test_tpm2_hierarchy.c
@@ -157,6 +157,11 @@ static void test_tpm2_hierarchy_from_optarg_valid_ids_enabled(void **state) {
     assert_int_equal(h, 0xBADC0DE);
 }
 
+/* link required symbol, but tpm2_tool.c declares it AND main, which
+ * we have a main below for cmocka tests.
+ */
+bool output_enabled = true;
+
 int main(int argc, char* argv[]) {
     (void)argc;
     (void)argv;

--- a/test/unit/test_tpm2_util.c
+++ b/test/unit/test_tpm2_util.c
@@ -153,6 +153,11 @@ static void test_tpm2_util_object_load(void **state) {
     assert_return_code(rc, errno);
 }
 
+/* link required symbol, but tpm2_tool.c declares it AND main, which
+ * we have a main below for cmocka tests.
+ */
+bool output_enabled = true;
+
 int main(int argc, char* argv[]) {
     (void)argc;
     (void)argv;


### PR DESCRIPTION
The reason for #1278 is a missing variable declaration. It is already present in [`test_tpm2_auth_util.c`](https://github.com/tpm2-software/tpm2-tools/blob/872076e1b31f22b18391c6761d47575a93891cd7/test/unit/test_tpm2_auth_util.c#L205), [`test_tpm2_policy.c`](https://github.com/tpm2-software/tpm2-tools/blob/872076e1b31f22b18391c6761d47575a93891cd7/test/unit/test_tpm2_policy.c#L378) and [`test_tpm2_session.c`](https://github.com/tpm2-software/tpm2-tools/blob/872076e1b31f22b18391c6761d47575a93891cd7/test/unit/test_tpm2_session.c#L299), which is where I copy-pasted it from.