### PR TITLE
tpm2_getrandom: bound on max hash size

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,9 @@
 ## Changelog
 ### next
+  * tpm2_getrandom: bound input request on max hash size per spec, allow -f to override this.
   * tpm_gettestresult: new tool for getting test results.
   * tpm2_pcrallocate: new tool for changing the allocated PCRs of a TPM.
-  * tpm2_incrementalselftest: Add tool to test support of specific algorithms. 
+  * tpm2_incrementalselftest: Add tool to test support of specific algorithms.
   * tpm2_verifysignature: Fix -G option to -g
   * tpm2_sign: Fix -G option to -g
   * tpm2_hash: Fix -G option to -g

--- a/man/tpm2_getrandom.1.md
+++ b/man/tpm2_getrandom.1.md
@@ -10,6 +10,11 @@
 
 **tpm2_getrandom** [*OPTIONS*] _SIZE_
 
+Will return _SIZE_ number of random bytes from the TPM. Note that the TPM specification
+recommends that TPM's fix the number of available entry to the maximum size of a hash
+algorithm output in bytes. Most TPMs do this, and thus the tool verifies that input size
+is bounded by property _TPM2_PT_MAX_DIGEST_ and issues an error if it is too large.
+
 # DESCRIPTION
 
 **tpm2_getrandom**(1) - Returns the next _SIZE_ octets from the random number
@@ -20,6 +25,11 @@ generator. The _SIZE_ parameter is expected as the only argument to the tool.
   * **-o**, **--out-file**=_FILE_
     specifies the filename to output the raw bytes to. Defaults to stdout as a hex
     string.
+
+  * **-f**, **--force**
+    Override checking that the:
+    - Requested size is within the hash size limit of the TPM.
+    - Number of retrieved random bytes matches requested amount.
 
 [common options](common/options.md)
 

--- a/test/integration/tests/getrandom.sh
+++ b/test/integration/tests/getrandom.sh
@@ -54,4 +54,14 @@ tpm2_getrandom 4 > random.out
 
 yaml_verify random.out
 
+# negative tests
+trap - ERR
+
+# larger than any known hash size should fail
+tpm2_getrandom 2000 &> /dev/null
+if [ $? -eq 0 ]; then
+    echo "tpm2_getrandom should fail with too big of request"
+    exit 1
+fi
+
 exit 0

--- a/tools/tpm2_getrandom.c
+++ b/tools/tpm2_getrandom.c
@@ -29,6 +29,7 @@
 // THE POSSIBILITY OF SUCH DAMAGE.
 //**********************************************************************;
 
+#include <inttypes.h>
 #include <stdbool.h>
 #include <stdlib.h>
 #include <stdio.h>
@@ -40,6 +41,7 @@
 #include "tpm2_options.h"
 #include "log.h"
 #include "files.h"
+#include "tpm2_capability.h"
 #include "tpm2_tool.h"
 #include "tpm2_util.h"
 
@@ -48,6 +50,7 @@ struct tpm_random_ctx {
     bool output_file_specified;
     char *output_file;
     UINT16 num_of_bytes;
+    bool force;
 };
 
 static tpm_random_ctx ctx;
@@ -61,6 +64,15 @@ static bool get_random_and_save(ESYS_CONTEXT *ectx) {
                                   ctx.num_of_bytes, &random_bytes);
     if (rval != TPM2_RC_SUCCESS) {
         LOG_PERR(Esys_GetRandom, rval);
+        return false;
+    }
+
+    /* ensure we got the expected number of bytes unless force is set */
+    if (!ctx.force && random_bytes->size != ctx.num_of_bytes) {
+        LOG_ERR("Got %"PRIu16" bytes, expected: %"PRIu16"\n"
+                "Lower your requested amount or"
+                " use --force to override this behavior", random_bytes->size,
+                ctx.num_of_bytes);
         return false;
     }
 
