### PR TITLE
Fix incorrect auth session handle usage

### DIFF
--- a/test/integration/tests/createak.sh
+++ b/test/integration/tests/createak.sh
@@ -63,4 +63,10 @@ tpm2_createak -C 0x8101000b -k - -G rsa -D sha256 -s rsassa -p ak.pub -n ak.name
 phandle=`yaml_get_kv ak.log \"ak\-persistent\-handle\"`
 tpm2_evictcontrol -Q -a o -c $phandle
 
+# Test tpm2_createak with endorsement password
+cleanup "no-shut-down"
+tpm2_changeauth -e endauth
+tpm2_createek -Q -e endauth -c 0x8101000b -G rsa -p ek.pub
+tpm2_createak -Q -e endauth -C 0x8101000b -k 0x8101000c -G rsa -p ak.pub -n ak.name
+
 exit 0

--- a/test/integration/tests/nv.sh
+++ b/test/integration/tests/nv.sh
@@ -214,4 +214,9 @@ if [ $? -eq 0 ];then
  exit 1
 fi
 
+# Check using authorisation with tpm2_nvrelease
+trap onerror ERR
+
+tpm2_nvrelease -x 0x1500015 -a 0x40000001 -P "owner"
+
 exit 0

--- a/tools/tpm2_createak.c
+++ b/tools/tpm2_createak.c
@@ -270,7 +270,7 @@ static bool create_ak(ESYS_CONTEXT *ectx) {
     ESYS_TR sess_handle = tpm2_session_get_handle(session);
     tpm2_session_free(&session);
 
-    ESYS_TR shandle = tpm2_auth_util_get_shandle(ectx, sess_handle,
+    ESYS_TR shandle = tpm2_auth_util_get_shandle(ectx, ESYS_TR_RH_ENDORSEMENT,
                         &ctx.ek.auth2.session_data, ctx.ek.auth2.session);
     if (shandle == ESYS_TR_NONE) {
         return false;

--- a/tools/tpm2_nvrelease.c
+++ b/tools/tpm2_nvrelease.c
@@ -75,7 +75,7 @@ static bool nv_space_release(ESYS_CONTEXT *ectx) {
     }
 
     ESYS_TR hierarchy = tpm2_tpmi_hierarchy_to_esys_tr(ctx.auth.hierarchy);
-    ESYS_TR shandle1 = tpm2_auth_util_get_shandle(ectx, nv_handle,
+    ESYS_TR shandle1 = tpm2_auth_util_get_shandle(ectx, hierarchy,
                             &ctx.auth.session_data, ctx.auth.session);
     if (shandle1 == ESYS_TR_NONE) {
         LOG_ERR("Couldn't get shandle");


### PR DESCRIPTION
tpm2_createak and tpm2_nvrelease both had errors whereby we were passing the incorrect auth session handle into Esys API calls. This PR fixes both tools and adds integration tests to check that authorisation works correctly with them.