### PR TITLE
tpm2_sign: make context static

### DIFF
--- a/tools/tpm2_sign.c
+++ b/tools/tpm2_sign.c
@@ -80,7 +80,7 @@ struct tpm_sign_ctx {
     char *key_auth_str;
 };
 
-tpm_sign_ctx ctx = {
+static tpm_sign_ctx ctx = {
         .auth = { .session_data = TPMS_AUTH_COMMAND_INIT(TPM2_RS_PW) },
         .halg = TPM2_ALG_SHA1,
         .digest = NULL,


### PR DESCRIPTION
The sign context structure should be static as the code depends
on initialization of 0. This can cause weird sideaffects, without
it, like the validation ticket being garbage and the TPM rejecting
signatures.

Signed-off-by: William Roberts <william.c.roberts@intel.com>