### PR TITLE
lib/tpm2_util.c:string_to_uint32: ensure the string does not overflow in uint32

### DIFF
--- a/lib/tpm2_util.c
+++ b/lib/tpm2_util.c
@@ -259,8 +259,8 @@ bool tpm2_util_string_to_uint32(const char *str, uint32_t *value) {
 
     /* clear errno before the call, should be 0 afterwards */
     errno = 0;
-    uint32_t tmp = strtoul(str, &endptr, 0);
-    if (errno) {
+    unsigned long int tmp = strtoul(str, &endptr, 0);
+    if (errno || tmp > UINT32_MAX) {
         return false;
     }
 
@@ -273,7 +273,7 @@ bool tpm2_util_string_to_uint32(const char *str, uint32_t *value) {
         return false;
     }
 
-    *value = tmp;
+    *value = (uint32_t) tmp;
     return true;
 }
 


### PR DESCRIPTION
Before this change input of "4294967295" generated output of 4294967295, which is UINT32_MAX = 2**32 - 1.  But input "4294967296" created output of 0.  The function is supposed to fail if the number is too big, rather than silently convert unsigned long int to uint32_t, ignoring some bits.