### PR TITLE
test: Add shut_down for abrmd unit tests and fix port detection

### DIFF
--- a/test/integration/tests/clearlock.sh
+++ b/test/integration/tests/clearlock.sh
@@ -37,7 +37,7 @@ source helpers.sh
 cleanup() {
     tpm2_clearlock -c -p
 
-       shut_down
+    shut_down
 }
 trap cleanup EXIT
 

--- a/test/integration/tests/tcti/abrmd/extended-sessions.sh
+++ b/test/integration/tests/tcti/abrmd/extended-sessions.sh
@@ -53,25 +53,23 @@ file_session_file="session.dat"
 
 secret="12345678"
 
-onerror() {
-    echo "$BASH_COMMAND on line ${BASH_LINENO[0]} failed: $?"
-    exit 1
-}
-trap onerror ERR
-
 cleanup() {
-  rm -f $file_input_data $file_primary_key_ctx $file_unseal_key_pub \
+    rm -f $file_input_data $file_primary_key_ctx $file_unseal_key_pub \
         $file_unseal_key_priv $file_unseal_key_ctx $file_unseal_key_name \
         $file_unseal_output_data $file_pcr_value \
         $file_policy $file_session_file
 
-  tpm2_flushcontext -S $file_session_file 2>/dev/null || true
+    tpm2_flushcontext -S $file_session_file 2>/dev/null || true
+
+    if [ "${1}" != "no-shutdown" ]; then
+        shut_down
+    fi
 }
 trap cleanup EXIT
 
 start_up
 
-cleanup
+cleanup "no-shutdown"
 
 echo $secret > $file_input_data
 
@@ -123,16 +121,11 @@ test "$unsealed" == "$secret"
 tpm2_policyrestart -S $file_session_file
 
 # negative test, clear the error handler
-trap - ERR
-
-tpm2_unseal -p"session:$file_session_file" -c $file_unseal_key_ctx 2>/dev/null
-rc=$?
-
-# restore the error handler
-trap onerror ERR
-if [ $rc -eq 0 ]; then
-  echo "Expected tpm2_unseal to fail after policy reset"
-  false
+if tpm2_unseal -p"session:$file_session_file" -c $file_unseal_key_ctx 2>/dev/null; then
+    echo "Expected tpm2_unseal to fail after policy reset"
+    exit 1
+else
+    true
 fi
 
 exit 0

--- a/test/integration/tests/tcti/abrmd/policyauthorize.sh
+++ b/test/integration/tests/tcti/abrmd/policyauthorize.sh
@@ -48,25 +48,28 @@ file_verifying_key_ctx="verifying_key_ctx"
 file_policyref="policyref"
 
 cleanup() {
-  rm -f  $file_pcr_value $file_policy $file_session_file $file_private_key \
+    rm -f  $file_pcr_value $file_policy $file_session_file $file_private_key \
     $file_public_key $file_verifying_key_public $file_verifying_key_name \
     $file_verifying_key_ctx $file_policyref $file_authorized_policy_1 \
     $file_authorized_policy_2
 
-  tpm2_flushcontext -S $file_session_file 2>/dev/null || true
+    tpm2_flushcontext -S $file_session_file 2>/dev/null || true
+
+    if [ "${1}" != "no-shutdown" ]; then
+        shut_down
+    fi
 }
 trap cleanup EXIT
 
 start_up
 
-cleanup
+cleanup "no-shutdown"
 
 generate_policy_authorize () {
-
-  tpm2_startauthsession -Q -S $file_session_file
-  tpm2_policyauthorize -Q -S $file_session_file  -o $3 -f $1 -q $2 -n $4
-  tpm2_flushcontext -S $file_session_file
-  rm $file_session_file
+    tpm2_startauthsession -Q -S $file_session_file
+    tpm2_policyauthorize -Q -S $file_session_file  -o $3 -f $1 -q $2 -n $4
+    tpm2_flushcontext -S $file_session_file
+    rm $file_session_file
 }
 
 openssl genrsa -out $file_private_key 2048 2>/dev/null

--- a/test/integration/tests/tcti/abrmd/policycommandcode.sh
+++ b/test/integration/tests/tcti/abrmd/policycommandcode.sh
@@ -47,15 +47,19 @@ file_session_data=session.dat
 secret="12345678"
 
 cleanup() {
-  rm -f  $file_primary_key_ctx $file_input_data $file_policy $file_unseal_key_pub\
+    rm -f  $file_primary_key_ctx $file_input_data $file_policy $file_unseal_key_pub\
     $file_unseal_key_priv $file_unseal_key_ctx $file_unseal_key_name\
     $file_output_data $file_session_data
+
+    if [ "${1}" != "no-shutdown" ]; then
+        shut_down
+    fi
 }
 trap cleanup EXIT
 
 start_up
 
-cleanup
+cleanup "no-shutdown"
 
 echo $secret > $file_input_data
 
@@ -81,9 +85,6 @@ tpm2_load -C $file_primary_key_ctx -u $file_unseal_key_pub \
 
 
 # Ensure unsealing passes with proper policy
-
-trap onerror ERR
-
 tpm2_startauthsession -a -S $file_session_data
 
 tpm2_policycommandcode -S $file_session_data -o $file_policy $TPM_CC_UNSEAL
@@ -96,15 +97,12 @@ rm $file_session_data
 
 cmp -s $file_output_data $file_input_data
 
-
 # Test that other operations fail
