### PR TITLE
Backport tpm2_pcrreset tool to 3.X

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -87,6 +87,7 @@ bin_PROGRAMS = \
     tools/tpm2_pcrevent \
     tools/tpm2_pcrextend \
     tools/tpm2_pcrlist \
+    tools/tpm2_pcrreset \
     tools/tpm2_quote \
     tools/tpm2_rc_decode \
     tools/tpm2_readpublic \
@@ -179,6 +180,7 @@ tools_tpm2_unseal_SOURCES = tools/tpm2_unseal.c $(TOOL_SRC)
 tools_tpm2_dictionarylockout_SOURCES = tools/tpm2_dictionarylockout.c $(TOOL_SRC)
 tools_tpm2_createpolicy_SOURCES = tools/tpm2_createpolicy.c $(TOOL_SRC)
 tools_tpm2_pcrextend_SOURCES = tools/tpm2_pcrextend.c $(TOOL_SRC)
+tools_tpm2_pcrreset_SOURCES = tools/tpm2_pcrreset.c $(TOOL_SRC)
 tools_tpm2_pcrevent_SOURCES = tools/tpm2_pcrevent.c $(TOOL_SRC)
 tools_tpm2_rc_decode_SOURCES = tools/tpm2_rc_decode.c $(TOOL_SRC)
 
@@ -279,6 +281,7 @@ if HAVE_MAN_PAGES
     man/man1/tpm2_pcrevent.1 \
     man/man1/tpm2_pcrextend.1 \
     man/man1/tpm2_pcrlist.1 \
+    man/man1/tpm2_pcrreset.1 \
     man/man1/tpm2_quote.1 \
     man/man1/tpm2_rc_decode.1 \
     man/man1/tpm2_readpublic.1 \

--- a/man/tpm2_pcrreset.1.md
+++ b/man/tpm2_pcrreset.1.md
@@ -1,0 +1,58 @@
+% tpm2_pcrreset(1) tpm2-tools | General Commands Manual
+%
+% JANUARY 2019
+
+# NAME
+
+**tpm2_pcrreset**(1) - Reset one or more PCR banks
+
+# SYNOPSIS
+
+**tpm2_pcrreset** [*OPTIONS*] _PCR\_INDEX_ ...
+
+# DESCRIPTION
+
+**tpm2_pcrreset**(1) - Reset PCR value in all banks for specified index.
+More than one PCR index can be specified.
+
+The reset value is manufacturer-dependent and is either sequence of 00 or FF
+on the length of the hash algorithm for each supported bank
+
+_PCR\_INDEX_ is a space separated list of PCR indexes to be reset when issuing
+the command. 
+
+# OPTIONS
+
+This tool accepts no tool specific options.
+
+[common options](common/options.md)
+
+[common tcti options](common/tcti.md)
+
+# EXAMPLES
+
+## Reset a single PCR
+```
+tpm2_pcrreset 23
+```
+
+## Reset multiple PCRs
+```
+tpm2_pcrreset 16 23
+```
+
+# NOTES
+
+On operating system's locality (generally locality 0), only PCR 23 can be reset.
+PCR-16 can also be reset on this locality, depending on TPM manufacturers
+which could define this PCR as resettable.
+
+PCR 0 to 15 are not resettable (being part of SRTM). PCR 16 to 22 are mostly
+reserved for DRTM or dedicated to specific localities and might not
+be resettable depending on current TPM locality.
+
+# RETURNS
+
+0 on success or 1 on failure.
+
+[footer](common/footer.md)

--- a/test/system/test_tpm2_pcrreset.sh
+++ b/test/system/test_tpm2_pcrreset.sh
@@ -1,0 +1,59 @@
+#!/bin/bash
+#;**********************************************************************;
+#
+# Copyright (c) 2019, Sebastien LE STUM
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# 1. Redistributions of source code must retain the above copyright notice,
+# this list of conditions and the following disclaimer.
+#
+# 2. Redistributions in binary form must reproduce the above copyright notice,
+# this list of conditions and the following disclaimer in the documentation
+# and/or other materials provided with the distribution.
+#
+# 3. Neither the name of Intel Corporation nor the names of its contributors
+# may be used to endorse or promote products derived from this software without
+# specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+# THE POSSIBILITY OF SUCH DAMAGE.
+#;**********************************************************************;
+
+source test_helpers.sh
+
+# Reset a resettable PCR
+tpm2_pcrreset 23
+
+# Reset more than one resettable PCR
+tpm2_pcrreset 16 23
+
+# Get PCR_Reset out of bound index error
+tpm2_pcrreset 999 2>&1 1>/dev/null | grep -q "out of bound PCR"
+
+# Get PCR_Reset wrong index error
+tpm2_pcrreset toto 2>&1 1>/dev/null | grep -q "invalid PCR"
+
+# Get PCR_Reset index out of range error
+if tpm2_pcrreset 29 2>&1 1>/dev/null ; then
+    echo "tpm2_pcrreset on out of range PCR index didn't fail"
+    exit 1
+else
+    true
+fi
+
+# Get PCR_Reset bad locality error
+tpm2_pcrreset 0 2>&1 1>/dev/null | grep -q "0x907"
+
+exit 0

