### PR TITLE
nv_define/relase: Default values for hierarchy "-a"

### DIFF
--- a/test/integration/tests/nv.sh
+++ b/test/integration/tests/nv.sh
@@ -63,6 +63,11 @@ cleanup "no-shut-down"
 
 tpm2_clear
 
+#Test default values for the hierarchy "-a" parameter
+tpm2_nvdefine -Q -x $nv_test_index -s 32 -t "ownerread|policywrite|ownerwrite"
+tpm2_nvrelease -Q -x $nv_test_index
+
+#Test writing and reading
 tpm2_nvdefine -Q -x $nv_test_index -a o -s 32 -t "ownerread|policywrite|ownerwrite"
 
 echo "please123abc" > nv.test_w

--- a/tools/tpm2_nvdefine.c
+++ b/tools/tpm2_nvdefine.c
@@ -71,7 +71,7 @@ struct tpm_nvdefine_ctx {
 static tpm_nvdefine_ctx ctx = {
     .auth= {
         .session_data = TPMS_AUTH_COMMAND_INIT(TPM2_RS_PW),
-        .hierarchy = ESYS_TR_RH_OWNER
+        .hierarchy = TPM2_RH_OWNER
     },
     .nvAuth = TPM2B_EMPTY_INIT,
     .size = TPM2_MAX_NV_BUFFER_SIZE,

--- a/tools/tpm2_nvrelease.c
+++ b/tools/tpm2_nvrelease.c
@@ -60,7 +60,8 @@ struct tpm_nvrelease_ctx {
 };
 
 static tpm_nvrelease_ctx ctx = {
-    .auth = { .session_data = TPMS_AUTH_COMMAND_INIT(TPM2_RS_PW) },
+    .auth = { .session_data = TPMS_AUTH_COMMAND_INIT(TPM2_RS_PW),
+              .hierarchy = TPM2_RH_OWNER },
 };
 
 static bool nv_space_release(ESYS_CONTEXT *ectx) {


### PR DESCRIPTION
I noticed that the tpm2_nvdefine and tpm2_nvrelease commands do not work without `-a`.
In the former case, it was a bug with the default value.
In the latter case, no default value was set.
Fixed and added a test for default the value for the hierarchy.