### PR TITLE
Fix test incrementalselftest.sh

### DIFF
--- a/test/integration/tests/incrementalselftest.sh
+++ b/test/integration/tests/incrementalselftest.sh
@@ -49,7 +49,7 @@ cleanup "no-shut-down"
 temp=$(mktemp)
 tpm2_incrementalselftest > "${temp}"
 cat ${temp}
-alglist="$(yaml_get_kv "${temp}" \"remaining\")"
+alglist="$(yaml_get_kv "${temp}" \"remaining\" || true)"
 rm -f "${temp}"
 
 # If the list of remaining algs is not empty, we can test
@@ -87,16 +87,16 @@ else
     rsamethods="$(populate_algs "details['signing'] and not details['hash'] and \"ec\" not in alg")"
 
     # Check testing of AES modes
-    tpm2_incrementalselftest "${aesmodes}" | grep -q "all tested"
+    tpm2_incrementalselftest ${aesmodes} | grep -q "all tested"
 
     # Check testing of Hash algorithms
-    tpm2_incrementalselftest "${hashalgs}" | grep -q "all tested"
+    tpm2_incrementalselftest ${hashalgs} | grep -q "all tested"
 
     # Check testing of ECC methods
-    tpm2_incrementalselftest "${eccmethods}" | grep -q "all tested"
+    tpm2_incrementalselftest ${eccmethods} | grep -q "all tested"
 
     # Check testing of RSA methods
-    tpm2_incrementalselftest "${rsamethods}" | grep -q "all tested"
+    tpm2_incrementalselftest ${rsamethods} | grep -q "all tested"
 fi
 
 exit 0


### PR DESCRIPTION
* If tpm2_incrementalselftest returns "all tested" status for the initial "Get the list of remaining algs to be tested", the test immediately quits with error.
* tpm2_incrementalselftest does not work with an string:
```
$ tpm2_incrementalselftest "sha1 sha256"
ERROR: Got invalid or unsupported algorithm: "sha1 sha256"
```

Signed-off-by: Dominic Grauvogl <dominicmanuel.grauvogl@infineon.com>