### PR TITLE
Backport PR #1277, #1279 and #1292 to 3.X

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 *.log
 *.trs
 aclocal.m4
+aminclude_static.am
 autom4te.cache/
 compile
 config.guess

--- a/Makefile.am
+++ b/Makefile.am
@@ -189,44 +189,44 @@ check_PROGRAMS = \
     test/unit/test_tpm2_errata
 
 test_unit_tpm2_rc_decode_unit_CFLAGS  = $(AM_CFLAGS) $(CMOCKA_CFLAGS)
-test_unit_tpm2_rc_decode_unit_LDADD   = $(CMOCKA_LIBS) $(LIB_COMMON)
+test_unit_tpm2_rc_decode_unit_LDADD   = $(CMOCKA_LIBS) $(LDADD)
 test_unit_tpm2_rc_decode_unit_SOURCES = test/unit/tpm2-rc-decode_unit.c
 
 test_unit_tpm2_rc_entry_unit_CFLAGS   = $(AM_CFLAGS) $(CMOCKA_CFLAGS)
-test_unit_tpm2_rc_entry_unit_LDADD    = $(CMOCKA_LIBS) $(LIB_COMMON)
+test_unit_tpm2_rc_entry_unit_LDADD    = $(CMOCKA_LIBS) $(LDADD)
 test_unit_tpm2_rc_entry_unit_SOURCES  = test/unit/tpm2-rc-entry_unit.c
 
 test_unit_test_string_bytes_CFLAGS   = $(AM_CFLAGS) $(CMOCKA_CFLAGS)
-test_unit_test_string_bytes_LDADD    = $(CMOCKA_LIBS) $(LIB_COMMON)
+test_unit_test_string_bytes_LDADD    = $(CMOCKA_LIBS) $(LDADD)
 test_unit_test_string_bytes_SOURCES  = test/unit/test_string_bytes.c
 
 test_unit_test_files_CFLAGS   = $(AM_CFLAGS) $(CMOCKA_CFLAGS)
-test_unit_test_files_LDADD    = $(LIB_COMMON) $(CMOCKA_LIBS)
+test_unit_test_files_LDADD    = $(CMOCKA_LIBS) $(LDADD)
 test_unit_test_files_SOURCES  = test/unit/test_files.c
 
 test_unit_test_tpm2_header_CFLAGS   = $(AM_CFLAGS) $(CMOCKA_CFLAGS)
-test_unit_test_tpm2_header_LDADD    = $(CMOCKA_LIBS) $(LIB_COMMON)
+test_unit_test_tpm2_header_LDADD    = $(CMOCKA_LIBS) $(LDADD)
 test_unit_test_tpm2_header_SOURCES  = test/unit/test_tpm2_header.c
 
 test_unit_test_tpm2_attr_util_CFLAGS   = $(AM_CFLAGS) $(CMOCKA_CFLAGS)
-test_unit_test_tpm2_attr_util_LDADD    = $(CMOCKA_LIBS) $(LIB_COMMON)
+test_unit_test_tpm2_attr_util_LDADD    = $(CMOCKA_LIBS) $(LDADD)
 test_unit_test_tpm2_attr_util_SOURCES  = test/unit/test_tpm2_attr_util.c
 
 test_unit_test_tpm2_alg_util_CFLAGS   = $(AM_CFLAGS) $(CMOCKA_CFLAGS)
-test_unit_test_tpm2_alg_util_LDADD    = $(CMOCKA_LIBS) $(LIB_COMMON)
+test_unit_test_tpm2_alg_util_LDADD    = $(CMOCKA_LIBS) $(LDADD)
 test_unit_test_tpm2_alg_util_SOURCES  = test/unit/test_tpm2_alg_util.c
 
 test_unit_test_pcr_CFLAGS   = $(AM_CFLAGS) $(CMOCKA_CFLAGS)
