### PR TITLE
tpm2_import extensions

### DIFF
--- a/man/tpm2_import.1.md
+++ b/man/tpm2_import.1.md
@@ -13,7 +13,8 @@
 # DESCRIPTION
 
 **tpm2_import**(1) - Imports an external generated key as TPM managed key object.
-It requires that the parent key object be a RSA key.
+It requires that the parent key object be a RSA key. Can also import a TPM managed 
+key object created by the tpm2_duplicate tool.
 
 # OPTIONS
 
@@ -40,6 +41,8 @@ These options control the key importation process:
     Specifies the filename for the RSA2048 private key file in PEM and PKCS#1
     format. A typical file is generated with `openssl genrsa`.
 
+    When importing a duplicated object this specifies the filename of the 'duplicate' part
+
   * **-C**, **--parent-key**=_PARENT\_CONTEXT_:
 
     Specifies the context object for the parent key. Either a file or a handle number.
@@ -52,14 +55,26 @@ These options control the key importation process:
     **tpm2_readpublic**(1) tool. If not specified, the tool invokes a tpm2_readpublic on the parent
     object.
 
+  * **-k**, **sym-alg-file**=_FILE_:
+
+    Optional. Specifies the file containing the symmetric algorithm key that was used for the 
+    inner wrapper. If the file is specified the tool assumes the algorithm is AES 128 in CFB mode 
+    otherwise none.
+
   * **-r**, **--privfile**=_FILE_:
 
     Specifies the file path required to save the encrypted private portion of
     the object imported as key.
 
+    When importing a duplicated object this option specifies the file containing the 
+    private portion of the object to be imported.
+
   * **-u**, **--pubfile**=_FILE_:
 
     Specifies the file path required to save the public portion of the object imported as key
+
+    When importing a duplicated object this option specifies the file containing the 
+    public portion of the object to be imported.
 
   * **-b**, **--object-attributes**=_ATTRIBUTES_:
 
@@ -76,6 +91,14 @@ These options control the key importation process:
     The authorization value for the key, optional.
     Follows the authorization formatting of the
     "password for parent key" option: **-P**.
+
+  * **-L**, **--policy-file**=_POLICY\_FILE_:
+
+    The policy file.
+
+  * **-s**, **--seed**=_FILE_:
+
+    Specifies the file containing the encrypted seed of the duplicated object.
 
   * **--passin**=_OSSL\_PEM\_FILE\_PASSWORD_
 
@@ -120,6 +143,11 @@ tpm2_import -C parent.ctx -G rsa -i private.pem -u key.pub -r key.priv
 openssl ecparam -name prime256v1 -genkey -noout -out private.ecc.pem
 
 tpm2_import -C parent.ctx -G ecc -i private.ecc.pem -u key.pub -r key.priv
