### PR TITLE
tools/tpm2_quote: Fix -G option to -g

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## Changelog
 ### next
+  * tpm2_verifysignature: Fix -G option to -g
+  * tpm2_sign: Fix -G option to -g
+  * tpm2_hash: Fix -G option to -g
+  * tpm2_quote: Fix -G option to -g
   * tpm2_testparms: new tool for querying tpm for supported algorithms.
   * tpm2_getcap: supports "pcr" option for listing hash algorithms and bank numbers.
   * tpm2_createprimary: add -u for supporting unique field when creating objects.

--- a/man/tpm2_hash.1.md
+++ b/man/tpm2_hash.1.md
@@ -29,7 +29,7 @@ sign.
       * **e** for **TPM_RH_ENDORSEMENT**
       * **n** for **TPM_RH_NULL**
 
-  * **-G**, **--halg**=_HASH\_ALGORITHM_:
+  * **-g**, **--halg**=_HASH\_ALGORITHM_:
     The hash algorithm to use.
     Algorithms should follow the "formatting standards", see section
     "Algorithm Specifiers".
@@ -55,7 +55,7 @@ sign.
 Hash a file with sha1 hash algorithm and save the hash and ticket to a file:
 
 ```
-tpm2_hash -H e -G sha1 -o hash.bin -t ticket.bin data.txt
+tpm2_hash -H e -g sha1 -o hash.bin -t ticket.bin data.txt
 ```
 
 # RETURNS

--- a/man/tpm2_policyauthorize.1.md
+++ b/man/tpm2_policyauthorize.1.md
@@ -94,7 +94,7 @@ verification of the signature on the pcr policy digest using **tpm2_policyauthor
  -L authorized.policy <<< "secret to seal"
 
 ## Satisfy policy and unseal the secret:
-* tpm2_verifysignature -c signing_key.ctx -G sha256 -m pcr.policy\
+* tpm2_verifysignature -c signing_key.ctx -g sha256 -m pcr.policy\
  -s pcr.signature -t verification.tkt -f rsassa
 * tpm2_startauthsession -a -S session.ctx
 * tpm2_policypcr -Q -S session.ctx -L sha256:0 -f pcr.policy

--- a/man/tpm2_quote.1.md
+++ b/man/tpm2_quote.1.md
@@ -63,7 +63,7 @@
     Data given as a Hex string to qualify the  quote, optional. This is typically
     used to add a nonce against replay attacks.
 
-  * **-G**, **--sig-hash-algorithm**:
+  * **-g**, **--halg**:
 
     Hash algorithm for signature. Required if **-p** is given.
 

--- a/man/tpm2_sign.1.md
+++ b/man/tpm2_sign.1.md
@@ -31,7 +31,7 @@ data and validation shall indicate that hashed data did not start with
     Authorization values should follow the "authorization formatting standards",
     see section "Authorization Formatting".
 
-  * **-G**, **--halg**=_HASH\_ALGORITHM_:
+  * **-g**, **--halg**=_HASH\_ALGORITHM_:
 
     The hash algorithm used to digest the message.
     Algorithms should follow the "formatting standards", see section
@@ -100,7 +100,7 @@ tpm2_create -G rsa -u rsa.pub -r rsa.priv -C primary.ctx
 tpm2_load -C primary.ctx -u rsa.pub -r rsa.priv -o rsa.ctx
 
 echo "my message > message.dat
-tpm2_sign -c rsa.ctx -G sha256 -m message.dat -s sig.rssa
+tpm2_sign -c rsa.ctx -g sha256 -m message.dat -s sig.rssa
 tpm2_verifysignature -c rsa.ctx -G sha256 -m message.dat -s sig.rssa
 ```
 
@@ -117,7 +117,7 @@ sha256sum data.in.raw | awk '{ print "000000 " $1 }' | xxd -r -c 32 > data.in.di
 tpm2_loadexternal -Q -G ecc -r private.ecc.pem -o key.ctx
 
 # Sign in the TPM and verify with OSSL
-tpm2_sign -Q -c key.ctx -G sha256 -D data.in.digest -f plain -s data.out.signed
+tpm2_sign -Q -c key.ctx -g sha256 -D data.in.digest -f plain -s data.out.signed
 openssl dgst -verify public.ecc.pem -keyform pem -sha256 -signature data.out.signed data.in.raw
 ```
 

