### PR TITLE
INSTALL.MD: Add missing dependency to autoconf-archive

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -49,8 +49,8 @@ your distros package manager.
 The packages in the below command can be ascertained via the package manager.
 
 ```
-sudo apt-get install autoconf automake libtool pkg-config gcc libssl-dev \
-    libcurl4-gnutls-dev
+sudo apt-get install autoconf autoconf-archive automake libtool pkg-config gcc \
+    libssl-dev libcurl4-gnutls-dev
 ```
 **Notes**:
 


### PR DESCRIPTION
This was already present for Fedora, but was missing from the description for Ubuntu.