### PR TITLE
Fix tpm2_rsaencrypt & tpm2_rsadecrypt when key is passed as a hex id

### DIFF
--- a/tools/tpm2_rsadecrypt.c
+++ b/tools/tpm2_rsadecrypt.c
@@ -154,6 +154,12 @@ static bool init(ESYS_CONTEXT *ectx) {
                                 &ctx.key_context_object);
     if (olrc == olrc_error) {
         return false;
+    } else if (!ctx.key_context_object.tr_handle) {
+        bool res = tpm2_util_sys_handle_to_esys_handle(ectx, ctx.key_context_object.handle,
+                &ctx.key_context_object.tr_handle);
+        if (!res) {
+            return false;
+        }
     }
 
    return true;

--- a/tools/tpm2_rsaencrypt.c
+++ b/tools/tpm2_rsaencrypt.c
@@ -136,6 +136,12 @@ static bool init(ESYS_CONTEXT *context) {
                                 ctx.context_arg, &ctx.key_context);
     if (olrc == olrc_error) {
         return false;
+    } else if (!ctx.key_context.tr_handle) {
+        bool res = tpm2_util_sys_handle_to_esys_handle(context, ctx.key_context.handle,
+                &ctx.key_context.tr_handle);
+        if (!res) {
+            return false;
+        }
     }
 
     ctx.message.size = BUFFER_SIZE(TPM2B_PUBLIC_KEY_RSA, buffer);


### PR DESCRIPTION
When a user passes a hex id of a TPM2_HANDLE we need to convert those to ESYS_TR handles for use in Esys_ calls.

Fixes #1323 