### PR TITLE
configure.ac: AC_ARG_ENABLE(unit... delete some implicit defaults

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -64,8 +64,7 @@ AC_SUBST([LIBDL_LDFLAGS])
 
 AC_ARG_ENABLE([unit],
             [AS_HELP_STRING([--enable-unit],
-                            [build cmocka unit tests])],
-            [enable_unit=$enableval],
+                            [build cmocka unit tests])],,
             [enable_unit=no])
 AM_CONDITIONAL([UNIT], [test "x$enable_unit" != xno])
 


### PR DESCRIPTION
In AC_ARG_ENABLE(a,b,c,d) enable_a is implicitly set to $enableval, when c is present or absent.
