### PR TITLE
configure.ac: tweak output of “./configure --help”

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -64,7 +64,7 @@ AC_SUBST([LIBDL_LDFLAGS])
 
 AC_ARG_ENABLE([unit],
             [AS_HELP_STRING([--enable-unit],
-                            [build cmocka unit tests (default is no)])],
+                            [build cmocka unit tests])],
             [enable_unit=$enableval],
             [enable_unit=no])
 AM_CONDITIONAL([UNIT], [test "x$enable_unit" != xno])
@@ -132,8 +132,8 @@ AC_ARG_ENABLE([dlclose],
  )
 
 AC_ARG_ENABLE([hardening],
-  [AS_HELP_STRING([--enable-hardening],
-    [Enable compiler and linker options to frustrate memory corruption exploits @<:@yes@:>@])],
+  [AS_HELP_STRING([--disable-hardening],
+    [Disable compiler and linker options to frustrate memory corruption exploits])],
   [hardening="$enableval"],
   [hardening="yes"])
 


### PR DESCRIPTION
The users asume, unless otherwise stated, that a feature has two states and it is either disabled or enabled.  For features enabled by default, the output of “./configure --help” is supposed to state how ot disable them and for features disabled by default, the very same output is supposed to state how to enable them.

This change adjusts the output of “./configure --help” accordingly.