### PR TITLE
Rename short option of --in-file to -i

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 ### next
   * tpm2_activatecredential: -f becomes -i
   * tpm2_create: -I becomes -i
+  * tpm2_encryptdecrypt: -I becomes -i
   * tpm2_create: supports TPM command CreateLoaded.
   * Add support for reading authorisation passwords from a file
   * tpm2_createek: now saves a context file for the generated primary's
@@ -48,7 +49,7 @@
   * tpm2_createak: -E becomes -e
   * tpm2_certify: -k becomes -p
   * tpm2_hash: -g changes to -G
-  * tpm2_encryptdecrypt: Support IVs via -i and algorithm modes via -G.
+  * tpm2_encryptdecrypt: Support IVs via -t and algorithm modes via -G.
   * tpm2_hmac: drop -g, just use the algorithm associated with the object.
   * tpm2_getmanufec: -g changes to -G
   * tpm2_createek: -g changes to -G

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
   * tpm2_activatecredential: -f becomes -i
   * tpm2_create: -I becomes -i
   * tpm2_encryptdecrypt: -I becomes -i
+  * tpm2_rsadecrypt: -I becomes -i
   * tpm2_create: supports TPM command CreateLoaded.
   * Add support for reading authorisation passwords from a file
   * tpm2_createek: now saves a context file for the generated primary's

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## Changelog
 ### next
   * tpm2_activatecredential: -f becomes -i
+  * tpm2_create: -I becomes -i
   * tpm2_create: supports TPM command CreateLoaded.
   * Add support for reading authorisation passwords from a file
   * tpm2_createek: now saves a context file for the generated primary's

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## Changelog
 ### next
+  * tpm2_activatecredential: -f becomes -i
   * tpm2_create: supports TPM command CreateLoaded.
   * Add support for reading authorisation passwords from a file
   * tpm2_createek: now saves a context file for the generated primary's

--- a/man/tpm2_activatecredential.1.md
+++ b/man/tpm2_activatecredential.1.md
@@ -41,7 +41,7 @@ These options control the object verification:
     The endorsement authorization value, optional. Follows the same formatting
     guidelines as the key authorization option -P.
 
-  * **-f**, **--in-file**=_INPUT\_FILE_:
+  * **-i**, **--in-file**=_INPUT\_FILE_:
     Input file path, containing the two structures needed by
     tpm2_activatecredential function. This is created via the
     tpm2_makecredential(1) command.
@@ -60,9 +60,9 @@ These options control the object verification:
 # EXAMPLES
 
 ```
-tpm2_activatecredential -c 0x81010002 -C 0x81010001 -P abc123 -E abc123 -f <filePath> -o <filePath>
-tpm2_activatecredential -c ak.dat -C ek.dat -P abc123 -E abc123 -f <filePath> -o <filePath>
-tpm2_activatecredential -c 0x81010002 -C 0x81010001 -P 123abc -E 1a1b1c -X -f <filePath> -o <filePath>
+tpm2_activatecredential -c 0x81010002 -C 0x81010001 -P abc123 -E abc123 -i <filePath> -o <filePath>
+tpm2_activatecredential -c ak.dat -C ek.dat -P abc123 -E abc123 -i <filePath> -o <filePath>
+tpm2_activatecredential -c 0x81010002 -C 0x81010001 -P 123abc -E 1a1b1c -X -i <filePath> -o <filePath>
 ```
 
 # RETURNS

--- a/man/tpm2_create.1.md
+++ b/man/tpm2_create.1.md
@@ -46,7 +46,7 @@ These options for creating the tpm entity:
     specified.
     It accepts friendly names just like -g option.
     See section "Supported Public Object Algorithms" for a list
-    of supported object algorithms. Mutually exclusive of **-I**.
+    of supported object algorithms. Mutually exclusive of **-i**.
 
   * **-A**, **--object-attributes**=_ATTRIBUTES_:
     The object attributes, optional. Object attributes follow the specifications
@@ -54,11 +54,11 @@ These options for creating the tpm entity:
 
     `TPMA_OBJECT_SIGN_ENCRYPT|TPMA_OBJECT_DECRYPT|TPMA_OBJECT_FIXEDTPM|TPMA_OBJECT_FIXEDPARENT|TPMA_OBJECT_SENSITIVEDATAORIGIN|TPMA_OBJECT_USERWITHAUTH`
 
-    When **-I** is specified for sealing, `TPMA_OBJECT_SIGN_ENCRYPT` and `TPMA_OBJECT_DECRYPT` are removed from the default attribute set.
+    When **-i** is specified for sealing, `TPMA_OBJECT_SIGN_ENCRYPT` and `TPMA_OBJECT_DECRYPT` are removed from the default attribute set.
     The algorithm is set in a way where the the object is only good for sealing and unsealing. Ie one cannot use an object for sealing and cryptography
     operations.
 
-  * **-I**, **--in-file**=_FILE_:
+  * **-i**, **--in-file**=_FILE_:
     The data file to be sealed, optional. If file is -, read from stdin.
     When sealing data only the _TPM_ALG_KEYEDHASH_ algorithm with a NULL scheme is allowed. Thus, **-G** cannot
     be specified.
