### PR TITLE
build: Use dbus-run-session in automake test harness.

### DIFF
--- a/.ci/docker.run
+++ b/.ci/docker.run
@@ -35,23 +35,6 @@ set -e
 
 source $TRAVIS_BUILD_DIR/.ci/docker-prelude.sh
 
-echo "starting dbus"
-mkdir -p /var/run/dbus
-if [ -e /var/run/dbus/pid ]; then
-  rm /var/run/dbus/pid
-fi
-
-if [ -e /var/run/dbus/system_bus_socket ]; then
-  rm /var/run/dbus/system_bus_socket
-fi
-
-# start dbus
-dbus-daemon --fork --system
-echo "dbus started"
-
-# let dbus have time to start up
-sleep 5
-
 if [ -d build ]; then
   rm -rf build
 fi
@@ -122,7 +105,7 @@ fi
 
 ../configure --enable-unit $config_flags
 make -j$(nproc)
-dbus-launch make -j$(nproc) check
+make -j$(nproc) check
 
 popd
 

--- a/Makefile.am
+++ b/Makefile.am
@@ -261,7 +261,8 @@ AM_TESTS_ENVIRONMENT =	\
 	TPM2_ABRMD="tpm2-abrmd" \
 	TPM2_SIM="tpm_server" \
 	PATH=$(abs_build_dir)/tools:$(abs_build_dir)/tools/misc:$(abs_top_srcdir)/test/integration:$(PATH) \
-	TPM2_TOOLS_TEST_FIXTURES=$(abs_top_srcdir)/test/integration/fixtures
+	TPM2_TOOLS_TEST_FIXTURES=$(abs_top_srcdir)/test/integration/fixtures \
+	dbus-run-session
 endif
 
 check-hook:


### PR DESCRIPTION
This commit removes the manual launching of the dbus session bus
instance in the docker.run file. This is replaced by adding the
'dbus-run-session' command to the AM_TEST_ENVIRONMENT. This allows
callers to simply execute 'make check' and the test harness will set up
a session bus instance automagically.

Signed-off-by: Philip Tricca <philip.b.tricca@intel.com>