### PR TITLE
MAINTAINERS: Remove myself

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -2,4 +2,3 @@
 
 * William Roberts <william.c.roberts@intel.com>
 * Joshua Lock <joshua.g.lock@intel.com>
-* Javier Martinez Canillas <javier@dowhile0.org>


### PR DESCRIPTION
I've been busy with other projects lately and couldn't find time to do the
work expected for someone listed as a maintainer of the project. So remove
myself from the MAINTAINERS.md file.

I will continue maintaining the tpm2-{tools,tss,abrmd} packages in Fedora
and try to help with this project but let's make the file reflect reality.

Signed-off-by: Javier Martinez Canillas <javierm@redhat.com>