### PR TITLE
Add ability to run tpm2_makecredential without a TPM

### DIFF
--- a/lib/tpm2_identity_util.c
+++ b/lib/tpm2_identity_util.c
@@ -1,0 +1,482 @@
+//**********************************************************************;
+// Copyright (c) 2017, Intel Corporation
+// Copyright (c) 2019 Massachusetts Institute of Technology
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+// 1. Redistributions of source code must retain the above copyright notice,
+// this list of conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright notice,
+// this list of conditions and the following disclaimer in the documentation
+// and/or other materials provided with the distribution.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+// THE POSSIBILITY OF SUCH DAMAGE.
+//**********************************************************************
+
+#include <errno.h>
+#include <stdint.h>
+#include <string.h>
+
+#include <openssl/aes.h>
+#include <openssl/bn.h>
+#include <openssl/evp.h>
+#include <openssl/err.h>
+#include <openssl/hmac.h>
+#include <openssl/obj_mac.h>
+#include <openssl/pem.h>
+#include <openssl/rand.h>
+#include <openssl/rsa.h>
+
+#include <tss2/tss2_mu.h>
+#include <tss2/tss2_sys.h>
+
+#include "files.h"
+#include "log.h"
+#include "tpm2_alg_util.h"
+#include "tpm2_kdfa.h"
+#include "tpm2_openssl.h"
+#include "tpm2_identity_util.h"
+#include "tpm2_util.h"
+
+
+// Identity-related functionality that the TPM normally does, but using OpenSSL
+
+#if defined(LIBRESSL_VERSION_NUMBER)
+static int RSA_padding_add_PKCS1_OAEP_mgf1(unsigned char *to, int tlen,
+        const unsigned char *from, int flen, const unsigned char *param, int plen,
+        const EVP_MD *md, const EVP_MD *mgf1md) {
+
+    int ret = 0;
+    int i, emlen = tlen - 1;
+    unsigned char *db, *seed;
+    unsigned char *dbmask, seedmask[EVP_MAX_MD_SIZE];
+    int mdlen;
+
+    if (md == NULL)
+        md = EVP_sha1();
+    if (mgf1md == NULL)
+        mgf1md = md;
+
+    mdlen = EVP_MD_size(md);
+
+    if (flen > emlen - 2 * mdlen - 1) {
+        RSAerr(RSA_F_RSA_PADDING_ADD_PKCS1_OAEP,
+               RSA_R_DATA_TOO_LARGE_FOR_KEY_SIZE);
+        return 0;
+    }
+
+    if (emlen < 2 * mdlen + 1) {
+        RSAerr(RSA_F_RSA_PADDING_ADD_PKCS1_OAEP,
+               RSA_R_KEY_SIZE_TOO_SMALL);
+        return 0;
+    }
+
+    to[0] = 0;
+    seed = to + 1;
+    db = to + mdlen + 1;
+
+    if (!EVP_Digest((void *)param, plen, db, NULL, md, NULL))
+        return 0;
+    memset(db + mdlen, 0, emlen - flen - 2 * mdlen - 1);
+    db[emlen - flen - mdlen - 1] = 0x01;
+    memcpy(db + emlen - flen - mdlen, from, (unsigned int)flen);
+    if (RAND_bytes(seed, mdlen) <= 0)
+        return 0;
+
+    dbmask = OPENSSL_malloc(emlen - mdlen);
+    if (dbmask == NULL) {
+        RSAerr(RSA_F_RSA_PADDING_ADD_PKCS1_OAEP, ERR_R_MALLOC_FAILURE);
+        return 0;
+    }
+
+    if (PKCS1_MGF1(dbmask, emlen - mdlen, seed, mdlen, mgf1md) < 0)
+        goto err;
+    for (i = 0; i < emlen - mdlen; i++)
+        db[i] ^= dbmask[i];
+
+    if (PKCS1_MGF1(seedmask, mdlen, db, emlen - mdlen, mgf1md) < 0)
+        goto err;
+    for (i = 0; i < mdlen; i++)
+        seed[i] ^= seedmask[i];
+
+    ret = 1;
+
+ err:
+    OPENSSL_free(dbmask);
+
+    return ret;
+}
+#endif
+
+static TPM2_KEY_BITS get_pub_asym_key_bits(TPM2B_PUBLIC *public) {
+
+    TPMU_PUBLIC_PARMS *p = &public->publicArea.parameters;
+    switch(public->publicArea.type) {
+    case TPM2_ALG_ECC:
+        /* fall-thru */
+    case TPM2_ALG_RSA:
+        return p->asymDetail.symmetric.keyBits.sym;
+    /* no default */
+    }
+
+    return 0;
+}
+
+static bool encrypt_seed_with_tpm2_rsa_public_key(TPM2B_DIGEST *protection_seed,
+        TPM2B_PUBLIC *parent_pub, unsigned char *label, int labelLen,
+        TPM2B_ENCRYPTED_SECRET *encrypted_protection_seed) {
+    bool rval = false;
+    RSA *rsa = NULL;
+
+    // Public modulus (RSA-only!)
+    TPMI_RSA_KEY_BITS mod_size_bits = parent_pub->publicArea.parameters.rsaDetail.keyBits;
+    UINT16 mod_size = mod_size_bits / 8;
+    TPM2B *pub_key_val = (TPM2B *)&parent_pub->publicArea.unique.rsa;
+    unsigned char *pub_modulus = malloc(mod_size);
+    if (pub_modulus == NULL) {
+        LOG_ERR("Failed to allocate memory to store public key's modulus.");
+        return false;
+    }
+    memcpy(pub_modulus, pub_key_val->buffer, mod_size);
+
+    TPMI_ALG_HASH parent_name_alg = parent_pub->publicArea.nameAlg;
+
+    /*
+     * This is the biggest buffer value, so it should always be sufficient.
+     */
+    unsigned char encoded[TPM2_MAX_DIGEST_BUFFER];
+    int return_code = RSA_padding_add_PKCS1_OAEP_mgf1(encoded,
+            mod_size, protection_seed->buffer, protection_seed->size, label, labelLen,
+            tpm2_openssl_halg_from_tpmhalg(parent_name_alg), NULL);
+    if (return_code != 1) {
+        LOG_ERR("Failed RSA_padding_add_PKCS1_OAEP_mgf1\n");
+        goto error;
+    }
+    BIGNUM* bne = BN_new();
+    if (!bne) {
+        LOG_ERR("BN_new for bne failed\n");
+        goto error;
+    }
+    return_code = BN_set_word(bne, RSA_F4);
+    if (return_code != 1) {
+        LOG_ERR("BN_set_word failed\n");
+        BN_free(bne);
+        goto error;
+    }
+    rsa = RSA_new();
+    if (!rsa) {
+        LOG_ERR("RSA_new failed\n");
+        BN_free(bne);
+        goto error;
+    }
+    return_code = RSA_generate_key_ex(rsa, mod_size_bits, bne, NULL);
+    BN_free(bne);
+    if (return_code != 1) {
+        LOG_ERR("RSA_generate_key_ex failed\n");
+        goto error;
+    }
+    BIGNUM *n = BN_bin2bn(pub_modulus, mod_size, NULL);
+    if (n == NULL) {
+        LOG_ERR("BN_bin2bn failed\n");
+        goto error;
+    }
+    if (!RSA_set0_key(rsa, n, NULL, NULL)) {
+        LOG_ERR("RSA_set0_key failed\n");
+        BN_free(n);
+        goto error;
+    }
+    // Encrypting
+    encrypted_protection_seed->size = mod_size;
+    return_code = RSA_public_encrypt(mod_size, encoded,
+            encrypted_protection_seed->secret, rsa, RSA_NO_PADDING);
+    if (return_code < 0) {
+        LOG_ERR("Failed RSA_public_encrypt\n");
+        goto error;
+    }
+
+    rval = true;
+
+error:
+    free(pub_modulus);
+    RSA_free(rsa);
+    return rval;
+}
+
+bool tpm2_identity_util_calc_outer_integrity_hmac_key_and_dupsensitive_enc_key(
+        TPM2B_PUBLIC *parent_pub,
+        TPM2B_NAME *pubname,
+        TPM2B_DIGEST *protection_seed,
+        TPM2B_MAX_BUFFER *protection_hmac_key,
+        TPM2B_MAX_BUFFER *protection_enc_key) {
+
+    TPM2B null_2b = { .size = 0 };
+
+    TPMI_ALG_HASH parent_alg = parent_pub->publicArea.nameAlg;
+    UINT16 parent_hash_size = tpm2_alg_util_get_hash_size(parent_alg);
+
+    TSS2_RC rval = tpm2_kdfa(parent_alg, (TPM2B *)protection_seed, "INTEGRITY",
+            &null_2b, &null_2b, parent_hash_size * 8, protection_hmac_key);
+    if (rval != TPM2_RC_SUCCESS) {
+        return false;
+    }
+
+    TPM2_KEY_BITS pub_key_bits = get_pub_asym_key_bits(parent_pub);
+
+    rval = tpm2_kdfa(parent_alg, (TPM2B *)protection_seed, "STORAGE",
+            (TPM2B *)pubname, &null_2b, pub_key_bits,
+            protection_enc_key);
+    if (rval != TPM2_RC_SUCCESS) {
+        return false;
+    }
+
+    return true;
+}
+
+
+bool tpm2_identity_util_encrypt_seed_with_public_key(TPM2B_DIGEST *protection_seed,
+        TPM2B_PUBLIC *parent_pub, unsigned char *label, int labelLen,
+        TPM2B_ENCRYPTED_SECRET *encrypted_protection_seed) {
+    bool result = false;
+    TPMI_ALG_PUBLIC alg = parent_pub->publicArea.type;
+    
+    switch (alg) {
+    case TPM2_ALG_RSA:
+        result = encrypt_seed_with_tpm2_rsa_public_key(protection_seed, 
+                parent_pub, label, labelLen, encrypted_protection_seed);
+        break;
+    case TPM2_ALG_ECC:
+        LOG_ERR("Algorithm '%s' not supported yet", tpm2_alg_util_algtostr(alg,
+            tpm2_alg_util_flags_any));
+        result = false;
+        break;
+    default:
+        LOG_ERR("Cannot handle algorithm, got: %s", tpm2_alg_util_algtostr(alg,
+            tpm2_alg_util_flags_any));
+        return false;
+    }
+    
+    return result;
+}
+
+static const EVP_CIPHER *tpm_alg_to_ossl(TPMT_SYM_DEF_OBJECT *sym) {
+
+    switch(sym->algorithm) {
+        case TPM2_ALG_AES: {
+            switch (sym->keyBits.aes) {
+            case 128:
+                return EVP_aes_128_cfb();
+            case 256:
+                return EVP_aes_256_cfb();
+            /* no default */
+            }
+        }
+        /* no default */
+    }
+
+    LOG_ERR("Unsupported parent key symmetric parameters");
+
+    return NULL;
+}
+
+static bool aes_encrypt_buffers(TPMT_SYM_DEF_OBJECT *sym, uint8_t *encryption_key,
+        uint8_t *buf1, size_t buf1_len,
+        uint8_t *buf2, size_t buf2_len,
+        TPM2B_MAX_BUFFER *cipher_text) {
+
+    bool result = false;
+
+    unsigned offset = 0;
+    size_t total_len = buf1_len + buf2_len;
+
+    if (total_len > sizeof(cipher_text->buffer)) {
+        LOG_ERR("Plaintext too big, got %zu, expected less then %zu",
+                total_len, sizeof(cipher_text->buffer));
+        return false;
+    }
+
+    const EVP_CIPHER *cipher = tpm_alg_to_ossl(sym);
+    if (!cipher) {
+        return false;
+    }
+
+    const unsigned char iv[512] = { 0 };
+
+    if (((unsigned long)EVP_CIPHER_iv_length(cipher)) > sizeof(iv)) {
+        LOG_ERR("IV size is bigger then IV buffer size");
+        return false;
+    }
+
+    EVP_CIPHER_CTX *ctx = tpm2_openssl_cipher_new();
+
+    int rc = EVP_EncryptInit_ex(ctx, cipher, NULL, encryption_key, iv);
+    if (!rc) {
+        return false;
+    }
+
+    EVP_CIPHER_CTX_set_padding(ctx, 0);
+
+    uint8_t *bufs[2] = {
+        buf1,
+        buf2
+    };
+
+    size_t lens[ARRAY_LEN(bufs)] = {
+        buf1_len,
+        buf2_len
+    };
+
+    unsigned i;
+    for (i=0; i < ARRAY_LEN(bufs); i++) {
+
+        uint8_t *b = bufs[i];
+        size_t l = lens[i];
+
+        if (!b) {
+            continue;
+        }
+
+        int output_len = total_len - offset;
+
+        rc = EVP_EncryptUpdate(ctx, &cipher_text->buffer[offset], &output_len - offset, b, l);
+        if (!rc) {
+            LOG_ERR("Encrypt failed");
+            goto out;
+        }
+
+        offset += l;
+    }
+
+    int tmp_len = 0;
+    rc = EVP_EncryptFinal_ex(ctx, NULL, &tmp_len);
+    if (!rc) {
+        LOG_ERR("Encrypt failed");
+        goto out;
+    }
+
+    cipher_text->size = total_len;
+
+    result = true;
+
+out:
+    tpm2_openssl_cipher_free(ctx);
+
+    return result;
+}
+
+static void hmac_outer_integrity(
+        TPMI_ALG_HASH parent_name_alg,
+        uint8_t *buffer1, uint16_t buffer1_size,
+        uint8_t *buffer2, uint16_t buffer2_size, uint8_t *hmac_key,
+        TPM2B_DIGEST *outer_integrity_hmac) {
+
+    uint8_t to_hmac_buffer[TPM2_MAX_DIGEST_BUFFER];
+    memcpy(to_hmac_buffer, buffer1, buffer1_size);
+    memcpy(to_hmac_buffer + buffer1_size, buffer2, buffer2_size);
+    uint32_t size = 0;
+
+    UINT16 hash_size = tpm2_alg_util_get_hash_size(parent_name_alg);
+
+    HMAC(tpm2_openssl_halg_from_tpmhalg(parent_name_alg), hmac_key, hash_size, to_hmac_buffer,
+            buffer1_size + buffer2_size, outer_integrity_hmac->buffer, &size);
+    outer_integrity_hmac->size = size;
+}
+
+bool tpm2_identity_util_calculate_inner_integrity(
+        TPMI_ALG_HASH name_alg, 
+        TPM2B_SENSITIVE *sensitive, 
+        TPM2B_NAME *pubname, 
+        TPM2B_DATA *enc_sensitive_key,
+        TPMT_SYM_DEF_OBJECT *sym_alg,
+        TPM2B_MAX_BUFFER *encrypted_inner_integrity) {
+
+    //Marshal sensitive area
+    uint8_t buffer_marshalled_sensitiveArea[TPM2_MAX_DIGEST_BUFFER] = { 0 };
+    size_t marshalled_sensitive_size = 0;
+    Tss2_MU_TPMT_SENSITIVE_Marshal(&sensitive->sensitiveArea,
+            buffer_marshalled_sensitiveArea + sizeof(uint16_t), TPM2_MAX_DIGEST_BUFFER,
+            &marshalled_sensitive_size);
+    size_t marshalled_sensitive_size_info = 0;
+    Tss2_MU_UINT16_Marshal(marshalled_sensitive_size, buffer_marshalled_sensitiveArea,
+            sizeof(uint16_t), &marshalled_sensitive_size_info);
+
+    //concatenate NAME
+    memcpy(
+            buffer_marshalled_sensitiveArea + marshalled_sensitive_size
+                    + marshalled_sensitive_size_info,
+            pubname->name,
+            pubname->size);
+
+    //Digest marshalled-sensitive || name
+    uint8_t *marshalled_sensitive_and_name_digest =
+            buffer_marshalled_sensitiveArea + marshalled_sensitive_size
+                    + marshalled_sensitive_size_info
+                    + pubname->size;
+    size_t digest_size_info = 0;
+    UINT16 hash_size = tpm2_alg_util_get_hash_size(name_alg);
+    Tss2_MU_UINT16_Marshal(hash_size, marshalled_sensitive_and_name_digest,
+            sizeof(uint16_t), &digest_size_info);
+
+    digester d = tpm2_openssl_halg_to_digester(name_alg);
+    d(buffer_marshalled_sensitiveArea,
+            marshalled_sensitive_size_info + marshalled_sensitive_size
+                    + pubname->size,
+            marshalled_sensitive_and_name_digest + digest_size_info);
+
+    //Inner integrity
+    encrypted_inner_integrity->size = marshalled_sensitive_size_info
+            + marshalled_sensitive_size + pubname->size;
+
+    return aes_encrypt_buffers(
+            sym_alg,
+            enc_sensitive_key->buffer,
+            marshalled_sensitive_and_name_digest, 
+            hash_size + digest_size_info,
+            buffer_marshalled_sensitiveArea, 
+            marshalled_sensitive_size_info + marshalled_sensitive_size,
+            encrypted_inner_integrity);
+}
+
+void tpm2_identity_util_calculate_outer_integrity(
+        TPMI_ALG_HASH parent_name_alg,
+        TPM2B_NAME *pubname,
+        TPM2B_MAX_BUFFER *marshalled_sensitive,
+        TPM2B_MAX_BUFFER *protection_hmac_key,
+        TPM2B_MAX_BUFFER *protection_enc_key,
+        TPMT_SYM_DEF_OBJECT *sym_alg,
+        TPM2B_MAX_BUFFER *encrypted_duplicate_sensitive,
+        TPM2B_DIGEST *outer_hmac) {
+
+    //Calculate dupSensitive
+    encrypted_duplicate_sensitive->size =
+            marshalled_sensitive->size;
+
+    aes_encrypt_buffers(
+            sym_alg,
+            protection_enc_key->buffer,
+            marshalled_sensitive->buffer,
+            marshalled_sensitive->size,
+            NULL, 0,
+            encrypted_duplicate_sensitive);
+    //Calculate outerHMAC
+    hmac_outer_integrity(
+            parent_name_alg,
+            encrypted_duplicate_sensitive->buffer,
+            encrypted_duplicate_sensitive->size,
+            pubname->name,
+            pubname->size, 
+            protection_hmac_key->buffer,
+            outer_hmac);
+}

