### PR TITLE
lib: Fix potential null pointer dereference in tpm2_session

### DIFF
--- a/lib/tpm2_session.c
+++ b/lib/tpm2_session.c
@@ -254,10 +254,12 @@ tpm2_session *tpm2_session_restore(ESYS_CONTEXT *ctx, const char *path) {
     tpm2_session_set_authhash(d, auth_hash);
 
     s = tpm2_session_new(NULL, d);
-    if (s) {
-        s->output.session_handle = handle;
+    if (!s) {
+    	LOG_ERR("oom new session object");
+	goto out;
     }
 
+    s->output.session_handle = handle;
     s->internal.path = strdup(dup_path);
 
 out:


### PR DESCRIPTION
If an allocation error or a failure on Esys_StartAuthSession occur
when creating the new session object, `s` would eventually be NULL.

The following statement `s->internal.path` would then trigger
a null pointer dereference.

Instead, check for the pointer being invalid and return the error

Signed-off-by: sebastien le stum <lestums@gmail.com>