### PR TITLE
Implement tpm2_nvincrement

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -85,6 +85,7 @@ bin_PROGRAMS = \
     tools/tpm2_loadexternal \
     tools/tpm2_makecredential \
     tools/tpm2_nvdefine \
+    tools/tpm2_nvincrement \
     tools/tpm2_nvlist \
     tools/tpm2_nvread \
     tools/tpm2_nvreadlock \
@@ -150,6 +151,7 @@ tools_tpm2_nvread_SOURCES = tools/tpm2_nvread.c $(TOOL_SRC)
 tools_tpm2_nvreadlock_SOURCES = tools/tpm2_nvreadlock.c $(TOOL_SRC)
 tools_tpm2_nvwrite_SOURCES = tools/tpm2_nvwrite.c $(TOOL_SRC)
 tools_tpm2_nvdefine_SOURCES = tools/tpm2_nvdefine.c $(TOOL_SRC)
+tools_tpm2_nvincrement_SOURCES = tools/tpm2_nvincrement.c $(TOOL_SRC)
 tools_tpm2_nvrelease_SOURCES = tools/tpm2_nvrelease.c $(TOOL_SRC)
 tools_tpm2_hmac_SOURCES = tools/tpm2_hmac.c $(TOOL_SRC)
 tools_tpm2_certify_SOURCES = tools/tpm2_certify.c $(TOOL_SRC)
@@ -320,6 +322,7 @@ if HAVE_MAN_PAGES
     man/man1/tpm2_loadexternal.1 \
     man/man1/tpm2_makecredential.1 \
     man/man1/tpm2_nvdefine.1 \
+    man/man1/tpm2_nvincrement.1 \
     man/man1/tpm2_nvlist.1 \
     man/man1/tpm2_nvread.1 \
     man/man1/tpm2_nvreadlock.1 \

--- a/man/tpm2_nvincrement.1.md
+++ b/man/tpm2_nvincrement.1.md
@@ -1,0 +1,68 @@
+% tpm2_nvincrement(1) tpm2-tools | General Commands Manual
+%
+% MARCH 2019
+
+# NAME
+
+**tpm2_nvincrement**(1) - Increment counter in a Non-Volatile (NV) index.
+
+# SYNOPSIS
+
+**tpm2_nvincrement** [*OPTIONS*]
+
+# DESCRIPTION
+
+**tpm2_nvincrement**(1) - Increment a counter at a Non-Volatile (NV) index.
+
+# OPTIONS
+
+  * **-x**, **--index**=_NV\_INDEX_:
+    Specifies the index to define the space at.
+
+  * **-a**, **--hierarchy**=_AUTH_:
+    specifies the handle used to authorize. Defaults to **o**, **TPM_RH_OWNER**,
+    when no value has been specified.
+    Supported options are:
+      * **o** for **TPM_RH_OWNER**
+      * **p** for **TPM_RH_PLATFORM**
+      * **`<num>`** where a raw number can be used.
+
+    When **-a** isn't explicitly passed the index handle will be used to
+    authorize against the index. The index auth value is set via the
+    **-p** option to tpm2_nvdefine(1).
+
+  * **-P**, **--auth-hierarchy**=_HIERARCHY\_AUTH_:
+    Specifies the authorization value for the hierarchy. Authorization values
+    should follow the "authorization formatting standards", see section
+    "Authorization Formatting".
+
+  * **-L**, **--set-list**==_PCR\_SELECTION\_LIST_:
+
+    The list of pcr banks and selected PCRs' ids.
+    _PCR\_SELECTION\_LIST_ values should follow the
+    pcr bank specifiers standards, see section "PCR Bank Specifiers".
+
+  * **-F**,**--pcr-input-file**=_PCR\_INPUT\_FILE_
+
+    Optional Path or Name of the file containing expected pcr values for the specified index.
+    Default is to read the current PCRs per the set list.
+
+[common options](common/options.md)
+
+[common tcti options](common/tcti.md)
+
+[authorization formatting](common/authorizations.md)
+
+# EXAMPLES
+
+To increment the counter at index 0x150016:
+
+```
+tpm2_nvincrement -x 0x1500016 -P "index" 
+```
+
+# RETURNS
+
+0 on success or 1 on failure.
+
+[footer](common/footer.md)

--- a/scripts/utils/analyze.py
+++ b/scripts/utils/analyze.py
@@ -157,7 +157,7 @@ class ToolConflictor(object):
                 "gname": "nv",
                 "tools-in-group": [
                     "tpm2_nvreadlock", "tpm2_nvrelease", "tpm2_nvdefine",
-                    "tpm2_nvread", "tpm2_nvwrite", "tpm2_nvlist"
+                    "tpm2_nvread", "tpm2_nvwrite", "tpm2_nvlist", "tpm2_nvincrement"
                 ],
                 "tools": [],
                 "conflict": None,

