### PR TITLE
test/integration: don't hardcode header file location

### DIFF
--- a/test/integration/tests/rc_decode.sh
+++ b/test/integration/tests/rc_decode.sh
@@ -49,20 +49,28 @@ trap - EXIT
 #
 declare -A codes
 
-if [ ! -f /usr/local/include/tss2/tss2_tpm2_types.h ]; then
-    echo "Expected TSS2 headers to be installed in /usr/local/include"
+tss2_tpm2_types=''
+for dir in "$(pkg-config --variable includedir tss2-esys)" /usr/local/include /usr/include; do
+    if [ -f "$dir/tss2/tss2_tpm2_types.h" ]; then
+        tss2_tpm2_types="$dir/tss2/tss2_tpm2_types.h"
+        break
+    fi
+done
+
+if [ -z "$tss2_tpm2_types" ]; then
+    echo "Could not find TSS2 headers"
     exit 1
 fi
 
 # Populate the main TPM2_RC values
-eval $(grep -Po "^#define \K(TPM2_RC.*)" /usr/local/include/tss2/tss2_tpm2_types.h \
+eval $(grep -Po "^#define \K(TPM2_RC.*)" "$tss2_tpm2_types" \
           | grep -v '+' \
           | sed "s%/*[^/]*/$%%g" \
           | sed "s%[[:space:]]*((TPM2_RC)[[:space:]]*%=%g" \
           | sed "s%)%%g")
 
 # Generate the TPM2_RC array based on TSS2 header
-varlist="$(sed -rn "s%^#define (TPM2_RC_[^[:space:]]*)[[:space:]]*\(\(TPM2_RC\) \((TPM2_RC[^\)]*)[^/]*/\* ([^\*]*) \*/%\1=\$\(\(\2\)\):\3%p" /usr/local/include/tss2/tss2_tpm2_types.h)"
+varlist="$(sed -rn "s%^#define (TPM2_RC_[^[:space:]]*)[[:space:]]*\(\(TPM2_RC\) \((TPM2_RC[^\)]*)[^/]*/\* ([^\*]*) \*/%\1=\$\(\(\2\)\):\3%p" "$tss2_tpm2_types")"
 while IFS='=' read key value; do
     codes[${key}]="${value}"
 done <<< "${varlist}"


### PR DESCRIPTION
The header file location depends on the way tpm2-tss is installed, see https://github.com/tpm2-software/tpm2-tools/pull/1401#discussion_r273539639. Attempt to determine the file location using pkg-config (pending https://github.com/tpm2-software/tpm2-tss/pull/1372), falling back to the default locations `/usr/include` and `/usr/local/include`.