--- a/lib/tpm2_identity_util.h
+++ b/lib/tpm2_identity_util.h
@@ -1,0 +1,141 @@
+//**********************************************************************;
+// Copyright (c) 2017, Intel Corporation
+// Copyright (c) 2019 Massachusetts Institute of Technology
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+// 1. Redistributions of source code must retain the above copyright notice,
+// this list of conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright notice,
+// this list of conditions and the following disclaimer in the documentation
+// and/or other materials provided with the distribution.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+// THE POSSIBILITY OF SUCH DAMAGE.
+//**********************************************************************
+
+#ifndef LIB_TPM2_IDENTITY_UTIL_H_
+#define LIB_TPM2_IDENTITY_UTIL_H_
+
+#include <tss2/tss2_sys.h>
+
+#include <openssl/err.h>
+#include <openssl/hmac.h>
+#include <openssl/rsa.h>
+
+
+/**
+ * Generates HMAC integrity and symmetric encryption keys for TPM2 identies.
+ *
+ * @param parent_pub
+ *  The public key used for seed generation and protection.
+ * @param pubname
+ *  The Name object associated with the parent_pub credential.
+ * @param protection_seed
+ *  The symmetric seed value used to generate protection keys.
+ * @param protection_hmac_key
+ *  The HMAC integrity key to populate.
+ * @param protection_enc_key
+ *  The symmetric encryption key to populate.
+ * @return
+ *  True on success, false on failure.
+ */
+bool tpm2_identity_util_calc_outer_integrity_hmac_key_and_dupsensitive_enc_key(
+        TPM2B_PUBLIC *parent_pub,
+        TPM2B_NAME *pubname,
+        TPM2B_DIGEST *protection_seed,
+        TPM2B_MAX_BUFFER *protection_hmac_key,
+        TPM2B_MAX_BUFFER *protection_enc_key);
+
+/**
+ * Encrypts seed with parent public key for TPM2 credential protection process.
+ *
+ * @param protection_seed
+ *  The identity structure protection seed that is to be encrypted.
+ * @param parent_pub
+ *  The public key used for encryption.
+ * @param label
+ *  Indicates label for the seed, such as "IDENTITY" or "DUPLICATE".
+ * @param labelLen
+ *  Length of label.
+ * @param encrypted_protection_seed
+ *  The encrypted protection seed to populate.
+ * @return
+ *  True on success, false on failure.
+ */
+bool tpm2_identity_util_encrypt_seed_with_public_key(
+        TPM2B_DIGEST *protection_seed,
+        TPM2B_PUBLIC *parent_pub,
+        unsigned char *label,
+        int labelLen,
+        TPM2B_ENCRYPTED_SECRET *encrypted_protection_seed);
+
+/**
+ * Marshalls Credential Value and encrypts it with the symmetric encryption key.
+ *
+ * @param name_alg
+ *  Hash algorithm used to compute Name of the public key.
+ * @param sensitive
+ *  The Credential Value to be marshalled and encrypted with symmetric key.
+ * @param pubname
+ *  The Name object corresponding to the public key.
+ * @param enc_sensitive_key
+ *  The symmetric encryption key.
+ * @param sym_alg
+ *  The algorithm used for the symmetric encryption key.
+ * @param encrypted_inner_integrity
+ *  The encrypted, marshalled Credential Value to populate.
+ * @return
+ *  True on success, false on failure.
+ */
+bool tpm2_identity_util_calculate_inner_integrity(
+        TPMI_ALG_HASH name_alg,
+        TPM2B_SENSITIVE *sensitive,
+        TPM2B_NAME *pubname,
+        TPM2B_DATA *enc_sensitive_key,
+        TPMT_SYM_DEF_OBJECT *sym_alg,
+        TPM2B_MAX_BUFFER *encrypted_inner_integrity);
+
+/**
+ * Encrypts Credential Value with enc key and calculates HMAC with hmac key.
+ *
+ * @param parent_name_alg
+ *  Hash algorithm used to compute Name of the public key.
+ * @param pubname
+ *  The Name object corresponding to the public key.
+ * @param marshalled_sensitive
+ *  Marshalled Credential Value to be encrypted with symmetric encryption key.
+ * @param protection_hmac_key
+ *  The HMAC integrity key.
+ * @param protection_enc_key
+ *  The symmetric encryption key.
+ * @param sym_alg
+ *  The algorithm used for the symmetric encryption key.
+ * @param encrypted_duplicate_sensitive
+ *  The encrypted Credential Value to populate.
+ * @param outer_hmac
+ *  The outer HMAC structure to populate.
+ */
+void tpm2_identity_util_calculate_outer_integrity(
+        TPMI_ALG_HASH parent_name_alg,
+        TPM2B_NAME *pubname,
+        TPM2B_MAX_BUFFER *marshalled_sensitive,
+        TPM2B_MAX_BUFFER *protection_hmac_key,
+        TPM2B_MAX_BUFFER *protection_enc_key,
+        TPMT_SYM_DEF_OBJECT *sym_alg,
+        TPM2B_MAX_BUFFER *encrypted_duplicate_sensitive,
+        TPM2B_DIGEST *outer_hmac);
+
+#endif /* LIB_TPM2_IDENTITY_UTIL_H_ */