--- a/test/integration/tests/nvinc.sh
+++ b/test/integration/tests/nvinc.sh
@@ -92,8 +92,9 @@ tpm2_createpolicy -Q -P -L ${alg_pcr_policy}:${pcr_ids} -F $file_pcr_value -f $f
 tpm2_nvdefine -Q -x 0x1500016 -a 0x40000001 -s 8 -L $file_policy -t "policyread|policywrite|nt=1"
 
 # Increment with index authorization for now, since tpm2_nvincrement does not support pcr policy.
-echo -n -e '\x00\x00\x00\x00\x00\x00\x00\x03' > nv.test_inc   # What?
+echo -n -e '\x00\x00\x00\x00\x00\x00\x00\x03' > nv.test_inc
 
+# Counter is initialised to highest value previously seen (in this case 2) then incremented
 tpm2_nvincrement -Q -x 0x1500016 -a 0x1500016 -L ${alg_pcr_policy}:${pcr_ids} -F $file_pcr_value
 
 tpm2_nvread -x 0x1500016 -a 0x1500016 -L ${alg_pcr_policy}:${pcr_ids} -F $file_pcr_value -s 8 > cmp.dat

--- a/test/integration/tests/nvinc.sh
+++ b/test/integration/tests/nvinc.sh
@@ -1,0 +1,173 @@
+#!/bin/bash
+#;**********************************************************************;
+#
+# Copyright (c) 2016-2018, Intel Corporation
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# 1. Redistributions of source code must retain the above copyright notice,
+# this list of conditions and the following disclaimer.
+#
+# 2. Redistributions in binary form must reproduce the above copyright notice,
+# this list of conditions and the following disclaimer in the documentation
+# and/or other materials provided with the distribution.
+#
+# 3. Neither the name of Intel Corporation nor the names of its contributors
+# may be used to endorse or promote products derived from this software without
+# specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+# THE POSSIBILITY OF SUCH DAMAGE.
+#;**********************************************************************;
+
+source helpers.sh
+
+nv_test_index=0x1500018
+
+alg_pcr_policy=sha1
+pcr_ids="0,1,2,3"
+file_pcr_value=pcr.bin
+file_policy=policy.data
+
+cleanup() {
+  tpm2_nvrelease -Q -x $nv_test_index -a o 2>/dev/null || true
+  tpm2_nvrelease -Q -x 0x1500016 -a 0x40000001 2>/dev/null || true
+  tpm2_nvrelease -Q -x 0x1500015 -a 0x40000001 -P owner 2>/dev/null || true
+
+  rm -f policy.bin test.bin nv.test_inc nv.readlock foo.dat cmp.dat \
+        $file_pcr_value $file_policy nv.out cap.out
+
+  if [ "$1" != "no-shut-down" ]; then
+     shut_down
+  fi
+}
+trap cleanup EXIT
+
+start_up
+
+cleanup "no-shut-down"
+
+tpm2_clear
+
+tpm2_nvdefine -Q -x $nv_test_index -a o -s 8 -t "ownerread|policywrite|ownerwrite|nt=1"
+
+tpm2_nvincrement -Q -x $nv_test_index -a o 
+
+tpm2_nvread -Q -x $nv_test_index -a o -s 8
+
+tpm2_nvlist > nv.out
+yaml_get_kv nv.out $nv_test_index > /dev/null
+
+# Test writing to and reading from an offset by:
+# 1. incrementing the nv counter
+# 2. reading back the index
+# 3. comparing the result.
+
+echo -n -e '\x00\x00\x00\x00\x00\x00\x00\x02' > nv.test_inc
+
+tpm2_nvincrement -Q -x $nv_test_index -a o 
+
+tpm2_nvread -x $nv_test_index -a o -s 8 > cmp.dat
+
+cmp nv.test_inc cmp.dat
+
+tpm2_nvrelease -x $nv_test_index -a o
+
+
+tpm2_pcrlist -Q -L ${alg_pcr_policy}:${pcr_ids} -o $file_pcr_value
+
+tpm2_createpolicy -Q -P -L ${alg_pcr_policy}:${pcr_ids} -F $file_pcr_value -f $file_policy
+
+tpm2_nvdefine -Q -x 0x1500016 -a 0x40000001 -s 8 -L $file_policy -t "policyread|policywrite|nt=1"
+
+# Increment with index authorization for now, since tpm2_nvincrement does not support pcr policy.
+echo -n -e '\x00\x00\x00\x00\x00\x00\x00\x03' > nv.test_inc   # What?
+
+tpm2_nvincrement -Q -x 0x1500016 -a 0x1500016 -L ${alg_pcr_policy}:${pcr_ids} -F $file_pcr_value
+
+tpm2_nvread -x 0x1500016 -a 0x1500016 -L ${alg_pcr_policy}:${pcr_ids} -F $file_pcr_value -s 8 > cmp.dat
+
+cmp nv.test_inc cmp.dat
+
+# this should fail because authread is not allowed
+trap - ERR
+tpm2_nvread -x 0x1500016 -a 0x1500016 -P "index" 2>/dev/null
+trap onerror ERR
+
+tpm2_nvrelease -Q -x 0x1500016 -a 0x40000001
+
+
+#
+# Test NV access locked
+#
+tpm2_nvdefine -Q -x $nv_test_index -a o -s 8 -t "ownerread|policywrite|ownerwrite|read_stclear|nt=1"
+
+tpm2_nvincrement -Q -x $nv_test_index -a o
+
+tpm2_nvread -Q -x $nv_test_index -a o -s 8
+
+tpm2_nvreadlock -Q -x $nv_test_index -a o
+
+# Reset ERR signal handler to test for expected nvread error
+trap - ERR
+
+tpm2_nvread -Q -x $nv_test_index -a o -s 8 2> /dev/null
+if [ $? != 1 ];then
+ echo "nvread didn't fail!"
+ exit 1
+fi
+
+#
+# Test that owner and index passwords work by
+# 1. Setting up the owner password
+# 2. Defining an nv index that can be satisfied by an:
+#   a. Owner authorization
+#   b. Index authorization
+# 3. Using index and owner based auth during write/read operations
+# 4. Testing that auth is needed or a failure occurs.
+#
+trap onerror ERR
+
+tpm2_changeauth -o owner
+
+tpm2_nvdefine -x 0x1500015 -a 0x40000001 -s 8 \
+  -t "policyread|policywrite|authread|authwrite|ownerwrite|ownerread|nt=1" \
+  -p "index" -P "owner"
+
+# Use index password write/read, implicit -a
+tpm2_nvincrement -Q -x 0x1500015 -P "index"
+tpm2_nvread -Q -x 0x1500015 -P "index"
+
+# Use index password write/read, explicit -a
+tpm2_nvincrement -Q -x 0x1500015 -a 0x1500015 -P "index"
+tpm2_nvread -Q -x 0x1500015 -a 0x1500015 -P "index"
+
+# use owner password
+tpm2_nvincrement -Q -x 0x1500015 -a 0x40000001 -P "owner"
+tpm2_nvread -Q -x 0x1500015 -a 0x40000001 -P "owner"
+
+# Check a bad password fails
+trap - ERR
+tpm2_nvincrement -Q -x 0x1500015 -a 0x1500015 -P "wrong" 2>/dev/null
+if [ $? -eq 0 ];then
+ echo "nvincrement with bad password should fail!"
+ exit 1
+fi
+
+# Check using authorisation with tpm2_nvrelease
+trap onerror ERR
+
+tpm2_nvrelease -x 0x1500015 -a 0x40000001 -P "owner"
+
+exit 0

