### PR TITLE
tools/tpm2_stirrandom: Add command to inject additional input in TPM 

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -110,6 +110,7 @@ bin_PROGRAMS = \
     tools/tpm2_sign \
     tools/tpm2_startauthsession \
     tools/tpm2_startup \
+    tools/tpm2_stirrandom \
     tools/tpm2_unseal \
     tools/tpm2_verifysignature
 
@@ -177,6 +178,7 @@ tools_tpm2_policypassword_SOURCES = tools/tpm2_policypassword.c $(TOOL_SRC)
 tools_tpm2_policysecret_SOURCES = tools/tpm2_policysecret.c $(TOOL_SRC)
 tools_tpm2_policyrestart_SOURCES = tools/tpm2_policyrestart.c $(TOOL_SRC)
 tools_tpm2_policycommandcode_SOURCES = tools/tpm2_policycommandcode.c $(TOOL_SRC)
+tools_tpm2_stirrandom_SOURCES = tools/tpm2_stirrandom.c $(TOOL_SRC)
 
 if UNIT
 TESTS = $(check_PROGRAMS)
@@ -344,6 +346,7 @@ if HAVE_MAN_PAGES
     man/man1/tpm2_sign.1 \
     man/man1/tpm2_startauthsession.1 \
     man/man1/tpm2_startup.1 \
+    man/man1/tpm2_stirrandom.1 \
     man/man1/tpm2_unseal.1 \
     man/man1/tpm2_verifysignature.1
 endif

--- a/lib/files.c
+++ b/lib/files.c
@@ -681,14 +681,10 @@ bool files_load_bytes_from_buffer_or_file_or_stdin(char *input_buffer,
                     LOG_ERR("Error reading data from \"<stdin>\"");
                     res = false;
                 } else {
-                    if (!feof(stdin)) {
-                        LOG_ERR("Data larger than expected. Got %u expected %u",
-                                original_size, *size);
-                        res = false;
-                    } else {
-                        res = true;
-                    }
+                    res = true;
                 }
+            } else {
+                res = true;
             }
         }
     }