@@ -104,7 +104,7 @@ tpm2_create -C parent.ctx -u obj.pub obj.priv
 
 Create an object and seal data to it:
 ```
-tpm2_create -C parent.ctx  -K def456 -G keyedhash -I seal.dat -u obj.pub -r obj.priv
+tpm2_create -C parent.ctx  -K def456 -G keyedhash -i seal.dat -u obj.pub -r obj.priv
 ```
 
 Create an rsa2048 object and load it into the TPM:

--- a/man/tpm2_encryptdecrypt.1.md
+++ b/man/tpm2_encryptdecrypt.1.md
@@ -32,7 +32,7 @@ specified symmetric key.
 
     Perform a decrypt operation. Default is encryption.
 
-  * **-I**, **--in-file**=_INPUT\_FILE_:
+  * **-i**, **--in-file**=_INPUT\_FILE_:
 
     Optional. Specifies the input file path for either the encrypted or decrypted
     data, depending on option **-D**. If not specified, defaults to **stdin**.
@@ -51,7 +51,7 @@ specified symmetric key.
     See section "Supported Public Object Algorithms" for a list
     of supported object algorithms.
 
-  * **-i**, **--iv**=_IV\_INPUT\_FILE_ : [ _IV\_OUTPUT\_FILE_ ]:
+  * **-t**, **--iv**=_IV\_INPUT\_FILE_ : [ _IV\_OUTPUT\_FILE_ ]:
 
   Optional. The initialization vector to use. Defaults to 0's. The specification
   syntax allows for an input file and output file source to be specified. The input file
@@ -69,9 +69,9 @@ specified symmetric key.
 # EXAMPLES
 
 ```
-tpm2_encryptdecrypt -C 0x81010001 -p abc123 -I <filePath> -o <filePath>
-tpm2_encryptdecrypt -C key.dat -p abc123 -I <filePath> -o <filePath>
-tpm2_encryptdecrypt -C 0x81010001 -p 123abca -X -I <filePath> -o <filePath>
+tpm2_encryptdecrypt -C 0x81010001 -p abc123 -i <filePath> -o <filePath>
+tpm2_encryptdecrypt -C key.dat -p abc123 -i <filePath> -o <filePath>
+tpm2_encryptdecrypt -C 0x81010001 -p 123abca -X -i <filePath> -o <filePath>
 ```
 
 # RETURNS

--- a/man/tpm2_policyauthorize.1.md
+++ b/man/tpm2_policyauthorize.1.md
@@ -90,7 +90,7 @@ verification of the signature on the pcr policy digest using **tpm2_policyauthor
 
 ## Create a TPM object like a sealing object with the authorized policy based authentication:
 * tpm2_createprimary -Q -a o -g sha256 -G rsa -o prim.ctx
-* tpm2_create -Q -g sha256 -u sealing_pubkey.pub -r sealing_prikey.pub -I- -C prim.ctx\
+* tpm2_create -Q -g sha256 -u sealing_pubkey.pub -r sealing_prikey.pub -i- -C prim.ctx\
  -L authorized.policy <<< "secret to seal"
 
 ## Satisfy policy and unseal the secret:

--- a/man/tpm2_policycommandcode.1.md
+++ b/man/tpm2_policycommandcode.1.md
@@ -48,7 +48,7 @@ tpm2_flushcontext -S session.dat
 ```
 tpm2_createprimary -a o -o prim.ctx
 tpm2_create -C prim.ctx -u sealkey.pub -r sealkey.priv -L policy.dat \
-  -I- <<< "SEALED-SECRET"
+  -i- <<< "SEALED-SECRET"
 ```
 
 # Try unseal operation

--- a/man/tpm2_policycommandcode.1.md
+++ b/man/tpm2_policycommandcode.1.md
@@ -64,7 +64,7 @@ tpm2_flushcontext -S session.dat
 # Try any other operation
 ```
 echo "Encrypt Me" > plain.txt
-tpm2_encryptdecrypt -I plain.txt -o enc.txt -c sealkey.ctx
+tpm2_encryptdecrypt -i plain.txt -o enc.txt -c sealkey.ctx
 if [ $? != 0 ]; then
  echo "Expected that operations other than unsealing will fail"
 fi

--- a/man/tpm2_policyor.1.md
+++ b/man/tpm2_policyor.1.md
@@ -76,7 +76,7 @@ and seal a secret. Unsealing with either of the PCR sets should be successful.
 
 ## Create a TPM object like a sealing object with the compounded auth policy:
 * tpm2_createprimary -Q -a o -g sha256 -G rsa -o prim.ctx
-* tpm2_create -Q -g sha256 -u sealing_key.pub -r sealing_key.pub -I- -C prim.ctx -L policy.or <<< "secret to seal"
+* tpm2_create -Q -g sha256 -u sealing_key.pub -r sealing_key.pub -i- -C prim.ctx -L policy.or <<< "secret to seal"
 
 ## Satisfy the policy and unseal the secret:
 * tpm2_startauthsession -a -S session.ctx

--- a/man/tpm2_policypassword.1.md
+++ b/man/tpm2_policypassword.1.md
@@ -61,13 +61,13 @@ tpm2_create -g sha256 -G aes -u key.pub -r key.priv -C prim.ctx -L policy.pass \
 ## Authenticate with plaintext passphrase input:
 ```
 tpm2_load -C prim.ctx -u key.pub -r key.priv -n key.name -o key.ctx