--- a/tools/tpm2_nvincrement.c
+++ b/tools/tpm2_nvincrement.c
@@ -1,0 +1,269 @@
+//**********************************************************************;
+// Copyright (c) 2015-2018, Intel Corporation
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+// 1. Redistributions of source code must retain the above copyright notice,
+// this list of conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright notice,
+// this list of conditions and the following disclaimer in the documentation
+// and/or other materials provided with the distribution.
+//
+// 3. Neither the name of Intel Corporation nor the names of its contributors
+// may be used to endorse or promote products derived from this software without
+// specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+// THE POSSIBILITY OF SUCH DAMAGE.
+//**********************************************************************;
+
+#include <errno.h>
+#include <stdbool.h>
+#include <stdlib.h>
+#include <stdio.h>
+#include <string.h>
+
+#include <limits.h>
+
+#include <tss2/tss2_esys.h>
+
+#include "files.h"
+#include "log.h"
+#include "pcr.h"
+#include "tpm2_auth_util.h"
+#include "tpm2_hierarchy.h"
+#include "tpm2_nv_util.h"
+#include "tpm2_policy.h"
+#include "tpm2_session.h"
+#include "tpm2_tool.h"
+#include "tpm2_util.h"
+
+typedef struct tpm_nvincrement_ctx tpm_nvincrement_ctx;
+struct tpm_nvincrement_ctx {
+    TPM2_HANDLE nv_index;
+    struct {
+        TPMS_AUTH_COMMAND session_data;
+        tpm2_session *session;
+        TPMI_RH_PROVISION hierarchy;
+    } auth;
+    char *raw_pcrs_file;
+    tpm2_session *policy_session;
+    TPML_PCR_SELECTION pcr_selection;
+    struct {
+        UINT8 L : 1;
+        UINT8 P : 1;
+        UINT8 a : 1;
+    } flags;
+    char *hierarchy_auth_str;
+};
+
+static tpm_nvincrement_ctx ctx = {
+    .auth = {
+            .session_data = TPMS_AUTH_COMMAND_INIT(TPM2_RS_PW),
+            .hierarchy = TPM2_RH_OWNER
+    }
+};
+
+static bool nv_increment(ESYS_CONTEXT *ectx) {
+    // Convert TPM2_HANDLE ctx.nv_index to an ESYS_TR
+    ESYS_TR nv_index;
+    TSS2_RC rval = Esys_TR_FromTPMPublic(ectx, ctx.nv_index,
+                        ESYS_TR_NONE, ESYS_TR_NONE, ESYS_TR_NONE, &nv_index);
+    if (rval != TPM2_RC_SUCCESS) {
+        LOG_PERR(Esys_TR_FromTPMPublic, rval);
+        return false;
+    }
+
+    // Convert TPMI_RH_PROVISION ctx.auth.hierarchy to an ESYS_TR
+    ESYS_TR hierarchy;
+    if (ctx.auth.hierarchy == ctx.nv_index) {
+        hierarchy = nv_index;
+    } else {
+        hierarchy = tpm2_tpmi_hierarchy_to_esys_tr(ctx.auth.hierarchy);
+    }
+
+    ESYS_TR shandle1 = tpm2_auth_util_get_shandle(ectx, hierarchy,
+                            &ctx.auth.session_data, ctx.auth.session);
+    if (shandle1 == ESYS_TR_NONE) {
+        LOG_ERR("Failed to get shandle");
+        return false;
+    }
+
+    rval = Esys_NV_Increment(ectx, hierarchy, nv_index,
+                    shandle1, ESYS_TR_NONE, ESYS_TR_NONE);
+    if (rval != TPM2_RC_SUCCESS) {
+        LOG_ERR("Failed to increment NV counter at index 0x%X", ctx.nv_index);
+        LOG_PERR(Tss2_Sys_NV_Write, rval);
+        return false;
+    }
+
+    return true;
+}
+
+static bool on_option(char key, char *value) {
+    bool result;
+
+    switch (key) {
+    case 'x':
+        result = tpm2_util_string_to_uint32(value, &ctx.nv_index);
+        if (!result) {
+            LOG_ERR("Could not convert NV index to number, got: \"%s\"",
+                    value);
+            return false;
+        }
+
+        if (ctx.nv_index == 0) {
+            LOG_ERR("NV Index cannot be 0");
+            return false;
+        }
+        break;
+    case 'a':
+        result = tpm2_hierarchy_from_optarg(value, &ctx.auth.hierarchy,
+                TPM2_HIERARCHY_FLAGS_O|TPM2_HIERARCHY_FLAGS_P);
+        if (!result) {
+            return false;
+        }
+        ctx.flags.a = 1;
+        break;
+    case 'P':
+        ctx.flags.P = 1;
+        ctx.hierarchy_auth_str = value;
+        break;
+    case 'L':
+        if (!pcr_parse_selections(value, &ctx.pcr_selection)) {
+            return false;
+        }
+        ctx.flags.L = 1;
+        break;
+    case 'F':
+        ctx.raw_pcrs_file = value;
+        break;
+    }
+
+    return true;
+}
+
+
+bool tpm2_tool_onstart(tpm2_options **opts) {
+
+    const struct option topts[] = {
+        { "index",                required_argument, NULL, 'x' },
+        { "hierarchy",            required_argument, NULL, 'a' },
+        { "auth-hierarchy",       required_argument, NULL, 'P' },
+        { "set-list",             required_argument, NULL, 'L' },
+        { "pcr-input-file",       required_argument, NULL, 'F' },
+    };
+
+    *opts = tpm2_options_new("x:a:P:L:F:", ARRAY_LEN(topts), topts,
+                             on_option, NULL, 0);
+
+    return *opts != NULL;
+}
+
+static bool start_auth_session(ESYS_CONTEXT *ectx) {
+
+    tpm2_session_data *session_data =
+            tpm2_session_data_new(TPM2_SE_POLICY);
+    if (!session_data) {
+        LOG_ERR("oom");
+        return false;
+    }
+
+    ctx.auth.session = tpm2_session_new(ectx,
+            session_data);
+    if (!ctx.auth.session) {
+        LOG_ERR("Could not start tpm session");
+        return false;
+    }
+
+    bool result = tpm2_policy_build_pcr(ectx, ctx.auth.session,
+            ctx.raw_pcrs_file,
+            &ctx.pcr_selection);
+    if (!result) {
+        LOG_ERR("Could not build a pcr policy");
+        return false;
+    }
+
+    return true;
+}
+
+
+int tpm2_tool_onrun(ESYS_CONTEXT *ectx, tpm2_option_flags flags) {
+
+    UNUSED(flags);
+
+    int rc = 1;
+    bool result;
+
+    if (ctx.flags.L && ctx.auth.session) {
+        LOG_ERR("Can only use either existing session or a new session,"
+                " not both!");
+        goto out;
+    }
+
+    if (ctx.flags.L) {
+        result = start_auth_session(ectx);
+        if (!result) {
+            goto out;
+        }
+    }
+
+    /* If the users doesn't specify an authorisation hierarchy use the index
+     * passed to -x/--index for the authorisation index.
+     */
+    if (!ctx.flags.a) {
+        ctx.auth.hierarchy = ctx.nv_index;
+    }
+
+    if (ctx.flags.P) {
+        result = tpm2_auth_util_from_optarg(ectx, ctx.hierarchy_auth_str,
+                &ctx.auth.session_data, &ctx.auth.session);
+        if (!result) {
+            LOG_ERR("Invalid handle authorization, got \"%s\"",
+                ctx.hierarchy_auth_str);
+            goto out;
+        }
+    }
+
+    result = nv_increment(ectx);
+    if (!result) {
+        goto out;
+    }
+
+    rc = 0;
+
+out:
+
+    if (ctx.flags.L) {
+        ESYS_TR sess_handle = tpm2_session_get_handle(ctx.auth.session);
+        TSS2_RC rval = Esys_FlushContext(ectx, sess_handle);
+        if (rval != TPM2_RC_SUCCESS) {
+            LOG_PERR(Esys_FlushContext, rval);
+            rc = 1;
+        }
+    } else {
+        result = tpm2_session_save(ectx, ctx.auth.session, NULL);
+        if (!result) {
+            rc = 1;
+        }
+    }
+
+    return rc;
+}
+
+void tpm2_onexit(void) {
+
+    tpm2_session_free(&ctx.auth.session);
+}


