### PR TITLE
tpm2_errata: Do not request unnecessary properties

### DIFF
--- a/lib/tpm2_errata.c
+++ b/lib/tpm2_errata.c
@@ -209,11 +209,11 @@ static void process(TPMS_CAPABILITY_DATA capability_data) {
 void tpm2_errata_init(ESYS_CONTEXT *ctx) {
 
     TPMS_CAPABILITY_DATA *capability_data;
-    bool ret = tpm2_capability_get(ctx, TPM2_CAP_TPM_PROPERTIES, TPM2_PT_FIXED,
-                    TPM2_PT_FIXED, &capability_data);
+    bool ret = tpm2_capability_get(ctx, TPM2_CAP_TPM_PROPERTIES, TPM2_PT_LEVEL,
+                    TPM2_PT_YEAR - TPM2_PT_LEVEL + 1, &capability_data);
     if (!ret) {
         LOG_ERR("Failed to GetCapability: capability: 0x%x, property: 0x%x, ",
-                TPM2_CAP_TPM_PROPERTIES, TPM2_PT_FIXED);
+                TPM2_CAP_TPM_PROPERTIES, TPM2_PT_LEVEL);
         return;
     }
 


### PR DESCRIPTION
Passing TPM2_PT_FIXED as count to tpm2_capability_get is semantically
wrong, since it is not a count of anything, but an index into the list of
properties. The intention might have been to just request all the
properties, but this is not necessary since process is only interested in a
small subset of all the properties that can be requested more efficiently.

Signed-off-by: Alexander Steffen <Alexander.Steffen@infineon.com>