### PR TITLE
remove option: -X|--openssl-backend

### DIFF
--- a/lib/tpm2_options.c
+++ b/lib/tpm2_options.c
@@ -61,7 +61,7 @@
 
 tpm2_options *tpm2_options_new(const char *short_opts, size_t len,
         const struct option *long_opts, tpm2_option_handler on_opt,
-        tpm2_arg_handler on_arg, UINT32 flags) {
+        tpm2_arg_handler on_arg, uint32_t flags) {
 
     tpm2_options *opts = calloc(1, sizeof(*opts) + (sizeof(*long_opts) * len));
     if (!opts) {

--- a/lib/tpm2_options.h
+++ b/lib/tpm2_options.h
@@ -42,12 +42,11 @@
 typedef union tpm2_option_flags tpm2_option_flags;
 union tpm2_option_flags {
     struct {
-        UINT8 verbose : 1;
-        UINT8 quiet   : 1;
-        UINT8 enable_errata  : 1;
-        UINT8 no_tpm  : 1;
+        uint8_t verbose : 1;
+        uint8_t quiet   : 1;
+        uint8_t enable_errata  : 1;
     };
-    UINT8 all;
+    uint8_t all;
 };
 
 /**
@@ -111,7 +110,7 @@ struct tpm2_options {
     } callbacks;
     char *short_opts;
     size_t len;
-    UINT32 flags;
+    uint32_t flags;
     struct option long_opts[];
 };
 
@@ -139,7 +138,7 @@ typedef struct tpm2_options tpm2_options;
  */
 tpm2_options *tpm2_options_new(const char *short_opts, size_t len,
         const struct option *long_opts, tpm2_option_handler on_opt,
-        tpm2_arg_handler on_arg, UINT32 flags);
+        tpm2_arg_handler on_arg, uint32_t flags);
 
 /**
  * Concatenates two tpm2_options objects, with src appended on

--- a/lib/tpm2_options.h
+++ b/lib/tpm2_options.h
@@ -102,6 +102,7 @@ typedef bool (*tpm2_arg_handler)(int argc, char **argv);
  *  Skip SAPI initialization. Removes the "-T" common option.
  */
 #define TPM2_OPTIONS_NO_SAPI 0x1
+#define TPM2_OPTIONS_OPTIONAL_SAPI 0x2
 
 struct tpm2_options {
     struct {

--- a/man/common/tcti.md
+++ b/man/common/tcti.md
@@ -21,6 +21,11 @@ The current known TCTIs are:
 
   * device - Used when talking directly to a TPM device file.
 
+  * none - Do not initalize a connection with the TPM. Some tools allow for off-tpm
+           options and thus support not using a TCTI. Tools that do not support it
+           will error when attempted to be used without a TCTI connection. Does not
+           support *ANY* options and *MUST BE* presented as the exact text of "none".
+
 The arguments to either the command line option or the environment variable are
 in the form:
 

--- a/man/tpm2_activatecredential.1.md
+++ b/man/tpm2_activatecredential.1.md
@@ -70,7 +70,7 @@ tpm2_activatecredential -c 0x81010002 -C 0x81010001 -P abc123 -E abc123 -i <file
 
 tpm2_activatecredential -c ak.dat -C ek.dat -P abc123 -E abc123 -i <filePath> -o <filePath>
 
-tpm2_activatecredential -c 0x81010002 -C 0x81010001 -P 123abc -E 1a1b1c -X -i <filePath> -o <filePath>
+tpm2_activatecredential -c 0x81010002 -C 0x81010001 -P 123abc -E 1a1b1c  -i <filePath> -o <filePath>
 ```
 
 # RETURNS

--- a/man/tpm2_certify.1.md
+++ b/man/tpm2_certify.1.md
@@ -87,7 +87,7 @@ tpm2_certify -H 0x81010002 -P 0x0011 -p 0x00FF -g 0x00B -a <fileName> -s <fileNa
 
 tpm2_certify -C obj.context -c key.context -P 0x0011 -p 0x00FF -g 0x00B -a <fileName> -s <fileName>
 
-tpm2_certify -H 0x81010002 -P 0011 -p 00FF -X -g 0x00B -a <fileName> -s <fileName>
+tpm2_certify -H 0x81010002 -P 0011 -p 00FF  -g 0x00B -a <fileName> -s <fileName>
 ```
 
 # RETURNS

--- a/man/tpm2_encryptdecrypt.1.md
+++ b/man/tpm2_encryptdecrypt.1.md
@@ -73,7 +73,7 @@ specified symmetric key.
 ```
 tpm2_encryptdecrypt -C 0x81010001 -p abc123 -i <filePath> -o <filePath>
 tpm2_encryptdecrypt -C key.dat -p abc123 -i <filePath> -o <filePath>
-tpm2_encryptdecrypt -C 0x81010001 -p 123abca -X -i <filePath> -o <filePath>
+tpm2_encryptdecrypt -C 0x81010001 -p 123abca  -i <filePath> -o <filePath>
 ```
 
 # RETURNS

--- a/man/tpm2_makecredential.1.md
+++ b/man/tpm2_makecredential.1.md
@@ -15,7 +15,7 @@ TPM.
 
 **tpm2_makecredential**(1) - Use a TPM public key to protect a secret that is used
 to encrypt the AK certificate.  This can be used without a TPM by using
-the **--openssl-backend** option.
+the **none** TCTI option.
 
 # OPTIONS
 

--- a/test/integration/tests/getrandom.sh
+++ b/test/integration/tests/getrandom.sh
@@ -64,4 +64,12 @@ if [ $? -eq 0 ]; then
     exit 1
 fi
 
+# verify that tpm2_getrandom requires a TCTI
+./tools/tpm2_listpersistent -T none &> /dev/null
+if [ $? -eq 0 ]; then
+    echo "tpm2_getrandom should fail with tcti: \"none\""
+    exit 1
+fi
+
+
 exit 0

--- a/test/integration/tests/makecredential.sh
+++ b/test/integration/tests/makecredential.sh
@@ -75,6 +75,7 @@ Loadkeyname=`cat $output_ak_pub_name | xxd -p -c $file_size`
 
 tpm2_makecredential -Q -e $output_ek_pub  -s $file_input_data  -n $Loadkeyname -o $output_mkcredential
 
-tpm2_makecredential -Q -e $output_ek_pub  -s $file_input_data  -n $Loadkeyname -o $output_mkcredential --openssl-backend
+# use no tpm backend
+tpm2_makecredential -T none -Q -e $output_ek_pub  -s $file_input_data  -n $Loadkeyname -o $output_mkcredential
 
 exit 0

--- a/tools/tpm2_makecredential.c
+++ b/tools/tpm2_makecredential.c
@@ -287,7 +287,7 @@ bool tpm2_tool_onstart(tpm2_options **opts) {
     };
 
     *opts = tpm2_options_new("e:s:n:o:", ARRAY_LEN(topts), topts, on_option,
-                             NULL, 0);
+                             NULL, TPM2_OPTIONS_OPTIONAL_SAPI);
 
     return *opts != NULL;
 }
@@ -301,10 +301,11 @@ int tpm2_tool_onrun(ESYS_CONTEXT *ectx, tpm2_option_flags flags) {
         return -11;
     }
 
-    // Run it outside of a TPM
-    if (flags.no_tpm) {
-        return make_external_credential_and_save() != true;
-    }
+    printf("make credential has ESAPI CTX: %p", ectx);
 
-    return make_credential_and_save(ectx) != true;
+    // Run it outside of a TPM
+    bool result = ectx ? make_credential_and_save(ectx) :
+            make_external_credential_and_save();
+
+    return result != true;
 }


### PR DESCRIPTION
# Major fix on PR:

The -X option was introduced as a global option, which presented some
issues, notably:
1. Possible NULL pointer dereferences on tools unaware of a possible
   NULL ESAPI.
2. Globaly reserved option for many tools that don't need it.
    
To correct this, make a new ESAPI flag for optional SAPI initialization
and couple it with a new TCTI called "none". Tools that have this
optional SAPI flag set, will also support --tcti=none. Tools that don't
support the "none" tcti, will throw an error. Update the makecredential
test which was using -X and and a negative test to getrandom to make
sure the none tcti fails properly when a tool requires a SAPI.
    
Fixes: #1442

# Minor Fixes
Also, correct some other issues noticed along the way:
- man page -X in examples
- UINT32/UINT8 to uint32_t uint8_t.
