### PR TITLE
Multiple fixes for handling PCR indexes

### DIFF
--- a/lib/pcr.c
+++ b/lib/pcr.c
@@ -48,22 +48,28 @@ static inline void set_pcr_select_size(TPMS_PCR_SELECTION *pcr_selection,
     pcr_selection->sizeofSelect = size;
 }
 
-static int pcr_get_id(const char *arg, UINT32 *pcrId)
+bool pcr_get_id(const char *arg, UINT32 *pcrId)
 {
     UINT32 n = 0;
 
-    if(arg == NULL || pcrId == NULL)
-        return -1;
+    if(arg == NULL || pcrId == NULL){
+        LOG_ERR("arg or pcrId is NULL");
+        return false;
+    }
 
-    if(!tpm2_util_string_to_uint32(arg, &n))
-        return -2;
+    if(!tpm2_util_string_to_uint32(arg, &n)) {
+        LOG_ERR("Got invalid PCR index: \"%s\"", arg);
+        return false;
+    }
 
-    if(n >= TPM2_MAX_PCRS)
-        return -3;
+    if(n >= TPM2_MAX_PCRS) {
+        LOG_ERR("Got out of bound PCR index: \"%s\"", arg);
+        return false;
+    }
 
     *pcrId = n;
 
-    return 0;
+    return true;
 }
 
 static bool pcr_parse_selection(const char *str, size_t len, TPMS_PCR_SELECTION *pcrSel) {
@@ -279,7 +285,7 @@ bool pcr_parse_list(const char *str, size_t len, TPMS_PCR_SELECTION *pcrSel) {
 
         snprintf(buf, lenCurrent + 1, "%s", strCurrent);
 
-        if (pcr_get_id(buf, &pcr) != 0) {
+        if (!pcr_get_id(buf, &pcr)) {
             return false;
         }
 

--- a/lib/pcr.h
+++ b/lib/pcr.h
@@ -51,12 +51,23 @@ struct tpm2_pcrs {
  * Echo out all PCR banks according to g_pcrSelection & g_pcrs->.
  * @param pcrSelect
  *  Description of which PCR registers are selected.
-^ * @param pcrs
-^ *  Struct containing PCR digests.
+ * @param pcrs
+ *  Struct containing PCR digests.
  * @return
  *  True on success, false otherwise.
  */
 bool pcr_print_pcr_struct(TPML_PCR_SELECTION *pcrSelect, tpm2_pcrs *pcrs);
+
+/**
+ * Set the PCR value into pcrId if string in arg is a valid PCR index.
+ * @param arg
+ *  PCR index as string
+ * @param pcrId
+ *  Caller-allocated PCR index as integer
+ * @return
+ *  True on success, false otherwise.
+ */
+bool pcr_get_id(const char *arg, UINT32 *pcrId);
 
 bool pcr_parse_selections(const char *arg, TPML_PCR_SELECTION *pcrSels);
 bool pcr_parse_list(const char *str, size_t len, TPMS_PCR_SELECTION *pcrSel);

--- a/lib/tpm2_alg_util.c
+++ b/lib/tpm2_alg_util.c
@@ -36,6 +36,7 @@
 
 #include "files.h"
 #include "log.h"
+#include "pcr.h"
 #include "tpm2_attr_util.h"
 #include "tpm2_errata.h"
 #include "tpm2_hash.h"
@@ -707,7 +708,7 @@ bool pcr_parse_digest_list(char **argv, int len,
         *digest_spec_str = '\0';
         digest_spec_str++;
 
-        bool result = tpm2_util_string_to_uint32(pcr_index_str, &dspec->pcr_index);
+        bool result = pcr_get_id(pcr_index_str, &dspec->pcr_index);
         if (!result) {
             LOG_ERR("Got invalid PCR Index: \"%s\", in digest spec: \"%s\"",
                     pcr_index_str, spec_str);

--- a/test/integration/tests/pcrextend.sh
+++ b/test/integration/tests/pcrextend.sh
@@ -70,13 +70,22 @@ tpm2_pcrextend 8:$digests
 # try extending two PCR in the same command.
 tpm2_pcrextend 8:$digests 9:$digests
 
-trap - ERR
+# Over-length hash should fail
+if tpm2_pcrextend 8:$digests,sha1=${alg_hashes["sha256"]}; then
+    echo "tpm2_pcrextend with over-length hash didn't fail!"
+    exit 1
+else
+    true
+fi
+
+oversizedspec="sha1=$(tpm2_pcrlist -g sha1 | tail +2 | cut -d':' -f2 | sed 's% %%g' | sed -z 's%\n%,sha1=%g')"
 
 # Over-length spec should fail
-tpm2_pcrextend 8:$digests,sha1=$sha1hash 2>/dev/null
-if [ $? != 1 ]; then
-  echo "tpm2_pcrextend with over-length spec didn't fail!"
-  exit 1
+if tpm2_pcrextend 8:${oversizedspec}; then
+    echo "tpm2_pcrextend with over-length spec didn't fail!"
+    exit 1
+else
+    true
 fi
 
 exit 0

--- a/test/unit/test_tpm2_alg_util.c
+++ b/test/unit/test_tpm2_alg_util.c
@@ -186,7 +186,7 @@ add_single_digest_pcr_parse_test(4, sha1, HASH_SHA1,
 add_single_digest_pcr_parse_test(9, sha256, HASH_SHA256,
         TPM2_ALG_SHA256, TPM2_SHA256_DIGEST_SIZE)
 
-add_single_digest_pcr_parse_test(67, sha384, HASH_SHA384,
+add_single_digest_pcr_parse_test(6, sha384, HASH_SHA384,
         TPM2_ALG_SHA384, TPM2_SHA384_DIGEST_SIZE)
 
 add_single_digest_pcr_parse_test(21, sha512, HASH_SHA512,

--- a/tools/tpm2_pcrreset.c
+++ b/tools/tpm2_pcrreset.c
@@ -92,19 +92,8 @@ static bool on_arg(int argc, char** argv){
     }
 
     for(i = 0; i < argc; i++){
-        if(!tpm2_util_string_to_uint32(argv[i], &pcr)){
-            LOG_ERR("Got invalid PCR Index: \"%s\"", argv[i]);
+        if(!pcr_get_id(argv[i], &pcr))
             return false;
-        }
-
-        /*
-        * If any specified PCR index is greater than the last valid
-        * index supported in the spec, throw an error 
-        */
-        if(pcr > TPM2_MAX_PCRS - 1){
-            LOG_ERR("Got out of bound PCR Index: \"%s\"", argv[i]);
-            return false;
-        }
 
         ctx.pcr_list[pcr] = 1;
     }


### PR DESCRIPTION
From an undefined variable in "pcrextend.sh" test suite, i carved up to PCR indexes on extend being allowed to be greater to `TPM2_MAX_PCRS`

Fixing everything i noticed from that pertaining PCR ids up to the test i was actually linting :)