### PR TITLE
tools: Add -u flag for to specify unique data for CreatePrimary

### DIFF
--- a/lib/tpm2_alg_util.c
+++ b/lib/tpm2_alg_util.c
@@ -880,9 +880,12 @@ bool tpm2_alg_util_public_init(char *alg_details, char *name_halg, char *attrs, 
         }
     }
 
-    /* load a policy from a path if present */
+    /* load the unique portion of TPMT_PUBLIC from a path if present */
     if (unique_file) {
         UINT16 unique_size = sizeof(public->publicArea.unique);
+        /* loaded size may be <= unique_size; user is responsible
+         * for ensuring that that this buffer is formatted as a
+         * TPMU_PUBLIC_ID union. unique_size is max size of the union */
         bool res = files_load_bytes_from_path(unique_file,
                     (UINT8*)&public->publicArea.unique, &unique_size);
         if (!res) {

--- a/lib/tpm2_alg_util.c
+++ b/lib/tpm2_alg_util.c
@@ -865,8 +865,8 @@ bool get_signature_scheme(ESYS_CONTEXT *context,
     return true;
 }
 
-bool tpm2_alg_util_public_init(char *alg_details, char *name_halg, char *attrs, char *auth_policy, TPMA_OBJECT def_attrs,
-        TPM2B_PUBLIC *public) {
+bool tpm2_alg_util_public_init(char *alg_details, char *name_halg, char *attrs, char *auth_policy, char *unique_file,
+        TPMA_OBJECT def_attrs, TPM2B_PUBLIC *public) {
 
     memset(public, 0, sizeof(*public));
 
@@ -875,6 +875,16 @@ bool tpm2_alg_util_public_init(char *alg_details, char *name_halg, char *attrs, 
         public->publicArea.authPolicy.size = sizeof(public->publicArea.authPolicy.buffer);
         bool res = files_load_bytes_from_path(auth_policy,
                     public->publicArea.authPolicy.buffer, &public->publicArea.authPolicy.size);
+        if (!res) {
+            return false;
+        }
+    }
+
+    /* load a policy from a path if present */
+    if (unique_file) {
+        UINT16 unique_size = sizeof(public->publicArea.unique);
+        bool res = files_load_bytes_from_path(unique_file,
+                    (UINT8*)&public->publicArea.unique, &unique_size);
         if (!res) {
             return false;
         }

--- a/lib/tpm2_alg_util.h
+++ b/lib/tpm2_alg_util.h
@@ -182,8 +182,8 @@ bool get_signature_scheme(ESYS_CONTEXT *context,
  * @param public
  * @return
  */
-bool tpm2_alg_util_public_init(char *alg_details, char *name_halg, char *attrs, char *auth_policy, TPMA_OBJECT def_attrs,
-       TPM2B_PUBLIC *public);
+bool tpm2_alg_util_public_init(char *alg_details, char *name_halg, char *attrs, char *auth_policy, char *unique_file,
+        TPMA_OBJECT def_attrs, TPM2B_PUBLIC *public);
 
 /**
  * Returns an ECC curve as a friendly name.

--- a/man/tpm2_createprimary.1.md
+++ b/man/tpm2_createprimary.1.md
@@ -69,6 +69,11 @@ interactions with the created primary.
 
     `TPMA_OBJECT_RESTRICTED|TPMA_OBJECT_DECRYPT|TPMA_OBJECT_FIXEDTPM|TPMA_OBJECT_FIXEDPARENT|TPMA_OBJECT_SENSITIVEDATAORIGIN|TPMA_OBJECT_USERWITHAUTH`
 
+  * **-u**, **--unique-data**=_UNIQUE\_FILE_:
+    An optional file input that contains the binary bits of a TPMU_PUBLIC_ID union where
+    numbers (such as length words) are in little-endian format. This is passed in the
+    unique field of TPMT_PUBLIC.
+
 [common options](common/options.md)
 
 [common tcti options](common/tcti.md)
@@ -85,9 +90,22 @@ interactions with the created primary.
 
 # EXAMPLES
 
+Create an ECC primary object:
+
 ```
 tpm2_createprimary -a o -g sha256 -G ecc -o context.out
 ```
+
+Create a primary object that follows the guidance of
+https://trustedcomputinggroup.org/wp-content/uploads/TCG-TPM-v2.0-Provisioning-Guidance-Published-v1r1.pdf
+where unique.dat contains the binary-formatted data: 0x00 0x01 (0x00 * 256)
+
+```
+tpm2_createprimary -a o -G rsa2048:aes128cfb -g sha256 -o prim.ctx \
+  -A 'restricted|decrypt|fixedtpm|fixedparent|sensitivedataorigin|userwithauth|noda' \
+  -u unique.dat
+```
+
 
 # RETURNS
 

--- a/test/integration/tests/createprimary.sh
+++ b/test/integration/tests/createprimary.sh
@@ -81,6 +81,16 @@ policy_new=$(yaml_get_kv pub.out \"authorization\ policy\")
 
 test "$policy_orig" == "$policy_new"
 
+# Test that -u can be specified to pass a TPMU_PUBLIC_ID union
+# in this case TPM2B_PUBLIC_KEY_RSA (256 bytes of zero)
+printf '\x00\x01' > ud.1
+dd if=/dev/zero bs=256 count=1 of=ud.2
+cat ud.1 ud.2 > unique.dat
+tpm2_createprimary -a o -G rsa2048:aes128cfb -g sha256 -o prim.ctx \
+  -A 'restricted|decrypt|fixedtpm|fixedparent|sensitivedataorigin|userwithauth|noda' \
+  -u unique.dat
+test -f prim.ctx
+
 # Test that -g/-G do not need to be specified.
 tpm2_createprimary -Q -o context.out
 

--- a/tools/tpm2_create.c
+++ b/tools/tpm2_create.c
@@ -317,8 +317,8 @@ int tpm2_tool_onrun(ESYS_CONTEXT *ectx, tpm2_option_flags flags) {
         attrs &= ~TPMA_OBJECT_DECRYPT;
     }
 
-    result = tpm2_alg_util_public_init(ctx.alg, ctx.halg, ctx.attrs, ctx.policy, attrs,
-            &ctx.in_public);
+    result = tpm2_alg_util_public_init(ctx.alg, ctx.halg, ctx.attrs, ctx.policy, NULL,
+            attrs, &ctx.in_public);
     if(!result) {
         goto out;
     }

--- a/tools/tpm2_createprimary.c
+++ b/tools/tpm2_createprimary.c
@@ -65,7 +65,7 @@ struct tpm_createprimary_ctx {
     } auth;
     tpm2_hierarchy_pdata objdata;
     char *context_file;
-    char* unique_file;
+    char *unique_file;
     struct {
         UINT8 P :1;
         UINT8 p :1;

--- a/tools/tpm2_createprimary.c
+++ b/tools/tpm2_createprimary.c
@@ -65,6 +65,7 @@ struct tpm_createprimary_ctx {
     } auth;
     tpm2_hierarchy_pdata objdata;
     char *context_file;
+    char* unique_file;
     struct {
         UINT8 P :1;
         UINT8 p :1;
@@ -123,6 +124,12 @@ static bool on_option(char key, char *value) {
             return false;
         }
         break;
+    case 'u':
+        ctx.unique_file = value;
+        if (ctx.unique_file == NULL || ctx.unique_file[0] == '\0') {
+            return false;
+        }
+        break;
     case 'L':
         ctx.policy=value;
     break;
@@ -146,9 +153,10 @@ bool tpm2_tool_onstart(tpm2_options **opts) {
         { "out-context-name",     required_argument, NULL, 'o' },
         { "policy-file",          required_argument, NULL, 'L' },
         { "object-attributes",    required_argument, NULL, 'A' },
+        { "unique-data",          required_argument, NULL, 'u' },
     };
 
-    *opts = tpm2_options_new("A:P:p:g:G:o:L:a:", ARRAY_LEN(topts), topts,
+    *opts = tpm2_options_new("A:P:p:g:G:o:L:a:u:", ARRAY_LEN(topts), topts,
             on_option, NULL, 0);
 
     return *opts != NULL;
@@ -182,7 +190,7 @@ int tpm2_tool_onrun(ESYS_CONTEXT *ectx, tpm2_option_flags flags) {
         ctx.objdata.in.sensitive.sensitive.userAuth = tmp.hmac;
     }
 
-    result = tpm2_alg_util_public_init(ctx.alg, ctx.halg, ctx.attrs, ctx.policy, DEFAULT_ATTRS,
+    result = tpm2_alg_util_public_init(ctx.alg, ctx.halg, ctx.attrs, ctx.policy, ctx.unique_file, DEFAULT_ATTRS,
             &ctx.objdata.in.public);
     if(!result) {
         goto out;


### PR DESCRIPTION
This change allows creating a primary object that follows
the guidance of https://trustedcomputinggroup.org/wp-content
/uploads/TCG-TPM-v2.0-Provisioning-Guidance-Published-v1r1.pdf

The below should be all on one line:

tpm2_createprimary -a o -G rsa2048:aes128cfb -g sha256
  -o prim.ctx
  -A 'restricted|decrypt|fixedtpm|fixedparent|
      sensitivedataorigin|userwithauth|noda' -u unique.dat

where unique.dat is: 0x00 0x01 (0x00 * 256)

Note that all numbers (as above) must be in little-endian
format. The marhsaling logic will for TPM2B_PUBLIC
will convert to big-endian.

Signed-off-by: Bryon Nevis <bryon.nevis@intel.com>