### PR TITLE
Fix error messages

### DIFF
--- a/lib/tpm2_error.c
+++ b/lib/tpm2_error.c
@@ -369,6 +369,7 @@ static const char *tpm2_err_handler_fmt0(TSS2_RC rc) {
             "the 7th handle in the handle area references a transient object"
             " or session that is not loaded",
             // 0x17 - EMPTY,
+            NULL,
             // 0x18 - TPM2_RC_REFERENCE_S0
             "the 1st authorization session handle references a session that"
             " is not loaded",
@@ -390,6 +391,8 @@ static const char *tpm2_err_handler_fmt0(TSS2_RC rc) {
             // 0x1E - TPM2_RC_REFERENCE_S6
             "the 7th authorization session handle references a session that"
             " is not loaded",
+            // 0x1F - EMPTY,
+            NULL,
             // 0x20 -TPM2_RC_NV_RATE
             "the TPM is rate-limiting accesses to prevent wearout of NV",
             // 0x21 - TPM2_RC_LOCKOUT

--- a/lib/tpm2_error.c
+++ b/lib/tpm2_error.c
@@ -225,7 +225,7 @@ static const char *tpm2_err_handler_fmt1(TPM2_RC rc) {
         // 0x15 - TPM2_RC_SIZE
         "structure is the wrong size",
         // 0x16 - TPM2_RC_SYMMETRIC
-        "unsupported symmetric algorithm or key size, or not appropriate for"
+        "unsupported symmetric algorithm or key size or not appropriate for"
         " instance",
         // 0x17 - TPM2_RC_TAG
         "incorrect structure tag",
@@ -322,7 +322,7 @@ static const char *tpm2_err_handler_fmt0(TSS2_RC rc) {
             // 0x3 - TPM2_RC_SESSION_MEMORY
             "out of memory for session contexts",
             // 0x4 - TPM2_RC_MEMORY
-            "out of shared object/session memory or need space for internal"
+            "out of shared objectsession memory or need space for internal"
             " operations",
             // 0x5 - TPM2_RC_SESSION_HANDLES
             "out of session handles",
@@ -331,12 +331,12 @@ static const char *tpm2_err_handler_fmt0(TSS2_RC rc) {
             // 0x7 - TPM2_RC_LOCALITY
             "bad locality",
             // 0x8 - TPM2_RC_YIELDED
-            "the TPM has suspended operation on the command; forward progress"
+            "the TPM has suspended operation on the command forward progress"
             " was made and the command may be retried",
             // 0x9 - TPM2_RC_CANCELED
             "the command was canceled",
             // 0xA - TPM2_RC_TESTING
-            "TPM is performing self-tests",
+            "TPM is performing selftests",
             // 0xB - EMPTY
             NULL,
             // 0xC - EMPTY
@@ -383,10 +383,10 @@ static const char *tpm2_err_handler_fmt0(TSS2_RC rc) {
             "the 4th authorization session handle references a session that"
             " is not loaded",
             // 0x1C - TPM2_RC_REFERENCE_S4
-            "the 5th authorization session handle references a session that"
+            "the 5th session handle references a session that"
             " is not loaded",
             // 0x1D - TPM2_RC_REFERENCE_S5
-            "the 6th authorization session handle references a session that"
+            "the 6th session handle references a session that"
             " is not loaded",
             // 0x1E - TPM2_RC_REFERENCE_S6
             "the 7th authorization session handle references a session that"
@@ -394,7 +394,7 @@ static const char *tpm2_err_handler_fmt0(TSS2_RC rc) {
             // 0x1F - EMPTY,
             NULL,
             // 0x20 -TPM2_RC_NV_RATE
-            "the TPM is rate-limiting accesses to prevent wearout of NV",
+            "the TPM is rate limiting accesses to prevent wearout of NV",
             // 0x21 - TPM2_RC_LOCKOUT
             "authorizations for objects subject to DA protection are not"
             " allowed at this time because the TPM is in DA lockout mode",
@@ -502,17 +502,19 @@ static const char *tpm2_err_handler_fmt0(TSS2_RC rc) {
         // 0x2C - EMPTY
         NULL,
         // 0x2D - TPM2_RC_UPGRADE
-        "TPM is in field upgrade mode unless called via"
-        " TPM2_FieldUpgradeData(), then it is not in field upgrade mode",
+        "For all commands, other than TPM2_FieldUpgradeData, "
+        "this code indicates that the TPM is in field upgrade mode. "
+        "For TPM2_FieldUpgradeData, this code indicates that the TPM " 
+        "is not in field upgrade mode",
         // 0x2E - TPM2_RC_TOO_MANY_CONTEXTS
         "context ID counter is at maximum",
         // 0x2F - TPM2_RC_AUTH_UNAVAILABLE
         "authValue or authPolicy is not available for selected entity",
         // 0x30 - TPM2_RC_REBOOT
-        "a _TPM_Init and Startup(CLEAR) is required before the TPM can"
+        "a _TPM_Init and StartupCLEAR is required before the TPM can"
         " resume operation",
         // 0x31 - TPM2_RC_UNBALANCED
-        "the protection algorithms (hash and symmetric) are not reasonably"
+        "the protection algorithms hash and symmetric are not reasonably"
         " balanced. The digest size of the hash must be larger than the key"
         " size of the symmetric algorithm.",
         // 0x32 - EMPTY
@@ -549,7 +551,7 @@ static const char *tpm2_err_handler_fmt0(TSS2_RC rc) {
         NULL,
         // 0x42 - TPM2_RC_COMMAND_SIZE
         "command commandSize value is inconsistent with contents of the"
-        " command buffer; either the size is not the same as the octets"
+        " command buffer. Either the size is not the same as the octets"
         " loaded by the hardware interface layer or the value is not large"
         " enough to hold a command header",
         // 0x43 - TPM2_RC_COMMAND_CODE
@@ -570,7 +572,7 @@ static const char *tpm2_err_handler_fmt0(TSS2_RC rc) {
         "NV access authorization fails in command actions",
         // 0x4A - TPM2_RC_NV_UNINITIALIZED
         "an NV Index is used before being initialized or the state saved"
-        " by TPM2_Shutdown(STATE) could not be restored",
+        " by TPM2_ShutdownSTATE could not be restored",
         // 0x4B - TPM2_RC_NV_SPACE
         "insufficient space for NV allocation",
         // 0x4C - TPM2_RC_NV_DEFINED
@@ -582,7 +584,7 @@ static const char *tpm2_err_handler_fmt0(TSS2_RC rc) {
         // 0x4F - EMPTY
         NULL,
         // 0x50 - TPM2_RC_BAD_CONTEXT
-        "context in TPM2_ContextLoad() is not valid",
+        "context in TPM2_ContextLoad is not valid",
         // 0x51 - TPM2_RC_CPHASH
         "cpHash value already set or not correct for use",
         // 0x52 - TPM2_RC_PARENT

--- a/test/integration/tests/rc_decode.sh
+++ b/test/integration/tests/rc_decode.sh
@@ -48,124 +48,48 @@ trap - EXIT
 #  - https://trustedcomputinggroup.org/wp-content/uploads/TPM-Rev-2.0-Part-2-Structures-01.38.pdf
 #
 declare -A codes
-codes=(
-  [TPM2_RC_SUCCESS]=0x0
-  [TPM2_RC_BAD_TAG]=0x1E
-  [TPM2_RC_INITIALIZE]=0x100
-  [TPM2_RC_FAILURE]=0x101
-  [TPM2_RC_SEQUENCE]=0x103
-  [TPM2_RC_PRIVATE]=0x10B
-  [TPM2_RC_HMAC]=0x119
-  [TPM2_RC_DISABLED]=0x120
-  [TPM2_RC_EXCLUSIVE]=0x121
-  [TPM2_RC_AUTH_TYPE]=0x124
-  [TPM2_RC_AUTH_MISSING]=0x125
-  [TPM2_RC_POLICY]=0x126
-  [TPM2_RC_PCR]=0x127
-  [TPM2_RC_PCR_CHANGED]=0x128
-  [TPM2_RC_UPGRADE]=0x12D
-  [TPM2_RC_TOO_MANY_CONTEXTS]=0x12E
-  [TPM2_RC_AUTH_UNAVAILABLE]=0x12F
-  [TPM2_RC_REBOOT]=0x130
-  [TPM2_RC_UNBALANCED]=0x131
-  [TPM2_RC_COMMAND_SIZE]=0x142
-  [TPM2_RC_COMMAND_CODE]=0x143
-  [TPM2_RC_AUTHSIZE]=0x144
-  [TPM2_RC_AUTH_CONTEXT]=0x145
-  [TPM2_RC_NV_RANGE]=0x146
-  [TPM2_RC_NV_SIZE]=0x147
-  [TPM2_RC_NV_LOCKED]=0x148
-  [TPM2_RC_NV_AUTHORIZATION]=0x149
-  [TPM2_RC_NV_UNINITIALIZED]=0x14A
-  [TPM2_RC_NV_SPACE]=0x14B
-  [TPM2_RC_NV_DEFINED]=0x14C
-  [TPM2_RC_BAD_CONTEXT]=0x150
-  [TPM2_RC_CPHASH]=0x151
-  [TPM2_RC_PARENT]=0x152
-  [TPM2_RC_NEEDS_TEST]=0x153
-  [TPM2_RC_NO_RESULT]=0x154
-  [TPM2_RC_SENSITIVE]=0x155
-  [TPM2_RC_ASYMMETRIC]=0x81
-  [TPM2_RC_ATTRIBUTES]=0x82
-  [TPM2_RC_HASH]=0x83
-  [TPM2_RC_VALUE]=0x84
-  [TPM2_RC_HIERARCHY]=0x85
-  [TPM2_RC_KEY_SIZE]=0x87
-  [TPM2_RC_MGF]=0x88
-  [TPM2_RC_MODE]=0x89
-  [TPM2_RC_TYPE]=0x8A
-  [TPM2_RC_HANDLE]=0x8B
-  [TPM2_RC_KDF]=0x8C
-  [TPM2_RC_RANGE]=0x8D
-  [TPM2_RC_AUTH_FAIL]=0x8E
-  [TPM2_RC_NONCE]=0x8F
-  [TPM2_RC_PP]=0x90
-  [TPM2_RC_SCHEME]=0x92
-  [TPM2_RC_SIZE]=0x95
-  [TPM2_RC_SYMMETRIC]=0x96
-  [TPM2_RC_TAG]=0x97
-  [TPM2_RC_SELECTOR]=0x98
-  [TPM2_RC_INSUFFICIENT]=0x9A
-  [TPM2_RC_SIGNATURE]=0x9B
-  [TPM2_RC_KEY]=0x9C
-  [TPM2_RC_POLICY_FAIL]=0x9D
-  [TPM2_RC_INTEGRITY]=0x9F
-  [TPM2_RC_TICKET]=0xA0
-  [TPM2_RC_RESERVED_BITS]=0xA1
-  [TPM2_RC_BAD_AUTH]=0xA2
-  [TPM2_RC_EXPIRED]=0xA3
-  [TPM2_RC_POLICY_CC]=0xA4
-  [TPM2_RC_BINDING]=0xA5
-  [TPM2_RC_CURVE]=0xA6
-  [TPM2_RC_ECC_POINT]=0xA7
-  [TPM2_RC_CONTEXT_GAP]=0x901
-  [TPM2_RC_OBJECT_MEMORY]=0x902
-  [TPM2_RC_SESSION_MEMORY]=0x903
-  [TPM2_RC_MEMORY]=0x904
-  [TPM2_RC_SESSION_HANDLES]=0x905
-  [TPM2_RC_OBJECT_HANDLES]=0x906
-  [TPM2_RC_LOCALITY]=0x907
-  [TPM2_RC_YIELDED]=0x908
-  [TPM2_RC_CANCELED]=0x909
-  [TPM2_RC_TESTING]=0x90A
-  [TPM2_RC_REFERENCE_H0]=0x910
-  [TPM2_RC_REFERENCE_H1]=0x911
-  [TPM2_RC_REFERENCE_H2]=0x912
-  [TPM2_RC_REFERENCE_H3]=0x913
-  [TPM2_RC_REFERENCE_H4]=0x914
-  [TPM2_RC_REFERENCE_H5]=0x915
-  [TPM2_RC_REFERENCE_H6]=0x916
-  [TPM2_RC_REFERENCE_S0]=0x918
-  [TPM2_RC_REFERENCE_S1]=0x919
-  [TPM2_RC_REFERENCE_S2]=0x91A
-  [TPM2_RC_REFERENCE_S3]=0x91B
-  [TPM2_RC_REFERENCE_S4]=0x91C
-  [TPM2_RC_REFERENCE_S5]=0x91D
-  [TPM2_RC_REFERENCE_S6]=0x91E
-  [TPM2_RC_NV_RATE]=0x920
-  [TPM2_RC_LOCKOUT]=0x921
-  [TPM2_RC_RETRY]=0x922
-  [TPM2_RC_NV_UNAVAILABLE]=0x923
-  [TPM2_RC_NOT_USED]=0x97F
 
-  [INVALID_1ST_PARAM]=0x1c4
-)
+if [ ! -f /usr/local/include/tss2/tss2_tpm2_types.h ]; then
+    echo "Expected TSS2 headers to be installed in /usr/local/include"
+    exit 1
+fi
+
+# Populate the main TPM2_RC values
+eval $(grep -Po "^#define \K(TPM2_RC.*)" /usr/local/include/tss2/tss2_tpm2_types.h \
+          | grep -v '+' \
+          | sed "s%/*[^/]*/$%%g" \
+          | sed "s%[[:space:]]*((TPM2_RC)[[:space:]]*%=%g" \
+          | sed "s%)%%g")
+
+# Generate the TPM2_RC array based on TSS2 header
+varlist="$(sed -rn "s%^#define (TPM2_RC_[^[:space:]]*)[[:space:]]*\(\(TPM2_RC\) \((TPM2_RC[^\)]*)[^/]*/\* ([^\*]*) \*/%\1=\$\(\(\2\)\):\3%p" /usr/local/include/tss2/tss2_tpm2_types.h)"
+while IFS='=' read key value; do
+    codes[${key}]="${value}"
+done <<< "${varlist}"
+
+fail=0
 
 for key in "${!codes[@]}"; do
-  value=${codes[$key]}
-  tpm2_rc_decode $value &>/dev/null
-done;
+    value="$(printf '0x%03x' "$(eval echo ${codes[$key]%%:*})")"
+    expected_msg="${codes[$key]##*:}"
+    received_msg="$(tpm2_rc_decode ${value} | cut -d':' -f3)"
+    
+    if ! grep -iq "${received_msg# }" <<< "${expected_msg}"; then  
+        echo "$value raised an invalid error message"
+        echo "      - Expected : ${expected_msg}"
+        echo "      - Seen     : ${received_msg# }"
+        fail=1
+    fi
+done
 
 #
 # Negative tests
-# clear the ERR trap before continuing.
 #
-trap - ERR
-cmd="tpm2_rc_decode 0x6666329840938498293849238 &>/dev/null"
-eval "$cmd"
-if [ $? -eq 0 ]; then
-  echo "Expected \"$cmd\" to fail."
-  exit 1
+if tpm2_rc_decode 0x6666329840938498293849238 &>/dev/null; then
+    echo "Expected \"$cmd\" to fail."
+    fail=1
+else
+    true
 fi
 
-exit 0
+exit "$fail"


### PR DESCRIPTION
Fixes #1399 

I also modified the `rc_decode` test to check output messages.

I based my checks on comments from TSS2 header. The main advantage of that is the test is more comprehensive but IMO not the best solution. 

As the ticket showed that errors can be introduced at this level, as strings from header and internal `tpm2_error` structures are pretty close and no header nor file exist in `tpm2-tools` to provide reliable mapping between values and error strings i assumed this was correct for now.