### PR TITLE
deheader: remove double #include’d headers

### DIFF
--- a/lib/tpm2_auth_util.c
+++ b/lib/tpm2_auth_util.c
@@ -33,7 +33,6 @@
 #include <stdbool.h>
 #include <stdlib.h>
 #include <string.h>
-#include <stdlib.h>
 
 #include <tss2/tss2_esys.h>
 #include <tss2/tss2_mu.h>

--- a/test/unit/test_tpm2_policy.c
+++ b/test/unit/test_tpm2_policy.c
@@ -34,7 +34,6 @@
 #include <stdlib.h>
 #include <string.h>
 
-#include <setjmp.h>
 #include <cmocka.h>
 
 #include <tss2/tss2_esys.h>

--- a/test/unit/test_tpm2_session.c
+++ b/test/unit/test_tpm2_session.c
@@ -36,7 +36,6 @@
 
 #include <unistd.h>
 
-#include <setjmp.h>
 #include <cmocka.h>
 
 #include <tss2/tss2_esys.h>

--- a/tools/tpm2_makecredential.c
+++ b/tools/tpm2_makecredential.c
@@ -43,7 +43,6 @@
 #include "files.h"
 #include "tpm2_options.h"
 #include "log.h"
-#include "files.h"
 #include "tpm2_alg_util.h"
 #include "tpm2_openssl.h"
 #include "tpm2_identity_util.h"


### PR DESCRIPTION
Found by http://www.catb.org/~esr/deheader/