--- a/lib/tpm2_openssl.c
+++ b/lib/tpm2_openssl.c
@@ -64,6 +64,32 @@ const EVP_MD *tpm2_openssl_halg_from_tpmhalg(TPMI_ALG_HASH algorithm) {
     /* no return, not possible */
 }
 
+#if defined(LIB_TPM2_OPENSSL_OPENSSL_PRE11)
+int RSA_set0_key(RSA *r, BIGNUM *n, BIGNUM *e, BIGNUM *d) {
+
+    if ((r->n == NULL && n == NULL) || (r->e == NULL && e == NULL)) {
+        return 0;
+    }
+
+    if (n != NULL) {
+        BN_free(r->n);
+        r->n = n;
+    }
+
+    if (e != NULL) {
+        BN_free(r->e);
+        r->e = e;
+    }
+
+    if (d != NULL) {
+        BN_free(r->d);
+        r->d = d;
+    }
+
+    return 1;
+}
+#endif
+
 static inline const char *get_openssl_err(void) {
     return ERR_error_string(ERR_get_error(), NULL);
 }

--- a/lib/tpm2_openssl.h
+++ b/lib/tpm2_openssl.h
@@ -32,10 +32,17 @@
 
 #include <openssl/err.h>
 #include <openssl/hmac.h>
