### PR TITLE
tpm2_create: add TPM CreateLoaded support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## Changelog
 ### next
+  * tpm2_create: supports TPM command CreateLoaded.
   * Add support for reading authorisation passwords from a file
   * tpm2_createek: now saves a context file for the generated primary's
     handle to disk.

--- a/man/tpm2_create.1.md
+++ b/man/tpm2_create.1.md
@@ -72,6 +72,13 @@ These options for creating the tpm entity:
   * **-r**, **--privfile**=_OUTPUT\_PRIVATE\_FILE_:
     The output file which contains the sensitive portion of the object, optional.
 
+  * **-o**, **--out-context**=_OUTPUT\_CONTEXT\_FILE_:
+    The output file which contains the key context, optional. The key context is analogous to the context
+    file produced by tpm2_load(1), however is generated via a TPM CreateLoaded command. This this option
+    can be used to avoid the normal *tpm2_create* and *tpm2_load* command sequences and do it all in one
+    command, atomically.
+
+
 [common options](common/options.md)
 
 [common tcti options](common/tcti.md)
@@ -90,10 +97,19 @@ These options for creating the tpm entity:
 
 # EXAMPLES
 
+Create an object whose parent is provided via parent.ctx:
 ```
-tpm2_create -C 0x81010001 -P abc123 -K def456 -g sha256 -G keyedhash-I data.File
-tpm2_create -C file:parent.context -P abc123 -p def456 -g sha256 -G keyedhash -I data.File
-tpm2_create -C 0x81010001 -P 123abc -K 456def -X -g sha256 -G keyedhash -I data.File
+tpm2_create -C parent.ctx -u obj.pub obj.priv
+```
+
+Create an object and seal data to it:
+```
+tpm2_create -C parent.ctx  -K def456 -G keyedhash -I seal.dat -u obj.pub -r obj.priv
+```
+
+Create an rsa2048 object and load it into the TPM:
+```
+tpm2_create -C primary.ctx -G rsa2048 -u obj.pub -r obj.priv -o obj.ctx
 ```
 
 # RETURNS

--- a/test/integration/tests/create.sh
+++ b/test/integration/tests/create.sh
@@ -34,7 +34,7 @@
 source helpers.sh
 
 cleanup() {
-  rm -f key.pub key.priv policy.bin out.pub
+  rm -f key.pub key.priv policy.bin out.pub key.ctx
 
   ina "$@" "keep-context"
   if [ $? -ne 0 ]; then
@@ -104,5 +104,9 @@ test "$mode" == "ofb"
 for alg in "rsa1024:rsaes" "ecc384:ecdaa4-sha256"; do
   tpm2_create -Q -C context.out -g sha256 -G "$alg" -u key.pub -r key.priv
 done
+
+# Test createloaded support
+tpm2_create -C context.out -u key.pub -r key.priv -o key.ctx
+tpm2_readpublic -c key.ctx 2>/dev/null
 
 exit 0


### PR DESCRIPTION
Allow tpm2_create to take the -c/--context output option to
produce a context file similar to tpm2_load()

Internally, this will yeild a call to ESYS_CreateLoaded over
ESYS_Create thus producing the loaded ctx object.

Fixes: #832

Signed-off-by: William Roberts <william.c.roberts@intel.com>