-
-trap - ERR
-
-tpm2_encryptdecrypt -i $file_input_data -o $file_output_data -c $file_unseal_key_ctx
-if [ $? != 1 ]; then
-  echo "tpm2_policycommandcode: Should have failed!"
-  exit 1
+if tpm2_encryptdecrypt -i $file_input_data -o $file_output_data -c $file_unseal_key_ctx; then
+    echo "tpm2_policycommandcode: Should have failed!"
+    exit 1
+else
+    true
 fi
 
 exit 0

--- a/test/integration/tests/tcti/abrmd/policyor.sh
+++ b/test/integration/tests/tcti/abrmd/policyor.sh
@@ -43,16 +43,20 @@ o_policy_digest=policy.digest
 concatenated=con.cat
 
 cleanup() {
-  rm -f $policy_1 $policy_2 $policy_init $test_vector $policyor_cc \
-  $session_ctx $policy_digest $concatenated
+    rm -f $policy_1 $policy_2 $policy_init $test_vector $policyor_cc \
+    $session_ctx $policy_digest $concatenated
 
-  tpm2_flushcontext -S $session_ctx 2>/dev/null || true
+    tpm2_flushcontext -S $session_ctx 2>/dev/null || true
+
+    if [ "${1}" != "no-shutdown" ]; then
+        shut_down
+    fi
 }
 trap cleanup EXIT
 
 start_up
 
-cleanup
+cleanup "no-shutdown"
 
 dd if=/dev/urandom of=$policy_1 bs=1 count=32
 dd if=/dev/urandom of=$policy_2 bs=1 count=32
@@ -63,7 +67,7 @@ openssl dgst -binary -sha256 $concatenated > $test_vector
 
 tpm2_startauthsession -S $session_ctx
 tpm2_policyor -o $o_policy_digest -L sha256:$policy_1,$policy_2 -S $session_ctx
-tpm2_flushcontext -S $session_ctx 
+tpm2_flushcontext -S $session_ctx
 
 diff $test_vector $o_policy_digest
 

--- a/test/integration/tests/tcti/abrmd/policypassword.sh
+++ b/test/integration/tests/tcti/abrmd/policypassword.sh
@@ -46,16 +46,20 @@ decrypted_txt=dec.txt
 testpswd=testpswd
 
 cleanup() {
-  rm -f  $policypassword $session_ctx $o_policy_digest $primary_key_ctx $key_ctx\
+    rm -f  $policypassword $session_ctx $o_policy_digest $primary_key_ctx $key_ctx\
     $key_pub $key_priv $plain_txt $encrypted_txt $decrypted_txt
 
-  tpm2_flushcontext -S $session_ctx 2>/dev/null || true
+    tpm2_flushcontext -S $session_ctx 2>/dev/null || true
+
+    if [ "${1}" != "no-shutdown" ]; then
+        shut_down
+    fi
 }
 trap cleanup EXIT
 
 start_up
 
-cleanup
+cleanup "no-shutdown"
 
 echo "plaintext" > $plain_txt
 

--- a/test/integration/tests/tcti/abrmd/policysecret.sh
+++ b/test/integration/tests/tcti/abrmd/policysecret.sh
@@ -42,38 +42,41 @@ seal_key_pub=sealing_key.pub
 seal_key_priv=sealing_key.priv
 seal_key_ctx=sealing_key.ctx
 
-
 cleanup() {
-  rm -f  $session_ctx $o_policy_digest $primary_ctx $seal_key_pub $seal_key_priv\
-   $seal_key_ctx
+    rm -f  $session_ctx $o_policy_digest $primary_ctx $seal_key_pub $seal_key_priv\
+    $seal_key_ctx
 
-  tpm2_flushcontext -S $session_ctx 2>/dev/null || true
+    tpm2_flushcontext -S $session_ctx 2>/dev/null || true
 
-  tpm2_clear
+    tpm2_clear
+
+    if [ "${1}" != "no-shutdown" ]; then
+        shut_down
+    fi
 }
 trap cleanup EXIT
 
 start_up
 
-cleanup
+cleanup "no-shutdown"
 
 tpm2_clear
 
 tpm2_changeauth -o ownerauth
 
-#Create Policy
+# Create Policy
 tpm2_startauthsession -S $session_ctx
 tpm2_policysecret -S $session_ctx -c $TPM_RH_OWNER -o $o_policy_digest ownerauth
 tpm2_flushcontext -S $session_ctx
 rm $session_ctx
 
-#Create and Load Object
+# Create and Load Object
 tpm2_createprimary -Q -a o  -o $primary_ctx -P ownerauth
 tpm2_create -Q -g sha256 -u $seal_key_pub -r $seal_key_priv -C $primary_ctx\
   -L $o_policy_digest -i- <<< $SEALED_SECRET
 tpm2_load -C $primary_ctx -u $seal_key_pub -r $seal_key_priv -o $seal_key_ctx
 
-#Satisfy policy and unseal data
+# Satisfy policy and unseal data
 tpm2_startauthsession -a -S $session_ctx
 echo -n "ownerauth" | tpm2_policysecret -S $session_ctx -c $TPM_RH_OWNER -o $o_policy_digest -
 unsealed=`tpm2_unseal -p"session:$session_ctx" -c $seal_key_ctx`


### PR DESCRIPTION
TCTI abrmd tests wasn't shutting down TPM simulator, leaving processes behind.

This could lead also to port being bound and unavailable for testing.

Unfortunately, an outdated option on 'tail' prevented to detect it correctly
on port selection. This has been also fixed while also improving processes
shutdown

Signed-off-by: sebastien le stum <lestums@gmail.com>