### PR TITLE
tools/tpm2_gettestresult: Add tool to get status on tests made by TPM

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -72,6 +72,7 @@ bin_PROGRAMS = \
     tools/tpm2_createprimary \
     tools/tpm2_dictionarylockout \
     tools/tpm2_getcap \
+    tools/tpm2_gettestresult \
     tools/tpm2_encryptdecrypt \
     tools/tpm2_evictcontrol \
     tools/tpm2_flushcontext \
@@ -191,6 +192,7 @@ tools_tpm2_policyduplicationselect_SOURCES = tools/tpm2_policyduplicationselect.
 tools_tpm2_policylocality_SOURCES = tools/tpm2_policylocality.c $(TOOL_SRC)
 tools_tpm2_testparms_SOURCES = tools/tpm2_testparms.c $(TOOL_SRC)
 tools_tpm2_incrementalselftest_SOURCES = tools/tpm2_incrementalselftest.c $(TOOL_SRC)
+tools_tpm2_gettestresult_SOURCES = tools/tpm2_gettestresult.c $(TOOL_SRC)
 
 if UNIT
 TESTS = $(check_PROGRAMS)
@@ -316,6 +318,7 @@ if HAVE_MAN_PAGES
     man/man1/tpm2_flushcontext.1 \
     man/man1/tpm2_getmanufec.1 \
     man/man1/tpm2_getrandom.1 \
+    man/man1/tpm2_gettestresult.1 \
     man/man1/tpm2_hash.1 \
     man/man1/tpm2_hmac.1 \
     man/man1/tpm2_import.1 \

--- a/man/tpm2_gettestresult.1.md
+++ b/man/tpm2_gettestresult.1.md
@@ -1,0 +1,52 @@
+% tpm2_gettestresult(1) tpm2-tools | General Commands Manual
+%
+% JANUARY 2019
+
+# NAME
+
+**tpm2_gettestresult**(1) - Get the result of tests performed by the TPM
+
+# SYNOPSIS
+
+**tpm2_gettestresult** [*OPTIONS*]
+
+# DESCRIPTION
+
+**tpm2_gettestresult**(1) will return the result of the tests conducted by the TPM
+
+Error code will state if the test executed successfully or have failed.
+
+If pending algorithms are scheduled to be tested, **tpm2_gettestresult** will
+return "TESTING". Otherwise "FAILED" will be returned or "SUCCESS" depending
+on the result to the test.
+
+Manufacturer-dependent information will also be printed in raw hex format.
+
+# OPTIONS
+
+This tool accepts no tool specific options.
+
+[common options](common/options.md)
+
+[common tcti options](common/tcti.md)
+
+# EXAMPLES
+
+Get the result of the TPM testing:
+
+```
+tpm2_gettestresult
+```
+
+# NOTES
+
+This command is the one of the few commands authorized to be submitted to TPM when in failure mode.
+
+# RETURNS
+
+- 0 on success 
+- 1 on failure
+- 2 on testing
+- 3 on TPM failure
+
+[footer](common/footer.md)

