### PR TITLE
Fix option analyser

### DIFF
--- a/scripts/utils/analyze.py
+++ b/scripts/utils/analyze.py
@@ -270,8 +270,7 @@ class Parser(object):
     '''Parses C files for long option style option blocks'''
 
     regx = re.compile(
-        r'^\s*{\s*"(\w+)"\s*,\s*(?:required_argument|no_argument)\s*,\s*\w+\s*,\s*\'(\w)\'\s*},+$',
-        re.MULTILINE)
+        r'{\s*"([^"]+)"\s*,\s*(?:required_argument|no_argument)\s*,\s*\w+\s*,\s*\'(\w)\'\s*}')
 
     def __init__(self, path=os.getcwd()):
         self._path = path

--- a/scripts/utils/analyze.py
+++ b/scripts/utils/analyze.py
@@ -80,7 +80,7 @@ class ToolConflictor(object):
                 ],
                 "tools": [],
                 "conflict": None,
-                "ignore": set(['r', 'privfile', 'u', 'pubfile', 's', 'secret', 'g', 'halg', 'n', 'name', 'f', 'format'])
+                "ignore": set(['s', 'secret', 'f', 'format'])
             },
             {
                 "gname": "duplication",
@@ -116,14 +116,14 @@ class ToolConflictor(object):
                 "tools-in-group": ["tpm2_certify", "tpm2_quote"],
                 "tools": [],
                 "conflict": None,
-                "ignore": set(['g', 'halg', 'm', 'message', 's', 'signature', 'p', 'pcrs'])
+                "ignore": set(['g', 'halg', 'm', 'message', 'signature', 'pcrs'])
             },
             {
                 "gname": "signing",
                 "tools-in-group": ["tpm2_verifysignature", "tpm2_sign"],
                 "tools": [],
                 "conflict": None,
-                "ignore": set(['f', 'format', 's', 'sig'])
+                "ignore": set(['s', 'sig'])
             },
             {
                 "gname": "integrity",
@@ -131,7 +131,7 @@ class ToolConflictor(object):
                 ["tpm2_pcrextend", "tpm2_pcrevent", "tpm2_pcrlist", "tpm2_pcrreset", "tpm2_checkquote"],
                 "tools": [],
                 "conflict": None,
-                "ignore": set(['g', 'G', 'halg', 'f', 'format', 's', 'algs', 'sig', 'p', 'pcrs', 'pubkey', 'm', 'message', 'c'])
+                "ignore": set(['g', 'halg', 'f', 'format', 's', 'algs'])
             },
             {
                 "gname": "ea",
@@ -139,8 +139,7 @@ class ToolConflictor(object):
                     "tpm2_policycommandcode", "tpm2_policysecret", "tpm2_policylocality", "tpm2_policyduplicationselect"],
                 "tools": [],
                 "conflict": None,
-                "ignore": set(['S', 'session', 'q', 'qualifier', 'n', 'name', 't', 'ticket', 'L', 'policy-list', 'o', 'policy-file', 'c', 'context',
-                    'N', 'new-parent-name', 'i', 'is-include-object'])
+                "ignore": set(['q', 'qualifier', 'n', 'name', 't', 'ticket', 'policy-list', 'c', 'context', 'N', 'new-parent-name', 'i', 'is-include-object'])
             },
             {
                 "gname": "hierarchy",
@@ -164,7 +163,7 @@ class ToolConflictor(object):
                 ],
                 "tools": [],
                 "conflict": None,
-                "ignore": set(['a', 'hierarchy', 'x', 'index', 'S', 'session', 't', 'attributes'])
+                "ignore": set(['S', 'session', 't', 'attributes'])
             },
             {
                 "gname": "capability",


### PR DESCRIPTION
#1330 discovered a bug in the [option analyser](https://github.com/tpm2-software/tpm2-tools/blob/master/scripts/utils/analyze.py): the last entry of an option array is not parsed if it does not end in a comma.

Unfortunately, the problem is deeper than that: if I understand correctly, the script is supposed to find options that are used by only one tool within the current group. Instead, the [current implementation](https://github.com/tpm2-software/tpm2-tools/blob/c66e4f069b04dcb13caed1f6408e4d199e6cf925/scripts/utils/analyze.py#L219) gathers a list of sets of options for each tool in the current group, then takes the symmetric difference of all sets in this list. This results in the [options that are used by an odd number of tools](https://en.wikipedia.org/wiki/Symmetric_difference#n-ary_symmetric_difference), which includes the unique options, but also gives some false positives. The new implementation in this PR instead collects all options of the tools within a group in a single list and returns the elements that occur exactly once.

Furthermore, the regex used to parse the options from the source code cannot handle option names containing a `-`. Replacing `\w` by `[^"]` (and removing the need for a trailing comma to fix the original issue in #1330) solves this problem, but uncovers a lot of previously undetected option conflicts. Most of these are probably harmless, but there are some that need to be addressed, e.g. `--key-alg` instead of the normally used `--kalg` in [`tpm2_loadexternal`](https://github.com/tpm2-software/tpm2-tools/blob/master/man/tpm2_loadexternal.1.md). As I am not very familiar with the option naming scheme, I would appreciate someone with more expertise looking into these conflicts listed in #1336.

Due to the newly found option conflicts, the CI build currently fails for this PR. The conflicts need to be handled before a merge by either renaming the affected options or adding them to the appropriate ignore list if they are harmless.