+#include <openssl/rsa.h>
 
 #if (OPENSSL_VERSION_NUMBER < 0x1010000fL && !defined(LIBRESSL_VERSION_NUMBER)) || (defined(LIBRESSL_VERSION_NUMBER) && LIBRESSL_VERSION_NUMBER < 0x20700000L) /* OpenSSL 1.1.0 */
 #define LIB_TPM2_OPENSSL_OPENSSL_PRE11
 #endif
+
+
+#if defined(LIB_TPM2_OPENSSL_OPENSSL_PRE11)
+int RSA_set0_key(RSA *r, BIGNUM *n, BIGNUM *e, BIGNUM *d);
+#endif
+
 
 /**
  * Function prototype for a hashing routine.

--- a/lib/tpm2_options.c
+++ b/lib/tpm2_options.c
@@ -338,13 +338,14 @@ tpm2_option_code tpm2_handle_options (int argc, char **argv,
         { "quiet",         no_argument,       NULL, 'Q' },
         { "version",       no_argument,       NULL, 'v' },
         { "enable-errata", no_argument,       NULL, 'Z' },
+        { "openssl-backend",        no_argument,       NULL, 'X' },
     };
 
     const char *tcti_conf_option = NULL;
 
 
     /* handle any options */
-    const char* common_short_opts = "T:h::vVQZ";
+    const char* common_short_opts = "T:h::vVQZX";
     tpm2_options *opts = tpm2_options_new(common_short_opts,
             ARRAY_LEN(long_options), long_options, NULL, NULL, true);
     if (!opts) {
@@ -403,6 +404,12 @@ tpm2_option_code tpm2_handle_options (int argc, char **argv,
             break;
         case 'Z':
             flags->enable_errata = 1;
+            break;
+        case 'X':
+            if (tool_opts) {
+                flags->no_tpm = 1;
+                tool_opts->flags |= TPM2_OPTIONS_NO_SAPI;
+            }
             break;
         case '?':
             goto out;

--- a/lib/tpm2_options.h
+++ b/lib/tpm2_options.h
@@ -45,6 +45,7 @@ union tpm2_option_flags {
         UINT8 verbose : 1;
         UINT8 quiet   : 1;
         UINT8 enable_errata  : 1;
+        UINT8 no_tpm  : 1;
     };
     UINT8 all;
 };

--- a/man/tpm2_makecredential.1.md
+++ b/man/tpm2_makecredential.1.md
@@ -14,7 +14,8 @@ TPM.
 # DESCRIPTION
 
 **tpm2_makecredential**(1) - Use a TPM public key to protect a secret that is used
-to encrypt the AK certificate.
+to encrypt the AK certificate.  This can be used without a TPM by using 
+the **--openssl-backend** option.
 
 # OPTIONS
 

--- a/test/integration/tests/makecredential.sh
+++ b/test/integration/tests/makecredential.sh
@@ -75,4 +75,6 @@ Loadkeyname=`cat $output_ak_pub_name | xxd -p -c $file_size`
 
 tpm2_makecredential -Q -e $output_ek_pub  -s $file_input_data  -n $Loadkeyname -o $output_mkcredential
 
+tpm2_makecredential -Q -e $output_ek_pub  -s $file_input_data  -n $Loadkeyname -o $output_mkcredential --openssl-backend
+
 exit 0

--- a/tools/tpm2_import.c
+++ b/tools/tpm2_import.c
@@ -54,15 +54,6 @@
 #include <stdio.h>
 #include <string.h>
 
-#include <openssl/aes.h>
-#include <openssl/bn.h>
-#include <openssl/evp.h>
-#include <openssl/err.h>
-#include <openssl/hmac.h>
-#include <openssl/pem.h>
-#include <openssl/rand.h>
-#include <openssl/rsa.h>
-
 #include <limits.h>
 #include <tss2/tss2_esys.h>
 #include <tss2/tss2_mu.h>
@@ -74,6 +65,7 @@
 #include "tpm2_kdfa.h"
 #include "tpm2_errata.h"
 #include "tpm2_openssl.h"
+#include "tpm2_identity_util.h"
 #include "tpm2_options.h"
 #include "tpm2_tool.h"
 #include "tpm2_util.h"
@@ -104,96 +96,6 @@ static tpm_import_ctx ctx = {
     .auth.session_data = TPMS_AUTH_COMMAND_INIT(TPM2_RS_PW),
 };
 
-#if defined(LIB_TPM2_OPENSSL_OPENSSL_PRE11)
-static int RSA_set0_key(RSA *r, BIGNUM *n, BIGNUM *e, BIGNUM *d) {
-
-    if ((r->n == NULL && n == NULL) || (r->e == NULL && e == NULL)) {
-        return 0;
-    }
-
-    if (n != NULL) {
-        BN_free(r->n);
-        r->n = n;
-    }
-
-    if (e != NULL) {
-        BN_free(r->e);
-        r->e = e;
-    }
-
-    if (d != NULL) {
-        BN_free(r->d);
-        r->d = d;
-    }
-
-    return 1;
-}
-#endif
-#if defined(LIBRESSL_VERSION_NUMBER)
-static int RSA_padding_add_PKCS1_OAEP_mgf1(unsigned char *to, int tlen,
-        const unsigned char *from, int flen, const unsigned char *param, int plen,
-        const EVP_MD *md, const EVP_MD *mgf1md) {
-
-    int i, emlen = tlen - 1;
-    unsigned char *db, *seed;
-    unsigned char *dbmask, seedmask[EVP_MAX_MD_SIZE];
-    int mdlen;
-
-    if (md == NULL)
-        md = EVP_sha1();
-    if (mgf1md == NULL)
-        mgf1md = md;
-
-    mdlen = EVP_MD_size(md);
-
-    if (flen > emlen - 2 * mdlen - 1) {
-        RSAerr(RSA_F_RSA_PADDING_ADD_PKCS1_OAEP,
-               RSA_R_DATA_TOO_LARGE_FOR_KEY_SIZE);
-        return 0;
-    }
-
-    if (emlen < 2 * mdlen + 1) {
-        RSAerr(RSA_F_RSA_PADDING_ADD_PKCS1_OAEP,
-               RSA_R_KEY_SIZE_TOO_SMALL);
-        return 0;
-    }
-
-    to[0] = 0;
-    seed = to + 1;
-    db = to + mdlen + 1;
-
-    if (!EVP_Digest((void *)param, plen, db, NULL, md, NULL))
-        return 0;
-    memset(db + mdlen, 0, emlen - flen - 2 * mdlen - 1);
-    db[emlen - flen - mdlen - 1] = 0x01;
-    memcpy(db + emlen - flen - mdlen, from, (unsigned int)flen);
-    if (RAND_bytes(seed, mdlen) <= 0)
-        return 0;
-
-    dbmask = OPENSSL_malloc(emlen - mdlen);
-    if (dbmask == NULL) {
-        RSAerr(RSA_F_RSA_PADDING_ADD_PKCS1_OAEP, ERR_R_MALLOC_FAILURE);
-        return 0;
-    }
-
-    if (PKCS1_MGF1(dbmask, emlen - mdlen, seed, mdlen, mgf1md) < 0)
-        goto err;
-    for (i = 0; i < emlen - mdlen; i++)
-        db[i] ^= dbmask[i];
-
-    if (PKCS1_MGF1(seedmask, mdlen, db, emlen - mdlen, mgf1md) < 0)
-        goto err;
-    for (i = 0; i < mdlen; i++)
-        seed[i] ^= seedmask[i];
-
-    OPENSSL_free(dbmask);
-    return 1;
-
- err:
-    OPENSSL_free(dbmask);
-    return 0;
-}
-#endif
 
 static bool tpm2_readpublic(ESYS_CONTEXT *ectx, ESYS_TR handle,
                 TPM2B_PUBLIC **public) {
@@ -207,210 +109,6 @@ static bool tpm2_readpublic(ESYS_CONTEXT *ectx, ESYS_TR handle,
     }
 
     return true;
-}
-
-static bool encrypt_seed_with_tpm2_rsa_public_key(TPM2B_DIGEST *protection_seed,
-        TPM2B_PUBLIC *parent_pub,
-        TPM2B_ENCRYPTED_SECRET *encrypted_protection_seed) {
-    bool rval = false;
-    RSA *rsa = NULL;
-
-    // Public modulus
-    TPMI_RSA_KEY_BITS mod_size_bits = parent_pub->publicArea.parameters.rsaDetail.keyBits;
-    UINT16 mod_size = mod_size_bits / 8;
-    TPM2B *pub_key_val = (TPM2B *)&parent_pub->publicArea.unique.rsa;
-    unsigned char *pub_modulus = malloc(mod_size);
-    if (pub_modulus == NULL) {
-        LOG_ERR("Failed to allocate memory to store public key's modulus.");
-        return false;
-    }
-    memcpy(pub_modulus, pub_key_val->buffer, mod_size);
-
-    TPMI_ALG_HASH parent_name_alg = parent_pub->publicArea.nameAlg;
-
-    /*
-     * This is the biggest buffer value, so it should always be sufficient.
-     */
-    unsigned char encoded[TPM2_MAX_DIGEST_BUFFER];
-    unsigned char label[10] = { 'D', 'U', 'P', 'L', 'I', 'C', 'A', 'T', 'E', 0 };
-    int return_code = RSA_padding_add_PKCS1_OAEP_mgf1(encoded,
-            mod_size, protection_seed->buffer, protection_seed->size, label, 10,
-            tpm2_openssl_halg_from_tpmhalg(parent_name_alg), NULL);
-    if (return_code != 1) {
-        LOG_ERR("Failed RSA_padding_add_PKCS1_OAEP_mgf1\n");
-        goto error;
-    }
-    BIGNUM* bne = BN_new();
-    if (!bne) {
-        LOG_ERR("BN_new for bne failed\n");
-        goto error;
-    }
-    return_code = BN_set_word(bne, RSA_F4);
-    if (return_code != 1) {
-        LOG_ERR("BN_set_word failed\n");
-        BN_free(bne);
-        goto error;
-    }
-    rsa = RSA_new();
-    if (!rsa) {
-        LOG_ERR("RSA_new failed\n");
-        BN_free(bne);
-        goto error;
-    }
-    return_code = RSA_generate_key_ex(rsa, mod_size_bits, bne, NULL);
-    BN_free(bne);
-    if (return_code != 1) {
-        LOG_ERR("RSA_generate_key_ex failed\n");
-        goto error;
-    }
-    BIGNUM *n = BN_bin2bn(pub_modulus, mod_size, NULL);
-    if (n == NULL) {
-        LOG_ERR("BN_bin2bn failed\n");
-        goto error;
-    }
-    if (!RSA_set0_key(rsa, n, NULL, NULL)) {
-        LOG_ERR("RSA_set0_key failed\n");
-        BN_free(n);
-        goto error;
-    }
-    // Encrypting
-    encrypted_protection_seed->size = mod_size;
-    return_code = RSA_public_encrypt(mod_size, encoded,
-            encrypted_protection_seed->secret, rsa, RSA_NO_PADDING);
-    if (return_code < 0) {
-        LOG_ERR("Failed RSA_public_encrypt\n");
-        goto error;
-    }
-
-    rval = true;
-
-error:
-    free(pub_modulus);
-    RSA_free(rsa);
-    return rval;
-}
-
-static const EVP_CIPHER *tpm_alg_to_ossl(TPMT_SYM_DEF_OBJECT *sym) {
-
-    switch(sym->algorithm) {
-        case TPM2_ALG_AES: {
-            switch (sym->keyBits.aes) {
-            case 128:
-                return EVP_aes_128_cfb();
-            case 256:
-                return EVP_aes_256_cfb();
-            /* no default */
-            }
-        }
-        /* no default */
-    }
-
-    LOG_ERR("Unsupported parent key symmetric parameters");
-
-    return NULL;
-}
-
-bool aes_encrypt_buffers(TPMT_SYM_DEF_OBJECT *sym, uint8_t *encryption_key,
-        uint8_t *buf1, size_t buf1_len,
-        uint8_t *buf2, size_t buf2_len,
-        TPM2B_MAX_BUFFER *cipher_text) {
-
-    bool result = false;
-
-    unsigned offset = 0;
-    size_t total_len = buf1_len + buf2_len;
-
-    if (total_len > sizeof(cipher_text->buffer)) {
-        LOG_ERR("Plaintext too big, got %zu, expected less then %zu",
-                total_len, sizeof(cipher_text->buffer));
-        return false;
-    }
-
-    const EVP_CIPHER *cipher = tpm_alg_to_ossl(sym);
-    if (!cipher) {
-        return false;
-    }
-
-    const unsigned char iv[512] = { 0 };
-
-    if (((unsigned long)EVP_CIPHER_iv_length(cipher)) > sizeof(iv)) {
-        LOG_ERR("IV size is bigger then IV buffer size");
-        return false;
-    }
-
-    EVP_CIPHER_CTX *ctx = tpm2_openssl_cipher_new();
-
-    int rc = EVP_EncryptInit_ex(ctx, cipher, NULL, encryption_key, iv);
-    if (!rc) {
-        return false;
-    }
-
-    EVP_CIPHER_CTX_set_padding(ctx, 0);
-
-    uint8_t *bufs[2] = {
-        buf1,
-        buf2
-    };
-
-    size_t lens[ARRAY_LEN(bufs)] = {
-        buf1_len,
-        buf2_len
-    };
-
-    unsigned i;
-    for (i=0; i < ARRAY_LEN(bufs); i++) {
-
-        uint8_t *b = bufs[i];
-        size_t l = lens[i];
-
-        if (!b) {
-            continue;
-        }
-
-        int output_len = total_len - offset;
-
-        rc = EVP_EncryptUpdate(ctx, &cipher_text->buffer[offset], &output_len - offset, b, l);
-        if (!rc) {
-            LOG_ERR("Encrypt failed");
-            goto out;
-        }
-
-        offset += l;
-    }
-
-    int tmp_len = 0;
-    rc = EVP_EncryptFinal_ex(ctx, NULL, &tmp_len);
-    if (!rc) {
-        LOG_ERR("Encrypt failed");
-        goto out;
-    }
-
-    cipher_text->size = total_len;
-
-    result = true;
-
-out:
-    tpm2_openssl_cipher_free(ctx);
-
-    return result;
-}
-
-static void hmac_outer_integrity(
-        TPMI_ALG_HASH parent_name_alg,
-        uint8_t *buffer1, uint16_t buffer1_size,
-        uint8_t *buffer2, uint16_t buffer2_size, uint8_t *hmac_key,
-        TPM2B_DIGEST *outer_integrity_hmac) {
-
-    uint8_t to_hmac_buffer[TPM2_MAX_DIGEST_BUFFER];
-    memcpy(to_hmac_buffer, buffer1, buffer1_size);
-    memcpy(to_hmac_buffer + buffer1_size, buffer2, buffer2_size);
-    uint32_t size = 0;
-
-    UINT16 hash_size = tpm2_alg_util_get_hash_size(parent_name_alg);
-
-    HMAC(tpm2_openssl_halg_from_tpmhalg(parent_name_alg), hmac_key, hash_size, to_hmac_buffer,
-            buffer1_size + buffer2_size, outer_integrity_hmac->buffer, &size);
-    outer_integrity_hmac->size = size;
 }
 
 static bool create_name(TPM2B_PUBLIC *public, TPM2B_NAME *pubname) {
@@ -453,130 +151,6 @@ static bool create_name(TPM2B_PUBLIC *public, TPM2B_NAME *pubname) {
     pubname->size = hash_size + 2;
 
     return true;
-}
-
-static TPM2_KEY_BITS get_pub_asym_key_bits(TPM2B_PUBLIC *public) {
-
-    TPMU_PUBLIC_PARMS *p = &public->publicArea.parameters;
-    switch(public->publicArea.type) {
-    case TPM2_ALG_ECC:
-        /* fall-thru */
-    case TPM2_ALG_RSA:
-        return p->asymDetail.symmetric.keyBits.sym;
-    /* no default */
-    }
-
-    return 0;
-}
-
-static bool calc_outer_integrity_hmac_key_and_dupsensitive_enc_key(
-        TPM2B_PUBLIC *parent_pub,
-        TPM2B_NAME *pubname,
-        TPM2B_DIGEST *protection_seed,
-        TPM2B_MAX_BUFFER *protection_hmac_key,
-        TPM2B_MAX_BUFFER *protection_enc_key) {
-
-    TPM2B null_2b = { .size = 0 };
-
-    TPMI_ALG_HASH parent_alg = parent_pub->publicArea.nameAlg;
-    UINT16 parent_hash_size = tpm2_alg_util_get_hash_size(parent_alg);
-
-    TSS2_RC rval = tpm2_kdfa(parent_alg, (TPM2B *)protection_seed, "INTEGRITY",
-            &null_2b, &null_2b, parent_hash_size * 8, protection_hmac_key);
-    if (rval != TPM2_RC_SUCCESS) {
-        return false;
-    }
-
-    TPM2_KEY_BITS pub_key_bits = get_pub_asym_key_bits(parent_pub);
-
-    rval = tpm2_kdfa(parent_alg, (TPM2B *)protection_seed, "STORAGE",
-            (TPM2B *)pubname, &null_2b, pub_key_bits,
-            protection_enc_key);
-    if (rval != TPM2_RC_SUCCESS) {
-        return false;
-    }
-
-    return true;
-}
-
-static void calculate_inner_integrity(TPMI_ALG_HASH name_alg, TPM2B_SENSITIVE *sensitive, TPM2B_NAME *pubname, TPM2B_DATA *enc_sensitive_key,
-        TPMT_SYM_DEF_OBJECT *sym_alg,
-        TPM2B_MAX_BUFFER *encrypted_inner_integrity) {
-
-    //Marshal sensitive area
-    uint8_t buffer_marshalled_sensitiveArea[TPM2_MAX_DIGEST_BUFFER] = { 0 };
-    size_t marshalled_sensitive_size = 0;
-    Tss2_MU_TPMT_SENSITIVE_Marshal(&sensitive->sensitiveArea,
-            buffer_marshalled_sensitiveArea + sizeof(uint16_t), TPM2_MAX_DIGEST_BUFFER,
-            &marshalled_sensitive_size);
-    size_t marshalled_sensitive_size_info = 0;
-    Tss2_MU_UINT16_Marshal(marshalled_sensitive_size, buffer_marshalled_sensitiveArea,
-            sizeof(uint16_t), &marshalled_sensitive_size_info);
-
-    //concatenate NAME
-    memcpy(
-            buffer_marshalled_sensitiveArea + marshalled_sensitive_size
-                    + marshalled_sensitive_size_info,
-            pubname->name,
-            pubname->size);
-
-    //Digest marshalled-sensitive || name
-    uint8_t *marshalled_sensitive_and_name_digest =
-            buffer_marshalled_sensitiveArea + marshalled_sensitive_size
-                    + marshalled_sensitive_size_info
-                    + pubname->size;
-    size_t digest_size_info = 0;
-    UINT16 hash_size = tpm2_alg_util_get_hash_size(name_alg);
-    Tss2_MU_UINT16_Marshal(hash_size, marshalled_sensitive_and_name_digest,
-            sizeof(uint16_t), &digest_size_info);
-
-    digester d = tpm2_openssl_halg_to_digester(name_alg);
-    d(buffer_marshalled_sensitiveArea,
-            marshalled_sensitive_size_info + marshalled_sensitive_size
-                    + pubname->size,
-            marshalled_sensitive_and_name_digest + digest_size_info);
-
-    //Inner integrity
-    encrypted_inner_integrity->size = marshalled_sensitive_size_info
-            + marshalled_sensitive_size + pubname->size;
-
-    aes_encrypt_buffers(
-            sym_alg,
-            enc_sensitive_key->buffer,
-            marshalled_sensitive_and_name_digest, hash_size + digest_size_info,
-            buffer_marshalled_sensitiveArea, marshalled_sensitive_size_info + marshalled_sensitive_size,
-            encrypted_inner_integrity);
-}
-
-static void calculate_outer_integrity(
-        TPMI_ALG_HASH parent_name_alg,
-        TPM2B_NAME *pubname,
-        TPM2B_MAX_BUFFER *encrypted_inner_integrity,
-        TPM2B_MAX_BUFFER *protection_hmac_key,
-        TPM2B_MAX_BUFFER *protection_enc_key,
-        TPM2B_MAX_BUFFER *encrypted_duplicate_sensitive,
-        TPMT_SYM_DEF_OBJECT *sym_alg,
-        TPM2B_DIGEST *outer_hmac) {
-
-    //Calculate dupSensitive
-    encrypted_duplicate_sensitive->size =
-            encrypted_inner_integrity->size;
-
-    aes_encrypt_buffers(
-            sym_alg,
-            protection_enc_key->buffer,
-            encrypted_inner_integrity->buffer,
-            encrypted_inner_integrity->size,
-            NULL, 0,
-            encrypted_duplicate_sensitive);
-    //Calculate outerHMAC
-    hmac_outer_integrity(
-            parent_name_alg,
-            encrypted_duplicate_sensitive->buffer,
-            encrypted_duplicate_sensitive->size,
-            pubname->name,
-            pubname->size, protection_hmac_key->buffer,
-            outer_hmac);
 }
 
 static void create_import_key_private_data(
@@ -660,7 +234,7 @@ static bool key_import(
 
     TPM2B_MAX_BUFFER hmac_key;
     TPM2B_MAX_BUFFER enc_key;
-    calc_outer_integrity_hmac_key_and_dupsensitive_enc_key(
+    tpm2_identity_util_calc_outer_integrity_hmac_key_and_dupsensitive_enc_key(
             parent_pub,
             &pubname,
             seed,
@@ -668,20 +242,20 @@ static bool key_import(
             &enc_key);
 
     TPM2B_MAX_BUFFER encrypted_inner_integrity = TPM2B_EMPTY_INIT;
-    calculate_inner_integrity(name_alg, privkey, &pubname, &enc_sensitive_key,
+    tpm2_identity_util_calculate_inner_integrity(name_alg, privkey, &pubname, &enc_sensitive_key,
             &parent_pub->publicArea.parameters.rsaDetail.symmetric,
             &encrypted_inner_integrity);
 
     TPM2B_DIGEST outer_hmac = TPM2B_EMPTY_INIT;
     TPM2B_MAX_BUFFER encrypted_duplicate_sensitive = TPM2B_EMPTY_INIT;
-    calculate_outer_integrity(
+    tpm2_identity_util_calculate_outer_integrity(
             parent_pub->publicArea.nameAlg,
             &pubname,
             &encrypted_inner_integrity,
             &hmac_key,
             &enc_key,
-            &encrypted_duplicate_sensitive,
             &parent_pub->publicArea.parameters.rsaDetail.symmetric,
+            &encrypted_duplicate_sensitive,
             &outer_hmac);
 
     TPM2B_PRIVATE private = TPM2B_EMPTY_INIT;
@@ -690,8 +264,10 @@ static bool key_import(
             &encrypted_duplicate_sensitive, &outer_hmac);
 
     TPM2B_ENCRYPTED_SECRET encrypted_seed = TPM2B_EMPTY_INIT;
-    res = encrypt_seed_with_tpm2_rsa_public_key(seed,
+    unsigned char label[10] = { 'D', 'U', 'P', 'L', 'I', 'C', 'A', 'T', 'E', 0 };
+    res = tpm2_identity_util_encrypt_seed_with_public_key(seed,
             parent_pub,
+            label, 10,
             &encrypted_seed);
     if (!res) {
         LOG_ERR("Failed Seed Encryption\n");

--- a/tools/tpm2_makecredential.c
+++ b/tools/tpm2_makecredential.c
@@ -1,5 +1,6 @@
 //**********************************************************************;
 // Copyright (c) 2015, Intel Corporation
+// Copyright (c) 2019 Massachusetts Institute of Technology
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without
@@ -36,12 +37,16 @@
 #include <limits.h>
 #include <ctype.h>
 
+#include <openssl/rand.h>
 #include <tss2/tss2_esys.h>
 
 #include "files.h"
 #include "tpm2_options.h"
 #include "log.h"
 #include "files.h"
+#include "tpm2_alg_util.h"
+#include "tpm2_openssl.h"
+#include "tpm2_identity_util.h"
 #include "tpm2_tool.h"
 #include "tpm2_util.h"
 
@@ -112,6 +117,93 @@ static bool write_cred_and_secret(const char *path, TPM2B_ID_OBJECT *cred,
 out:
     fclose(fp);
     return result;
+}
+
+static bool make_external_credential_and_save() {
+
+    /*
+     * Get name_alg from the public key
+     */
+    TPMI_ALG_HASH name_alg = ctx.public.publicArea.nameAlg;
+
+
+    /* 
+     * Generate and encrypt seed
+     */
+    TPM2B_DIGEST seed = TPM2B_TYPE_INIT(TPM2B_DIGEST, buffer);
+    seed.size = tpm2_alg_util_get_hash_size(name_alg);
+    RAND_bytes(seed.buffer, seed.size);
+
+    TPM2B_ENCRYPTED_SECRET encrypted_seed = TPM2B_EMPTY_INIT;
+    unsigned char label[10] = { 'I', 'D', 'E', 'N', 'T', 'I', 'T', 'Y', 0 };
+    bool res = tpm2_identity_util_encrypt_seed_with_public_key(&seed,
+            &ctx.public, label, 9,
+            &encrypted_seed);
+    if (!res) {
+        LOG_ERR("Failed Seed Encryption\n");
+        return false;
+    }
+
+    /* 
+     * Perform identity structure calculations (off of the TPM)
+     */
+    TPM2B_MAX_BUFFER hmac_key;
+    TPM2B_MAX_BUFFER enc_key;
+    tpm2_identity_util_calc_outer_integrity_hmac_key_and_dupsensitive_enc_key(
+            &ctx.public,
+            &ctx.object_name,
+            &seed,
+            &hmac_key,
+            &enc_key);
+
+    /*
+     * The ctx.credential needs to be marshalled into struct with 
+     * both size and contents together (to be encrypted as a block)
+     */
+    TPM2B_MAX_BUFFER marshalled_inner_integrity = TPM2B_EMPTY_INIT;
+    marshalled_inner_integrity.size = ctx.credential.size + sizeof(ctx.credential.size);
+    UINT16 credSize = ctx.credential.size;
+    if (!tpm2_util_is_big_endian()) {
+        credSize = tpm2_util_endian_swap_16(credSize);
+    }
+    memcpy(marshalled_inner_integrity.buffer, &credSize, sizeof(credSize));
+    memcpy(&marshalled_inner_integrity.buffer[2], ctx.credential.buffer, ctx.credential.size);
+
+    /*
+     * Perform inner encryption (encIdentity) and outer HMAC (outerHMAC)
+     */
+    TPM2B_DIGEST outer_hmac = TPM2B_EMPTY_INIT;
+    TPM2B_MAX_BUFFER encrypted_sensitive = TPM2B_EMPTY_INIT;
+    tpm2_identity_util_calculate_outer_integrity(
+            name_alg,
+            &ctx.object_name,
+            &marshalled_inner_integrity,
+            &hmac_key,
+            &enc_key,
+            &ctx.public.publicArea.parameters.rsaDetail.symmetric,
+            &encrypted_sensitive,
+            &outer_hmac);
+
+    /*
+     * Package up the info to save
+     * cred_bloc = outer_hmac || encrypted_sensitive
+     * secret = encrypted_seed (with pubEK)
+     */
+    TPM2B_ID_OBJECT cred_blob = TPM2B_TYPE_INIT(TPM2B_ID_OBJECT, credential);
+
+    UINT16 outer_hmac_size = outer_hmac.size;
+    if (!tpm2_util_is_big_endian()) {
+        outer_hmac_size = tpm2_util_endian_swap_16(outer_hmac_size);
+    }
+    int offset = 0;
+    memcpy(cred_blob.credential + offset, &outer_hmac_size, sizeof(outer_hmac.size));offset += sizeof(outer_hmac.size);
+    memcpy(cred_blob.credential + offset, outer_hmac.buffer, outer_hmac.size);offset += outer_hmac.size;
+    //NOTE: do NOT include the encrypted_sensitive size, since it is encrypted with the blob!
+    memcpy(cred_blob.credential + offset, encrypted_sensitive.buffer, encrypted_sensitive.size);
+
+    cred_blob.size = outer_hmac.size + encrypted_sensitive.size + sizeof(outer_hmac.size);
+
+    return write_cred_and_secret(ctx.out_file_path, &cred_blob, &encrypted_seed);
 }
 
 static bool make_credential_and_save(ESYS_CONTEXT *ectx)
@@ -208,6 +300,11 @@ int tpm2_tool_onrun(ESYS_CONTEXT *ectx, tpm2_option_flags flags) {
     if (!ctx.flags.e || !ctx.flags.n || !ctx.flags.o || !ctx.flags.s) {
         LOG_ERR("Expected options e, n, o and s.");
         return -11;
+    }
+
+    // Run it outside of a TPM
+    if (flags.no_tpm) {
+        return make_external_credential_and_save() != true;
     }
 
     return make_credential_and_save(ectx) != true;


### PR DESCRIPTION
Performing the Make Credential routine does not require usage of a TPM, though the current implementation relies on leveraging the TPM to perform this function.  This PR adds functionality to tpm2_makecredential that allows it to perform this routine without needing a TPM to be present, supporting RSA right now. 

A large portion of this PR involves moving shared code from tpm2_import.c into a new library called tpm2_identity_util.c, since the TPM-less makecredential also will use these functions.  Some of these functions were renamed to be compliant with the library naming conventions (e.g., begin with "tpm2_identity_util_XX"). 

The function `tpm2_identity_util_encrypt_seed_with_public_key` was also generalized to accept either IDENTITY mode or DUPLICATE mode (so it still supports tpm2_import). 

In order to toggle between the TPM and TPM-less versions, we have added a new global -X/--no-tpm option for any tools that can operate w/o a TPM (though right now makecredential is the only such tool). 