### PR TITLE
lib/tpm2_options: fix potential dereference of NULL return value

### DIFF
--- a/lib/tpm2_options.c
+++ b/lib/tpm2_options.c
@@ -226,6 +226,9 @@ static void parse_env_tcti(const char *optstr, tcti_conf *conf) {
 
 static char* parse_device_tcti(void) {
     const char *device = getenv(TPM2TOOLS_ENV_DEVICE);
+    if (!device) {
+        device = "";
+    }
     return strdup(device);
 }
 


### PR DESCRIPTION
Coverity reported "Dereferencing a pointer that might be null" due to the
fact that getenv() returns NULL if no matching variable was found in the
environment.

Handle this case by ensuring we assign a value to device when getenv()
returns NULL.

Signed-off-by: Joshua Lock <joshua.g.lock@intel.com>