--- a/man/tpm2_sign.1.md
+++ b/man/tpm2_sign.1.md
@@ -101,7 +101,7 @@ tpm2_load -C primary.ctx -u rsa.pub -r rsa.priv -o rsa.ctx
 
 echo "my message > message.dat
 tpm2_sign -c rsa.ctx -g sha256 -m message.dat -s sig.rssa
-tpm2_verifysignature -c rsa.ctx -G sha256 -m message.dat -s sig.rssa
+tpm2_verifysignature -c rsa.ctx -g sha256 -m message.dat -s sig.rssa
 ```
 
 Sign with the TPM and verify with OSSL

--- a/man/tpm2_verifysignature.1.md
+++ b/man/tpm2_verifysignature.1.md
@@ -26,7 +26,7 @@ symmetric key, both the public and private portions need to be loaded.
     Context object for the key context used for the operation. Either a file
     or a handle number. See section "Context Object Format".
 
-  * **-G**, **--halg**=_HASH\_ALGORITHM_:
+  * **-g**, **--halg**=_HASH\_ALGORITHM_:
 
     The hash algorithm used to digest the message.
     Algorithms should follow the "formatting standards", see section
@@ -87,7 +87,7 @@ tpm2_load -C primary.ctx -u rsa.pub -r rsa.priv -o rsa.ctx
 
 echo "my message > message.dat
 tpm2_sign -c rsa.ctx -g sha256 -m message.dat -s sig.rssa
-tpm2_verifysignature -c rsa.ctx -G sha256 -m message.dat -s sig.rssa
+tpm2_verifysignature -c rsa.ctx -g sha256 -m message.dat -s sig.rssa
 ```
 
 Sign with openssl and verify with the TPM
@@ -109,7 +109,7 @@ openssl dgst -verify public.ecc.pem -keyform pem -sha256 -signature data.out.sig
 
 # Sign with openssl and verify with TPM
 openssl dgst -sha256 -sign private.ecc.pem -out data.out.signed data.in.raw
-tpm2_verifysignature -Q -c key.ctx -G sha256 -m data.in.raw -f ecdsa -s data.out.signed
+tpm2_verifysignature -Q -c key.ctx -g sha256 -m data.in.raw -f ecdsa -s data.out.signed
 ```
 
 # RETURNS

--- a/man/tpm2_verifysignature.1.md
+++ b/man/tpm2_verifysignature.1.md
@@ -86,7 +86,7 @@ tpm2_create -G rsa -u rsa.pub -r rsa.priv -C primary.ctx
 tpm2_load -C primary.ctx -u rsa.pub -r rsa.priv -o rsa.ctx
 
 echo "my message > message.dat
-tpm2_sign -c rsa.ctx -G sha256 -m message.dat -s sig.rssa
+tpm2_sign -c rsa.ctx -g sha256 -m message.dat -s sig.rssa
 tpm2_verifysignature -c rsa.ctx -G sha256 -m message.dat -s sig.rssa
 ```
 
@@ -104,7 +104,7 @@ sha256sum data.in.raw | awk '{ print "000000 " $1 }' | xxd -r -c 32 > data.in.di
 tpm2_loadexternal -Q -G ecc -r private.ecc.pem -o key.ctx
 
 # Sign in the TPM and verify with OSSL
-tpm2_sign -Q -c key.ctx -G sha256 -D data.in.digest -f plain -s data.out.signed
+tpm2_sign -Q -c key.ctx -g sha256 -D data.in.digest -f plain -s data.out.signed
 openssl dgst -verify public.ecc.pem -keyform pem -sha256 -signature data.out.signed data.in.raw
 
 # Sign with openssl and verify with TPM

--- a/scripts/utils/analyze.py
+++ b/scripts/utils/analyze.py
@@ -102,7 +102,7 @@ class ToolConflictor(object):
                 ["tpm2_encryptdecrypt", "tpm2_hmac", "tpm2_hash"],
                 "tools": [],
                 "conflict": None,
