### PR TITLE
[3.X] test_tpm2_alg_util: fix compatibility with tss 2.2.0+

### DIFF
--- a/test/unit/test_tpm2_alg_util.c
+++ b/test/unit/test_tpm2_alg_util.c
@@ -50,7 +50,9 @@
     \
         TPM2_ALG_ID found_id = tpm2_alg_util_strtoalg(str(friendly)); \
         const char *found_str = tpm2_alg_util_algtostr(value); \
-        TPM2_ALG_ID from_hex_str = tpm2_alg_util_from_optarg(str(value));    \
+        char str_value[256]; \
+        snprintf(str_value, sizeof(str_value), "0x%X", value); \
+        TPM2_ALG_ID from_hex_str = tpm2_alg_util_from_optarg(str_value);    \
         TPM2_ALG_ID from_nice_str = tpm2_alg_util_from_optarg(str(friendly));    \
         \
         assert_ptr_not_equal(found_id, NULL); \


### PR DESCRIPTION
3.X backport of #1254 / re6b9930 originally authored by Safayet Ahmed.

Original description:

Pull request https://github.com/tpm2-software/tpm2-tss/pull/1211/files adds
explicit casts to `TPM2_ALG_ID` macro definitions. That change prevents
stringifying the `TPM2_ALG_ID` macros diretcly, breaking the
`nv_single_item_test2` tests. Instead, use `snprintf` to create the hex-value
strings.

----

Original discussion about this here: https://github.com/tpm2-software/tpm2-tools/pull/1254#issuecomment-463491554