--- a/scripts/utils/analyze.py
+++ b/scripts/utils/analyze.py
@@ -191,7 +191,7 @@ class ToolConflictor(object):
             },
             {
                 "gname": "testing",
-                "tools-in-group": ["tpm2_selftest", "tpm2_incrementalselftest"],
+                "tools-in-group": ["tpm2_selftest", "tpm2_incrementalselftest", "tpm2_gettestresult"],
                 "tools": [],
                 "conflict": None,
                 "ignore": set()

--- a/test/integration/tests/gettestresult.sh
+++ b/test/integration/tests/gettestresult.sh
@@ -1,0 +1,53 @@
+#!/bin/bash
+#;**********************************************************************;
+#
+# Copyright (c) 2019, Sebastien LE STUM
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# 1. Redistributions of source code must retain the above copyright notice,
+# this list of conditions and the following disclaimer.
+#
+# 2. Redistributions in binary form must reproduce the above copyright notice,
+# this list of conditions and the following disclaimer in the documentation
+# and/or other materials provided with the distribution.
+#
+# 3. Neither the name of Intel Corporation nor the names of its contributors
+# may be used to endorse or promote products derived from this software without
+# specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+# THE POSSIBILITY OF SUCH DAMAGE.
+#;**********************************************************************;
+
+source helpers.sh
+
+cleanup() {
+    if [ "$1" != "no-shut-down" ]; then
+        shut_down
+    fi
+}
+trap cleanup EXIT
+
+start_up
+
+cleanup "no-shut-down"
+
+tempfile=$(mktemp)
+
+# Verify that tests have succeeded
+tpm2_gettestresult > "${tempfile}"
+yaml_get_kv "${tempfile}" \"status\" | grep "success"
+
+exit 0

--- a/tools/tpm2_gettestresult.c
+++ b/tools/tpm2_gettestresult.c
@@ -1,0 +1,109 @@
+//**********************************************************************;
+// Copyright (c) 2019, Sebastien LE STUM
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+// 1. Redistributions of source code must retain the above copyright notice,
+// this list of conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright notice,
+// this list of conditions and the following disclaimer in the documentation
+// and/or other materials provided with the distribution.
+//
+// 3. Neither the name of Intel Corporation nor the names of its contributors
+// may be used to endorse or promote products derived from this software without
+// specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+// THE POSSIBILITY OF SUCH DAMAGE.
+//**********************************************************************;
+
+#include <ctype.h>
+#include <errno.h>
+#include <stdbool.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include <tss2/tss2_esys.h>
+
+#include "log.h"
+#include "tpm2_options.h"
+#include "tpm2_tool.h"
+#include "tpm2_alg_util.h"
+
+typedef struct tpm_gettestresult_ctx tpm_gettestresult_ctx;
+
+struct tpm_gettestresult_ctx {
+    TPM2B_MAX_BUFFER*    output;
+    TPM2_RC              status;
+};
+
+static tpm_gettestresult_ctx ctx;
+
+static int tpm_gettestresult(ESYS_CONTEXT *ectx) {
+    TSS2_RC rval = Esys_GetTestResult(ectx, ESYS_TR_NONE, ESYS_TR_NONE, ESYS_TR_NONE, &(ctx.output), &(ctx.status));
+    if (rval != TSS2_RC_SUCCESS) {
+        LOG_PERR(Esys_SelfTest, rval);
+        return 3;
+    }
+    int retcode;
+
+    tpm2_tool_output("status: ");
+    print_yaml_indent(1);
+    if(ctx.status){
+        if((ctx.status & TPM2_RC_TESTING) == TPM2_RC_TESTING) {
+            tpm2_tool_output("testing");
+            retcode = 2;
+        } else {
+            tpm2_tool_output("failed");
+            retcode = 1;
+        }
+    } else {
+        tpm2_tool_output("success");
+        retcode = 0;
+    }
+
+    if(ctx.output->size > 0){
+        tpm2_tool_output("\ndata: ");
+        print_yaml_indent(1);
+        tpm2_util_hexdump(ctx.output->buffer, ctx.output->size);
+    }
+    tpm2_tool_output("\n");
+
+    free(ctx.output);
+
+    return retcode;
+}
+
+static bool on_arg(int argc, char **argv){
+    UNUSED(argv);
+    if (argc > 0) {
+        LOG_ERR("No argument expected, got: %d", argc);
+        return false;
+    }
+
+    return true;
+}
+
+bool tpm2_tool_onstart(tpm2_options **opts) {
+    *opts = tpm2_options_new(NULL, 0, NULL, NULL, on_arg, 0);
+
+    return *opts != NULL;
+}
+
+int tpm2_tool_onrun(ESYS_CONTEXT *ectx, tpm2_option_flags flags) {
+    UNUSED(flags);
+    return tpm_gettestresult(ectx);
+}
+


### PR DESCRIPTION
- Added command to makefile
- Added manual entry for tpm2_selftest
- Added command relying on ESAPI
- Added integration test for coverage

Signed-off-by: sebastien le stum <lestums@gmail.com>