--- a/tools/tpm2_pcrreset.c
+++ b/tools/tpm2_pcrreset.c
@@ -1,0 +1,129 @@
+//**********************************************************************;
+// Copyright (c) 2017, Intel Corporation
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+// 1. Redistributions of source code must retain the above copyright notice,
+// this list of conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright notice,
+// this list of conditions and the following disclaimer in the documentation
+// and/or other materials provided with the distribution.
+//
+// 3. Neither the name of Intel Corporation nor the names of its contributors
+// may be used to endorse or promote products derived from this software without
+// specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+// THE POSSIBILITY OF SUCH DAMAGE.
+//**********************************************************************;
+
+#include <ctype.h>
+#include <errno.h>
+#include <stdbool.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include <tss2/tss2_sys.h>
+
+#include "log.h"
+#include "pcr.h"
+#include "tpm2_options.h"
+#include "tpm2_tool.h"
+#include "tpm2_util.h"
+
+typedef struct tpm_pcr_reset_ctx tpm_pcr_reset_ctx;
+struct tpm_pcr_reset_ctx {
+    bool            pcr_list[TPM2_MAX_PCRS];
+};
+
+static tpm_pcr_reset_ctx ctx;
+
+static bool pcr_reset_one(TSS2_SYS_CONTEXT *sapi_context, TPMI_DH_PCR pcr_index) {
+    TSS2L_SYS_AUTH_RESPONSE sessions_data_out;
+    TSS2L_SYS_AUTH_COMMAND sessions_data = { 1, {{ .sessionHandle=TPM2_RS_PW }}};
+
+    TSS2_RC rval = TSS2_RETRY_EXP(Tss2_Sys_PCR_Reset(sapi_context, pcr_index, &sessions_data,
+            &sessions_data_out));
+    if (rval != TSS2_RC_SUCCESS) {
+        LOG_ERR("Could not reset PCR index: %d", pcr_index);
+        return false;
+    }
+
+    return true;
+}
+
+static bool pcr_reset(TSS2_SYS_CONTEXT *sapi_context) {
+    size_t i;
+
+    for (i = 0; i < TPM2_MAX_PCRS; i++) {
+        if(!ctx.pcr_list[i])
+            continue;
+
+        bool result = pcr_reset_one(sapi_context, i);
+        if (!result) {
+            return false;
+        }
+    }
+
+    return true;
+}
+
+static bool on_arg(int argc, char** argv){
+    int i;
+    uint32_t pcr;
+
+    memset(ctx.pcr_list, 0, TPM2_MAX_PCRS);
+    
+    if (argc < 1) {
+        LOG_ERR("Expected at least one PCR index"
+                "ie: <pcr index>, got: 0");
+        return false;
+    }
+
+    for(i = 0; i < argc; i++){
+        if(!tpm2_util_string_to_uint32(argv[i], &pcr)){
+            LOG_ERR("Got invalid PCR Index: \"%s\"", argv[i]);
+            return false;
+        }
+
+        /*
+        * If any specified PCR index is greater than the last valid
+        * index supported in the spec, throw an error 
+        */
+        if(pcr > TPM2_MAX_PCRS - 1){
+            LOG_ERR("Got out of bound PCR Index: \"%s\"", argv[i]);
+            return false;
+        }
+
+        ctx.pcr_list[pcr] = 1;
+    }
+
+    return true;
+}
+
+bool tpm2_tool_onstart(tpm2_options **opts) {
+
+    *opts = tpm2_options_new(NULL, 0, NULL, NULL, on_arg, 0);
+
+    return *opts != NULL;
+}
+
+int tpm2_tool_onrun(TSS2_SYS_CONTEXT *sapi_context, tpm2_option_flags flags) {
+
+    UNUSED(flags);
+
+    return pcr_reset(sapi_context) != true;
+}
+


### PR DESCRIPTION
Backport the tpm2_pcrreset tool to 3.X branch (based on commit [0ef0f31775](https://github.com/tpm2-software/tpm2-tools/commit/0ef0f3177532205fa6ed8e8ecc384d7a8fb3457b))