-test_unit_test_pcr_LDADD    = $(CMOCKA_LIBS) $(LIB_COMMON)
+test_unit_test_pcr_LDADD    = $(CMOCKA_LIBS) $(LDADD)
 test_unit_test_pcr_SOURCES  = test/unit/test_pcr.c
 
 test_unit_test_tpm2_password_util_CFLAGS   = $(AM_CFLAGS) $(CMOCKA_CFLAGS)
-test_unit_test_tpm2_password_util_LDADD    = $(CMOCKA_LIBS) $(LIB_COMMON)
+test_unit_test_tpm2_password_util_LDADD    = $(CMOCKA_LIBS) $(LDADD)
 test_unit_test_tpm2_password_util_SOURCES  = test/unit/test_tpm2_password_util.c
 
 test_unit_test_tpm2_errata_CFLAGS   = $(AM_CFLAGS) $(CMOCKA_CFLAGS)
 test_unit_test_tpm2_errata_LDFLAGS  = -Wl,--wrap=Tss2_Sys_GetCapability
-test_unit_test_tpm2_errata_LDADD    = $(CMOCKA_LIBS) $(LIB_COMMON)
+test_unit_test_tpm2_errata_LDADD    = $(CMOCKA_LIBS) $(LDADD)
 test_unit_test_tpm2_errata_SOURCES  = test/unit/test_tpm2_errata.c
 
 endif

--- a/Makefile.am
+++ b/Makefile.am
@@ -39,7 +39,7 @@ else
 @CODE_COVERAGE_RULES@
 endif
 
-ACLOCAL_AMFLAGS = -I m4
+ACLOCAL_AMFLAGS = -I m4 --install
 
 INCLUDE_DIRS = -I$(top_srcdir)/tools -I$(top_srcdir)/lib
 LIB_COMMON := lib/libcommon.a

--- a/Makefile.am
+++ b/Makefile.am
@@ -29,7 +29,15 @@
 # ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
 # THE POSSIBILITY OF SUCH DAMAGE.
 #;**********************************************************************;
+
+# ax_code_coverage
+if AUTOCONF_CODE_COVERAGE_2019_01_06
+include $(top_srcdir)/aminclude_static.am
+clean-local: code-coverage-clean
+distclean-local: code-coverage-dist-clean
+else
 @CODE_COVERAGE_RULES@
+endif
 
 ACLOCAL_AMFLAGS = -I m4
 

--- a/configure.ac
+++ b/configure.ac
@@ -11,7 +11,7 @@ m4_ifdef([AM_SILENT_RULES], [AM_SILENT_RULES([yes])])
 AC_CONFIG_FILES([Makefile])
 AC_CHECK_PROG([PANDOC],[pandoc],[yes])
 AS_IF(
-    [test "x${PANDOC}" == x"yes"],
+    [test "x${PANDOC}" = x"yes"],
     [],
     [AC_MSG_WARN([Required executable pandoc not found, man pages will not be built])])
 AM_CONDITIONAL([HAVE_PANDOC],[test "x${PANDOC}" = "xyes"])
