### PR TITLE
tools/tpm2_unseal: Fix option from "item-context" to "context-object"

### DIFF
--- a/test/integration/tests/unseal.sh
+++ b/test/integration/tests/unseal.sh
@@ -106,7 +106,7 @@ tpm2_create -Q -g $alg_create_obj -u $file_unseal_key_pub -r $file_unseal_key_pr
 
 tpm2_load -Q -C $file_primary_key_ctx  -u $file_unseal_key_pub  -r $file_unseal_key_priv -n $file_unseal_key_name -o $file_unseal_key_ctx
 
-unsealed=`tpm2_unseal -c $file_unseal_key_ctx -L ${alg_pcr_policy}:${pcr_ids} -F $file_pcr_value`
+unsealed=`tpm2_unseal --context-object $file_unseal_key_ctx -L ${alg_pcr_policy}:${pcr_ids} -F $file_pcr_value`
 
 test "$unsealed" == "$secret"
 

--- a/tools/tpm2_unseal.c
+++ b/tools/tpm2_unseal.c
@@ -198,7 +198,7 @@ bool tpm2_tool_onstart(tpm2_options **opts) {
     static const struct option topts[] = {
       { "auth-key",             required_argument, NULL, 'p' },
       { "out-file",             required_argument, NULL, 'o' },
-      { "item-context",         required_argument, NULL, 'c' },
+      { "context-object",       required_argument, NULL, 'c' },
       { "set-list",             required_argument, NULL, 'L' },
       { "pcr-input-file",       required_argument, NULL, 'F' },
     };


### PR DESCRIPTION
Fixes : #1260

Also modified test script to check long option naming

Signed-off-by: sebastien le stum <lestums@gmail.com>