### PR TITLE
test/integration/helpers.sh:start_up: remove unused line

### DIFF
--- a/test/integration/helpers.sh
+++ b/test/integration/helpers.sh
@@ -291,7 +291,6 @@ function start_up() {
         echo "export TPM2TOOLS_TCTI=\"$tpm2_tcti_opts\""
         export TPM2TOOLS_TCTI="$tpm2_tcti_opts"
     elif [ -n "$TPM2_SIM" ]; then
-        export TPM2TOOLS_TCTI="socket:port=$tpm2_sim_port"
         echo "Not starting tpm2-abrmd"
         echo "Setting TCTI to use mssim"
         echo "export TPM2TOOLS_TCTI=\"mssim:port=$tpm2_sim_port\""


### PR DESCRIPTION
Only a few lines later the variable TPM2TOOLS_TCTI is set to a new value:
```diff
diff --git a/test/integration/helpers.sh b/test/integration/helpers.sh
--- a/test/integration/helpers.sh
+++ b/test/integration/helpers.sh
@@ -290,9 +290,8 @@ function start_up() {
         echo "Setting TCTI to use abrmd"
         echo "export TPM2TOOLS_TCTI=\"$tpm2_tcti_opts\""
         export TPM2TOOLS_TCTI="$tpm2_tcti_opts"
     elif [ -n "$TPM2_SIM" ]; then
-        export TPM2TOOLS_TCTI="socket:port=$tpm2_sim_port"
         echo "Not starting tpm2-abrmd"
         echo "Setting TCTI to use mssim"
         echo "export TPM2TOOLS_TCTI=\"mssim:port=$tpm2_sim_port\""
         export TPM2TOOLS_TCTI="mssim:port=$tpm2_sim_port"
```