### PR TITLE
tpm2_capability: Fix infinite loop and out-of-bounds memory access

### DIFF
--- a/test/unit/test_tpm2_errata.c
+++ b/test/unit/test_tpm2_errata.c
@@ -59,7 +59,6 @@ TSS2_RC __wrap_Esys_GetCapability(ESYS_CONTEXT *context,
     UNUSED(session1);
     UNUSED(session2);
     UNUSED(session3);
-    UNUSED(capability);
     UNUSED(property);
     UNUSED(propertyCount);
 
@@ -69,6 +68,7 @@ TSS2_RC __wrap_Esys_GetCapability(ESYS_CONTEXT *context,
     *moreData = TPM2_NO;
 
     *capabilityData = calloc(1, sizeof(**capabilityData));
+    (*capabilityData)->capability = capability;
     TPML_TAGGED_TPM_PROPERTY *properties = &(*capabilityData)->data.tpmProperties;
 
     properties->count = 4;


### PR DESCRIPTION
TPM2_GetCapability may return its data in one of several formats, depending
on the capability parameter. All formats are part of a union, but they may
have a different internal structure, so specific union members need to be
accessed to avoid accessing data in the wrong format.

If moreData is set, the next request needs to use a higher value for
property in order to prevent infinite loops. Ideally, the highest value
returned by the TPM +1 is used.

While reworking the code, also avoid unnecessary memory allocations and
just reuse the structure already allocated by Esys_GetCapability.

Fixes #1311.

Signed-off-by: Alexander Steffen <Alexander.Steffen@infineon.com>