### PR TITLE
scripts/utils: Add pcr_allocate in analyze

### DIFF
--- a/scripts/utils/analyze.py
+++ b/scripts/utils/analyze.py
@@ -128,7 +128,7 @@ class ToolConflictor(object):
             {
                 "gname": "integrity",
                 "tools-in-group":
-                ["tpm2_pcrextend", "tpm2_pcrevent", "tpm2_pcrlist", "tpm2_pcrreset", "tpm2_checkquote"],
+                ["tpm2_pcrextend", "tpm2_pcrevent", "tpm2_pcrlist", "tpm2_pcrreset", "tpm2_checkquote", "tpm2_pcrallocate"],
                 "tools": [],
                 "conflict": None,
                 "ignore": set(['g', 'halg', 'f', 'format', 's', 'algs'])
@@ -209,7 +209,7 @@ class ToolConflictor(object):
                     found = True
                     break
             if not found:
-                sys.exit("Did not find group for tool: %s", tool.name)
+                sys.exit("Group not found for tool : %s" % tool.name)
 
     def process(self):
         '''Processes the tool groups and generates the conflict data'''


### PR DESCRIPTION
Also fixed an error exit issue when a tool has not
been found. Python was actually interpreting the
comma as being part of function argument splitter instead
of string expansion delimiter

Signed-off-by: sebastien le stum <lestums@gmail.com>