### PR TITLE
tools/tpm2_selftest: Add command to perform TPM selftest

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -106,6 +106,7 @@ bin_PROGRAMS = \
     tools/tpm2_rsadecrypt \
     tools/tpm2_rsaencrypt \
     tools/tpm2_send \
+    tools/tpm2_selftest \
     tools/tpm2_sign \
     tools/tpm2_startauthsession \
     tools/tpm2_startup \
@@ -158,6 +159,7 @@ tools_tpm2_evictcontrol_SOURCES = tools/tpm2_evictcontrol.c $(TOOL_SRC)
 tools_tpm2_loadexternal_SOURCES = tools/tpm2_loadexternal.c $(TOOL_SRC)
 tools_tpm2_rsadecrypt_SOURCES = tools/tpm2_rsadecrypt.c $(TOOL_SRC)
 tools_tpm2_rsaencrypt_SOURCES = tools/tpm2_rsaencrypt.c $(TOOL_SRC)
+tools_tpm2_selftest_SOURCES = tools/tpm2_selftest.c $(TOOL_SRC)
 tools_tpm2_sign_SOURCES = tools/tpm2_sign.c $(TOOL_SRC)
 tools_tpm2_unseal_SOURCES = tools/tpm2_unseal.c $(TOOL_SRC)
 tools_tpm2_dictionarylockout_SOURCES = tools/tpm2_dictionarylockout.c $(TOOL_SRC)
@@ -338,6 +340,7 @@ if HAVE_MAN_PAGES
     man/man1/tpm2_rsadecrypt.1 \
     man/man1/tpm2_rsaencrypt.1 \
     man/man1/tpm2_send.1 \
+    man/man1/tpm2_selftest.1 \
     man/man1/tpm2_sign.1 \
     man/man1/tpm2_startauthsession.1 \
     man/man1/tpm2_startup.1 \

--- a/man/tpm2_selftest.1.md
+++ b/man/tpm2_selftest.1.md
@@ -1,0 +1,48 @@
+% tpm2_selftest(1) tpm2-tools | General Commands Manual
+%
+% JANUARY 2019
+
+# NAME
+
+**tpm2_selftest**(1) - Run TPM's self-test internal routines
+
+# SYNOPSIS
+
+**tpm2_selftest** [*OPTIONS*]
+
+# DESCRIPTION
+
+**tpm2_selftest**(1) Cause the TPM to execute self-test of its capabilities.
+
+Self-test can be executed in two modes :
+
+* Simple test - TPM will test functions that require testing
+* Full test - TPM will test all functions regardless of what has already been tested
+
+# OPTIONS
+
+* **-f**, **--fulltest** : Run self-test in full mode
+
+[common options](common/options.md)
+
+[common tcti options](common/tcti.md)
+
+# EXAMPLES
+
+Perform a simple TPM self-test:
+
+```
+tpm2_selftest
+```
+
+Perform a complete TPM self-test:
+
+```
+tpm2_selftest -f
+```
+
+# RETURNS
+
+0 on success or 1 on failure.
+
+[footer](common/footer.md)

--- a/scripts/utils/analyze.py
+++ b/scripts/utils/analyze.py
@@ -187,6 +187,13 @@ class ToolConflictor(object):
                 "conflict": None,
                 "ignore": set()
             },
+            {
+                "gname": "testing",
+                "tools-in-group": ["tpm2_selftest"],
+                "tools": [],
+                "conflict": None,
+                "ignore": set()
+            }
         ]
 
         for tool in tools:

--- a/test/integration/tests/selftest.sh
+++ b/test/integration/tests/selftest.sh
@@ -1,0 +1,53 @@
+#!/bin/bash
+#;**********************************************************************;
+#
+# Copyright (c) 2019, Sebastien LE STUM
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# 1. Redistributions of source code must retain the above copyright notice,
+# this list of conditions and the following disclaimer.
+#
+# 2. Redistributions in binary form must reproduce the above copyright notice,
+# this list of conditions and the following disclaimer in the documentation
+# and/or other materials provided with the distribution.
+#
+# 3. Neither the name of Intel Corporation nor the names of its contributors
+# may be used to endorse or promote products derived from this software without
+# specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+# THE POSSIBILITY OF SUCH DAMAGE.
+#;**********************************************************************;
+
+source helpers.sh
+
+cleanup() {
+    if [ "$1" != "no-shut-down" ]; then
+          shut_down
+    fi
+}
+trap cleanup EXIT
+
+start_up
+
+cleanup "no-shut-down"
+
+# Perform simple selftest
+tpm2_selftest
+
+# Perform full selftest
+tpm2_selftest --fulltest
+
+exit 0

--- a/tools/tpm2_selftest.c
+++ b/tools/tpm2_selftest.c
@@ -1,0 +1,98 @@
+//**********************************************************************;
+// Copyright (c) 2019, Sebastien LE STUM
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+// 1. Redistributions of source code must retain the above copyright notice,
+// this list of conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright notice,
+// this list of conditions and the following disclaimer in the documentation
+// and/or other materials provided with the distribution.
+//
+// 3. Neither the name of Intel Corporation nor the names of its contributors
+// may be used to endorse or promote products derived from this software without
+// specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+// THE POSSIBILITY OF SUCH DAMAGE.
+//**********************************************************************;
+
+#include <ctype.h>
+#include <errno.h>
+#include <stdbool.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include <tss2/tss2_esys.h>
+
+#include "log.h"
+#include "tpm2_options.h"
+#include "tpm2_tool.h"
+
+typedef struct tpm_selftest_ctx tpm_selftest_ctx;
+
+struct tpm_selftest_ctx {
+    TPMI_YES_NO     fulltest;
+};
+
+static tpm_selftest_ctx ctx;
+
+static bool tpm_selftest(ESYS_CONTEXT *ectx) {
+    TSS2_RC rval = Esys_SelfTest(ectx, ESYS_TR_NONE, ESYS_TR_NONE, ESYS_TR_NONE, ctx.fulltest);
+    if (rval != TSS2_RC_SUCCESS) {
+        LOG_ERR("TPM SelfTest failed !");
+        LOG_PERR(Esys_SelfTest, rval);
+        return false;
+    }
+
+    return true;
+}
+
+static bool on_option(char key, char *value) {
+
+    UNUSED(value);
+
+    switch (key) {
+    case 'f':
+        ctx.fulltest = TPM2_YES;
+        break;
+    }
+
+    return true;
+}
+
+bool tpm2_tool_onstart(tpm2_options **opts) {
+
+    static const struct option topts[] = {
+        { "fulltest", no_argument, NULL, 'f' }
+    };
+
+    ctx.fulltest = TPM2_NO;
+
+    *opts = tpm2_options_new("f", ARRAY_LEN(topts), topts, on_option, NULL, 0);
+
+    return *opts != NULL;
+}
+
+int tpm2_tool_onrun(ESYS_CONTEXT *ectx, tpm2_option_flags flags) {
+
+    UNUSED(flags);
+
+    return tpm_selftest(ectx) != true;
+}
+
+void tpm2_tool_onexit(void) {
+    return;
+}


### PR DESCRIPTION
Fixes: #872

- Added command to makefile
- Added manual entry for tpm2_selftest
- Added command relying on ESAPI
- Added integration test for coverage

Signed-off-by: sebastien le stum <lestums@gmail.com>