### PR TITLE
Makefile.am: include man pages on “make dist” with the dist_man prefix.

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -304,7 +304,7 @@ EXTRA_DIST = $(top_srcdir)/man \
 	     RELEASE.md \
 	     test/integration
 if HAVE_MAN_PAGES
-    man1_MANS := \
+    dist_man1_MANS := \
     man/man1/tpm2_activatecredential.1 \
     man/man1/tpm2_certify.1 \
     man/man1/tpm2_changeauth.1 \
@@ -365,10 +365,7 @@ if HAVE_MAN_PAGES
     man/man1/tpm2_verifysignature.1
 endif
 
-if HAVE_PANDOC
-# If pandoc is enabled, we want to generate the manpages for the dist tarball
-EXTRA_DIST += $(man1_MANS)
-else
+if !HAVE_PANDOC
 # If pandoc is not enabled, we want to complain that you need pandoc for make dist,
 # so hook the target and complain.
 dist-hook:


### PR DESCRIPTION
When PANDOC is absent, “make dist” fails.

When PANDOC is present, the man pages are generated and man pages are included by “make dist”, as these are prefixed with dist_.

There is no point in putting EXTRA_DIST in AM_CONDITIONAL, as the logic of conditionals is irrelevant when “make dist” calculates which files to include.