-tpm2_encryptdecrypt -c key.ctx -o encrypt.out -I plain.txt -p text
+tpm2_encryptdecrypt -c key.ctx -o encrypt.out -i plain.txt -p text
 ```
 ## Authenticate with password and the policy:
 ```
 tpm2_startauthsession -a -S session.dat
 tpm2_policypassword -S session.dat -o policy.dat
-tpm2_encryptdecrypt -c key.ctx -o encrypt.out -I plain.txt \
+tpm2_encryptdecrypt -c key.ctx -o encrypt.out -i plain.txt \
   -p session:session.dat+testpswd
 tpm2_flushcontext -S session.dat
 ```

--- a/man/tpm2_policypcr.1.md
+++ b/man/tpm2_policypcr.1.md
@@ -68,7 +68,7 @@ tpm2_policypcr -Q -S session.dat -L "sha1:0,1,2,3" -F pcr.dat -f policy.dat
 tpm2_flushcontext -H "$handle"
 
 tpm2_create -Q -g sha256 -G keyedhash -u key.pub -r key.priv -C primary.ctx -L policy.dat \
-  -A 'sign|fixedtpm|fixedparent|sensitivedataorigin' -I- <<< "12345678"
+  -A 'sign|fixedtpm|fixedparent|sensitivedataorigin' -i- <<< "12345678"
 
 tpm2_load -Q -C primary.ctx -u key.pub -r key.priv -n unseal.key.name -o unseal.key.ctx
 

--- a/man/tpm2_policysecret.1.md
+++ b/man/tpm2_policysecret.1.md
@@ -59,7 +59,7 @@ was satisfied to the unseal tool.
 
 ## Create a TPM object like a sealing object with the policy:
 * tpm2_createprimary -Q -a o -g sha256 -G rsa -o prim.ctx
-* tpm2_create -Q -g sha256 -u sealing_key.pub -r sealing_key.priv -I- -C prim.ctx
+* tpm2_create -Q -g sha256 -u sealing_key.pub -r sealing_key.priv -i- -C prim.ctx
 -L secret.policy <<< "SEALED-SECRET"
 tpm2_load -C prim.ctx -u sealing_key.pub -r sealing_key.priv -n sealing_key.name -o sealing_key.ctx
 

--- a/man/tpm2_rsadecrypt.1.md
+++ b/man/tpm2_rsadecrypt.1.md
@@ -34,7 +34,7 @@ The key referenced by key-context is **required** to be:
     Authorization values should follow the "authorization formatting standards",
     see section "Authorization Formatting".
 
-  * **-I**, **--in-file**=_INPUT\FILE_:
+  * **-i**, **--in-file**=_INPUT\FILE_:
 
     Input file path, containing the data to be decrypted.
 
@@ -53,7 +53,7 @@ The key referenced by key-context is **required** to be:
 # EXAMPLES
 
 ```
