### PR TITLE
Add tool tpm2_pcrallocate

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -92,6 +92,7 @@ bin_PROGRAMS = \
     tools/tpm2_nvreadlock \
     tools/tpm2_nvrelease \
     tools/tpm2_nvwrite \
+    tools/tpm2_pcrallocate \
     tools/tpm2_pcrevent \
     tools/tpm2_pcrextend \
     tools/tpm2_pcrlist \
@@ -171,6 +172,7 @@ tools_tpm2_sign_SOURCES = tools/tpm2_sign.c $(TOOL_SRC)
 tools_tpm2_unseal_SOURCES = tools/tpm2_unseal.c $(TOOL_SRC)
 tools_tpm2_dictionarylockout_SOURCES = tools/tpm2_dictionarylockout.c $(TOOL_SRC)
 tools_tpm2_createpolicy_SOURCES = tools/tpm2_createpolicy.c $(TOOL_SRC)
+tools_tpm2_pcrallocate_SOURCES = tools/tpm2_pcrallocate.c $(TOOL_SRC)
 tools_tpm2_pcrextend_SOURCES = tools/tpm2_pcrextend.c $(TOOL_SRC)
 tools_tpm2_pcrevent_SOURCES = tools/tpm2_pcrevent.c $(TOOL_SRC)
 tools_tpm2_pcrreset_SOURCES = tools/tpm2_pcrreset.c $(TOOL_SRC)
@@ -329,6 +331,7 @@ if HAVE_MAN_PAGES
     man/man1/tpm2_nvreadlock.1 \
     man/man1/tpm2_nvrelease.1 \
     man/man1/tpm2_nvwrite.1 \
+    man/man1/tpm2_pcrallocate.1 \
     man/man1/tpm2_pcrevent.1 \
     man/man1/tpm2_pcrextend.1 \
     man/man1/tpm2_pcrlist.1 \

