### PR TITLE
Various build tweaks

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -272,10 +272,11 @@ test_unit_test_tpm2_util_SOURCES   = test/unit/test_tpm2_util.c
 abs_build_dir=$(abspath $(builddir))
 
 AM_TESTS_ENVIRONMENT =	\
-	TPM2_ABRMD="tpm2-abrmd" \
-	TPM2_SIM="tpm_server" \
-	PATH=$(abs_build_dir)/tools:$(abs_build_dir)/tools/misc:$(abs_top_srcdir)/test/integration:$(PATH) \
-	TPM2_TOOLS_TEST_FIXTURES=$(abs_top_srcdir)/test/integration/fixtures
+	TPM2_ABRMD=tpm2-abrmd; export TPM2_ABRMD; \
+	TPM2_SIM=tpm_server; export TPM2_SIM; \
+	PATH=$(abs_build_dir)/tools:$(abs_build_dir)/tools/misc:$(abs_top_srcdir)/test/integration:$(PATH); \
+	TPM2_TOOLS_TEST_FIXTURES=$(abs_top_srcdir)/test/integration/fixtures; \
+	export TPM2_TOOLS_TEST_FIXTURES;
 
 SH_LOG_COMPILER = dbus-run-session
 AM_SH_LOG_FLAGS = --

--- a/Makefile.am
+++ b/Makefile.am
@@ -275,9 +275,13 @@ AM_TESTS_ENVIRONMENT =	\
 	TPM2_ABRMD="tpm2-abrmd" \
 	TPM2_SIM="tpm_server" \
 	PATH=$(abs_build_dir)/tools:$(abs_build_dir)/tools/misc:$(abs_top_srcdir)/test/integration:$(PATH) \
-	TPM2_TOOLS_TEST_FIXTURES=$(abs_top_srcdir)/test/integration/fixtures \
-	dbus-run-session
+	TPM2_TOOLS_TEST_FIXTURES=$(abs_top_srcdir)/test/integration/fixtures
+
+SH_LOG_COMPILER = dbus-run-session
+AM_SH_LOG_FLAGS = --
 endif
+
+TEST_EXTENSIONS = .sh
 
 check-hook:
 	rm -rf .lock_file


### PR DESCRIPTION
This series includes a few build patches. The first 2 patches clean up how we set `AM_TEST_ENVIRONMENT` such that we can override it at _make check_ time.