-                "ignore": set(['a', 'hierarchy', 'D', 'decrypt', 't', 'ticket', 'i', 'iv', 'mode', 'halg'])
+                "ignore": set(['a', 'hierarchy', 'D', 'decrypt', 't', 'ticket', 'i', 'iv', 'mode', 'halg', 'g', 'G'])
             },
             {
                 "gname": "random",

--- a/test/integration/tests/checkquote.sh
+++ b/test/integration/tests/checkquote.sh
@@ -87,7 +87,7 @@ tpm2_createak -C $handle_ek -k $handle_ak -G $ak_alg -D $digestAlg -s $signAlg -
 
 # Quoting
 getrandom 20
-tpm2_quote -C $handle_ak -L sha256:15,16,22 -q $loaded_randomness -m $output_quote -s $output_quotesig -p $output_quotepcr -G $digestAlg -P "$akpw"
+tpm2_quote -C $handle_ak -L sha256:15,16,22 -q $loaded_randomness -m $output_quote -s $output_quotesig -p $output_quotepcr -g $digestAlg -P "$akpw"
 
 # Verify quote
 tpm2_checkquote -c $output_ak_pub_pem -m $output_quote -s $output_quotesig -p $output_quotepcr -G $digestAlg -q $loaded_randomness

--- a/test/integration/tests/hash.sh
+++ b/test/integration/tests/hash.sh
@@ -57,7 +57,7 @@ echo "T0naX0u123abc" > $hash_in_file
 
 # Test with ticket and hash output files and verify that the output hash
 # is correct. Ticket is not stable and changes run to run, don't verify it.
-tpm2_hash -a e -G sha1 -o $hash_out_file -t $ticket_file $hash_in_file 1>/dev/null
+tpm2_hash -a e -g sha1 -o $hash_out_file -t $ticket_file $hash_in_file 1>/dev/null
 
 expected=`sha1sum $hash_in_file | awk '{print $1}'`
 actual=`cat $hash_out_file | xxd -p -c 20`
@@ -69,7 +69,7 @@ cleanup "no-shut-down"
 # Test platform hierarchy with multiple files and verify output against sha256sum
 # Test a file redirection as well.
 echo "T0naX0u123abc" > $hash_in_file
-tpm2_hash -a p -G sha256 -Q -o $hash_out_file -t $ticket_file < $hash_in_file
+tpm2_hash -a p -g sha256 -Q -o $hash_out_file -t $ticket_file < $hash_in_file
 
 expected=`sha256sum $hash_in_file | awk '{print $1}'`
 actual=`cat $hash_out_file | xxd -p -c 32`

--- a/test/integration/tests/import.sh
+++ b/test/integration/tests/import.sh
@@ -101,7 +101,7 @@ run_rsa_import_test() {
 
 	sha256sum data.in.raw | awk '{ print "000000 " $1 }' | xxd -r -c 32 > data.in.digest
 
-	tpm2_sign -Q -c import_rsa_key.ctx -G sha256 -D data.in.digest -f plain -o data.out.signed
+	tpm2_sign -Q -c import_rsa_key.ctx -g sha256 -D data.in.digest -f plain -o data.out.signed
 
 	openssl dgst -verify public.pem -keyform pem -sha256 -signature data.out.signed data.in.raw
 
@@ -135,7 +135,7 @@ run_ecc_import_test() {
 	tpm2_load -Q -C $1 -u ecc.pub -r ecc.priv -n ecc.name -o ecc.ctx
 
 	# Sign in the TPM and verify with OSSL
-	tpm2_sign -Q -c ecc.ctx -G sha256 -D data.in.digest -f plain -o data.out.signed
+	tpm2_sign -Q -c ecc.ctx -g sha256 -D data.in.digest -f plain -o data.out.signed
 	openssl dgst -verify public.ecc.pem -keyform pem -sha256 -signature data.out.signed data.in.raw
 
 	# Sign with openssl and verify with TPM.

--- a/test/integration/tests/import.sh
+++ b/test/integration/tests/import.sh
@@ -109,7 +109,7 @@ run_rsa_import_test() {
 	openssl dgst -sha256 -sign private.pem -out data.out.signed data.in.raw
 
 	# Verify with the TPM
-	tpm2_verifysignature -Q -c import_rsa_key.ctx -G sha256 -m data.in.raw -f rsassa -s data.out.signed -t ticket.out
+	tpm2_verifysignature -Q -c import_rsa_key.ctx -g sha256 -m data.in.raw -f rsassa -s data.out.signed -t ticket.out
 
 	rm import_rsa_key.ctx
 }
@@ -140,7 +140,7 @@ run_ecc_import_test() {
 
 	# Sign with openssl and verify with TPM.
 	openssl dgst -sha256 -sign private.ecc.pem -out data.out.signed data.in.raw
-	tpm2_verifysignature -Q -c ecc.ctx -G sha256 -m data.in.raw -f ecdsa -s data.out.signed
+	tpm2_verifysignature -Q -c ecc.ctx -g sha256 -m data.in.raw -f ecdsa -s data.out.signed
 
 	rm ecc.ctx
 }

--- a/test/integration/tests/loadexternal.sh
+++ b/test/integration/tests/loadexternal.sh
@@ -183,7 +183,7 @@ run_ecc_test() {
 	# Sign with openssl and verify with TPM but only with the public portion of an object loaded
 	tpm2_loadexternal -Q -G ecc -u public.ecc.pem -o key.ctx
 	openssl dgst -sha256 -sign private.ecc.pem -out data.out.signed data.in.raw
-	tpm2_verifysignature -Q -c key.ctx -G sha256 -m data.in.raw -f ecdsa -s data.out.signed
+	tpm2_verifysignature -Q -c key.ctx -g sha256 -m data.in.raw -f ecdsa -s data.out.signed
 
     cleanup "no-shut-down"
 }

--- a/test/integration/tests/loadexternal.sh
+++ b/test/integration/tests/loadexternal.sh
@@ -177,7 +177,7 @@ run_ecc_test() {
     tpm2_loadexternal -Q -G ecc -r private.ecc.pem -o key.ctx
 
 	# Sign in the TPM and verify with OSSL
-	tpm2_sign -Q -c key.ctx -G sha256 -D data.in.digest -f plain -o data.out.signed
+	tpm2_sign -Q -c key.ctx -g sha256 -D data.in.digest -f plain -o data.out.signed
 	openssl dgst -verify public.ecc.pem -keyform pem -sha256 -signature data.out.signed data.in.raw
 
 	# Sign with openssl and verify with TPM but only with the public portion of an object loaded

--- a/test/integration/tests/output_formats.sh
+++ b/test/integration/tests/output_formats.sh
@@ -103,7 +103,7 @@ tpm2_createak -Q -G $alg_ak -C $handle_ek -k $handle_ak -p "$file_pubak_tss" -n 
 
 tpm2_readpublic -Q -c $handle_ak -f "pem" -o "$file_pubak_pem"
 
-tpm2_hash -Q -a e -G $alg_hash -t "$file_hash_ticket" -o "$file_hash_result" "$file_hash_input"
+tpm2_hash -Q -a e -g $alg_hash -t "$file_hash_ticket" -o "$file_hash_result" "$file_hash_input"
 
 for fmt in tss plain; do
     this_sig="${file_sig_base}.${fmt}"

--- a/test/integration/tests/output_formats.sh
+++ b/test/integration/tests/output_formats.sh
@@ -107,7 +107,7 @@ tpm2_hash -Q -a e -g $alg_hash -t "$file_hash_ticket" -o "$file_hash_result" "$f
 
 for fmt in tss plain; do
     this_sig="${file_sig_base}.${fmt}"
-    tpm2_sign -Q -c $handle_ak -G $alg_hash -m "${file_hash_input}" -f $fmt -o "${this_sig}" -t "${file_hash_ticket}"
+    tpm2_sign -Q -c $handle_ak -g $alg_hash -m "${file_hash_input}" -f $fmt -o "${this_sig}" -t "${file_hash_ticket}"
 
     if [ "$fmt" = plain ]; then
         openssl dgst -verify "$file_pubak_pem" -keyform pem -${alg_hash} -signature "$this_sig" "$file_hash_input" > /dev/null

--- a/test/integration/tests/quote.sh
+++ b/test/integration/tests/quote.sh
@@ -91,24 +91,24 @@ tpm2_create -Q -g $alg_create_obj -G $alg_create_key -u $file_quote_key_pub -r $
 
 tpm2_load -Q -C $file_primary_key_ctx  -u $file_quote_key_pub  -r $file_quote_key_priv -n $file_quote_key_name -o $file_quote_key_ctx
 
-tpm2_quote -C $file_quote_key_ctx  -L $alg_quote:16,17,18 -q $nonce -m $toss_out -s $toss_out -p $toss_out -G $alg_primary_obj > $out
+tpm2_quote -C $file_quote_key_ctx  -L $alg_quote:16,17,18 -q $nonce -m $toss_out -s $toss_out -p $toss_out -g $alg_primary_obj > $out
 
 yaml_verify $out
 
-tpm2_quote -Q -C $file_quote_key_ctx  -L $alg_quote:16,17,18+$alg_quote1:16,17,18 -q $nonce -m $toss_out -s $toss_out -p $toss_out -G $alg_primary_obj
+tpm2_quote -Q -C $file_quote_key_ctx  -L $alg_quote:16,17,18+$alg_quote1:16,17,18 -q $nonce -m $toss_out -s $toss_out -p $toss_out -g $alg_primary_obj
 
 #####handle testing
 tpm2_evictcontrol -Q -a o -c $file_quote_key_ctx -p $Handle_ak_quote
 
-tpm2_quote -Q -C $Handle_ak_quote -L $alg_quote:16,17,18 -q $nonce -m $toss_out -s $toss_out -p $toss_out -G $alg_primary_obj
+tpm2_quote -Q -C $Handle_ak_quote -L $alg_quote:16,17,18 -q $nonce -m $toss_out -s $toss_out -p $toss_out -g $alg_primary_obj
 
-tpm2_quote -Q -C $Handle_ak_quote  -L $alg_quote:16,17,18+$alg_quote1:16,17,18 -q $nonce -m $toss_out -s $toss_out -p $toss_out -G $alg_primary_obj
+tpm2_quote -Q -C $Handle_ak_quote  -L $alg_quote:16,17,18+$alg_quote1:16,17,18 -q $nonce -m $toss_out -s $toss_out -p $toss_out -g $alg_primary_obj
 
 #####AK
 tpm2_createek -Q -c $Handle_ek_quote -G 0x01 -p ek.pub2
 
 tpm2_createak -Q -C $Handle_ek_quote -k  $Handle_ak_quote2 -p ak.pub2 -n ak.name_2
 
-tpm2_quote -Q -C $Handle_ak_quote -L $alg_quote:16,17,18 -l 16,17,18 -q $nonce -m $toss_out -s $toss_out -p $toss_out -G $alg_primary_obj
+tpm2_quote -Q -C $Handle_ak_quote -L $alg_quote:16,17,18 -l 16,17,18 -q $nonce -m $toss_out -s $toss_out -p $toss_out -g $alg_primary_obj
 
 exit 0

--- a/test/integration/tests/sign.sh
+++ b/test/integration/tests/sign.sh
@@ -91,7 +91,7 @@ test_symmetric() {
 
     # generate hash and test validation
 
-    tpm2_hash -Q -a e -G $alg_hash -o $file_output_hash -t $file_output_ticket $file_input_data
+    tpm2_hash -Q -a e -g $alg_hash -o $file_output_hash -t $file_output_ticket $file_input_data
 
     tpm2_sign -Q -c $handle_signing_key -G $alg_hash -o $file_output_data -m $file_input_data -t $file_output_ticket
 

--- a/test/integration/tests/sign.sh
+++ b/test/integration/tests/sign.sh
@@ -79,13 +79,13 @@ test_symmetric() {
 
     tpm2_load -Q -C $file_primary_key_ctx -u $file_signing_key_pub -r $file_signing_key_priv -n $file_signing_key_name -o $file_signing_key_ctx
 
-    tpm2_sign -Q -c $file_signing_key_ctx -G $alg_hash -m $file_input_data -o $file_output_data
+    tpm2_sign -Q -c $file_signing_key_ctx -g $alg_hash -m $file_input_data -o $file_output_data
 
     rm -f $file_output_data
 
     tpm2_evictcontrol -Q -a o -c $file_signing_key_ctx -p $handle_signing_key
 
-    tpm2_sign -Q -c $handle_signing_key -G $alg_hash -m $file_input_data -o $file_output_data
+    tpm2_sign -Q -c $handle_signing_key -g $alg_hash -m $file_input_data -o $file_output_data
 
     rm -f $file_output_data
 
@@ -93,7 +93,7 @@ test_symmetric() {
 
     tpm2_hash -Q -a e -g $alg_hash -o $file_output_hash -t $file_output_ticket $file_input_data
 
-    tpm2_sign -Q -c $handle_signing_key -G $alg_hash -o $file_output_data -m $file_input_data -t $file_output_ticket
+    tpm2_sign -Q -c $handle_signing_key -g $alg_hash -o $file_output_data -m $file_input_data -t $file_output_ticket
 
     rm -f $file_output_data
 
@@ -101,21 +101,21 @@ test_symmetric() {
 
     sha256sum $file_input_data | awk '{ print "000000 " $1 }' | xxd -r -c 32 > $file_input_digest
 
-    tpm2_sign -Q -c $handle_signing_key -G $alg_hash -D $file_input_digest -o $file_output_data
+    tpm2_sign -Q -c $handle_signing_key -g $alg_hash -D $file_input_digest -o $file_output_data
 
     rm -f $file_output_data
 
     # test with digest + message/validation (warning generated)
 
-    tpm2_sign -Q -c $handle_signing_key -G $alg_hash -D $file_input_digest -o $file_output_data -m $file_input_data -t $file_output_ticket |& grep -q ^WARN
+    tpm2_sign -Q -c $handle_signing_key -g $alg_hash -D $file_input_digest -o $file_output_data -m $file_input_data -t $file_output_ticket |& grep -q ^WARN
 }
 
 create_signature() {
     local sign_scheme=$1
     if [ "$sign_scheme" = "" ]; then
-        tpm2_sign -Q -c $file_signing_key_ctx -G $alg_hash -m $file_input_data -f plain -o $file_output_data
+        tpm2_sign -Q -c $file_signing_key_ctx -g $alg_hash -m $file_input_data -f plain -o $file_output_data
     else
-        tpm2_sign -Q -c $file_signing_key_ctx -G $alg_hash -s $sign_scheme -m $file_input_data -f plain -o $file_output_data
+        tpm2_sign -Q -c $file_signing_key_ctx -g $alg_hash -s $sign_scheme -m $file_input_data -f plain -o $file_output_data
     fi
 }
 

--- a/test/integration/tests/verifysignature.sh
+++ b/test/integration/tests/verifysignature.sh
@@ -77,7 +77,7 @@ tpm2_create -Q -g $alg_hash -G $alg_signing_key -u $file_signing_key_pub -r $fil
 
 tpm2_load -Q -C $file_primary_key_ctx  -u $file_signing_key_pub  -r $file_signing_key_priv -n $file_signing_key_name -o $file_signing_key_ctx
 
-tpm2_sign -Q -c $file_signing_key_ctx -G $alg_hash -m $file_input_data -o $file_output_data
+tpm2_sign -Q -c $file_signing_key_ctx -g $alg_hash -m $file_input_data -o $file_output_data
 
 tpm2_verifysignature -Q -c $file_signing_key_ctx  -G $alg_hash -m $file_input_data  -s $file_output_data -t $file_verify_tk_data
 

--- a/test/integration/tests/verifysignature.sh
+++ b/test/integration/tests/verifysignature.sh
@@ -81,7 +81,7 @@ tpm2_sign -Q -c $file_signing_key_ctx -G $alg_hash -m $file_input_data -o $file_
 
 tpm2_verifysignature -Q -c $file_signing_key_ctx  -G $alg_hash -m $file_input_data  -s $file_output_data -t $file_verify_tk_data
 
-tpm2_hash -Q -a n -G $alg_hash -o $file_input_data_hash -t $file_input_data_hash_tk $file_input_data
+tpm2_hash -Q -a n -g $alg_hash -o $file_input_data_hash -t $file_input_data_hash_tk $file_input_data
 
 rm -f $file_verify_tk_data
 tpm2_verifysignature -Q -c $file_signing_key_ctx  -D  $file_input_data_hash -s $file_output_data  -t $file_verify_tk_data

--- a/test/integration/tests/verifysignature.sh
+++ b/test/integration/tests/verifysignature.sh
@@ -73,22 +73,22 @@ tpm2_clear
 
 tpm2_createprimary -Q -a e -g $alg_hash -G $alg_primary_key -o $file_primary_key_ctx
 
-tpm2_create -Q -g $alg_hash -G $alg_signing_key -u $file_signing_key_pub -r $file_signing_key_priv  -C $file_primary_key_ctx
+tpm2_create -Q -g $alg_hash -G $alg_signing_key -u $file_signing_key_pub -r $file_signing_key_priv -C $file_primary_key_ctx
 
-tpm2_load -Q -C $file_primary_key_ctx  -u $file_signing_key_pub  -r $file_signing_key_priv -n $file_signing_key_name -o $file_signing_key_ctx
+tpm2_load -Q -C $file_primary_key_ctx -u $file_signing_key_pub -r $file_signing_key_priv -n $file_signing_key_name -o $file_signing_key_ctx
 
 tpm2_sign -Q -c $file_signing_key_ctx -g $alg_hash -m $file_input_data -o $file_output_data
 
-tpm2_verifysignature -Q -c $file_signing_key_ctx  -G $alg_hash -m $file_input_data  -s $file_output_data -t $file_verify_tk_data
+tpm2_verifysignature -Q -c $file_signing_key_ctx -g $alg_hash -m $file_input_data -s $file_output_data -t $file_verify_tk_data
 
 tpm2_hash -Q -a n -g $alg_hash -o $file_input_data_hash -t $file_input_data_hash_tk $file_input_data
 
 rm -f $file_verify_tk_data
-tpm2_verifysignature -Q -c $file_signing_key_ctx  -D  $file_input_data_hash -s $file_output_data  -t $file_verify_tk_data
+tpm2_verifysignature -Q -c $file_signing_key_ctx -D $file_input_data_hash -s $file_output_data -t $file_verify_tk_data
 
-rm -f $file_verify_tk_data $file_signing_key_ctx  -rf
-tpm2_loadexternal -Q -a n -u $file_signing_key_pub -o  $file_signing_key_ctx
+rm -f $file_verify_tk_data $file_signing_key_ctx -rf
+tpm2_loadexternal -Q -a n -u $file_signing_key_pub -o $file_signing_key_ctx
 
-tpm2_verifysignature -Q -c $file_signing_key_ctx  -G $alg_hash -m $file_input_data  -s $file_output_data -t $file_verify_tk_data
+tpm2_verifysignature -Q -c $file_signing_key_ctx -g $alg_hash -m $file_input_data -s $file_output_data -t $file_verify_tk_data
 
 exit 0

--- a/tools/tpm2_hash.c
+++ b/tools/tpm2_hash.c
@@ -141,7 +141,7 @@ static bool on_option(char key, char *value) {
             return false;
         }
         break;
-    case 'G':
+    case 'g':
         ctx.halg = tpm2_alg_util_from_optarg(value, tpm2_alg_util_flags_hash);
         if (ctx.halg == TPM2_ALG_ERROR) {
             return false;
@@ -162,7 +162,7 @@ bool tpm2_tool_onstart(tpm2_options **opts) {
 
     static struct option topts[] = {
         {"hierarchy", required_argument, NULL, 'a'},
-        {"halg",      required_argument, NULL, 'G'},
+        {"halg",      required_argument, NULL, 'g'},
         {"out-file",  required_argument, NULL, 'o'},
         {"ticket",    required_argument, NULL, 't'},
     };
@@ -170,7 +170,7 @@ bool tpm2_tool_onstart(tpm2_options **opts) {
     /* set up non-static defaults here */
     ctx.input_file = stdin;
 
-    *opts = tpm2_options_new("a:G:o:t:", ARRAY_LEN(topts), topts, on_option,
+    *opts = tpm2_options_new("a:g:o:t:", ARRAY_LEN(topts), topts, on_option,
                              on_args, 0);
 
     return *opts != NULL;

--- a/tools/tpm2_quote.c
+++ b/tools/tpm2_quote.c
@@ -297,7 +297,7 @@ static bool on_option(char key, char *value) {
             return false;
          }
          break;
-    case 'G':
+    case 'g':
         ctx.sig_hash_algorithm = tpm2_alg_util_from_optarg(value, tpm2_alg_util_flags_hash);
         if(ctx.sig_hash_algorithm == TPM2_ALG_ERROR) {
             LOG_ERR("Could not convert signature hash algorithm selection, got: \"%s\"", value);
@@ -322,10 +322,10 @@ bool tpm2_tool_onstart(tpm2_options **opts) {
         { "message",              required_argument, NULL, 'm' },
         { "pcrs",                 required_argument, NULL, 'p' },
         { "format",               required_argument, NULL, 'f' },
-        { "sig-hash-algorithm",   required_argument, NULL, 'G' }
+        { "halg",                 required_argument, NULL, 'g' }
     };
 
-    *opts = tpm2_options_new("C:P:l:L:q:s:m:p:f:G:", ARRAY_LEN(topts), topts,
+    *opts = tpm2_options_new("C:P:l:L:q:s:m:p:f:g:", ARRAY_LEN(topts), topts,
                              on_option, NULL, 0);
 
     return *opts != NULL;

--- a/tools/tpm2_sign.c
+++ b/tools/tpm2_sign.c
@@ -231,7 +231,7 @@ static bool on_option(char key, char *value) {
         ctx.flags.p = 1;
         ctx.key_auth_str = value;
         break;
-    case 'G': {
+    case 'g': {
         ctx.halg = tpm2_alg_util_from_optarg(value, tpm2_alg_util_flags_hash);
         if (ctx.halg == TPM2_ALG_ERROR) {
             LOG_ERR("Could not convert to number or lookup algorithm, got: \"%s\"",
@@ -294,7 +294,7 @@ bool tpm2_tool_onstart(tpm2_options **opts) {
 
     static const struct option topts[] = {
       { "auth-key",             required_argument, NULL, 'p' },
-      { "halg",                 required_argument, NULL, 'G' },
+      { "halg",                 required_argument, NULL, 'g' },
       { "sig-scheme",           required_argument, NULL, 's' },
       { "message",              required_argument, NULL, 'm' },
       { "digest",               required_argument, NULL, 'D' },
@@ -304,7 +304,7 @@ bool tpm2_tool_onstart(tpm2_options **opts) {
       { "format",               required_argument, NULL, 'f' }
     };
 
-    *opts = tpm2_options_new("p:G:m:D:t:o:c:f:s:", ARRAY_LEN(topts), topts,
+    *opts = tpm2_options_new("p:g:m:D:t:o:c:f:s:", ARRAY_LEN(topts), topts,
                              on_option, NULL, 0);
 
     return *opts != NULL;

--- a/tools/tpm2_verifysignature.c
+++ b/tools/tpm2_verifysignature.c
@@ -209,7 +209,7 @@ static bool on_option(char key, char *value) {
 	case 'c':
 	    ctx.context_arg = value;
 	    break;
-	case 'G': {
+	case 'g': {
 		ctx.halg = tpm2_alg_util_from_optarg(value, tpm2_alg_util_flags_hash);
 		if (ctx.halg == TPM2_ALG_ERROR) {
 			LOG_ERR("Unable to convert algorithm, got: \"%s\"", value);
@@ -260,7 +260,7 @@ bool tpm2_tool_onstart(tpm2_options **opts) {
 
     const struct option topts[] = {
             { "digest",       required_argument, NULL, 'D' },
-            { "halg",         required_argument, NULL, 'G' },
+            { "halg",         required_argument, NULL, 'g' },
             { "message",      required_argument, NULL, 'm' },
             { "format",      required_argument, NULL,  'f' },
             { "sig",          required_argument, NULL, 's' },
@@ -269,7 +269,7 @@ bool tpm2_tool_onstart(tpm2_options **opts) {
     };
 
 
-    *opts = tpm2_options_new("G:m:D:f:s:t:c:", ARRAY_LEN(topts), topts,
+    *opts = tpm2_options_new("g:m:D:f:s:t:c:", ARRAY_LEN(topts), topts,
                              on_option, NULL, 0);
 
     return *opts != NULL;


### PR DESCRIPTION
Fixes : #1315

Work is already done on `tpm2_certify`

Some files are left to be checked for the same kind of fix (-G while it can be -g) :

> tools/tpm2_hash.c
> tools/tpm2_quote.c
> tools/tpm2_sign.c
> tools/tpm2_import.c
> tools/tpm2_getmanufec.c
> tools/tpm2_createek.c
> tools/tpm2_create.c
> tools/tpm2_createprimary.c
> tools/tpm2_listpersistent.c
> tools/tpm2_createak.c
> tools/tpm2_encryptdecrypt.c
> tools/tpm2_loadexternal.c
> tools/tpm2_verifysignature.c

Do i proceed on the same PR ?

Signed-off-by: sebastien le stum <lestums@gmail.com>