--- a/man/tpm2_stirrandom.1.md
+++ b/man/tpm2_stirrandom.1.md
@@ -1,0 +1,73 @@
+% tpm2_stirrandom(1) tpm2-tools | General Commands Manual
+%
+% MARCH 2019
+
+# NAME
+
+**tpm2_stirrandom**(1) - Add "additional information" into TPM RNG state.
+
+# SYNOPSIS
+
+**tpm2_stirrandom** [*OPTIONS*] _INPUT\_FILE_
+
+# DESCRIPTION
+
+**tpm2_stirrandom**(1) Inject "additional information" as bytes into TPM entropy Protected Capability pool.
+
+"Additional information" can be extracted from _INPUT\_FILE_ or being read from stdin
+if _INPUT\_FILE_ is not specified.
+
+Up to 128 bytes can be injected at once through standard input to **tpm2_stirrandom**(1).
+
+If _INPUT\_FILE_ is larger than 128 bytes, **tpm2_stirrandom**(1) will fail.
+
+Adding data through **tpm2_stirrandom**(1) will trigger a reseeding of TPM
+DRBG Protected Capability. It is used when performing any sensitive action
+on a shielded location such as loading a persistent key or acting on a
+Protected Capability like updating TPM firmware.
+
+# OPTIONS
+
+This command has no option
+
+[common options](common/options.md)
+
+[common tcti options](common/tcti.md)
+
+# EXAMPLES
+
+Inject from stdin using echo:
+
+```
+echo -n "myrandomdata" | tpm2_stirrandom
+```
+
+Inject 64 bytes from stdin using a file
+
+```
+dd if=/dev/urandom bs=1 count=64 > myrandom.bin
+tpm2_stirrandom < ./myrandom.bin
+```
+
+Inject bytes from a file and reading up to 128 bytes
+
+```
+dd if=/dev/urandom of=./myrandom.bin bs=1 count=42
+tpm2_stirrandom ./myrandom.bin
+```
+
+# NOTES
+
+Please be aware that even if the "additional information" added
+by **tpm2_stirrandom**(1) can be entropy gathered from other DRBG
+sources, the TPM has no way of determining if the value has any entropy or not.
+As a consequence, it will just be considered as "additional input".
+
+The "additional input" is as defined in NIST SP800-90A (See 
+https://nvlpubs.nist.gov/nistpubs/Legacy/SP/nistspecialpublication800-90.pdf)
+
+# RETURNS
+
+0 on success or 1 on failure.
+
+[footer](common/footer.md)

--- a/scripts/utils/analyze.py
+++ b/scripts/utils/analyze.py
@@ -105,7 +105,7 @@ class ToolConflictor(object):
             },
             {
                 "gname": "random",
-                "tools-in-group": ["tpm2_getrandom"],
+                "tools-in-group": ["tpm2_getrandom", "tpm2_stirrandom"],
                 "tools": [],
                 "conflict": None,
                 "ignore": set()

--- a/test/integration/tests/stirrandom.sh
+++ b/test/integration/tests/stirrandom.sh
@@ -1,0 +1,80 @@
+#!/bin/bash
+#;**********************************************************************;
+#
+# Copyright (c) 2019, Sebastien LE STUM
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# 1. Redistributions of source code must retain the above copyright notice,
+# this list of conditions and the following disclaimer.
+#
+# 2. Redistributions in binary form must reproduce the above copyright notice,
+# this list of conditions and the following disclaimer in the documentation
+# and/or other materials provided with the distribution.
+#
+# 3. Neither the name of Intel Corporation nor the names of its contributors
+# may be used to endorse or promote products derived from this software without
+# specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+# THE POSSIBILITY OF SUCH DAMAGE.
+#;**********************************************************************;
+
+source helpers.sh
+
+goodfile=$(mktemp)
+bigfile=$(mktemp)
+{
+    dd if=/dev/urandom of="${bigfile}" bs=1 count=256
+    dd if=/dev/urandom of="${goodfile}" bs=1 count=42
+} &>/dev/null
+
+cleanup() {
+    if [ "$1" != "no-shut-down" ]; then
+        shut_down
+        rm -f "${bigfile}"
+        rm -f "${goodfile}"
+    fi
+}
+
+trap cleanup EXIT
+
+start_up
+
+cleanup "no-shut-down"
+
+# Sending bytes from stdin (pipe)
+echo -n "return 4" | tpm2_stirrandom -V 2>&1 1>/dev/null | grep -q "Submitting 8 bytes to TPM"
+
+# Sending bytes from stdin (file)
+tpm2_stirrandom -V < "${goodfile}" 2>&1 1>/dev/null | grep -q "Submitting 42 bytes to TPM"
+
+# Read more than 128 bytes from stdin (pipe)
+dd if=/dev/urandom bs=1 count=256 | tpm2_stirrandom -V 2>&1 1>/dev/null | grep -q "Submitting 128 bytes to TPM"
+
+# Read more than 128 bytes from stdin (file)
+dd if=/dev/urandom bs=1 count=256 | tpm2_stirrandom -V < "${bigfile}" 2>&1 1>/dev/null | grep -q "Submitting 128 bytes to TPM"
+
+# Read a complete file
+tpm2_stirrandom "${goodfile}" -V 2>&1 1>/dev/null | grep -q "Submitting 42 bytes to TPM"
+
+# Try to read more than 128 bytes from file and get an error
+if tpm2_stirrandom "${bigfile}"; then
+    echo "tpm2_stirrandom didn't fail on exceeding requested size"
+    exit 1
+else
+    true
+fi
+
+exit 0

--- a/tools/tpm2_stirrandom.c
+++ b/tools/tpm2_stirrandom.c
@@ -1,0 +1,120 @@
+//**********************************************************************;
+// Copyright (c) 2019, Sebastien LE STUM
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+// 1. Redistributions of source code must retain the above copyright notice,
+// this list of conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright notice,
+// this list of conditions and the following disclaimer in the documentation
+// and/or other materials provided with the distribution.
+//
+// 3. Neither the name of Intel Corporation nor the names of its contributors
+// may be used to endorse or promote products derived from this software without
+// specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+// THE POSSIBILITY OF SUCH DAMAGE.
+//**********************************************************************;
+
+#include <ctype.h>
+#include <errno.h>
+#include <stdbool.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include <tss2/tss2_esys.h>
+
+#include "files.h"
+#include "log.h"
+#include "tpm2_options.h"
+#include "tpm2_tool.h"
+#include "tpm2_util.h"
+
+/* Spec enforce input data to be not longer than 128 bytes */
+#define MAX_SIZE_TO_READ 128
+
+typedef struct tpm_stirrandom_ctx tpm_stirrandom_ctx;
+struct tpm_stirrandom_ctx {
+    TPM2B_SENSITIVE_DATA in_data;
+    char *in_file;
+};
+
+static tpm_stirrandom_ctx ctx;
+
+static bool do_stirrandom(ESYS_CONTEXT *ectx) {
+
+    TSS2_RC rval = Esys_StirRandom(ectx, ESYS_TR_NONE, ESYS_TR_NONE,
+                                   ESYS_TR_NONE, &ctx.in_data);
+    if (rval != TSS2_RC_SUCCESS) {
+        LOG_ERR("Error while injecting specified additionnal data into TPM "
+                "random pool");
+        LOG_PERR(Esys_StirRandom, rval);
+        return false;
+    }
+
+    return true;
+}
+
+static bool on_args(int argc, char **argv) {
+
+    if (argc != 1) {
+        LOG_ERR("Only supports one FILE_INPUT file, got %d arguments", argc);
+        return false;
+    }
+
+    ctx.in_file = argv[0];
+
+    return true;
+}
+
+bool tpm2_tool_onstart(tpm2_options **opts) {
+
+    *opts = tpm2_options_new(NULL, 0, NULL, NULL, on_args, 0);
+
+    return *opts != NULL;
+}
+
+static bool load_sensitive(void) {
+
+    ctx.in_data.size = MAX_SIZE_TO_READ;
+
+    bool res = files_load_bytes_from_buffer_or_file_or_stdin(NULL,
+                        ctx.in_file, &ctx.in_data.size, ctx.in_data.buffer);
+    if (!res) {
+        LOG_ERR("Error while reading data from file or stdin");
+        return false;
+    }
+
+    if (ctx.in_data.size == 0) {
+        LOG_ERR("Data size to send is zero");
+        return false;
+    }
+
+    LOG_INFO("Submitting %d bytes to TPM", ctx.in_data.size);
+
+    return true;
+}
+
+int tpm2_tool_onrun(ESYS_CONTEXT *ectx, tpm2_option_flags flags) {
+
+    UNUSED(flags);
+
+    if (!load_sensitive()) {
+        return 1;
+    }
+
+    return do_stirrandom(ectx) != true;
+}


### PR DESCRIPTION
Fixes: #876

    Added command to makefile
    Added manual entry for tpm2_stirrandom
    Added command relying on ESAPI
    Added integration test for coverage

Signed-off-by: sebastien le stum <lestums@gmail.com>