### PR DESCRIPTION
Implemented tpm2_nvincrement, a copy/paste/rename from tpm2_nvwrite

I have noticed that the increments do not behave as I would have expected, perhaps I am missing something?

Tested against Infineon TPM9670

$ tpm2_clear

$ tpm2_nvdefine -x 0x1500001 -a o -s 8 -t "ownerread|ownerwrite|nt=1"
$ tpm2_nvdefine -x 0x1500002 -a o -s 8 -t "ownerread|ownerwrite|nt=1"
$ tpm2_nvdefine -x 0x1500003 -a o -s 8 -t "ownerread|ownerwrite|nt=1"

$ tpm2_nvincrement -x 0x1500001 -a o 
$ tpm2_nvread -x 0x1500001 -a o -s 8 | hexdump -C
00000000  00 00 00 00 00 00 00 03                           |........|

$ tpm2_nvincrement -x 0x1500002 -a o 
$ tpm2_nvread -x 0x1500002 -a o -s 8 | hexdump -C
00000000  00 00 00 00 00 00 00 04                           |........|

$ tpm2_nvincrement -x 0x1500003 -a o
$ tpm2_nvread -x 0x1500003 -a o -s 8 | hexdump -C
00000000  00 00 00 00 00 00 00 05                           |........|

$ tpm2_nvlist
0x1500001:
  hash algorithm:
    friendly: sha256
    value: 0xB
  attributes:
    friendly: ownerwrite|nt=0x1|ownerread|written
    value: 0x12000220
  size: 8

0x1500002:
  hash algorithm:
    friendly: sha256
    value: 0xB
  attributes:
    friendly: ownerwrite|nt=0x1|ownerread|written
    value: 0x12000220
  size: 8

0x1500003:
  hash algorithm:
    friendly: sha256
    value: 0xB
  attributes:
    friendly: ownerwrite|nt=0x1|ownerread|written
    value: 0x12000220
  size: 8