### PR TITLE
test/integration: replace yaml.load by yaml.safe_load

### DIFF
--- a/test/integration/helpers.sh
+++ b/test/integration/helpers.sh
@@ -42,7 +42,7 @@ import yaml
 
 with open("$1") as f:
     try:
-        y = yaml.load(f)
+        y = yaml.safe_load(f)
         for alg, details in y.iteritems():
             if $2:
                 print(alg)
@@ -109,7 +109,7 @@ import yaml
 
 with open("$1") as f:
     try:
-        y = yaml.load(f)
+        y = yaml.safe_load(f)
     except yaml.YAMLError as exc:
         sys.exit(exc)
 pyscript
@@ -136,7 +136,7 @@ import yaml
 
 with open("$1") as f:
     try:
-        y = yaml.load(f)
+        y = yaml.safe_load(f)
         if $# == 3:
             print(y[$2][$third_arg])
         else:

--- a/test/integration/tests/activecredential.sh
+++ b/test/integration/tests/activecredential.sh
@@ -64,7 +64,7 @@ from __future__ import print_function
 import yaml
 
 with open('ak.out', 'r') as f:
-    doc = yaml.load(f)
+    doc = yaml.safe_load(f)
     print(doc['loaded-key']['name'])
 pyscript`
 

--- a/test/integration/tests/getcap.sh
+++ b/test/integration/tests/getcap.sh
@@ -54,7 +54,7 @@ import yaml
 
 with open("$1") as f:
     try:
-        y = yaml.load(f)
+        y = yaml.safe_load(f)
         print(' '.join(y))
     except yaml.YAMLError as exc:
         sys.exit(exc)

--- a/test/integration/tests/listpersistent.sh
+++ b/test/integration/tests/listpersistent.sh
@@ -65,7 +65,7 @@ import yaml
 
 with open("$1") as f:
     try:
-        y = yaml.load(f)
+        y = yaml.safe_load(f)
         print(len(y))
     except yaml.YAMLError as exc:
         sys.exit(exc)

--- a/test/integration/tests/print.sh
+++ b/test/integration/tests/print.sh
@@ -78,7 +78,7 @@ import re
 import yaml
 
 with open("$print_file") as fd:
-    yaml = yaml.load(fd)
+    yaml = yaml.safe_load(fd)
 
     assert(yaml["magic"] == "ff544347")
     assert(yaml["type"] == 8018)


### PR DESCRIPTION
`yaml.load` is [deprecated since PyYAML 5.1](https://msg.pyyaml.org/load) because it is unsafe, therefore it now emits a warning
```
YAMLLoadWarning: calling yaml.load() without Loader=... is deprecated, as the default Loader is unsafe. Please read https://msg.pyyaml.org/load for full details.
```
A safer alternative is `yaml.safe_load`, which is available in all PyYAML versions. It only parses a subset of YAML, but this is enough for our purposes. I successfully tested this with PyYAML 3.13 and 5.1, the latter does not emit `YAMLLoadWarning`s any more with this PR.

Fixes #1420