### PR TITLE
MAN: Fix context parameter for tpm2_readpublic

### DIFF
--- a/man/tpm2_readpublic.1.md
+++ b/man/tpm2_readpublic.1.md
@@ -16,7 +16,7 @@
 
 # OPTIONS
 
-  * **-c**, **--context-object**=_OBJECT\_CONTEXT_:
+  * **-c**, **--context**=_OBJECT\_CONTEXT_:
 
     Context object for the object to read. Either a file or a handle number.
     See section "Context Object Format".


### PR DESCRIPTION
The tool uses --context, not --context-object.
https://github.com/tpm2-software/tpm2-tools/blob/0a326e5b5d716c4552a5b5e31dcb5f9ec52ba4fa/tools/tpm2_readpublic.c#L152
Fixed the man-page.