@@ -90,10 +102,45 @@ static bool on_option(char key, char *value) {
 
     UNUSED(key);
 
-    ctx.output_file_specified = true;
-    ctx.output_file = value;
+    switch (key) {
+    case 'f':
+        ctx.force = true;
+        break;
+    case 'o':
+        ctx.output_file_specified = true;
+        ctx.output_file = value;
+        break;
+        /* no default */
+    }
 
     return true;
+}
+
+static bool get_max_random(ESYS_CONTEXT *ectx, UINT32 *value) {
+
+    TPMS_CAPABILITY_DATA *cap_data = NULL;
+    bool res = tpm2_capability_get (ectx,
+            TPM2_CAP_TPM_PROPERTIES,
+            TPM2_PT_FIXED,
+            TPM2_MAX_TPM_PROPERTIES,
+            &cap_data);
+    if (!res) {
+        return false;
+    }
+
+    UINT32 i;
+    for (i=0; i < cap_data->data.tpmProperties.count; i++) {
+        TPMS_TAGGED_PROPERTY *p = &cap_data->data.tpmProperties.tpmProperty[i];
+        if (p->property == TPM2_PT_MAX_DIGEST) {
+            *value = p->value;
+            free(cap_data);
+            return true;
+        }
+    }
+
+    LOG_ERR("TPM does not have property TPM2_PT_MAX_DIGEST");
+    free(cap_data);
+    return false;
 }
 
 static bool on_args(int argc, char **argv) {
@@ -117,9 +164,10 @@ bool tpm2_tool_onstart(tpm2_options **opts) {
 
     const struct option topts[] = {
         { "out-file",   required_argument, NULL, 'o' },
+        { "force",      required_argument, NULL, 'f' },
     };
 
-    *opts = tpm2_options_new("o:", ARRAY_LEN(topts), topts, on_option, on_args,
+    *opts = tpm2_options_new("o:f", ARRAY_LEN(topts), topts, on_option, on_args,
                              0);
 
     return *opts != NULL;
@@ -128,6 +176,31 @@ bool tpm2_tool_onstart(tpm2_options **opts) {
 int tpm2_tool_onrun(ESYS_CONTEXT *ectx, tpm2_option_flags flags) {
 
     UNUSED(flags);
+
+    /*
+     * Error if bytes requested is bigger than max hash size, which is what TPMs
+     * should bound their requests by and always have available per the spec.
+     *
+     * Per 16.1 of:
+     *  - https://trustedcomputinggroup.org/wp-content/uploads/TPM-Rev-2.0-Part-3-Commands-01.38.pdf
+     *
+     *  Allow the force flag to override this behavior.
+     */
+    if (!ctx.force) {
+        UINT32 max = 0;
+        bool res = get_max_random(ectx, &max);
+        if (!res) {
+            return 1;
+        }
+
+        if (ctx.num_of_bytes > max) {
+            LOG_ERR ("TPM getrandom is bounded by max hash size, which is: "
+                    "%"PRIu32"\n"
+                    "Please lower your request (preferred) and try again or"
+                    " use --force (advanced)", max);
+            return 1;
+        }
+    }
 
     return get_random_and_save(ectx) != true;
 }


### PR DESCRIPTION
Per 16.1 of:
  - https://trustedcomputinggroup.org/wp-content/uploads/TPM-Rev-2.0-Part-3-Commands-01.38.pdf

It is recommended that TPMs bound entropy available to max hash size in
bytes and always make that available. TPMs do not issue an error when
size requested comes up short. Thus add checks for these two conditions
and allow a --force flag to override this behavior. Document and test.

$ tpm2_getrandom 2000
ERROR: TPM getrandom is bounded by max hash size, which is: 48
Please lower your request (preferred) and try again or use --force (advanced)
ERROR: Unable to run ./tools/tpm2_getrandom
echo $?
1

Fixes: #1405

Signed-off-by: William Roberts <william.c.roberts@intel.com>