### PR TITLE
Set default aes key size to 128 bit

### DIFF
--- a/lib/tpm2_alg_util.c
+++ b/lib/tpm2_alg_util.c
@@ -347,16 +347,6 @@ static bool handle_rsa(const char *ext, TPM2B_PUBLIC *public) {
     TPMS_RSA_PARMS *r = &public->publicArea.parameters.rsaDetail;
     r->exponent = 0;
 
-    /*
-     * Deal with normalizing the input strings.
-     *
-     * "rsa --> maps to rsa2048:aes128cbc
-     * "rsa:aes --> maps to rsa2048:aes128cbc
-     * "rsa:null" -- maps to rsa2048:null
-     *
-     * This function is invoked with rsa removed.
-     */
-
     bool is_restricted = !!(public->publicArea.objectAttributes & TPMA_OBJECT_RESTRICTED);
 
     size_t len = strlen(ext);

--- a/lib/tpm2_alg_util.c
+++ b/lib/tpm2_alg_util.c
@@ -146,12 +146,10 @@ static bool handle_aes_raw(const char *ext, TPMT_SYM_DEF_OBJECT *s) {
 
     if (!strncmp(ext, "128", 3)) {
         s->keyBits.aes = 128;
+    } else if (!strncmp(ext, "192", 3)) {
+        s->keyBits.aes = 192;
     } else if (!strncmp(ext, "256", 3)) {
         s->keyBits.aes = 256;
-    } else if (!strncmp(ext, "384", 3)) {
-        s->keyBits.aes = 384;
-    } else if (!strncmp(ext, "512", 3)) {
-        s->keyBits.aes = 512;
     } else {
         return false;
     }

--- a/lib/tpm2_alg_util.c
+++ b/lib/tpm2_alg_util.c
@@ -141,7 +141,7 @@ static bool handle_aes_raw(const char *ext, TPMT_SYM_DEF_OBJECT *s) {
     s->algorithm = TPM2_ALG_AES;
 
     if (*ext == '\0') {
-        ext = "256";
+        ext = "128";
     }
 
     if (!strncmp(ext, "128", 3)) {

--- a/man/common/alg.md
+++ b/man/common/alg.md
@@ -65,9 +65,9 @@ general format for specifying this data:
    This portion of the complex algorithm specifier is required. The remaining scheme and symmetric details
    will default based on the type specified and the type of the object being created.
 
-  * aes - Default AES: aes128cfb
+  * aes - Default AES: aes128
   * aes128`<mode>` - 128 bit AES with optional mode (*ctr*|*ofb*|*cbc*|*cfb*|*ecb*). If mode is not
-      specified, defaults to *cfb*.
+      specified, defaults to *null*.
   * aes256`<mode>` - Same as aes128`<mode>`, except for a 256 bit key size.
   * ecc - Elliptical Curve, defaults to ecc256.
   * ecc192 - 192 bit ECC

--- a/man/common/alg.md
+++ b/man/common/alg.md
@@ -68,6 +68,7 @@ general format for specifying this data:
   * aes - Default AES: aes128
   * aes128`<mode>` - 128 bit AES with optional mode (*ctr*|*ofb*|*cbc*|*cfb*|*ecb*). If mode is not
       specified, defaults to *null*.
+  * aes192`<mode>` - Same as aes128`<mode>`, except for a 192 bit key size.
   * aes256`<mode>` - Same as aes128`<mode>`, except for a 256 bit key size.
   * ecc - Elliptical Curve, defaults to ecc256.
   * ecc192 - 192 bit ECC

--- a/man/common/object-alg.md
+++ b/man/common/object-alg.md
@@ -9,7 +9,7 @@ The AES cipher has a bitsize and a mode. When the mode is not specified, ie a
 mode is specified during object creation, only that mode is allowed in
 subsequent use cases.
 
-  * **aes** - Default AES selection. The default AES Selection is AES 256 with
+  * **aes** - Default AES selection. The default AES Selection is AES 128 with
     a NULL mode.
 
   * **aes[128|192|256]** - AES with a key size of 128, 192 and 256 respectively
@@ -40,7 +40,7 @@ on an RSA scheme, like RSAES_OAEP.
 
     * restricted object - scheme of null and a NULL symmetric algorithm.
 
-    * non-restricted object - scheme of null and an aes256cfb symmetric algorithm.
+    * non-restricted object - scheme of null and an aes128cfb symmetric algorithm.
 
   * **rsa[1024|2048]** -
     Similar to **rsa** option, but provides control over the key
@@ -49,7 +49,7 @@ on an RSA scheme, like RSAES_OAEP.
   * **rsa[1024|2048|4096]:[oaep|rsaes]** -
     Similar to **rsa[1024|2048|4096]** option, but provides the ability
     to control the scheme. The algorithms encryption options will default to:
-    aes256cfb.
+    aes128cfb.
 
   * **rsa[1024|2048]:[oaep|rsaes]:[aes]**
     Similar to **rsa[1024|2048]:[oaep|rsaes]** option, but provides
@@ -76,7 +76,7 @@ on an asymmetric encryption scheme, like RSAES_OAEP.
 
     * restricted object - scheme of null and a NULL symmetric algorithm.
 
-    * non-restricted object - scheme of null and an aes256cfb symmetric algorithm.
+    * non-restricted object - scheme of null and an aes128cfb symmetric algorithm.
 
   * **ecc[224|256|384|521]** -
     Similar to **ecc** option, but provides control over the curve
@@ -85,7 +85,7 @@ on an asymmetric encryption scheme, like RSAES_OAEP.
   * **ecc[224|256|384|521]:[oaep|rsaes]** -
     Similar to **ecc[224|256|384|521]** option, but provides the ability
     to control the scheme. The algorithms encryption options will default to:
-    aes256cfb.
+    aes128cfb.
 
   * **ecc[224|256|384|521]:[oaep|rsaes]:[aes]**
     Similar to **ecc[224|256|384|521]:[oaep|rsaes]** option, but provides

--- a/man/common/object-alg.md
+++ b/man/common/object-alg.md
@@ -42,16 +42,16 @@ on an RSA scheme, like RSAES_OAEP.
 
     * non-restricted object - scheme of null and an aes128cfb symmetric algorithm.
 
-  * **rsa[1024|2048]** -
+  * **rsa[1024|2048|4096]** -
     Similar to **rsa** option, but provides control over the key
-    size to either 1024 or 2048 respectively.
+    size to either 1024, 2048 or 4096 respectively.
 
   * **rsa[1024|2048|4096]:[oaep|rsaes]** -
     Similar to **rsa[1024|2048|4096]** option, but provides the ability
     to control the scheme. The algorithms encryption options will default to:
     aes128cfb.
 
-  * **rsa[1024|2048]:[oaep|rsaes]:[aes]**
+  * **rsa[1024|2048|4096]:[oaep|rsaes]:[aes]**
     Similar to **rsa[1024|2048]:[oaep|rsaes]** option, but provides
     full control over the aes key options. See the section **AES**
     for details of these AES strings.

--- a/man/tpm2_createprimary.1.md
+++ b/man/tpm2_createprimary.1.md
@@ -58,7 +58,7 @@ interactions with the created primary.
   * **-G**, **\--kalg**=_KEY\_ALGORITHM_:
 
     Algorithm type for generated key. If not specified, the default key
-    algorithm is RSA. See section "Supported Public Object Algorithms"
+    algorithm is rsa2048:null:aes128cfb. See section "Supported Public Object Algorithms"
     for a list of supported object algorithms.
 
   * **-o**, **\--out-context-name**=_CONTEXT\_FILE\_NAME_:

--- a/tools/tpm2_createprimary.c
+++ b/tools/tpm2_createprimary.c
@@ -55,7 +55,7 @@
     |TPMA_OBJECT_FIXEDTPM|TPMA_OBJECT_FIXEDPARENT \
     |TPMA_OBJECT_SENSITIVEDATAORIGIN|TPMA_OBJECT_USERWITHAUTH
 
-#define DEFAULT_PRIMARY_KEY_ALG "rsa2048:aes256"
+#define DEFAULT_PRIMARY_KEY_ALG "rsa2048:null:aes128cfb"
 
 typedef struct tpm_createprimary_ctx tpm_createprimary_ctx;
 struct tpm_createprimary_ctx {


### PR DESCRIPTION
Set `DEFAULT_PRIMARY_KEY_ALG` of `tpm2_createprimary` to `rsa` instead of `rsa2048:aes256`.

So default algorithm of `tpm2_createprimary` is also compliant with "TCG PC Client Platform TPM Profile (PTP)", where AES256 is still optional.

Signed-off-by: Dominic Grauvogl <dominicmanuel.grauvogl@infineon.com>