+```
+
+## Import a duplicated key
+```
+tpm2_import -C parent.ctx -i key.dup -u key.pub -r key.priv -L policy.dat
 ```
 
 # LIMITATIONS

--- a/test/integration/tests/import_tpm.sh
+++ b/test/integration/tests/import_tpm.sh
@@ -1,0 +1,141 @@
+#!/bin/bash
+
+TPM_CC_DUPLICATE=0x14B
+
+source helpers.sh
+
+cleanup() {
+rm -f primary.ctx \
+          new_parent.prv new_parent.pub new_parent.ctx \
+          ipolicy.dat dpolicy.dat session.dat \
+          key.prv key.pub key.ctx \
+          dup.prv dup.pub dup.seed \
+          key2.prv key2.pub key2.ctx \
+          sym_key_in.bin \
+          dup.ctx
+
+    if [ "$1" != "no-shut-down" ]; then
+          shut_down
+    fi
+}
+trap cleanup EXIT
+
+start_up
+
+create_policy() {
+    tpm2_startauthsession -Q -S session.dat
+    tpm2_policycommandcode -Q -S session.dat -o $1 $2
+    tpm2_flushcontext -Q -S session.dat
+    rm session.dat
+}
+
+start_session() {
+    tpm2_startauthsession -Q --policy-session -S session.dat
+    tpm2_policycommandcode -Q -S session.dat -o $1 $2
+}
+
+end_session() {
+    tpm2_flushcontext -Q -S session.dat
+    rm session.dat
+}
+
+create_load_new_parent() {
+    # Create new parent
+    tpm2_create -Q -C primary.ctx -g sha256 -G rsa -r new_parent.prv -u new_parent.pub  -b "restricted|sensitivedataorigin|decrypt|userwithauth"
+    # Load new parent key, only the public part
+    tpm2_loadexternal -Q -a o -u new_parent.pub -o new_parent.ctx
+}
+
+load_new_parent() {
+    # Load new parent key, public & private parts
+    tpm2_load -Q -C primary.ctx -r new_parent.prv -u new_parent.pub -o new_parent.ctx
+}
+
+create_load_duplicatee() {
+    # Create the key we want to duplicate
+    create_policy dpolicy.dat $TPM_CC_DUPLICATE
+    tpm2_create -Q -C primary.ctx -g sha256 -G $1 -p foo -r key.prv -u key.pub -L dpolicy.dat -b "sensitivedataorigin|decrypt|userwithauth"
+    # Load the key
+    tpm2_load -Q -C primary.ctx -r key.prv -u key.pub -o key.ctx
+    # Extract the public part for import later
+    tpm2_readpublic -Q -c key.ctx -o dup.pub
+}
+
+do_duplication() {
+    start_session dpolicy.dat $TPM_CC_DUPLICATE
+    if [ "$2" = "aes" ]
+    then
+        tpm2_duplicate -Q -C new_parent.ctx -c key.ctx -g aes -o sym.key -p "session:session.dat" -r dup.dup -s dup.seed
+    else
+        tpm2_duplicate -Q -C new_parent.ctx -c key.ctx -g null -p "session:session.dat" -r dup.dup -s dup.seed
+    fi
+    end_session
+}
+
+do_import_load() {
+    if [ "$2" = "aes" ]
+    then
+        tpm2_import -Q -C new_parent.ctx -k sym.key -u dup.pub -i dup.dup -r dup.prv -s dup.seed  -L dpolicy.dat
+    else
+        tpm2_import -Q -C new_parent.ctx -u dup.pub -i dup.dup -r dup.prv -s dup.seed  -L dpolicy.dat
+    fi
+    tpm2_load -Q -C new_parent.ctx -r dup.prv -u dup.pub -o dup.ctx
+}
+
+test() {
+    # New parent ...
+    create_load_new_parent
+    # Key to be duplicated
+    create_load_duplicatee $1
+    # Duplicate the key
+    do_duplication $2
+    # Remove, we're done with it
+    rm new_parent.ctx
+    # Load the full thing this time
+    load_new_parent
+    # Import & load the duplicate
+    do_import_load $2
+}
+
+# Part 1 : Duplicate 3 varieties of key (aes, rsa or ecc) 
+# and protect them using sym_alg null or aes, verify they
+# can be imported & loaded
+for dup_key_type in aes rsa ecc; do
+    for sym_key_type in aes null; do
+        tpm2_createprimary -Q -a o -g sha256 -G rsa -o primary.ctx
+        test $dup_key_type $sym_key_type
+        cleanup "no-shut-down"
+    done
+done
+
+# Part 2 : 
+# Create a rsa key (Kd)
+# Encrypt a message using Kd
+# Duplicate Kd
+# Import & Load Kd
+# Decrypt the message and verify
+tpm2_createprimary -Q -a o -g sha256 -G rsa -o primary.ctx
+# New parent ...
+create_load_new_parent
+# Key to be duplicated
+create_load_duplicatee rsa
+# Encrypt a secret message 
+echo "Mary had a little lamb ..." > plain.txt
+tpm2_rsaencrypt -Q -c key.ctx -o cipher.txt plain.txt
+# Duplicate the key
+do_duplication null
+# Remove, we're done with it
+rm new_parent.ctx
+# Load the full thing this time
+load_new_parent
+# Import & load the duplicate
+do_import_load null
+# Decrypt the secret message using duplicated key
+tpm2_rsadecrypt -Q -p foo -c dup.ctx -i cipher.txt -o recovered.txt
+# Check we got it right ...
+diff recovered.txt plain.txt
+# Cleanup
+rm plain.txt recovered.txt cipher.txt
+cleanup "no-shut-down"
+
+exit 0

--- a/tools/tpm2_import.c
+++ b/tools/tpm2_import.c
@@ -77,15 +77,18 @@ struct tpm_import_ctx {
         tpm2_session *session;
     } auth;
     char *input_key_file;
-    char *import_key_public_file;
-    char *import_key_private_file;
+    char *public_key_file;
+    char *private_key_file;
     char *parent_key_public_file;
     char *name_alg;
     char *attrs; /* The attributes to use */
     char *key_auth_str;
     char *parent_auth_str;
     char *auth_key_file; /* an optional auth string for the input key file for OSSL */
-
+    char *input_seed_file;
+    char *input_enc_key_file;
+    char *policy;
+    bool import_tpm; /* Any param that is exclusively used by import tpm object sets this flag */
     TPMI_ALG_PUBLIC key_type;
     const char *parent_ctx_arg;
 };
@@ -193,7 +196,8 @@ static bool do_import(ESYS_CONTEXT *ectx,
 
     TSS2_RC rval = Esys_Import(ectx, phandle,
                     shandle1, ESYS_TR_NONE, ESYS_TR_NONE,
-                    enc_sensitive_key, public, private, encrypted_seed, sym_alg,
+                    enc_sensitive_key,
+                    public, private, encrypted_seed, sym_alg,
                     imported_private);
     if (rval != TPM2_RC_SUCCESS) {
         LOG_PERR(Esys_Import, rval);
@@ -312,17 +316,29 @@ static bool on_option(char key, char *value) {
     case 'K':
         ctx.parent_key_public_file = value;
         break;
+    case 'k':
+        ctx.import_tpm = true;
+        ctx.input_enc_key_file = value;
+        break;
     case 'u':
-        ctx.import_key_public_file = value;
+        ctx.public_key_file = value;
         break;
     case 'r':
-        ctx.import_key_private_file = value;
+        ctx.private_key_file = value;
         break;
     case 'b':
         ctx.attrs = value;
         break;
     case 'g':
         ctx.name_alg = value;
+        break;
+    case 's':
+        ctx.import_tpm = true;
+        ctx.input_seed_file = value;
+        break;
+    case 'L':
+        ctx.import_tpm = true;
+        ctx.policy = value;
         break;
     case 0:
         ctx.auth_key_file = value;
@@ -348,10 +364,13 @@ bool tpm2_tool_onstart(tpm2_options **opts) {
       { "pubkey",             required_argument, NULL, 'u'},
       { "object-attributes",  required_argument, NULL, 'b'},
       { "halg",               required_argument, NULL, 'g'},
+      { "seed",               required_argument, NULL, 's'},
+      { "policy-file",        required_argument, NULL, 'L'},
+      { "sym-alg-file",       required_argument, NULL, 'k'},
       { "passin",             required_argument, NULL,  0 },
     };
 
-    *opts = tpm2_options_new("P:p:G:i:C:K:u:r:b:g:", ARRAY_LEN(topts), topts, on_option,
+    *opts = tpm2_options_new("P:p:G:i:C:K:u:r:b:g:s:L:k:", ARRAY_LEN(topts), topts, on_option,
                              NULL, 0);
 
     return *opts != NULL;
@@ -366,26 +385,53 @@ static int check_options(void) {
 
     int rc = 0;
 
+    /* Check the tpm import specific options */
+    if(ctx.import_tpm) {
+
+        if(!ctx.policy) {
+            LOG_ERR("Expected imported key policy to be specified via \"-L\","
+                    " missing option.");
+            rc = -1;
+        }
+
+        if(!ctx.input_seed_file) {
+            LOG_ERR("Expected SymSeed to be specified via \"-s\","
+                    " missing option.");
+            rc = -1;
+        }
+
+        /* If a key file is specified we choose aes else null
+        for symmetricAlgdefinition */
+        if(!ctx.input_enc_key_file) {
+            ctx.key_type = TPM2_ALG_NULL;
+        } else {
+            ctx.key_type = TPM2_ALG_AES;
+        }
+
+    } else {    /* Openssl specific option(s) */
+
+        if (!ctx.key_type) {
+            LOG_ERR("Expected key type to be specified via \"-G\","
+                    " missing option.");
+            rc = -1;
+        }
+    }
+
+    /* Common options */
     if (!ctx.input_key_file) {
         LOG_ERR("Expected to be imported key data to be specified via \"-i\","
                 " missing option.");
         rc = -1;
     }
 
-    if (!ctx.import_key_public_file) {
+    if (!ctx.public_key_file) {
         LOG_ERR("Expected output public file missing, specify \"-u\","
                 " missing option.");
         rc = -1;
     }
 
-    if (!ctx.import_key_private_file) {
+    if (!ctx.private_key_file) {
         LOG_ERR("Expected output private file missing, specify \"-r\","
-                " missing option.");
-        rc = -1;
-    }
-
-    if (!ctx.key_type) {
-        LOG_ERR("Expected key type to be specified via \"-G\","
                 " missing option.");
         rc = -1;
     }
@@ -399,22 +445,13 @@ static int check_options(void) {
     return rc;
 }
 
-int tpm2_tool_onrun(ESYS_CONTEXT *ectx, tpm2_option_flags flags) {
+static int openssl_import(ESYS_CONTEXT *ectx) {
 
-    UNUSED(flags);
-
-    int rc = 1;
     bool result;
     bool free_ppub = false;
 
     tpm2_loaded_object parent_ctx;
-
-    rc = check_options();
-    if (rc) {
-        goto out;
-    }
-
-    rc = 1;
+    int rc = 1;
 
     /*
      * Load the parent public file, or read it from the TPM if not specified.
@@ -542,12 +579,12 @@ int tpm2_tool_onrun(ESYS_CONTEXT *ectx, tpm2_option_flags flags) {
     /*
      * Save the public and imported_private structure to disk
      */
-    bool res = files_save_public(&public, ctx.import_key_public_file);
+    bool res = files_save_public(&public, ctx.public_key_file);
     if(!res) {
         goto keyout;
     }
 
-    res = files_save_private(imported_private, ctx.import_key_private_file);
+    res = files_save_private(imported_private, ctx.private_key_file);
     if (!res) {
         goto keyout;
     }
@@ -566,3 +603,138 @@ out:
     }
     return rc;
 }
+
+static bool set_key_algorithm(TPMI_ALG_PUBLIC alg, TPMT_SYM_DEF_OBJECT * obj) {
+    bool result = true;
+    switch (alg) {
+    case TPM2_ALG_AES :
+        obj->algorithm = TPM2_ALG_AES;
+        obj->keyBits.aes = 128;
+        obj->mode.aes = TPM2_ALG_CFB;
+        break;
+    case TPM2_ALG_NULL :
+        obj->algorithm = TPM2_ALG_NULL;
+        break;
+    default:
+        LOG_ERR("The algorithm type input(0x%x) is not supported!", alg);
+        result = false;
+        break;
+    }
+    return result;
+}
+
+static int tpm_import(ESYS_CONTEXT *ectx) {
+    bool result;
+    TPM2B_DATA enc_key = TPM2B_EMPTY_INIT;
+    TPM2B_PUBLIC public = TPM2B_EMPTY_INIT;
+    TPM2B_PRIVATE duplicate;
+    TPM2B_ENCRYPTED_SECRET encrypted_seed;
+    TPM2B_PRIVATE *imported_private;
+    tpm2_loaded_object parent_object_context;
+    TPMT_SYM_DEF_OBJECT sym_alg;
+
+    result = tpm2_util_object_load(ectx, ctx.parent_ctx_arg,
+                                &parent_object_context);
+    if (!result) {
+      return 1;
+    }
+
+    if (ctx.parent_auth_str) {
+        result = tpm2_auth_util_from_optarg(ectx, ctx.parent_auth_str,
+            &ctx.auth.session_data, &ctx.auth.session);
+        if (!result) {
+            LOG_ERR("Invalid parent key authorization, got\"%s\"", ctx.parent_auth_str);
+            return 1;
+        }
+    }
+
+    result = set_key_algorithm(ctx.key_type, &sym_alg);
+    if(!result) {
+        return 1;
+    }
+
+    /* Symmetric key */
+    if(ctx.input_enc_key_file) {
+        enc_key.size = 16;
+        result = files_load_bytes_from_path(ctx.input_enc_key_file, enc_key.buffer, &enc_key.size);
+        if(!result) {
+            LOG_ERR("Failed to load symmetric encryption key\"%s\"", ctx.input_enc_key_file);
+            return 1;
+        }
+        if(enc_key.size != 16) {
+            LOG_ERR("Invalid AES key size, got %u bytes, expected 16", enc_key.size);
+            return 1;
+        }
+    }
+
+    /* Private key */
+    result = files_load_private(ctx.input_key_file, &duplicate);
+    if(!result) {
+        LOG_ERR("Failed to load duplicate \"%s\"", ctx.input_key_file);
+        return 1;
+    }
+
+    /* Encrypted seed */
+    result = files_load_encrypted_seed(ctx.input_seed_file, &encrypted_seed);
+    if(!result) {
+        LOG_ERR("Failed to load encrypted seed \"%s\"", ctx.input_seed_file);
+        return 1;
+    }
+
+    /* Public key */
+    result = files_load_public(ctx.public_key_file, &public);
+    if(!result) {
+        LOG_ERR(":( Failed to load public key \"%s\"", ctx.public_key_file);
+        return 1;
+    }
+
+    public.publicArea.authPolicy.size = sizeof(public.publicArea.authPolicy.buffer);
+    result = files_load_bytes_from_path(ctx.policy,
+                public.publicArea.authPolicy.buffer, &public.publicArea.authPolicy.size);
+    if (!result) {
+        return 1;
+    }
+
+    result = do_import(
+            ectx,
+            parent_object_context.tr_handle,
+            &encrypted_seed, 
+            &enc_key,
+            &duplicate, 
+            &public,
+            &sym_alg,
+            &imported_private);
+
+    if (!result) {
+        return 1;
+    }
+
+    result = files_save_private(imported_private, ctx.private_key_file);
+    free(imported_private);
+    if (!result) {
+        LOG_ERR("Failed to save private key into file \"%s\"",
+                ctx.private_key_file);
+        return 1;
+    }
+
+
+    result = tpm2_session_save(ectx, ctx.auth.session, NULL);
+
+    return result ? 0 : 1;
+}
+
+int tpm2_tool_onrun(ESYS_CONTEXT *ectx, tpm2_option_flags flags) {
+    int rc;
+    UNUSED(flags);
+
+    rc = check_options();
+    if (rc) {
+        return 1;
+    }
+
+    if(!ctx.import_tpm) {
+        return openssl_import(ectx);
+    }
+    return tpm_import(ectx);
+}
+


### PR DESCRIPTION
This PR extends the tpm2_import tool enable it to import TPM objects created by the tpm2_duplicate tool. See the included TCs for example usage

Signed-off-by: GlovePuppet <touched.by.his.noodley.appendage@gmail.com>