-tpm2_rsadecrypt -C 0x81010001 -I encrypted.in -o plain.out
+tpm2_rsadecrypt -C 0x81010001 -i encrypted.in -o plain.out
 ```
 
 # RETURNS

--- a/scripts/utils/analyze.py
+++ b/scripts/utils/analyze.py
@@ -79,7 +79,7 @@ class ToolConflictor(object):
                 ],
                 "tools": [],
                 "conflict": None,
-                "ignore": set(['r', 'privfile', 'u', 'pubfile', 's', 'secret', 'g', 'halg', 'n', 'name'])
+                "ignore": set(['r', 'privfile', 'u', 'pubfile', 's', 'secret', 'g', 'halg', 'n', 'name', 'f', 'format'])
             },
             {
                 "gname": "duplication",

--- a/test/integration/tests/activecredential.sh
+++ b/test/integration/tests/activecredential.sh
@@ -76,6 +76,6 @@ test "$loaded_key_name_yaml" == "$loaded_key_name"
 
 tpm2_makecredential -Q -e ek.pub  -s secret.data -n $loaded_key_name -o mkcred.out
 
-tpm2_activatecredential -Q -c 0x8101000a -C 0x81010009 -f mkcred.out -o actcred.out
+tpm2_activatecredential -Q -c 0x8101000a -C 0x81010009 -i mkcred.out -o actcred.out
 
 exit 0

--- a/test/integration/tests/encryptdecrypt.sh
+++ b/test/integration/tests/encryptdecrypt.sh
@@ -76,9 +76,9 @@ tpm2_create -Q -g sha256 -G aes -u key.pub -r key.priv -C primary.ctx
 
 tpm2_load -Q -C primary.ctx -u key.pub -r key.priv -n key.name -o decrypt.ctx
 
-tpm2_encryptdecrypt -Q -c decrypt.ctx  -I secret.dat -o encrypt.out
+tpm2_encryptdecrypt -Q -c decrypt.ctx  -i secret.dat -o encrypt.out
 
-tpm2_encryptdecrypt -Q -c decrypt.ctx -D -I encrypt.out -o decrypt.out
+tpm2_encryptdecrypt -Q -c decrypt.ctx -D -i encrypt.out -o decrypt.out
 
 # Test using stdin/stdout
 cat secret.dat | tpm2_encryptdecrypt -c decrypt.ctx | tpm2_encryptdecrypt -c decrypt.ctx -D > secret2.dat
@@ -100,19 +100,19 @@ tpm2_load -Q -C primary.ctx -u key.pub -r key.priv -n key.name -o decrypt.ctx
 echo -n "1234567812345678" > secret.dat
 
 # specified mode
-tpm2_encryptdecrypt -Q -c decrypt.ctx -G cbc -I secret.dat --iv=iv.dat  -o encrypt.out
+tpm2_encryptdecrypt -Q -c decrypt.ctx -G cbc -i secret.dat --iv=iv.dat  -o encrypt.out
 
 # Unspecified mode (figure out via readpublic)
-tpm2_encryptdecrypt -Q -D -c decrypt.ctx -I encrypt.out --iv iv.dat -o decrypt.out
+tpm2_encryptdecrypt -Q -D -c decrypt.ctx -i encrypt.out --iv iv.dat -o decrypt.out
 
 cmp secret.dat decrypt.out
 
 # Test that iv looping works
-tpm2_encryptdecrypt -Q -c decrypt.ctx -G cbc -I secret.dat --iv=iv.dat:iv2.dat -o encrypt.out
-tpm2_encryptdecrypt -Q -c decrypt.ctx -G cbc -I secret.dat --iv=iv2.dat -o encrypt2.out
+tpm2_encryptdecrypt -Q -c decrypt.ctx -G cbc -i secret.dat --iv=iv.dat:iv2.dat -o encrypt.out
+tpm2_encryptdecrypt -Q -c decrypt.ctx -G cbc -i secret.dat --iv=iv2.dat -o encrypt2.out
 
-tpm2_encryptdecrypt -Q -D -c decrypt.ctx -I encrypt.out --iv iv.dat -o decrypt.out
-tpm2_encryptdecrypt -Q -D -c decrypt.ctx -I encrypt2.out --iv iv2.dat -o decrypt2.out
+tpm2_encryptdecrypt -Q -D -c decrypt.ctx -i encrypt.out --iv iv.dat -o decrypt.out
+tpm2_encryptdecrypt -Q -D -c decrypt.ctx -i encrypt2.out --iv iv2.dat -o decrypt2.out
 
 cmp secret.dat decrypt.out
 cmp secret.dat decrypt2.out
@@ -121,6 +121,6 @@ cmp secret.dat decrypt2.out
 trap - ERR
 
 # mode CFB should fail, since the object was explicitly created with mode CBC
-tpm2_encryptdecrypt -Q -c decrypt.ctx -G cfb -I secret.dat --iv=iv.dat  -o encrypt.out
+tpm2_encryptdecrypt -Q -c decrypt.ctx -G cfb -i secret.dat --iv=iv.dat  -o encrypt.out
 
 exit 0

--- a/test/integration/tests/import.sh
+++ b/test/integration/tests/import.sh
@@ -92,7 +92,7 @@ run_rsa_import_test() {
 	openssl rsa -in private.pem -out public.pem -outform PEM -pubout
 	openssl rsautl -encrypt -inkey public.pem -pubin -in plain.txt -out plain.rsa.enc
 
-	tpm2_rsadecrypt -c import_rsa_key.ctx -I plain.rsa.enc -o plain.rsa.dec
+	tpm2_rsadecrypt -c import_rsa_key.ctx -i plain.rsa.enc -o plain.rsa.dec
 
 	diff plain.txt plain.rsa.dec
 

--- a/test/integration/tests/import.sh
+++ b/test/integration/tests/import.sh
@@ -66,7 +66,7 @@ run_aes_import_test() {
 
 	echo "plaintext" > "plain.txt"
 
-	tpm2_encryptdecrypt -c import_key.ctx  -I plain.txt -o plain.enc
+	tpm2_encryptdecrypt -c import_key.ctx  -i plain.txt -o plain.enc
 
 	openssl enc -in plain.enc -out plain.dec.ssl -d -K `xxd -p sym.key` -iv 0 \
 	-aes-128-cfb

--- a/test/integration/tests/loadexternal.sh
+++ b/test/integration/tests/loadexternal.sh
@@ -111,7 +111,7 @@ run_rsa_test() {
 
     tpm2_loadexternal -G rsa -a n -p foo -r private.pem -o key.ctx
 
-    tpm2_rsadecrypt -c key.ctx -p foo -I plain.rsa.enc -o plain.rsa.dec
+    tpm2_rsadecrypt -c key.ctx -p foo -i plain.rsa.enc -o plain.rsa.dec
 
     diff plain.txt plain.rsa.dec
 

--- a/test/integration/tests/loadexternal.sh
+++ b/test/integration/tests/loadexternal.sh
@@ -147,7 +147,7 @@ run_aes_test() {
 
     echo "plaintext" > "plain.txt"
 
-    tpm2_encryptdecrypt -c key.ctx -I plain.txt -o plain.enc
+    tpm2_encryptdecrypt -c key.ctx -i plain.txt -o plain.enc
 
     openssl enc -in plain.enc -out plain.dec.ssl -d -K `xxd -p sym.key` -iv 0 \
         -aes-$1-cfb

--- a/test/integration/tests/rsadecrypt.sh
+++ b/test/integration/tests/rsadecrypt.sh
@@ -78,6 +78,6 @@ tpm2_rsaencrypt -Q -c $file_rsaencrypt_key_ctx -o $file_rsa_en_output_data < $fi
 
 tpm2_load -Q -C $file_primary_key_ctx -u $file_rsaencrypt_key_pub -r $file_rsaencrypt_key_priv  -n $file_rsaencrypt_key_name  -o $file_rsadecrypt_key_ctx
 
-tpm2_rsadecrypt -Q -c $file_rsadecrypt_key_ctx -p foo -I  $file_rsa_en_output_data -o  $file_rsa_de_output_data
+tpm2_rsadecrypt -Q -c $file_rsadecrypt_key_ctx -p foo -i  $file_rsa_en_output_data -o  $file_rsa_de_output_data
 
 exit 0

--- a/test/integration/tests/tcti/abrmd/extended-sessions.sh
+++ b/test/integration/tests/tcti/abrmd/extended-sessions.sh
@@ -103,7 +103,7 @@ tpm2_policypcr -Q -S $file_session_file -L ${alg_pcr_policy}:${pcr_ids} -F $file
 
 tpm2_flushcontext -S $file_session_file
 
-tpm2_create -Q -g $alg_create_obj -u $file_unseal_key_pub -r $file_unseal_key_priv -I- -C $file_primary_key_ctx -L $file_policy \
+tpm2_create -Q -g $alg_create_obj -u $file_unseal_key_pub -r $file_unseal_key_priv -i- -C $file_primary_key_ctx -L $file_policy \
   -A 'fixedtpm|fixedparent' <<< $secret
 
 tpm2_load -Q -C $file_primary_key_ctx -u $file_unseal_key_pub -r $file_unseal_key_priv -n $file_unseal_key_name -o $file_unseal_key_ctx

--- a/test/integration/tests/tcti/abrmd/policycommandcode.sh
+++ b/test/integration/tests/tcti/abrmd/policycommandcode.sh
@@ -74,7 +74,7 @@ tpm2_flushcontext -S $file_session_data
 rm $file_session_data
 
 tpm2_create -C $file_primary_key_ctx -u $file_unseal_key_pub \
-  -r $file_unseal_key_priv -L $file_policy -I- <<< $secret
+  -r $file_unseal_key_priv -L $file_policy -i- <<< $secret
 
 tpm2_load -C $file_primary_key_ctx -u $file_unseal_key_pub \
   -r $file_unseal_key_priv -n $file_unseal_key_name -o $file_unseal_key_ctx

--- a/test/integration/tests/tcti/abrmd/policycommandcode.sh
+++ b/test/integration/tests/tcti/abrmd/policycommandcode.sh
@@ -101,7 +101,7 @@ cmp -s $file_output_data $file_input_data
 
 trap - ERR
 
-tpm2_encryptdecrypt -I $file_input_data -o $file_output_data -c $file_unseal_key_ctx
+tpm2_encryptdecrypt -i $file_input_data -o $file_output_data -c $file_unseal_key_ctx
 if [ $? != 1 ]; then
   echo "tpm2_policycommandcode: Should have failed!"
   exit 1

--- a/test/integration/tests/tcti/abrmd/policypassword.sh
+++ b/test/integration/tests/tcti/abrmd/policypassword.sh
@@ -70,11 +70,11 @@ tpm2_create -g sha256 -G aes -u $key_pub -r $key_priv -C $primary_key_ctx \
   -L $policypassword -p $testpswd
 
 tpm2_load -C $primary_key_ctx -u $key_pub -r $key_priv -o $key_ctx
-tpm2_encryptdecrypt -c $key_ctx -o $encrypted_txt -I $plain_txt -p $testpswd
+tpm2_encryptdecrypt -c $key_ctx -o $encrypted_txt -i $plain_txt -p $testpswd
 
 tpm2_startauthsession -a -S $session_ctx
 tpm2_policypassword -S $session_ctx -o $policypassword
-tpm2_encryptdecrypt -c $key_ctx -I $encrypted_txt -o $decrypted_txt -D \
+tpm2_encryptdecrypt -c $key_ctx -i $encrypted_txt -o $decrypted_txt -D \
   -p session:$session_ctx+$testpswd
 tpm2_flushcontext -S $session_ctx
 rm $session_ctx

--- a/test/integration/tests/tcti/abrmd/policysecret.sh
+++ b/test/integration/tests/tcti/abrmd/policysecret.sh
@@ -70,7 +70,7 @@ rm $session_ctx
 #Create and Load Object
 tpm2_createprimary -Q -a o  -o $primary_ctx -P ownerauth
 tpm2_create -Q -g sha256 -u $seal_key_pub -r $seal_key_priv -C $primary_ctx\
-  -L $o_policy_digest -I- <<< $SEALED_SECRET
+  -L $o_policy_digest -i- <<< $SEALED_SECRET
 tpm2_load -C $primary_ctx -u $seal_key_pub -r $seal_key_priv -o $seal_key_ctx
 
 #Satisfy policy and unseal data

--- a/test/integration/tests/unseal.sh
+++ b/test/integration/tests/unseal.sh
@@ -73,7 +73,7 @@ tpm2_clear
 
 tpm2_createprimary -Q -a e -g $alg_primary_obj -G $alg_primary_key -o $file_primary_key_ctx
 
-tpm2_create -Q -g $alg_create_obj -u $file_unseal_key_pub -r $file_unseal_key_priv -I $file_input_data -C $file_primary_key_ctx
+tpm2_create -Q -g $alg_create_obj -u $file_unseal_key_pub -r $file_unseal_key_priv -i $file_input_data -C $file_primary_key_ctx
 
 tpm2_load -Q -C $file_primary_key_ctx  -u $file_unseal_key_pub  -r $file_unseal_key_priv -n $file_unseal_key_name -o $file_unseal_key_ctx
 
@@ -81,11 +81,11 @@ tpm2_unseal -Q -c $file_unseal_key_ctx -o $file_unseal_output_data
 
 cmp -s $file_unseal_output_data $file_input_data
 
-# Test -I using stdin via pipe
+# Test -i using stdin via pipe
 
 rm $file_unseal_key_pub $file_unseal_key_priv $file_unseal_key_name $file_unseal_key_ctx
 
-cat $file_input_data | tpm2_create -Q -g $alg_create_obj -u $file_unseal_key_pub -r $file_unseal_key_priv -I- -C $file_primary_key_ctx
+cat $file_input_data | tpm2_create -Q -g $alg_create_obj -u $file_unseal_key_pub -r $file_unseal_key_priv -i- -C $file_primary_key_ctx
 
 tpm2_load -Q -C $file_primary_key_ctx  -u $file_unseal_key_pub  -r $file_unseal_key_priv -n $file_unseal_key_name -o $file_unseal_key_ctx
 
@@ -93,7 +93,7 @@ tpm2_unseal -Q -c $file_unseal_key_ctx -o $file_unseal_output_data
 
 cmp -s $file_unseal_output_data $file_input_data
 
-# Test using a PCR policy for auth and use file based stdin for -I
+# Test using a PCR policy for auth and use file based stdin for -i
 
 rm $file_unseal_key_pub $file_unseal_key_priv $file_unseal_key_name $file_unseal_key_ctx
 
@@ -101,7 +101,7 @@ tpm2_pcrlist -Q -L ${alg_pcr_policy}:${pcr_ids} -o $file_pcr_value
 
 tpm2_createpolicy -Q -P -L ${alg_pcr_policy}:${pcr_ids} -F $file_pcr_value -f $file_policy
 
-tpm2_create -Q -g $alg_create_obj -u $file_unseal_key_pub -r $file_unseal_key_priv -I- -C $file_primary_key_ctx -L $file_policy \
+tpm2_create -Q -g $alg_create_obj -u $file_unseal_key_pub -r $file_unseal_key_priv -i- -C $file_primary_key_ctx -L $file_policy \
   -A 'fixedtpm|fixedparent' <<< $secret
 
 tpm2_load -Q -C $file_primary_key_ctx  -u $file_unseal_key_pub  -r $file_unseal_key_priv -n $file_unseal_key_name -o $file_unseal_key_ctx
@@ -142,7 +142,7 @@ tpm2_pcrlist -Q -L ${alg_pcr_policy}:${pcr_ids} -o $file_pcr_value
 
 tpm2_createpolicy -Q -P -L ${alg_pcr_policy}:${pcr_ids} -F $file_pcr_value -f $file_policy
 
-tpm2_create -Q -g $alg_create_obj -u $file_unseal_key_pub -r $file_unseal_key_priv -I- -C $file_primary_key_ctx -L $file_policy -p secretpass <<< $secret
+tpm2_create -Q -g $alg_create_obj -u $file_unseal_key_pub -r $file_unseal_key_priv -i- -C $file_primary_key_ctx -L $file_policy -p secretpass <<< $secret
 
 tpm2_load -Q -C $file_primary_key_ctx  -u $file_unseal_key_pub  -r $file_unseal_key_priv -n $file_unseal_key_name -o $file_unseal_key_ctx
 

--- a/tools/tpm2_activatecredential.c
+++ b/tools/tpm2_activatecredential.c
@@ -54,7 +54,7 @@ typedef struct tpm_activatecred_ctx tpm_activatecred_ctx;
 struct tpm_activatecred_ctx {
 
     struct {
-        UINT8 f : 1;
+        UINT8 i : 1;
         UINT8 o : 1;
         UINT8 P : 1;
         UINT8 E : 1;
@@ -240,14 +240,14 @@ static bool on_option(char key, char *value) {
         ctx.flags.E = 1;
         ctx.endorse_auth_str = value;
         break;
-    case 'f':
+    case 'i':
         /* logs errors */
         result = read_cert_secret(value, &ctx.credentialBlob,
                 &ctx.secret);
         if (!result) {
             return false;
         }
-        ctx.flags.f = 1;
+        ctx.flags.i = 1;
         break;
     case 'o':
         ctx.output_file = value;
@@ -265,11 +265,11 @@ bool tpm2_tool_onstart(tpm2_options **opts) {
          {"key-context",    required_argument, NULL, 'C'},
          {"auth-key",       required_argument, NULL, 'P'},
          {"auth-endorse",   required_argument, NULL, 'E'},
-         {"in-file",        required_argument, NULL, 'f'},
+         {"in-file",        required_argument, NULL, 'i'},
          {"out-file",       required_argument, NULL, 'o'},
     };
 
-    *opts = tpm2_options_new("c:C:P:E:f:o:", ARRAY_LEN(topts), topts,
+    *opts = tpm2_options_new("c:C:P:E:i:o:", ARRAY_LEN(topts), topts,
                              on_option, NULL, 0);
 
     return *opts != NULL;
@@ -282,8 +282,8 @@ int tpm2_tool_onrun(ESYS_CONTEXT *ectx, tpm2_option_flags flags) {
 
     if ((!ctx.ctx_arg)
             && (!ctx.key_ctx_arg)
-            && !ctx.flags.f && !ctx.flags.o) {
-        LOG_ERR("Expected options c and C and f and o.");
+            && !ctx.flags.i && !ctx.flags.o) {
+        LOG_ERR("Expected options c and C and i and o.");
         return -1;
     }
 

--- a/tools/tpm2_create.c
+++ b/tools/tpm2_create.c
@@ -83,7 +83,7 @@ struct tpm_create_ctx {
         UINT16 P : 1;
         UINT16 p : 1;
         UINT16 A : 1;
-        UINT16 I : 1;
+        UINT16 i : 1;
         UINT16 L : 1;
         UINT16 u : 1;
         UINT16 r : 1;
@@ -225,9 +225,9 @@ static bool on_option(char key, char *value) {
         ctx.attrs = value;
         ctx.flags.A = 1;
     break;
-    case 'I':
+    case 'i':
         ctx.input = strcmp("-", value) ? value : NULL;
-        ctx.flags.I = 1;
+        ctx.flags.i = 1;
         break;
     case 'L':
         ctx.policy = value;
@@ -260,7 +260,7 @@ bool tpm2_tool_onstart(tpm2_options **opts) {
       { "halg",                 required_argument, NULL, 'g' },
       { "kalg",                 required_argument, NULL, 'G' },
       { "object-attributes",    required_argument, NULL, 'A' },
-      { "in-file",              required_argument, NULL, 'I' },
+      { "in-file",              required_argument, NULL, 'i' },
       { "policy-file",          required_argument, NULL, 'L' },
       { "pubfile",              required_argument, NULL, 'u' },
       { "privfile",             required_argument, NULL, 'r' },
@@ -268,7 +268,7 @@ bool tpm2_tool_onstart(tpm2_options **opts) {
       { "out-context",          required_argument, NULL, 'o' },
     };
 
-    *opts = tpm2_options_new("P:p:g:G:A:I:L:u:r:C:o:", ARRAY_LEN(topts), topts,
+    *opts = tpm2_options_new("P:p:g:G:A:i:L:u:r:C:o:", ARRAY_LEN(topts), topts,
                              on_option, NULL, 0);
 
     return *opts != NULL;
@@ -295,9 +295,9 @@ int tpm2_tool_onrun(ESYS_CONTEXT *ectx, tpm2_option_flags flags) {
         return -1;
     }
 
-    if (ctx.flags.I) {
+    if (ctx.flags.i) {
         if (ctx.flags.G) {
-            LOG_ERR("Cannot specify -G and -I together.");
+            LOG_ERR("Cannot specify -G and -i together.");
             return -1;
         }
 
@@ -327,7 +327,7 @@ int tpm2_tool_onrun(ESYS_CONTEXT *ectx, tpm2_option_flags flags) {
         ctx.in_public.publicArea.objectAttributes &= ~TPMA_OBJECT_USERWITHAUTH;
     }
 
-    if (ctx.flags.I && ctx.in_public.publicArea.type != TPM2_ALG_KEYEDHASH) {
+    if (ctx.flags.i && ctx.in_public.publicArea.type != TPM2_ALG_KEYEDHASH) {
         LOG_ERR("Only TPM2_ALG_KEYEDHASH algorithm is allowed when sealing data");
         goto out;
     }

--- a/tools/tpm2_encryptdecrypt.c
+++ b/tools/tpm2_encryptdecrypt.c
@@ -68,7 +68,7 @@ struct tpm_encrypt_decrypt_ctx {
     struct {
         UINT8 p : 1;
         UINT8 D : 1;
-        UINT8 I : 1;
+        UINT8 i : 1;
         UINT8 X : 1;
     } flags;
     char *key_auth_str;
@@ -174,9 +174,9 @@ static bool on_option(char key, char *value) {
     case 'D':
         ctx.is_decrypt = 1;
         break;
-    case 'I':
+    case 'i':
         ctx.input_path = value;
-        ctx.flags.I = 1;
+        ctx.flags.i = 1;
         break;
     case 'o':
         ctx.out_file_path = value;
@@ -188,7 +188,7 @@ static bool on_option(char key, char *value) {
             return false;
         }
         break;
-    case 'i':
+    case 't':
         parse_iv(value);
         break;
     }
@@ -201,14 +201,14 @@ bool tpm2_tool_onstart(tpm2_options **opts) {
     const struct option topts[] = {
         { "auth-key",             required_argument, NULL, 'p' },
         { "decrypt",              no_argument,       NULL, 'D' },
-        { "in-file",              required_argument, NULL, 'I' },
-        { "iv",                   required_argument, NULL, 'i' },
+        { "in-file",              required_argument, NULL, 'i' },
+        { "iv",                   required_argument, NULL, 't' },
         { "mode",                 required_argument, NULL, 'G' },
         { "out-file",             required_argument, NULL, 'o' },
         { "key-context",          required_argument, NULL, 'c' },
     };
 
-    *opts = tpm2_options_new("p:DI:o:c:i:G:", ARRAY_LEN(topts), topts, on_option,
+    *opts = tpm2_options_new("p:Di:o:c:i:G:", ARRAY_LEN(topts), topts, on_option,
                              NULL, 0);
 
     return *opts != NULL;

--- a/tools/tpm2_rsadecrypt.c
+++ b/tools/tpm2_rsadecrypt.c
@@ -47,7 +47,7 @@ typedef struct tpm_rsadecrypt_ctx tpm_rsadecrypt_ctx;
 struct tpm_rsadecrypt_ctx {
     struct {
         UINT8 p : 1;
-        UINT8 I : 1;
+        UINT8 i : 1;
         UINT8 o : 1;
         UINT8 unused : 3;
     } flags;
@@ -108,14 +108,14 @@ static bool on_option(char key, char *value) {
         ctx.flags.p = 1;
         ctx.key_auth_str = value;
         break;
-    case 'I': {
+    case 'i': {
         ctx.cipher_text.size = sizeof(ctx.cipher_text) - 2;
         bool result = files_load_bytes_from_path(value, ctx.cipher_text.buffer,
                 &ctx.cipher_text.size);
         if (!result) {
             return false;
         }
-        ctx.flags.I = 1;
+        ctx.flags.i = 1;
     }
         break;
     case 'o': {
@@ -131,12 +131,12 @@ bool tpm2_tool_onstart(tpm2_options **opts) {
 
     static struct option topts[] = {
       { "auth-key",     required_argument, NULL, 'p' },
-      { "in-file",      required_argument, NULL, 'I' },
+      { "in-file",      required_argument, NULL, 'i' },
       { "out-file",     required_argument, NULL, 'o' },
       { "key-context",  required_argument, NULL, 'c' },
     };
 
-    *opts = tpm2_options_new("p:I:o:c:", ARRAY_LEN(topts), topts,
+    *opts = tpm2_options_new("p:i:o:c:", ARRAY_LEN(topts), topts,
                              on_option, NULL, 0);
 
     return *opts != NULL;
@@ -145,8 +145,8 @@ bool tpm2_tool_onstart(tpm2_options **opts) {
 static bool init(ESYS_CONTEXT *ectx) {
 
 
-    if (!(ctx.context_arg && ctx.flags.I && ctx.flags.o)) {
-        LOG_ERR("Expected arguments I, o and c.");
+    if (!(ctx.context_arg && ctx.flags.i && ctx.flags.o)) {
+        LOG_ERR("Expected arguments i, o and c.");
         return false;
     }
 


### PR DESCRIPTION
The CI build in #1330 fails due to an option conflict of [`-f`/`--in-file`](https://github.com/tpm2-software/tpm2-tools/blob/c66e4f069b04dcb13caed1f6408e4d199e6cf925/tools/tpm2_activatecredential.c#L268) in `tpm2_activatecredential` and [`-f`/`--format`](https://github.com/tpm2-software/tpm2-tools/blob/c66e4f069b04dcb13caed1f6408e4d199e6cf925/tools/tpm2_readpublic.c#L139) in `tpm2_readpublic`. This conflict already existed previous to the mentioned PR, but wasn't detected correctly because it was the last entry in the options array.

As per the discussion in this PR, rename the short option of `--in-file` consistently to `-i` to avoid this conflict. This needs to be done in `tpm2_create`, `tpm2_encryptdecrypt` and `tpm2_rsadecrypt` as well: these tools previously used `-I`, which is not in line with using capital letters only for parent objects.

As `tpm2_encryptdecrypt` already has a (unique) option `-i`/`--iv`, rename that one to `-t` to be able to use `-i`/`--input-file` consistently. This option was only introduced on master and the short option doesn't seem to be used anyway (the tests use the long option instead).

The option parser is fixed in a separate PR, see #1335.