### PR TITLE
Bash completions refinements

### DIFF
--- a/dist/bash-completion/tpm2-tools/tpm2_completion.bash
+++ b/dist/bash-completion/tpm2-tools/tpm2_completion.bash
@@ -5,9 +5,6 @@ _tpm2_tools()
     local cur prev words cword split
     _init_completion -s || return
     local common_options=(-h --help -v --version -V --verbose -Q --quiet -Z --enable-errata -T --tcti=)
-    local aux1=$( ${COMP_WORDS[0]} -h no-man 2>/dev/null )
-    local aux2=$( echo "${aux1}" | tr "[]|" " " | awk '{if(NR>2)print}' | tr " " "\n" | sed 's/=<value>//')
-    local suggestions=("${aux2[@]}" "${common_options[@]}") #generate all the opts for the tool
     local halg=(sha1 sha256 sha384 sha512 sm3_256)
     local public_object_alg=(rsa keyedhash ecc 0x25 symcipher)
     local signing_alg=(hmac rsassa rsapss ecdsa ecdaa sm2 ecschnorr)
@@ -117,6 +114,10 @@ _tpm2_tools()
 
     esac
     $split && return
+
+    local aux1=$( ${COMP_WORDS[0]} -h no-man 2>/dev/null )
+    local aux2=$( echo "${aux1}" | tr "[]|" " " | awk '{if(NR>2)print}' | tr " " "\n" | sed 's/=<value>//')
+    local suggestions=("${aux2[@]}" "${common_options[@]}") #generate all the opts for the tool
 
     if [[ "$cur" == -* ]]; then #start completion
         # exclude the already completed options from the suggested completions

--- a/dist/bash-completion/tpm2-tools/tpm2_completion.bash
+++ b/dist/bash-completion/tpm2-tools/tpm2_completion.bash
@@ -1,14 +1,9 @@
-#!/bin/sh
-# bash completion for tmp2-tools                                 -*- shell-script -*-
-
+# bash completion for tmp2-tools                           -*- shell-script -*-
 
 _tpm2_tools()
 {
-
-
-
-    local cur prev words cword
-    _init_completion || return
+    local cur prev words cword split
+    _init_completion -s || return
     local common_options=(-h --help -v --version -V --verbose -Q --quiet -Z --enable-errata -T --tcti=)
     local aux1=$( ${COMP_WORDS[0]} -h no-man 2>/dev/null )
     local aux2=$( echo "${aux1}" | tr "[]|" " " | awk '{if(NR>2)print}' | tr " " "\n" | sed 's/=<value>//')
@@ -18,7 +13,6 @@ _tpm2_tools()
     local signing_alg=(hmac rsassa rsapss ecdsa ecdaa sm2 ecschnorr)
     local signing_schemes=(hmac rsassa rsaes rsapss oeap)
     local tcti_opts=(device: mssim: abrmd:)
-
 
     case $prev in
       -g | --halg)
@@ -49,7 +43,7 @@ _tpm2_tools()
           return;;
 
       -h | --help)
-          suggestions=( $( compgen -W 'summary manpage' -- "$cur" ) )
+          suggestions=( $( compgen -W 'man no-man' -- "$cur" ) )
           COMPREPLY=("${suggestions[@]}")
           return;;
       -T | --tcti)
@@ -122,6 +116,7 @@ _tpm2_tools()
          return;;
 
     esac
+    $split && return
 
     if [[ "$cur" == -* ]]; then #start completion
         _exclude_completed_opts
@@ -131,9 +126,7 @@ _tpm2_tools()
     fi
 
     COMPREPLY=( $( compgen -W '$( echo ${suggestions[@]} )' -- "$cur" ) )
-
-}
-
+} &&
 complete -F _tpm2_tools ${COMP_WORDS[0]##*/}
 
 #function used to exlude the already completed options from the suggested completions
@@ -148,3 +141,5 @@ _exclude_completed_opts() {
       fi
   done
 }
+
+# ex: filetype=sh

--- a/dist/bash-completion/tpm2-tools/tpm2_completion.bash
+++ b/dist/bash-completion/tpm2-tools/tpm2_completion.bash
@@ -14,55 +14,45 @@ _tpm2_tools()
     case $prev in
       -g | --halg)
           if [[ "${COMP_WORDS[0]}" != "tpm2_createek" && "${COMP_WORDS[0]}" != "tpm2_getmanufec" && "${COMP_WORDS[0]}" != "tpm2_createak" ]]; then
