### PR TITLE
tools/tpm2_testparms: Add a tool to check if an algorithm suite is supported

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -114,6 +114,7 @@ bin_PROGRAMS = \
     tools/tpm2_startauthsession \
     tools/tpm2_startup \
     tools/tpm2_stirrandom \
+    tools/tpm2_testparms \
     tools/tpm2_unseal \
     tools/tpm2_verifysignature
 
@@ -185,6 +186,7 @@ tools_tpm2_policycommandcode_SOURCES = tools/tpm2_policycommandcode.c $(TOOL_SRC
 tools_tpm2_stirrandom_SOURCES = tools/tpm2_stirrandom.c $(TOOL_SRC)
 tools_tpm2_policyduplicationselect_SOURCES = tools/tpm2_policyduplicationselect.c $(TOOL_SRC)
 tools_tpm2_policylocality_SOURCES = tools/tpm2_policylocality.c $(TOOL_SRC)
+tools_tpm2_testparms_SOURCES = tools/tpm2_testparms.c $(TOOL_SRC)
 
 if UNIT
 TESTS = $(check_PROGRAMS)
@@ -348,6 +350,7 @@ if HAVE_MAN_PAGES
     man/man1/tpm2_startauthsession.1 \
     man/man1/tpm2_startup.1 \
     man/man1/tpm2_stirrandom.1 \
+    man/man1/tpm2_testparms.1 \
     man/man1/tpm2_unseal.1 \
     man/man1/tpm2_verifysignature.1
 endif

--- a/lib/tpm2_alg_util.c
+++ b/lib/tpm2_alg_util.c
@@ -520,7 +520,7 @@ static const char *alg_spec_fixup(const char *alg_spec) {
     return alg_spec;
 }
 
-static bool tpm2_alg_util_handle_ext_alg(const char *alg_spec, TPM2B_PUBLIC *public) {
+bool tpm2_alg_util_handle_ext_alg(const char *alg_spec, TPM2B_PUBLIC *public) {
 
     /*
      * Fix up numerics, like 0x1 for rsa

--- a/lib/tpm2_alg_util.h
+++ b/lib/tpm2_alg_util.h
@@ -173,6 +173,18 @@ bool get_signature_scheme(ESYS_CONTEXT *context,
 
 /**
  *
+ * @param alg_spec
+ *  Friendly specification of public algorithm set (algname:...:....)
+ * @param public
+ *  Public structure which will contain relevant information about
+ *  specified algorithm
+ * @pre public is caller allocated and must not be NULL
+ * @return
+ */
+bool tpm2_alg_util_handle_ext_alg(const char *alg_spec, TPM2B_PUBLIC *public);
+
+/**
+ *
  * @param alg_details
  * @param name_halg
  * @param attrs

--- a/man/tpm2_testparms.1.md
+++ b/man/tpm2_testparms.1.md
@@ -1,0 +1,54 @@
+% tpm2_testparms(1) tpm2-tools | General Commands Manual
+%
+% MARCH 2019
+
+# NAME
+
+**tpm2_testparms**(1) - Verify that specified algorithm suite is supported by TPM
+
+# SYNOPSIS
+
+**tpm2_testparms** [*OPTIONS*] _ALG\_SPEC_
+
+# DESCRIPTION
+
+**tpm2_testparms**(1) checks that the suite specified by _ALG\_SPEC_ is available for
+usage.
+
+Algorithms should follow the "formatting standards", see section "Algorithm Specifiers".
+
+Also, see section "Supported Signing Schemes" for a list of supported hash algorithms.
+
+# OPTIONS
+
+This tool accepts no tool specific options.
+
+[common options](common/options.md)
+
+[common tcti options](common/tcti.md)
+
+[algorithm specifiers](common/alg.md)
+
+[supported hash algorithms](common/hash.md)
+
+[supported signing schemes](common/signschemes.md)
+
+# EXAMPLES
+
+Check whether if "rsa" is supported:
+
+```
+tpm2_testparms rsa
+```
+
+Check that ECDSA signing scheme using P-256 curve with AES 128 CTR mode is available :
+
+```
+tpm2_testparms ecc256:ecdsa:aes128ctr
+```
+
+# RETURNS
+
+0 on success or 1 on failure.
+
+[footer](common/footer.md)

--- a/scripts/utils/analyze.py
+++ b/scripts/utils/analyze.py
@@ -167,10 +167,10 @@ class ToolConflictor(object):
             },
             {
                 "gname": "capability",
-                "tools-in-group": ["tpm2_getcap"],
+                "tools-in-group": ["tpm2_getcap", "tpm2_testparms"],
                 "tools": [],
                 "conflict": None,
-                "ignore": set()
+                "ignore": set(['capability', 'c', 'list', 'l'])
             },
             {
                 "gname": "dictionary",

--- a/test/integration/helpers.sh
+++ b/test/integration/helpers.sh
@@ -50,11 +50,15 @@ with open("$1") as f:
 pyscript
 }
 
+populate_algs() {
+    algs="$(mktemp)"
+    tpm2_getcap -c algorithms > "${algs}"
+    filter_algs_by "${algs}" "${1}" 
+    rm "${algs}"
+}
+
 populate_hash_algs() {
-	algs=`mktemp`
-	`tpm2_getcap -c algorithms > "$algs"`
-	filter_algs_by "$algs" "details['hash'] and not details['method'] and not details['symmetric'] and not details['signing'] $1"
-	rm "$algs"
+    populate_algs "details['hash'] and not details['method'] and not details['symmetric'] and not details['signing'] $1"
 }
 
 # Return alg argument if supported by TPM.

--- a/test/integration/tests/testparms.sh
+++ b/test/integration/tests/testparms.sh
@@ -1,0 +1,101 @@
+#!/bin/bash
+#;**********************************************************************;
+#
+# Copyright (c) 2019, Sebastien LE STUM
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# 1. Redistributions of source code must retain the above copyright notice,
+# this list of conditions and the following disclaimer.
+#
+# 2. Redistributions in binary form must reproduce the above copyright notice,
+# this list of conditions and the following disclaimer in the documentation
+# and/or other materials provided with the distribution.
+#
+# 3. Neither the name of Intel Corporation nor the names of its contributors
+# may be used to endorse or promote products derived from this software without
+# specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+# THE POSSIBILITY OF SUCH DAMAGE.
+#;**********************************************************************;
+
+source helpers.sh
+
+cleanup() {
+    if [ "$1" != "no-shut-down" ]; then
+        shut_down
+    fi
+}
+
+trap cleanup EXIT
+
+start_up
+
+cleanup "no-shut-down"
+
+aesmodes="$(populate_algs "details['encrypting'] and details['symmetric']")"
+hashalgs="$(populate_algs "details['hash'] and not details['method'] \
+                                           and not details['signing'] \
+                                           and not details['symmetric'] \
+                                           and alg is not None")"
+eccmethods="$(populate_algs "details['signing'] and not details['hash'] and \"rsa\" not in alg")"
+rsamethods="$(populate_algs "details['signing'] and not details['hash'] and \"ec\" not in alg")"
+
+# Test that common algorithms are supported
+for i in "rsa" "xor" "hmac" "ecc" "keyedhash"; do
+    tpm2_testparms "${i}"
+done
+
+# Test that RSA signing schemes are supported
+for i in ${rsamethods}; do
+    tpm2_testparms "rsa:${i}"
+done
+
+# Test that ECC signing schemes are supported
+for i in ${eccmethods}; do
+    tpm2_testparms "ecc:${i}"
+done
+
+# Test that aes modes are supported
+for i in ${aesmodes}; do
+    tpm2_testparms "aes128${i}"
+done
+
+# Test that xor on hash algs is supported
+for i in ${hashalgs}; do
+    tpm2_testparms "xor:${i}"
+done
+
+# Test that hmac on hash algs is supported
+for i in ${hashalgs}; do
+    tpm2_testparms "hmac:${i}"
+done
+
+# Test that null algorithm raise an error (error from software stack)
+if ! tpm2_testparms "null" 2>&1 1>/dev/null | grep -q "Invalid or unsupported by the tool : null"; then
+    echo "tpm2_testparms with 'null' algorithm didn't fail"
+    exit 1
+else
+    true
+fi
+
+# Attempt to specify a suite that is not supported (error from TPM)
+if tpm2_testparms "ecc521:ecdsa:aes256cbc" &>/dev/null; then
+    echo "tpm2_testparms succeeded while it shouldn't or TPM failed"
+    exit 1
+else
+    true
+fi
+exit 0

--- a/tools/tpm2_testparms.c
+++ b/tools/tpm2_testparms.c
@@ -1,0 +1,130 @@
+//**********************************************************************;
+// Copyright (c) 2019, Sebastien LE STUM
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+// 1. Redistributions of source code must retain the above copyright notice,
+// this list of conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright notice,
+// this list of conditions and the following disclaimer in the documentation
+// and/or other materials provided with the distribution.
+//
+// 3. Neither the name of Intel Corporation nor the names of its contributors
+// may be used to endorse or promote products derived from this software without
+// specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+// THE POSSIBILITY OF SUCH DAMAGE.
+//**********************************************************************;
+
+#include <ctype.h>
+#include <errno.h>
+#include <stdbool.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include <tss2/tss2_esys.h>
+
+#include "log.h"
+#include "tpm2_options.h"
+#include "tpm2_tool.h"
+#include "tpm2_alg_util.h"
+
+typedef struct tpm_testparms_ctx tpm_testparms_ctx;
+
+struct tpm_testparms_ctx {
+    TPMT_PUBLIC_PARMS  inputalg;
+};
+
+static tpm_testparms_ctx ctx;
+
+static int tpm_testparms(ESYS_CONTEXT *ectx) {
+    TSS2_RC rval = Esys_TestParms(ectx, ESYS_TR_NONE, ESYS_TR_NONE, ESYS_TR_NONE, &(ctx.inputalg));
+    if (rval != TSS2_RC_SUCCESS) {
+        if ((rval & (TPM2_RC_P | TPM2_RC_1)) == (TPM2_RC_P | TPM2_RC_1)){
+            rval &= ~(TPM2_RC_P | TPM2_RC_1);
+            switch (rval){
+                case TPM2_RC_CURVE:
+                    LOG_ERR("Specified elliptic curve is unsupported");
+                    break;
+                case TPM2_RC_HASH:
+                    LOG_ERR("Specified hash is unsupported");
+                    break;
+                case TPM2_RC_SCHEME:
+                    LOG_ERR("Specified signing scheme is unsupported or incompatible");
+                    break;
+                case TPM2_RC_KDF:
+                    LOG_ERR("Specified key derivation function is unsupported");
+                    break;
+                case TPM2_RC_MGF:
+                    LOG_ERR("Specified mask generation function is unsupported");
+                    break;
+                case TPM2_RC_KEY_SIZE:
+                    LOG_ERR("Specified key size is unsupported");
+                    break;
+                case TPM2_RC_SYMMETRIC:
+                    LOG_ERR("Specified symmetric algorithm or key length is unsupported");
+                    break;
+                case TPM2_RC_ASYMMETRIC:
+                    LOG_ERR("Specified asymmetric algorithm is unsupported");
+                    break;
+                case TPM2_RC_MODE:
+                    LOG_ERR("Specified symmetric mode unsupported");
+                    break;
+                case TPM2_RC_VALUE:
+                default:
+                    LOG_ERR("Unsupported algorithm specification");
+                    break;
+            }
+            return 2;
+        }
+        LOG_PERR(Esys_TestParms, rval);
+        return 1;
+    }
+
+    return 0;
+}
+
+static bool on_arg(int argc, char **argv){
+
+    if (argc < 1) {
+        LOG_ERR("Expected one algorithm specification, got: 0");
+        return false;
+    }
+
+    TPM2B_PUBLIC algorithm = { 0 };
+
+    if(!tpm2_alg_util_handle_ext_alg(argv[0], &algorithm)){
+        LOG_ERR("Invalid or unsupported by the tool : %s", argv[0]);
+        return false;
+    }
+
+    ctx.inputalg.type = algorithm.publicArea.type;
+    memcpy(&ctx.inputalg.parameters, &algorithm.publicArea.parameters, sizeof(TPMU_PUBLIC_PARMS));
+    return true;
+}
+
+bool tpm2_tool_onstart(tpm2_options **opts) {
+    *opts = tpm2_options_new(NULL, 0, NULL, NULL, on_arg, 0);
+
+    return *opts != NULL;
+}
+
+int tpm2_tool_onrun(ESYS_CONTEXT *ectx, tpm2_option_flags flags) {
+
+    UNUSED(flags);
+
+    return tpm_testparms(ectx);
+}


### PR DESCRIPTION
No implementation issue was opened but this tool might be handy in some situation (like migration or tests)

- Added command to makefile
- Added manual entry for tpm2_selftest
- Added command relying on ESAPI
- Added integration test for coverage

Signed-off-by: sebastien le stum <lestums@gmail.com>