### PR TITLE
tools/tpm2_changeauth.c:tpm2_tool_onstart() there is no command line parameter -S

### DIFF
--- a/tools/tpm2_changeauth.c
+++ b/tools/tpm2_changeauth.c
@@ -418,8 +418,7 @@ bool tpm2_tool_onstart(tpm2_options **opts) {
         { "key-parent-context",         required_argument, NULL, 'a' },
         { "privfile",                   required_argument, NULL, 'r' },
     };
-
-    *opts = tpm2_options_new("o:e:l:O:E:L:p:P:c:a:r:S:", ARRAY_LEN(topts), topts,
+    *opts = tpm2_options_new("o:e:l:O:E:L:p:P:c:a:r:", ARRAY_LEN(topts), topts,
                              on_option, NULL, 0);
 
     return *opts != NULL;


### PR DESCRIPTION
Introduced by commit ed4c389f7.  This parameter is neither described nor handled.