-            suggestions=( $( compgen -W "${halg[*]}" -- "$cur" ) )
-            COMPREPLY=("${suggestions[@]}")
+            COMPREPLY=( $(compgen -W "${halg[*]}" -- "$cur") )
           else
-            suggestions=( $( compgen -W "${public_object_alg[*]}" -- "$cur" ) )
-            COMPREPLY=("${suggestions[@]}")
+            COMPREPLY=( $(compgen -W "${public_object_alg[*]}" -- "$cur") )
           fi
           return;;
       -G | --kalg)
           if [[  "${COMP_WORDS[0]}" != "tpm2_import"  && "${COMP_WORDS[0]}" != "tpm2_quote" ]]; then
-            suggestions=( $( compgen -W "${public_object_alg[*]}" -- "$cur" ) )
-            COMPREPLY=("${suggestions[@]}")
+            COMPREPLY=( $(compgen -W "${public_object_alg[*]}" -- "$cur") )
           else
-            suggestions=( $( compgen -W "${halg[*]}" -- "$cur" ) )
-            COMPREPLY=("${suggestions[@]}")
+            COMPREPLY=( $(compgen -W "${halg[*]}" -- "$cur") )
           fi
           return;;
       -D | --digest-alg)
           if [[  "${COMP_WORDS[0]}" == "tpm2_createak" ]]; then
-            suggestions=( $( compgen -W "${halg[*]}" -- "$cur" ) )
-            COMPREPLY=("${suggestions[@]}")
+            COMPREPLY=( $(compgen -W "${halg[*]}" -- "$cur") )
           else
             _filedir
           fi
           return;;
 
       -h | --help)
-          suggestions=( $( compgen -W 'man no-man' -- "$cur" ) )
-          COMPREPLY=("${suggestions[@]}")
+          COMPREPLY=( $(compgen -W 'man no-man' -- "$cur") )
           return;;
       -T | --tcti)
-          suggestions=( $( compgen -W "${tcti_opts[*]}" -- "$cur" ) )
-          COMPREPLY=("${suggestions[@]}")
+          COMPREPLY=( $(compgen -W "${tcti_opts[*]}" -- "$cur") )
           [[ $COMPREPLY == *: ]] && compopt -o nospace
           return;;
       -f)
           if [[ "${COMP_WORDS[0]}" == "tpm2_activatecredential" || "${COMP_WORDS[0]}" == "print" ]]; then
             _filedir
           elif [[ "${COMP_WORDS[0]}" == "tpm2_quote" || "${COMP_WORDS[0]}" == "tpm2_sign" ]]; then
-            suggestions=( $( compgen -W 'plain tss' -- "$cur" ) )
-            COMPREPLY=("${suggestions[@]}")
+            COMPREPLY=( $(compgen -W 'plain tss' -- "$cur") )
           elif [[ "${COMP_WORDS[0]}" == "tpm2_verifysignature" ]]; then
-            suggestions=( $( compgen -W "${signing_schemes[*]}" -- "$cur" ) )
-            COMPREPLY=("${suggestions[@]}")
+            COMPREPLY=( $(compgen -W "${signing_schemes[*]}" -- "$cur") )
           fi
           return;;
       -s)
           if [[ "${COMP_WORDS[0]}" == "tpm2_createak" ]]; then
-            suggestions=( $( compgen -W "${signing_alg[*]}" -- "$cur" ) )
-            COMPREPLY=("${suggestions[@]}")
+            COMPREPLY=( $(compgen -W "${signing_alg[*]}" -- "$cur") )
           elif [["${COMP_WORDS[0]}" == "tpm2_verifysignature" ]];then
             _filedir
           fi
@@ -131,7 +121,7 @@ _tpm2_tools()
                 suggestions=( "${suggestions[@]/$aux}" )
             fi
         done
-        COMPREPLY=( $( compgen -W '$( echo ${suggestions[@]} )' -- "$cur" ) )
+        COMPREPLY=( $(compgen -W '$( echo ${suggestions[@]} )' -- "$cur") )
         [[ $COMPREPLY == *= ]] && compopt -o nospace
         return
     fi


### PR DESCRIPTION
* Align `dist/bash-completion/tpm2-tools/tpm2_completion.bash` to the conventions used in github.com/scop/bash-completion/completions
* Don’t leak the variable suggestions in the environment
* Handle `--tcti=<TAB>` and `-tcti<SPACE><TAB>` the same way (and all other --long-options)
* Skip calling `tpm2_… --help no-man`, when the results of the call are irrelevant
* Complete on `--help <TAB>` with "man no-man", not with "summary manpage"