### PR TITLE
configure.ac:AC_ARG_ENABLE(hardening,…) follow Autoconf conventions

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -133,14 +133,13 @@ AC_ARG_ENABLE([dlclose],
 
 AC_ARG_ENABLE([hardening],
   [AS_HELP_STRING([--disable-hardening],
-    [Disable compiler and linker options to frustrate memory corruption exploits])],
-  [hardening="$enableval"],
-  [hardening="yes"])
+    [Disable compiler and linker options to frustrate memory corruption exploits])],,
+  [enable_hardening="yes"])
 
 # Good information on adding flags, and dealing with compilers can be found here:
 #   https://github.com/zcash/zcash/issues/1832
 #   https://github.com/kmcallister/autoharden/
-AS_IF([test x"$hardening" != x"no"], [
+AS_IF([test x"$enable_hardening" != x"no"], [
 
   AC_DEFUN([add_hardened_c_flag], [
     AX_CHECK_COMPILE_FLAG([$1],


### PR DESCRIPTION
The convention is, that the variable enable_hardening is defined by Autoconf.  The code used to define another variable, ${hardening}, that has the same value and purpose as ${enable_hardening}.  This patch abolishes ${hardening} and uses ${enable_hardening}.