--- a/lib/pcr.c
+++ b/lib/pcr.c
@@ -309,6 +309,13 @@ bool pcr_parse_list(const char *str, size_t len, TPMS_PCR_SELECTION *pcrSel) {
     pcrSel->pcrSelect[1] = 0;
     pcrSel->pcrSelect[2] = 0;
 
+    if (!strncmp(str, "all", 3)) {
+        pcrSel->pcrSelect[0] = 0xff;
+        pcrSel->pcrSelect[1] = 0xff;
+        pcrSel->pcrSelect[2] = 0xff;
+        return true;
+    }
+
     do {
         strCurrent = str;
         str = memchr(strCurrent, ',', len);

--- a/lib/pcr.h
+++ b/lib/pcr.h
@@ -69,6 +69,7 @@ bool pcr_print_pcr_struct(TPML_PCR_SELECTION *pcrSelect, tpm2_pcrs *pcrs);
  */
 bool pcr_get_id(const char *arg, UINT32 *pcrId);
 
+bool pcr_print_pcr_selections(TPML_PCR_SELECTION *pcr_selections);
 bool pcr_parse_selections(const char *arg, TPML_PCR_SELECTION *pcrSels);
 bool pcr_parse_list(const char *str, size_t len, TPMS_PCR_SELECTION *pcrSel);
 bool pcr_get_banks(ESYS_CONTEXT *esys_context, TPMS_CAPABILITY_DATA *capability_data, tpm2_algorithm *algs);

--- a/man/common/pcr.md
+++ b/man/common/pcr.md
@@ -3,7 +3,7 @@
 PCR Bank Selection lists follow the below specification:
 
 ```
-<BANK>:<PCR>[,<PCR>]
+<BANK>:<PCR>[,<PCR>] or <BANK>:all
 ```
 
 multiple banks may be separated by '+'.
@@ -11,9 +11,9 @@ multiple banks may be separated by '+'.
 For example:
 
 ```
-sha1:3,4+sha256:5,6
+sha1:3,4+sha256:all
 ```
-will select PCRs 3 and 4 from the SHA1 bank and PCRs 5 and 6
+will select PCRs 3 and 4 from the SHA1 bank and PCRs 0 to 23
 from the SHA256 bank.
 
 ## Note

--- a/man/tpm2_pcrallocate.1.md
+++ b/man/tpm2_pcrallocate.1.md
@@ -1,0 +1,59 @@
+% tpm2_pcrallocate(1) tpm2-tools | General Commands Manual
+%
+% MARCH 2019
+
+# NAME
+
+**tpm2_pcrallocate**(1) - Change the allocated PCRs of a TPM
+
+# SYNOPSIS
+
+**tpm2_pcrallocate** [*OPTIONS*] [*ALLOCATION*]
+
+# DESCRIPTION
+
+**tpm2_pcrallocate**(1) - allows the user to specify an allocation for the TPM.
+If no *ALLOCATION* is given, then SHA1 and SHA256 banks with PCRs 0 - 23 are
+allocated.
+
+Note: The new allocations become effective after the next reboot.
+
+# ALLOCATION
+
+A list of banks and selected pcrs. The _ALLOCATION_ values should 
+follow the pcr bank specifiers standards, see section "PCR Bank Specifiers".
+
+
+# OPTIONS
+
+  * **-P**, **--auth-platform**=_AUTH\_HIERARCHY_\VALUE_:
+
+    Optional authorization value. Authorization values should follow the
+    "authorization formatting standards", see section "Authorization Formatting".
+
+[common options](common/options.md)
+
+[common tcti options](common/tcti.md)
+
+[context object format](common/ctxobj.md)
+
+[authorization formatting](common/authorizations.md)
+
+[pcr bank specifiers](common/pcr.md)
+
+# EXAMPLES
+
+## To allocate the two default banks
+```
+tpm2_pcrallocate
+```
+## To make a custom allocation with a platform authorization
+```
+tpm2_pcrallocate -P abc sha1:7,8,9,10,16,17,18,19+sha256:all
+```
+
+# RETURNS
+
+0 on success or 1 on failure.
+
+[footer](common/footer.md)

--- a/test/integration/tests/pcrallocate.sh
+++ b/test/integration/tests/pcrallocate.sh
@@ -1,0 +1,67 @@
+#!/bin/bash
+#;**********************************************************************;
+#
+# Copyright (c) 2016-2018, Intel Corporation
+# Copyright (c) 2019, Fraunhofer SIT
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# 1. Redistributions of source code must retain the above copyright notice,
+# this list of conditions and the following disclaimer.
+#
+# 2. Redistributions in binary form must reproduce the above copyright notice,
+# this list of conditions and the following disclaimer in the documentation
+# and/or other materials provided with the distribution.
+#
+# 3. Neither the name of Intel Corporation nor the names of its contributors
+# may be used to endorse or promote products derived from this software without
+# specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+# THE POSSIBILITY OF SUCH DAMAGE.
+#;**********************************************************************;
+
+source helpers.sh
+
+cleanup() {
+    rm -f pcrs.out
+
+    if [ "$1" != "no-shut-down" ]; then
+          shut_down
+    fi
+}
+trap cleanup EXIT
+
+start_up
+
+cleanup "no-shut-down"
+
+# Store the old banks because e.g. some TPM-simuators don't support SHA512
+OLDBANKS=$(tpm2_getcap -c pcrs | grep bank | sed 's/.*bank\: \(.*\)/+\1:all/' | tr -d "\n")
+
+echo "OLDBANKS: $OLDBANKS"
+
+tpm2_pcrallocate -P "" sha1:7,8,9,10,16,17,18,19+sha256:all \
+    | tee out.yml
+yaml_verify out.yml
+
+tpm2_pcrallocate sha1:all+sha256:all | tee out.yml
+yaml_verify out.yml
+
+tpm2_pcrallocate ${OLDBANKS:1}
+
+#Note: We cannot check if the allocations were performed by the TPM, since they
+#      will only take effect once the TPM reboots.
+
+exit 0

--- a/tools/tpm2_getcap.c
+++ b/tools/tpm2_getcap.c
@@ -41,6 +41,7 @@
 #include "tpm2_tool.h"
 #include "tpm2_util.h"
 #include "tpm2_capability.h"
+#include "pcr.h"
 
 /* convenience macro to convert flags into "1" / "0" strings */
 #define prop_str(val) val ? "1" : "0"
@@ -856,49 +857,6 @@ dump_handles (TPM2_HANDLE     handles[],
          tpm2_tool_output ("- 0x%X\n", handles[i]);
 }
 /*
- * Dump the TPML_PCR_SELECTION
- */
-static void
-dump_pcrselection (TPMS_PCR_SELECTION   pcrselection[],
-                   UINT32               count)
-{
-    UINT32 i;
-    int j;
-    bool first;
-    tpm2_tool_output ("activePCRs:\n");
-    for (i = 0; i < count; i++) {
-        switch(pcrselection[i].hash) {
-            case TPM2_ALG_SHA1:
-                tpm2_tool_output ("  - bank: sha1\n");
-                break;
-            case TPM2_ALG_SHA256:
-                tpm2_tool_output ("  - bank: sha256\n");
-                break;
-            case TPM2_ALG_SHA384:
-                tpm2_tool_output ("  - bank: sha384\n");
-                break;
-            case TPM2_ALG_SHA512:
-                tpm2_tool_output ("  - bank: sha512\n");
-                break;
-            default:
-                tpm2_tool_output ("  - bank: alg0x%08x\n",
-                                  pcrselection[i].hash);
-        }
-        first = true;
-        for (j = 0; j < 24; j++) {
-            if (pcrselection[i].pcrSelect[j / 8] & 1<<(j % 8)) {
-                if (first) {
-                    tpm2_tool_output ("    pcrs: [ %i", j);
-                    first = false;
-                } else {
-                    tpm2_tool_output(", %i", j);
-                }
-            }
-        }
-        tpm2_tool_output (" ]\n");
-    }
-}
-/*
  * Query the TPM for TPM capabilities.
  */
 static TSS2_RC
@@ -963,8 +921,7 @@ static bool dump_tpm_capability (TPMU_CAPABILITIES *capabilities) {
         }
         break;
     case TPM2_CAP_PCRS:
-        dump_pcrselection (capabilities->assignedPCR.pcrSelections,
-                           capabilities->assignedPCR.count);
+        pcr_print_pcr_selections(&capabilities->assignedPCR);
         break;
     default:
         return false;

--- a/tools/tpm2_pcrallocate.c
+++ b/tools/tpm2_pcrallocate.c
@@ -1,0 +1,168 @@
+//**********************************************************************;
+// Copyright (c) 2015-2018, Intel Corporation
+// Copyright (c) 2019, Fraunhofer SIT
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+// 1. Redistributions of source code must retain the above copyright notice,
+// this list of conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright notice,
+// this list of conditions and the following disclaimer in the documentation
+// and/or other materials provided with the distribution.
+//
+// 3. Neither the name of Intel Corporation nor the names of its contributors
+// may be used to endorse or promote products derived from this software without
+// specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+// THE POSSIBILITY OF SUCH DAMAGE.
+//**********************************************************************;
+
+#include <ctype.h>
+#include <errno.h>
+#include <stdbool.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include <tss2/tss2_esys.h>
+
+#include "log.h"
+#include "pcr.h"
+#include "tpm2_alg_util.h"
+#include "tpm2_auth_util.h"
+#include "tpm2_options.h"
+#include "tpm2_session.h"
+#include "tpm2_tool.h"
+#include "tpm2_util.h"
+
+static struct {
+    TPML_PCR_SELECTION pcrSelection;
+    const char *platform_auth_str;
+    struct {
+        TPMS_AUTH_COMMAND session_data;
+        tpm2_session *session;
+    } auth;
+} ctx = {
+    .pcrSelection = {
+        .count = 2,
+        .pcrSelections = { {
+            .hash = TPM2_ALG_SHA1,
+            .sizeofSelect = 3,
+            .pcrSelect = { 0xff, 0xff, 0xff, }
+            }, {
+            .hash = TPM2_ALG_SHA256,
+            .sizeofSelect = 3,
+            .pcrSelect = { 0xff, 0xff, 0xff, }
+        }, }
+    },
+};
+
+static bool pcr_allocate(ESYS_CONTEXT *ectx) {
+    TSS2_RC rval;
+    TPMI_YES_NO allocationSuccess;
+    UINT32 maxPCR;
+    UINT32 sizeNeeded;
+    UINT32 sizeAvailable;
+
+    ESYS_TR shandle1 = tpm2_auth_util_get_shandle(ectx, ESYS_TR_RH_PLATFORM,
+                            &ctx.auth.session_data, ctx.auth.session);
+    if (shandle1 == ESYS_TR_NONE) {
+        LOG_ERR("Couldn't get shandle for lockout hierarchy");
+        return false;
+    }
+
+    pcr_print_pcr_selections(&ctx.pcrSelection);
+
+    rval = Esys_PCR_Allocate(ectx, ESYS_TR_RH_PLATFORM, 
+                             shandle1, ESYS_TR_NONE, ESYS_TR_NONE,
+                             &ctx.pcrSelection, &allocationSuccess,
+                             &maxPCR, &sizeNeeded, &sizeAvailable);
+    if (rval != TSS2_RC_SUCCESS) {
+        LOG_ERR("Could not allocate PCRs.");
+        LOG_PERR(Esys_PCR_Allocate, rval);
+        return false;
+    }
+
+    if (!allocationSuccess) {
+        LOG_ERR("Allocation failed. "
+                "MaxPCR: %i, Size Needed: %i, Size available: %i",
+                maxPCR, sizeNeeded, sizeAvailable);
+        return false;
+    }
+
+    return true;
+}
+
+static bool on_arg(int argc, char **argv){
+    if (argc > 1) {
+        LOG_ERR("Too many arguments");
+        return false;
+    }
+
+    if(argc == 1 && !pcr_parse_selections(argv[0], &ctx.pcrSelection))
+    {
+        LOG_ERR("Could not parse pcr selections");
+        return false;
+    }
+
+    return true;
+}
+
+static bool on_option(char key, char *value) {
+    switch (key) {
+    case 'P':
+        ctx.platform_auth_str = value;
+        break;
+    }
+
+    return true;
+}
+
+bool tpm2_tool_onstart(tpm2_options **opts) {
+    const struct option topts[] = {
+        { "auth-platform",     required_argument, NULL, 'P' },
+    };
+ 
+    *opts = tpm2_options_new("P:", ARRAY_LEN(topts), topts, on_option, on_arg,
+                             0);
+
+    return *opts != NULL;
+}
+
+int tpm2_tool_onrun(ESYS_CONTEXT *ectx, tpm2_option_flags flags) {
+    UNUSED(flags);
+    bool result;
+
+    if (ctx.platform_auth_str) {
+        if (!tpm2_auth_util_from_optarg(ectx, ctx.platform_auth_str,
+                &ctx.auth.session_data, &ctx.auth.session)) {
+            LOG_ERR("Invalid platform authorization format");
+            return 1;
+        }
+    }
+    
+    result = pcr_allocate(ectx);
+
+    if (!tpm2_session_save(ectx, ctx.auth.session, NULL)) {
+        LOG_ERR("Error saving sessions after command execution");
+        return 1;
+    }
+
+    return (result == true)? 0 : 1;
+}
+
+void tpm2_tool_onexit(void) {
+    tpm2_session_free(&ctx.auth.session);
+}


### PR DESCRIPTION
This is mostly an RFC on the command parameter structure.
This is the idea:
```
$ tpm2_pcrallocate     #Will set a default of sha1 + sha256 with pcrs 0-23

$ tpm2_pcrallocate sha1: all sha256: all sha384: all sha512: all

$ tpm2_pcrallocate -P "" sha1: 7 8 9 10 16 17 18 19  sha256: 0 1 2 3 4 5 6
```

What do you think ?

Fixes: #852 