@@ -101,11 +101,11 @@ AX_CHECK_PREPROC_FLAG([-D_GNU_SOURCE],
 
 # Best attempt, strip unused stuff from the binary to reduce size.
 # Rather than nesting these and making them ugly just use a counter.
-AX_CHECK_COMPILE_FLAG([-fdata-sections], [strip+="y"])
-AX_CHECK_COMPILE_FLAG([-ffunction-sections], [strip+="y"])
-AX_CHECK_LINK_FLAG([[-Wl,--gc-sections]], [strip+="y"])
+AX_CHECK_COMPILE_FLAG([-fdata-sections], [strip="${strip}y"])
+AX_CHECK_COMPILE_FLAG([-ffunction-sections], [strip="${strip}y"])
+AX_CHECK_LINK_FLAG([[-Wl,--gc-sections]], [strip="${strip}y"])
 
-AS_IF([test x"$strip" == x"yyy"], [
+AS_IF([test x"$strip" = x"yyy"], [
   EXTRA_CFLAGS="$EXTRA_CFLAGS -fdata-sections -ffunction-sections"
   EXTRA_LDFLAGS="$EXTRA_LDFLAGS -Wl,--gc-sections"
 ],
@@ -114,13 +114,13 @@ AS_IF([test x"$strip" == x"yyy"], [
 
 AC_CHECK_PROG([BASH_SHELL],[bash],[yes])
 AS_IF(
-    [test "x${BASH_SHELL}" == x"yes"],
+    [test "x${BASH_SHELL}" = x"yes"],
     [],
     [AC_MSG_WARN([Required executable bash not found, system tests require a bash shell!])])
 
 AC_CHECK_PROG([PYTHON],[python],[yes])
 AS_IF(
-    [test "x${PYTHON}" == x"yes"],
+    [test "x${PYTHON}" = x"yes"],
     [],
     [AC_MSG_WARN([Required executable python not found, some system tests will fail!])])
 

--- a/configure.ac
+++ b/configure.ac
@@ -6,6 +6,10 @@ LT_INIT
 AM_INIT_AUTOMAKE([foreign
                   subdir-objects])
 AX_CODE_COVERAGE
+m4_ifdef([_AX_CODE_COVERAGE_RULES],
+         [AM_CONDITIONAL(AUTOCONF_CODE_COVERAGE_2019_01_06, [true])],
+         [AM_CONDITIONAL(AUTOCONF_CODE_COVERAGE_2019_01_06, [false])])
+AX_ADD_AM_MACRO_STATIC([])
 # enable "silent-rules" option by default
 m4_ifdef([AM_SILENT_RULES], [AM_SILENT_RULES([yes])])
 AC_CONFIG_FILES([Makefile])

--- a/test/unit/test_files.c
+++ b/test/unit/test_files.c
@@ -263,6 +263,11 @@ static void test_file_exists_bad_args(void **state) {
     assert_false(res);
 }
 
+/* link required symbol, but tpm2_tool.c declares it AND main, which
+ * we have a main below for cmocka tests.
+ */
+bool output_enabled = true;
+
 int main(int argc, char* argv[]) {
     (void)argc;
     (void)argv;

--- a/test/unit/test_pcr.c
+++ b/test/unit/test_pcr.c
@@ -57,6 +57,11 @@ static void test_pcr_alg_nice_names(void **state) {
             sizeof(raw_pcr_selections));
 }
 
+/* link required symbol, but tpm2_tool.c declares it AND main, which
+ * we have a main below for cmocka tests.
+ */
+bool output_enabled = true;
+
 int main(int argc, char* argv[]) {
     (void) argc;
     (void) argv;

--- a/test/unit/test_string_bytes.c
+++ b/test/unit/test_string_bytes.c
@@ -101,6 +101,11 @@ TEST_ENDIAN_NTOH(16, 0xFF00, 0x00FF)
 TEST_ENDIAN_NTOH(32, 0xAABBCCDD, 0xDDCCBBAA)
 TEST_ENDIAN_NTOH(64, 0x0011223344556677, 0x7766554433221100)
 
+/* link required symbol, but tpm2_tool.c declares it AND main, which
+ * we have a main below for cmocka tests.
+ */
+bool output_enabled = true;
+
 int main(int argc, char* argv[]) {
     (void)argc;
     (void)argv;

--- a/test/unit/test_tpm2_alg_util.c
+++ b/test/unit/test_tpm2_alg_util.c
@@ -430,6 +430,11 @@ static void test_tpm2_alg_util_get_hash_size(void **state) {
     assert_int_equal(hsize, 0);
 }
 
+/* link required symbol, but tpm2_tool.c declares it AND main, which
+ * we have a main below for cmocka tests.
+ */
+bool output_enabled = true;
+
 int main(int argc, char* argv[]) {
     (void) argc;
     (void) argv;

--- a/test/unit/test_tpm2_attr_util.c
+++ b/test/unit/test_tpm2_attr_util.c
@@ -363,6 +363,11 @@ static void test_tpm2_attr_util_obj_from_optarg_good(void **state) {
     assert_int_equal(TPMA_OBJECT_FIXEDTPM, objattrs);
 }
 
+/* link required symbol, but tpm2_tool.c declares it AND main, which
+ * we have a main below for cmocka tests.
+ */
+bool output_enabled = true;
+
 int main(int argc, char* argv[]) {
     (void) argc;
     (void) argv;

--- a/test/unit/test_tpm2_errata.c
+++ b/test/unit/test_tpm2_errata.c
@@ -164,6 +164,11 @@ static void test_tpm2_errata_init_no_match_and_apply(void **state) {
                     TPMA_OBJECT_SIGN_ENCRYPT);
 }
 
+/* link required symbol, but tpm2_tool.c declares it AND main, which
+ * we have a main below for cmocka tests.
+ */
+bool output_enabled = true;
+
 int main(int argc, char *argv[]) {
     UNUSED(argc);
     UNUSED(argv);

--- a/test/unit/test_tpm2_header.c
+++ b/test/unit/test_tpm2_header.c
@@ -140,6 +140,11 @@ static void test_tpm_response_header(void **state) {
     assert_true(rc == 0x00);
 }
 
+/* link required symbol, but tpm2_tool.c declares it AND main, which
+ * we have a main below for cmocka tests.
+ */
+bool output_enabled = true;
+
 int main(int argc, char* argv[]) {
     (void)argc;
     (void)argv;

--- a/test/unit/test_tpm2_password_util.c
+++ b/test/unit/test_tpm2_password_util.c
@@ -140,6 +140,11 @@ static void test_tpm2_password_util_from_optarg_empty_str_hex_prefix(void **stat
     assert_int_equal(dest.size, 0);
 }
 
+/* link required symbol, but tpm2_tool.c declares it AND main, which
+ * we have a main below for cmocka tests.
+ */
+bool output_enabled = true;
+
 int main(int argc, char* argv[]) {
     (void)argc;
     (void)argv;

--- a/test/unit/tpm2-rc-decode_unit.c
+++ b/test/unit/tpm2-rc-decode_unit.c
@@ -656,6 +656,10 @@ tpm2_rc_get_tss_err_code_bad_size_from_sys (void **state)
     assert_int_equal (TSS2_BASE_RC_BAD_SIZE,
                       tpm2_rc_get_tss_err_code (rc));
 }
+/* link required symbol, but tpm2_tool.c declares it AND main, which
+ * we have a main below for cmocka tests.
+ */
+bool output_enabled = true;
 int
 main (int argc, char* argv[])
 {

--- a/test/unit/tpm2-rc-entry_unit.c
+++ b/test/unit/tpm2-rc-entry_unit.c
@@ -281,6 +281,10 @@ tpm2_rc_entry_warn_bad (void **state)
     (void) state;
     LOOKUP_FAILURE (0x17, tpm2_get_warn_entry);
 }
+/* link required symbol, but tpm2_tool.c declares it AND main, which
+ * we have a main below for cmocka tests.
+ */
+bool output_enabled = true;
 int
 main (int   argc,
       char *argv[])


### PR DESCRIPTION
It would be nice to have the following PRs in the next release of tpm2-tools 3.X:
- #1277 and #1279 because the issues these PRs fix lead to errors in the Arch Linux reproducible builds scripts, see #1278. Note that #1279 needs an additional fix in `Makefile.am` in comparison to the master branch, see https://github.com/tpm2-software/tpm2-tools/pull/1279#issuecomment-454125823.
- #1292 because Gentoo (and probably other distributions as well) needs these changes to build with the recent version 2019.01.06 of Autoconf Archive, see e.g. https://github.com/tpm2-software/tpm2-tss/pull/1245 or https://github.com/tpm2-software/tpm2-tss/issues/1250.