### PR TITLE
[3.X] Fix Travis CI build

### DIFF
--- a/.ci/docker.run
+++ b/.ci/docker.run
@@ -52,7 +52,7 @@ sleep 5
 
 echo "starting tpm server"
 # start the tpm server
-/ibmtpm974/src/tpm_server &
+tpm_server &
 echo "tpm server started"
 
 # start tpm2-abrmd

--- a/.ci/download-deps.sh
+++ b/.ci/download-deps.sh
@@ -55,7 +55,7 @@ function get_deps() {
 	git checkout 2.0.1 -b release-2.0.1
 	echo "pwd build abrmd: `pwd`"
 	./bootstrap
-	./configure
+	./configure --with-dbuspolicydir=/etc/dbus-1/system.d
 	make -j$(nproc)
 	make install
 	popd


### PR DESCRIPTION
The new Dockerfile-based container has `tpm_sever` on the path (in `/usr/local/bin`) instead of in `/ibmtpm974/src`. This should hopefully fix the build failures observed by #1390 and #1430.