### PR TITLE
Apply build changes from tpm2-tss

### DIFF
--- a/.ci/download-deps.sh
+++ b/.ci/download-deps.sh
@@ -40,7 +40,7 @@ function get_deps() {
 		git clone --depth=1 https://github.com/tpm2-software/tpm2-tss.git
 		pushd tpm2-tss
 		echo "pwd build tss: `pwd`"
-		./bootstrap -I /usr/share/gnulib/m4
+		./bootstrap
 		./configure CFLAGS=-g
 		make -j4
 		make install

--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 *.log
 *.trs
 aclocal.m4
+aminclude_static.am
 autom4te.cache/
 compile
 config.guess

--- a/Makefile.am
+++ b/Makefile.am
@@ -41,7 +41,7 @@ endif
 
 include src_vars.mk
 
-ACLOCAL_AMFLAGS = -I m4
+ACLOCAL_AMFLAGS = -I m4 --install
 
 INCLUDE_DIRS = -I$(top_srcdir)/tools -I$(top_srcdir)/lib
 LIB_COMMON := lib/libcommon.a

--- a/Makefile.am
+++ b/Makefile.am
@@ -29,7 +29,15 @@
 # ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
 # THE POSSIBILITY OF SUCH DAMAGE.
 #;**********************************************************************;
+
+# ax_code_coverage
+if AUTOCONF_CODE_COVERAGE_2019_01_06
+include $(top_srcdir)/aminclude_static.am
+clean-local: code-coverage-clean
+distclean-local: code-coverage-dist-clean
+else
 @CODE_COVERAGE_RULES@
+endif
 
 include src_vars.mk
 

--- a/configure.ac
+++ b/configure.ac
@@ -9,6 +9,10 @@ AM_INIT_AUTOMAKE([foreign
 # enable "silent-rules" option by default
 m4_ifdef([AM_SILENT_RULES], [AM_SILENT_RULES([yes])])
 AX_CODE_COVERAGE
+m4_ifdef([_AX_CODE_COVERAGE_RULES],
+         [AM_CONDITIONAL(AUTOCONF_CODE_COVERAGE_2019_01_06, [true])],
+         [AM_CONDITIONAL(AUTOCONF_CODE_COVERAGE_2019_01_06, [false])])
+AX_ADD_AM_MACRO_STATIC([])
 AC_CONFIG_FILES([Makefile])
 AC_CHECK_PROG([PANDOC],[pandoc],[yes])
 AS_IF(


### PR DESCRIPTION
This PR applies the following recent changes to the build system from tpm2-tss:
- Support for Autoconf Archive 2019.01.06: https://github.com/tpm2-software/tpm2-tss/pull/1238, including the fix for older versions in https://github.com/tpm2-software/tpm2-tss/pull/1256
- Installation of the aclocal macros to the `m4/` subdirectory: https://github.com/tpm2-software/tpm2-tss/pull/1245
- Removal of the Gnulib dependency: https://github.com/tpm2-software/tpm2-tss/pull/1254