### PR TITLE
man: fixes for dashes with pandoc > 1.17.2

### DIFF
--- a/man/common/options.md
+++ b/man/common/options.md
@@ -3,7 +3,7 @@
 This collection of options are common to many programs and provide
 information that many users may expect.
 
-  * **-h**, **--help=[man|no-man]**:
+  * **-h**, **\--help=[man|no-man]**:
     Display the tools manpage. By default, it attempts to invoke the manpager for the tool,
     however, on failure will output a short tool summary. This is the same behavior if the
     "man" option argument is specified, however if explicit "man" is requested, the tool will
@@ -13,17 +13,17 @@ information that many users may expect.
     To successfully use the manpages feature requires the manpages to be installed or on
     _MANPATH_, See man(1) for more details.
 
-  * **-v**, **--version**:
+  * **-v**, **\--version**:
     Display version information for this tool, supported tctis and exit.
 
-  * **-V**, **--verbose**:
+  * **-V**, **\--verbose**:
     Increase the information that the tool prints to the console during its
     execution. When using this option the file and line number are printed.
 
-  * **-Q**, **--quiet**:
+  * **-Q**, **\--quiet**:
     Silence normal tool output to stdout.
 
-  * **-Z**, **--enable-errata**:
+  * **-Z**, **\--enable-errata**:
     Enable the application of errata fixups. Useful if an errata fixup needs to be
     applied to commands sent to the TPM. Defining the environment
     TPM2TOOLS\_ENABLE\_ERRATA is equivalent.

--- a/man/common/pubkey.md
+++ b/man/common/pubkey.md
@@ -1,4 +1,4 @@
-  * **-f**, **--format**:
+  * **-f**, **\--format**:
 
     Format selection for the public key output file. 'tss' (the default) will
     output a binary blob according to the TPM 2.0 Specification. 'pem' will

--- a/man/common/tcti.md
+++ b/man/common/tcti.md
@@ -6,7 +6,7 @@ mediums.
 
 To control the TCTI, the tools respect:
 
-  1. The command line option **-T** or **--tcti**
+  1. The command line option **-T** or **\--tcti**
   2. The environment variable: _TPM2TOOLS\_TCTI_.
 
 **Note:** The command line option always overrides the environment variable.
@@ -86,14 +86,14 @@ available:
       ```bus_name=com.example.FooBar```:
 
       ```
-      --tcti=tabrmd:bus_name=com.example.FooBar
+      \--tcti=tabrmd:bus_name=com.example.FooBar
       ```
 
       Specify the default (abrmd) tcti and a config string of
       ```bus_type=session```:
 
       ```
-      --tcti:bus_type=session
+      \--tcti:bus_type=session
       ```
 
       **NOTE**: abrmd and tabrmd are synonymous.

--- a/man/tpm2_activatecredential.1.md
+++ b/man/tpm2_activatecredential.1.md
@@ -22,36 +22,36 @@ TCG profile compliant EK as the key handle.
 
 These options control the object verification:
 
-  * **-c**, **--context**=_OBJ\_CTX\_OR\_HANDLE_:
+  * **-c**, **\--context**=_OBJ\_CTX\_OR\_HANDLE_:
 
     _CONTEXT\_OBJECT_ of the content object associated with the created
     certificate by CA.
     Either a file or a handle number. See section "Context Object Format".
 
-  * **-C**, **--key-context**=_KEY\_CONTEXT\_OBJECT_:
+  * **-C**, **\--key-context**=_KEY\_CONTEXT\_OBJECT_:
 
     The _KEY\_CONTEXT\_OBJECT_ of the loaded key used to decrypt the random seed.
     Either a file or a handle number. See section "Context Object Format".
 
-  * **-P**, **--auth-key**=_AUTH\_VALUE_:
+  * **-P**, **\--auth-key**=_AUTH\_VALUE_:
 
     Use _AUTH\_VALUE_ for providing an authorization value for the
     _KEY\_CONTEXT\_OBJECT_.
     Passwords should follow the "authorization formatting standards", see
     section "Authorization Formatting".
 
-  * **-E**, **--auth-endorse**=_ENDORSE\_PASSWORD_:
+  * **-E**, **\--auth-endorse**=_ENDORSE\_PASSWORD_:
 
     The endorsement authorization value, optional. Follows the same formatting
     guidelines as the key authorization option **-P**.
 
-  * **-i**, **--in-file**=_INPUT\_FILE_:
+  * **-i**, **\--in-file**=_INPUT\_FILE_:
 
     Input file path, containing the two structures needed by
     **tpm2_activatecredential**(1) function. This is created via the
     **tpm2_makecredential**(1) command.
 
-  * **-o**, **--out-file**=_OUTPUT\_FILE_:
+  * **-o**, **\--out-file**=_OUTPUT\_FILE_:
 
     Output file path, record the secret to decrypt the certificate.
 

--- a/man/tpm2_certify.1.md
+++ b/man/tpm2_certify.1.md
@@ -26,24 +26,24 @@ An object that only has its public area loaded cannot be certified.
 
 These options control the certification:
 
-  * **-C**, **--obj-context**=_CONTEXT\_OBJECT_:
+  * **-C**, **\--obj-context**=_CONTEXT\_OBJECT_:
 
     Context object for the object to be certified. Either a file or a handle number.
     See section "Context Object Format".
 
-  * **-c**, **--key-context**=_KEY\_CONTEXT_:
+  * **-c**, **\--key-context**=_KEY\_CONTEXT_:
 
     Context object for the key used to sign the attestation structure.
     See section "Context Object Format".
 
-  * **-P**, **--auth-object**=_OBJECT\_AUTH_:
+  * **-P**, **\--auth-object**=_OBJECT\_AUTH_:
 
     Use _OBJECT\_AUTH_ for providing an authorization value for the object specified
     in _CONTEXT\_OBJECT_.
     Authorization values should follow the "authorization formatting standards",
     see section "Authorization Formatting".
 
-  * **-g**, **--halg**=_HASH\_ALGORITHM_:
+  * **-g**, **\--halg**=_HASH\_ALGORITHM_:
 
     The hash algorithm to use.
     Algorithms should follow the "formatting standards", see section
@@ -51,22 +51,22 @@ These options control the certification:
     Also, see section "Supported Hash Algorithms" for a list of supported hash
     algorithms.
 
-  * **-p**, **--auth-key**=_KEY\_AUTH_:
+  * **-p**, **\--auth-key**=_KEY\_AUTH_:
 
     Use _KEY\_AUTH_ for providing an authorization value for the key specified
     in _KEY\_CONTEXT_.
     Follows the same formatting guidelines as the object handle authorization or
     **-P** option.
 
-  * **-o**, **--out-attest-file**=_ATTEST\_FILE_:
+  * **-o**, **\--out-attest-file**=_ATTEST\_FILE_:
 
     Output file name for the attestation data.
 
-  * **-s**, **--sig-file**=_SIG\_FILE_:
+  * **-s**, **\--sig-file**=_SIG\_FILE_:
 
     Output file name for the signature data.
 
-  * **-f**, **--format**
+  * **-f**, **\--format**
 
     Format selection for the signature output file. See section "Signature Format Specifiers".
 

--- a/man/tpm2_changeauth.1.md
+++ b/man/tpm2_changeauth.1.md
@@ -28,49 +28,49 @@ to changing auth are not invalidated.
 Passwords should follow the "password authorization formatting standards",
 see section "Authorization Formatting".
 
-  * **-w**, **--new-owner-passwd**=_OWNER\_PASSWORD_:
+  * **-w**, **\--new-owner-passwd**=_OWNER\_PASSWORD_:
 
     The new authorization value for the owner hierarchy.
 
-  * **-e**, **--new-endorsement-passwd**=_ENDORSEMENT\_PASSWORD_:
+  * **-e**, **\--new-endorsement-passwd**=_ENDORSEMENT\_PASSWORD_:
 
     The new authorization value for the endorsement hierarchy.
 
-  * **-l**, **--new-lockout-passwd**=_LOCKOUT\_PASSWORD_:
+  * **-l**, **\--new-lockout-passwd**=_LOCKOUT\_PASSWORD_:
 
     The new authorization value for the dictionary lockout.
 
-  * **-W**, **--current-owner-passwd**=_CURRENT\_OWNER\_AUTH_:
+  * **-W**, **\--current-owner-passwd**=_CURRENT\_OWNER\_AUTH_:
 
     The current authorization value for the owner hierarchy .
 
-  * **-E**, **--current-endorsement-passwd**=_CURRENT\_ENDORSEMENT\_AUTH_:
+  * **-E**, **\--current-endorsement-passwd**=_CURRENT\_ENDORSEMENT\_AUTH_:
 
     The current authorization value for the endorsement hierarchy.
 
-  * **-L**, **--current-lockout-passwd**=_CURRENT\_LOCKOUT\_AUTH_:
+  * **-L**, **\--current-lockout-passwd**=_CURRENT\_LOCKOUT\_AUTH_:
 
     The current authorization value for the dictionary lockout authority.
 
-  * **-p**, **--new-handle-passwd**=_TPM\_HANDLE\_PASSWORD_:
+  * **-p**, **\--new-handle-passwd**=_TPM\_HANDLE\_PASSWORD_:
 
     The new authorization value for the TPM handle.
 
-  * **-P**, **--current-handle-passwd**=_CURRENT\_TPM\_HANDLE\_PASSWORD_:
+  * **-P**, **\--current-handle-passwd**=_CURRENT\_TPM\_HANDLE\_PASSWORD_:
 
     The current authorization value for the TPM handle .
 
-  * **-c**, **--key-context**=_KEY\_CONTEXT\_OBJECT_:
+  * **-c**, **\--key-context**=_KEY\_CONTEXT\_OBJECT_:
 
     Name of the key context object to be used for the operation.
     Either a file or a handle number. See section "Context Object Format".
 
-  * **-C**, **--parent-context**=_PARENT\_CONTEXT\_OBJECT_:
+  * **-C**, **\--parent-context**=_PARENT\_CONTEXT\_OBJECT_:
     Name of the parent context object specified either with a file or a handle number
     (see section "Context Object Format").
-    This is the parent of the object whose auth is being modified with **--key-context** option.
+    This is the parent of the object whose auth is being modified with **\--key-context** option.
 
-  * **-r**, **--privfile**=_OUTPUT\_PRIVATE\_FILE_:
+  * **-r**, **\--privfile**=_OUTPUT\_PRIVATE\_FILE_:
     The output file which contains the new sensitive portion of the object whose auth was being changed.
 
 [common options](common/options.md)
@@ -117,7 +117,7 @@ tpm2_flushcontext -S session.ctx
 
 NVIndex=0x1500015
 tpm2_nvdefine -x $NVIndex -a o -s 32 -t "authread|authwrite" -L policy.nvchange
-tpm2_startauthsession --policy-session -S session.ctx
+tpm2_startauthsession \--policy-session -S session.ctx
 
 tpm2_policycommandcode -S session.ctx -c $TPM2_NV_ChangeAuth -o policy.nvchange
 

--- a/man/tpm2_checkquote.1.md
+++ b/man/tpm2_checkquote.1.md
@@ -18,12 +18,12 @@ provided, verify that the qualifying data and PCR values match those in the quot
 
 # OPTIONS
 
-  * **-c**, **--key-context**=_KEY\_CONTEXT\_OBJECT_:
+  * **-c**, **\--key-context**=_KEY\_CONTEXT\_OBJECT_:
 
     Context object for the key context used for the operation. Either a file
     or a handle number. See section "Context Object Format".
 
-  * **-G**, **--halg**=_HASH\_ALGORITHM_:
+  * **-G**, **\--halg**=_HASH\_ALGORITHM_:
 
     The hash algorithm used to digest the message.
     Algorithms should follow the "formatting standards", see section
@@ -31,15 +31,15 @@ provided, verify that the qualifying data and PCR values match those in the quot
     Also, see section "Supported Hash Algorithms" for a list of supported hash
     algorithms.
 
-  * **-m**, **--message**=_MSG\_FILE_:
+  * **-m**, **\--message**=_MSG\_FILE_:
 
     The quote message that makes up the data that is signed by the TPM.
 
-  * **-s**, **--sig**=_SIG\_FILE_:
+  * **-s**, **\--sig**=_SIG\_FILE_:
 
     The input signature file of the signature to be validated.
 
-  * **-f**, **--format**:
+  * **-f**, **\--format**:
 
     Set the input signature file to a specified format. The default is the TPM2.0 **TPMT_SIGNATURE**
     data format, however different schemes can be selected if the data came from an external
@@ -50,12 +50,12 @@ provided, verify that the qualifying data and PCR values match those in the quot
     Also, see section "Supported Signing Schemes" for a list of supported hash
     algorithms.
 
-  * **-p**, **--pcrs**:
+  * **-p**, **\--pcrs**:
 
     PCR output file, optional, records the list of PCR values that were included
     in the quote.
 
-  * **-q**, **--qualify-data**:
+  * **-q**, **\--qualify-data**:
 
     Data given as a hex string that was used to qualify the quote. This is typically
     used to add a nonce against replay attacks.

--- a/man/tpm2_clear.1.md
+++ b/man/tpm2_clear.1.md
@@ -17,14 +17,14 @@ values. If the lockout password option is missing, assume NULL.
 
 # OPTIONS
 
-  * **-p**, **--platform**:
+  * **-p**, **\--platform**:
 
     Specifies the tool should operate on the platform hierarchy. By default
     it operates on the lockout hierarchy.
 
     **NOTE : Operating on platform hierarchy require platform authentication.**
 
-  * **-L**, **--auth-lockout**=_LOCKOUT\_AUTH_:
+  * **-L**, **\--auth-lockout**=_LOCKOUT\_AUTH_:
 
     The lockout authorization value.
 

--- a/man/tpm2_clearlock.1.md
+++ b/man/tpm2_clearlock.1.md
@@ -18,19 +18,19 @@ is missing, assume NULL.
 
 # OPTIONS
 
-  * **-c**, **--clear**:
+  * **-c**, **\--clear**:
 
     Specifies the tool should unlock access to the clear command.
     By default it will try to disable the clear command.
 
-  * **-p**, **--platform**:
+  * **-p**, **\--platform**:
 
     Specifies the tool should operate on the platform hierarchy. By default
     it operates on the lockout hierarchy.
 
     **NOTE : Operating on platform hierarchy require platform authentication.**
 
-  * **-L**, **--auth-lockout**=_LOCKOUT\_PASSWORD_:
+  * **-L**, **\--auth-lockout**=_LOCKOUT\_PASSWORD_:
 
     The lockout authorization value.
 

--- a/man/tpm2_create.1.md
+++ b/man/tpm2_create.1.md
@@ -20,24 +20,24 @@ The object will need to be loaded before it may be used.
 
 These options for creating the TPM entity:
 
-  * **-C**, **--context-parent**=_PARENT\_CONTEXT\_OBJECT_:
+  * **-C**, **\--context-parent**=_PARENT\_CONTEXT\_OBJECT_:
 
     Context object for the created object's parent. Either a file or a handle
     number. See section "Context Object Format".
 
-  * **-P**, **--auth-parent**=_PARENT\_KEY\_AUTH_:
+  * **-P**, **\--auth-parent**=_PARENT\_KEY\_AUTH_:
 
     The authorization value for using the parent key, optional.
     Authorization values should follow the "authorization formatting standards",
     see section "Authorization Formatting".
 
-  * **-p**, **--auth-key**=_KEY\_AUTH_:
+  * **-p**, **\--auth-key**=_KEY\_AUTH_:
 
     The authorization value for the key, optional.
     Follows the authorization formatting of the
     "password for parent key" option: **-P**.
 
-  * **-g**, **--halg**=_ALGORITHM_:
+  * **-g**, **\--halg**=_ALGORITHM_:
 
     The hash algorithm for generating the objects name. This is optional
     and defaults to sha256 when not specified. Algorithms should follow the
@@ -45,7 +45,7 @@ These options for creating the TPM entity:
     Also, see section "Supported Hash Algorithms" for a list of supported
     hash algorithms.
 
-  * **-G**, **--kalg**=_KEY\_ALGORITHM_:
+  * **-G**, **\--kalg**=_KEY\_ALGORITHM_:
 
     The key algorithm associated with this object. It defaults to "rsa" if not
     specified.
@@ -53,7 +53,7 @@ These options for creating the TPM entity:
     See section "Supported Public Object Algorithms" for a list
     of supported object algorithms. Mutually exclusive of **-i**.
 
-  * **-b**, **--object-attributes**=_ATTRIBUTES_:
+  * **-b**, **\--object-attributes**=_ATTRIBUTES_:
 
     The object attributes, optional. Object attributes follow the specifications
     as outlined in "object attribute specifiers". The default for created objects is:
@@ -66,25 +66,25 @@ These options for creating the TPM entity:
     I.e. one cannot use an object for sealing and cryptography
     operations.
 
-  * **-i**, **--in-file**=_FILE_:
+  * **-i**, **\--in-file**=_FILE_:
 
     The data file to be sealed, optional. If file is -, read from stdin.
     When sealing data only the _TPM\_ALG\_KEYEDHASH_ algorithm with a NULL scheme is allowed.
     Thus, **-G** cannot be specified.
 
-  * **-L**, **--policy-file**=_POLICY\_FILE_:
+  * **-L**, **\--policy-file**=_POLICY\_FILE_:
 
     The input policy file, optional.
 
-  * **-u**, **--pubfile**=_OUTPUT\_PUBLIC\_FILE_:
+  * **-u**, **\--pubfile**=_OUTPUT\_PUBLIC\_FILE_:
 
     The output file which contains the public portion of the created object, optional.
 
-  * **-r**, **--privfile**=_OUTPUT\_PRIVATE\_FILE_:
+  * **-r**, **\--privfile**=_OUTPUT\_PRIVATE\_FILE_:
 
     The output file which contains the sensitive portion of the object, optional.
 
-  * **-o**, **--out-context**=_OUTPUT\_CONTEXT\_FILE_:
+  * **-o**, **\--out-context**=_OUTPUT\_CONTEXT\_FILE_:
 
     The output file which contains the key context, optional. The key context is analogous to the context
     file produced by **tpm2_load**(1), however is generated via a **tpm2_createloaded**(1) command. This option

--- a/man/tpm2_createak.1.md
+++ b/man/tpm2_createak.1.md
@@ -31,34 +31,34 @@ loaded-key:
 
 # OPTIONS
 
-  * **-e**, **--auth-endorse**=_ENDORSE\_AUTH_:
+  * **-e**, **\--auth-endorse**=_ENDORSE\_AUTH_:
 
     Specifies current endorsement authorization.
     Authorizations should follow the "authorization formatting standards", see section
     "Authorization Formatting".
 
-  * **-P**, **--auth-ak**=_AK\_AUTH_
+  * **-P**, **\--auth-ak**=_AK\_AUTH_
 
     Specifies the AK authorization when created.
     Same formatting as the endorse authorization value or **-e** option.
 
-  * **-w**, **--auth-owner**=_OWNER\_AUTH_
+  * **-w**, **\--auth-owner**=_OWNER\_AUTH_
 
     Specifies the current owner authorization.
     Same formatting as the endorse password value or **-e** option.
 
-  * **-C**, **--ek-context**=_EK\_CONTEXT\_OBJECT_:
+  * **-C**, **\--ek-context**=_EK\_CONTEXT\_OBJECT_:
 
     Specifies the object context of the EK. Either a file or a handle number.
     See section "Context Object Format".
 
-  * **-k**, **--ak-handle**=_AK\_HANDLE_:
+  * **-k**, **\--ak-handle**=_AK\_HANDLE_:
 
     Specifies the handle used to make AK persistent.
     If a value of **-** is passed the tool will find a vacant persistent handle
     to use and print out the automatically selected handle.
 
-  * **-c**, **--context**=_CONTEXT\_FILE\_NAME_:
+  * **-c**, **\--context**=_CONTEXT\_FILE\_NAME_:
 
     Optional, specifies a path to save the context of the AK handle. If the AK
     is not persisted to a handle (via **-k**) the tool defaults to saving a
@@ -66,14 +66,14 @@ loaded-key:
     If one saves the context file via this option and the public key via the
     **-p** option, the AK can be restored via a call to **tpm2_loadexternal**(1).
 
-  * **-G**, **--algorithm**=_ALGORITHM_:
+  * **-G**, **\--algorithm**=_ALGORITHM_:
 
     Specifies the algorithm type of AK. Supports:
     * ecc - An P256 key.
     * rsa - An RSA2048 key.
     * keyedhash - hmac key.
 
-  * **-D**, **--digest-alg**=_HASH\_ALGORITHM_:
+  * **-D**, **\--digest-alg**=_HASH\_ALGORITHM_:
 
     Like **-G**, but specifies the digest algorithm used for signing.
     Algorithms should follow the
@@ -81,25 +81,25 @@ loaded-key:
     See section "Supported Hash Algorithms" for a list of supported hash
     algorithms.
 
-  * **-s**, **--sign-alg**=_SIGN\_ALGORITHM_:
+  * **-s**, **\--sign-alg**=_SIGN\_ALGORITHM_:
 
     Like **-G** but specifies signing algorithm. Algorithms should follow the
     "formatting standards", see section "Algorithm Specifiers".
     See section "Supported Signing Algorithms" for a list of supported
     signing algorithms.
 
-  * **-p**, **--file**=_FILE_:
+  * **-p**, **\--file**=_FILE_:
 
     Specifies the file used to save the public portion of AK. This will be a
     binary data structure corresponding to the **TPM2B_PUBLIC** struct in the
     specification. One can control the output to other formats via the
-    **--format** option.
+    **\--format** option.
 
-  * **-n**, **--ak-name**=_NAME_:
+  * **-n**, **\--ak-name**=_NAME_:
 
     Specifies the file used to save the ak name, optional.
 
-  * **-r**, **--privfile**=_OUTPUT\_PRIVATE\_FILE_:
+  * **-r**, **\--privfile**=_OUTPUT\_PRIVATE\_FILE_:
 
     The output file which contains the sensitive portion of the object, optional.
     If the object is an asymmetric key-pair, then this is the private key.

--- a/man/tpm2_createek.1.md
+++ b/man/tpm2_createek.1.md
@@ -23,23 +23,23 @@ Refer to:
 
 # OPTIONS
 
-  * **-e**, **--auth-endorse**=_ENDORSE\_AUTH_:
+  * **-e**, **\--auth-endorse**=_ENDORSE\_AUTH_:
 
     Specifies current endorsement authorization.
     authorizations should follow the "authorization formatting standards", see section
     "Authorization Formatting".
 
-  * **-P**, **--auth-ek**=_EK\_AUTH_
+  * **-P**, **\--auth-ek**=_EK\_AUTH_
 
     Specifies the EK authorization when created.
     Same formatting as the endorse authorization value or **-e** option.
 
-  * **-w**, **--auth-owner**=_OWNER\_AUTH_
+  * **-w**, **\--auth-owner**=_OWNER\_AUTH_
 
     Specifies the current owner authorization.
     Same formatting as the endorse password value or **-e** option.
 
-  * **-c**, **--context**=_CONTEXT\_OBJECT_:
+  * **-c**, **\--context**=_CONTEXT\_OBJECT_:
 
     Specifies the name of a context object used to store the EK, either a path
     to save the context of the EK or a handle used to persist EK in the TPM.
@@ -51,21 +51,21 @@ Refer to:
     If one saves the context file via this option and the public key via the
     **-p** option, the EK can be restored via a call to **tpm2_loadexternal**(1).
 
-  * **-G**, **--algorithm**=_ALGORITHM_:
+  * **-G**, **\--algorithm**=_ALGORITHM_:
 
     Specifies the algorithm type of EK. Supports:
     * **ecc** - An P256 key.
     * **rsa** - An RSA2048 key.
     * **keyedhash** - hmac key.
 
-  * **-p**, **--file**=_FILE_:
+  * **-p**, **\--file**=_FILE_:
 
     Optional: specifies the file used to save the public portion of EK. This defaults
     to a binary data structure corresponding to the **TPM2B_PUBLIC** structure in the
-    specification. Using the **--format** option allows one to change this
+    specification. Using the **\--format** option allows one to change this
     behavior.
 
-  * **-t**, **--template**:
+  * **-t**, **\--template**:
 
     Optional: Uses the manufacturer defined EK Template and EK Nonce to populate
     the **TPM2B_PUBLIC** public area. See the TCG EK Credential Profile

--- a/man/tpm2_createpolicy.1.md
+++ b/man/tpm2_createpolicy.1.md
@@ -21,31 +21,31 @@ object creation and or tools using the object.
 
 These options control creating the policy authorization session:
 
-  * **-o**, **--out-policy-file**=_POLICY\_FILE_:
+  * **-o**, **\--out-policy-file**=_POLICY\_FILE_:
 
     File to save the policy digest.
 
-  * **--policy-pcr**:
+  * **\--policy-pcr**:
 
     Identifies the PCR policy type for policy creation.
 
-  * **-g**, **--policy-digest-alg**=_HASH\_ALGORITHM_:
+  * **-g**, **\--policy-digest-alg**=_HASH\_ALGORITHM_:
 
     The hash algorithm used in computation of the policy digest. Algorithms
     should follow the "formatting standards", see section "Algorithm Specifiers".
     Also, see section "Supported Hash Algorithms" for a list of supported hash
     algorithms.
 
-  * **-L**, **--set-list**=_PCR\_LIST_:
+  * **-L**, **\--set-list**=_PCR\_LIST_:
 
     The list of PCR banks and selected PCRs' ids for each bank.
 
-  * **-F**, **--pcr-input-file**=_PCR\_FILE_:
+  * **-F**, **\--pcr-input-file**=_PCR\_FILE_:
 
     Optional Path or Name of the file containing expected PCR values for the
     specified index. Default is to read the current PCRs per the set list.
 
-  * **--policy-session**:
+  * **\--policy-session**:
 
     Start a policy session of type **TPM_SE_POLICY**. Default without this option
     is **TPM_SE_TRIAL**.
@@ -64,7 +64,7 @@ These options control creating the policy authorization session:
 
 ## Create a authorization policy tied to a specific PCR index
 ```
-tpm2_createpolicy --policy-pcr -L 0x4:0 -o policy.file -F pcr0.bin
+tpm2_createpolicy \--policy-pcr -L 0x4:0 -o policy.file -F pcr0.bin
 ```
 
 # RETURNS

--- a/man/tpm2_createprimary.1.md
+++ b/man/tpm2_createprimary.1.md
@@ -22,7 +22,7 @@ interactions with the created primary.
 
 # OPTIONS
 
-  * **-a**, **--hierarchy**=_HIERARCHY_:
+  * **-a**, **\--hierarchy**=_HIERARCHY_:
 
     Specify the hierarchy under which the object is created. This will also
     dictate which authorization secret (if any) must be supplied. Defaults to
@@ -34,20 +34,20 @@ interactions with the created primary.
       * **n** for **TPM_RH_NULL**
       * **`<num>`** where a raw number can be used.
 
-  * **-P**, **--auth-hierarchy**=_HIERARCHY\_\_AUTH\_VALUE_:
+  * **-P**, **\--auth-hierarchy**=_HIERARCHY\_\_AUTH\_VALUE_:
 
     Optional authorization value when authorization is required to create object
     under the specified hierarchy given via the **-a** option. Authorization
     values should follow the "authorization formatting standards", see section
     "Authorization Formatting".
 
-  * **-p**, **--auth-object**=_OBJECT\_AUTH_:
+  * **-p**, **\--auth-object**=_OBJECT\_AUTH_:
 
     Optional authorization password for the newly created object. Password
     values should follow the "authorization formatting standards", see section
     "Authorization Formatting".
 
-  * **-g**, **--halg**=_ALGORITHM_:
+  * **-g**, **\--halg**=_ALGORITHM_:
 
     The hash algorithm to use for generating the objects name.
     If not specified, the default name algorithm is SHA256.
@@ -55,29 +55,29 @@ interactions with the created primary.
     "Algorithm Specifiers". Also, see section
     "Supported Hash Algorithms" for a list of supported hash algorithms.
 
-  * **-G**, **--kalg**=_KEY\_ALGORITHM_:
+  * **-G**, **\--kalg**=_KEY\_ALGORITHM_:
 
     Algorithm type for generated key. If not specified, the default key
     algorithm is RSA. See section "Supported Public Object Algorithms"
     for a list of supported object algorithms.
 
-  * **-o**, **--out-context-name**=_CONTEXT\_FILE\_NAME_:
+  * **-o**, **\--out-context-name**=_CONTEXT\_FILE\_NAME_:
 
     Optional file name to use for the returned object context, otherwise a
     default of _primary.ctx_ is used.
 
-  * **-L**, **--policy-file**=_POLICY\_FILE_:
+  * **-L**, **\--policy-file**=_POLICY\_FILE_:
 
     An optional file input that contains the policy digest for policy based authorization of the object.
 
-  * **-b**, **--object-attributes**=_ATTRIBUTES_:
+  * **-b**, **\--object-attributes**=_ATTRIBUTES_:
 
     The object attributes, optional. Object attributes follow the specifications
     as outlined in "object attribute specifiers". The default for created objects is:
 
     `TPMA_OBJECT_RESTRICTED|TPMA_OBJECT_DECRYPT|TPMA_OBJECT_FIXEDTPM|TPMA_OBJECT_FIXEDPARENT|TPMA_OBJECT_SENSITIVEDATAORIGIN|TPMA_OBJECT_USERWITHAUTH`
 
-  * **-u**, **--unique-data**=_UNIQUE\_FILE_:
+  * **-u**, **\--unique-data**=_UNIQUE\_FILE_:
 
     An optional file input that contains the binary bits of a **TPMU_PUBLIC_ID** union where
     numbers (such as length words) are in little-endian format. This is passed in the

--- a/man/tpm2_dictionarylockout.1.md
+++ b/man/tpm2_dictionarylockout.1.md
@@ -17,12 +17,12 @@ dictionary-attack-lockout state. If any password option is missing, assume NULL.
 
 # OPTIONS
 
-  * **-s**, **--setup-parameters**:
+  * **-s**, **\--setup-parameters**:
 
     Specifies the tool should operate to setup dictionary-attack-lockout
     parameters.
 
-  * **-c**, **--clear-lockout**:
+  * **-c**, **\--clear-lockout**:
 
     Specifies the tool should operate to clear dictionary-attack-lockout state.
 
@@ -31,18 +31,18 @@ dictionary-attack-lockout state. If any password option is missing, assume NULL.
     Specifies the wait time in seconds before another **TPM_RH_LOCKOUT**
     authentication attempt can be made after a failed authentication.
 
-  * **-t**, **--recovery-time**=_RECOVERY\_TIME_:
+  * **-t**, **\--recovery-time**=_RECOVERY\_TIME_:
 
     Specifies the wait time in seconds before another DA-protected-object
     authentication attempt can be made after max-tries number of failed
     authentications.
 
-  * **-n**, **--max-tries**=_MAX\_TRYS_:
+  * **-n**, **\--max-tries**=_MAX\_TRYS_:
 
     Specifies the maximum number of allowed authentication attempts on
     DA-protected-object; after which DA is activated.
 
-  * **-p**, **--auth-lockout**=_LOCKOUT\_AUTH_:
+  * **-p**, **\--auth-lockout**=_LOCKOUT\_AUTH_:
 
     The lockout authorization value.
 

--- a/man/tpm2_duplicate.1.md
+++ b/man/tpm2_duplicate.1.md
@@ -18,34 +18,34 @@ tpm2_duplicate(1) -  Duplicates a loaded object so that it may be used in a diff
 
 These options control the key importation process:
 
-  * **-g**, **--inner-wrapper-alg**=_ALGORITHM_:
+  * **-g**, **\--inner-wrapper-alg**=_ALGORITHM_:
 
     The symmetric algorithm to be used for the inner wrapper. Supports:
     * aes - AES 128 in CFB mode.
     * null - none
 
-  * **-i**, **--input-key-file**=_FILE_:
+  * **-i**, **\--input-key-file**=_FILE_:
 
     Specifies the filename of the symmetric key (128 bit data) to be used for the inner wrapper. Valid only when specified symmetric algorithm is not null
 
-  * **-o**, **--output-key-file**=_FILE_:
+  * **-o**, **\--output-key-file**=_FILE_:
 
-    Specifies the filename to store the symmetric key (128 bit data) that was used for the inner wrapper. Valid only when specified symmetric algorithm is not null and --input-key-file is not specified
+    Specifies the filename to store the symmetric key (128 bit data) that was used for the inner wrapper. Valid only when specified symmetric algorithm is not null and \--input-key-file is not specified
 
-  * **-C**, **--parent-key**=_PARENT\_CONTEXT_:
+  * **-C**, **\--parent-key**=_PARENT\_CONTEXT_:
 
     Specifies the context object for the parent key. Either a file, a handle number or null to select TPM2_RH_NULL.
 
-  * **-r**, **--duplicate-key-private**=_FILE_:
+  * **-r**, **\--duplicate-key-private**=_FILE_:
 
     Specifies the file path to save the private portion of the duplicated object.
 
-  * **-s**, **--output-enc-seed-file**=_FILE_:
+  * **-s**, **\--output-enc-seed-file**=_FILE_:
 
     Specifies the file path required to save the encrypted seed of the duplicated
     object.
 
-  * **-p**, **--auth-key**=_KEY\_AUTH_:
+  * **-p**, **\--auth-key**=_KEY\_AUTH_:
     The authorization value for the key, optional.
     Follows the authorization formatting of the
     "password for parent key" option: **-P**.
@@ -71,7 +71,7 @@ tpm2_create -C primary.ctxt -g sha256 -G rsa -r key.prv -u key.pub -L policy.dat
 
 tpm2_loadexternal -a o -u new_parent.pub -o new_parent.ctxt
 
-tpm2_startauthsession --policy-session -S session.dat
+tpm2_startauthsession \--policy-session -S session.dat
 tpm2_policycommandcode -S session.dat -o policy.dat 0x14B
 tpm2_duplicate -C new_parent.ctxt -c key.ctxt -G null -p "session:session.dat" -r duprv.bin -s seed.dat
 tpm2_flushcontext -S session.dat

--- a/man/tpm2_encryptdecrypt.1.md
+++ b/man/tpm2_encryptdecrypt.1.md
@@ -17,32 +17,32 @@ specified symmetric key.
 
 # OPTIONS
 
-  * **-c**, **--key-context**=_KEY\_CONTEXT\_OBJECT_:
+  * **-c**, **\--key-context**=_KEY\_CONTEXT\_OBJECT_:
 
     Name of the key context object to be used for the  operation. Either a file
     or a handle number. See section "Context Object Format".
 
-  * **-p**, **--auth-key**=_KEY\_AUTH_:
+  * **-p**, **\--auth-key**=_KEY\_AUTH_:
 
     Optional authorization value to use the key specified by **-c**.
     Authorization values should follow the "authorization formatting standards",
     see section "Authorization Formatting".
 
-  * **-D**, **--decrypt**:
+  * **-D**, **\--decrypt**:
 
     Perform a decrypt operation. Default is encryption.
 
-  * **-i**, **--in-file**=_INPUT\_FILE_:
+  * **-i**, **\--in-file**=_INPUT\_FILE_:
 
     Optional. Specifies the input file path for either the encrypted or decrypted
     data, depending on option **-D**. If not specified, defaults to **stdin**.
 
-  * **-o**, **--out-file**=_OUT\_FILE_:
+  * **-o**, **\--out-file**=_OUT\_FILE_:
 
     Optional. Specifies the output file path for either the encrypted or decrypted
     data, depending on option **-D**. If not specified, defaults to **stdout**.
 
-  * **-G**, **--mode**=_CIPHER\_MODE\_ALGORITHM_:
+  * **-G**, **\--mode**=_CIPHER\_MODE\_ALGORITHM_:
 
     The key algorithm associated with this object. It defaults to the object's
     mode or CFB if left unconfigured.
@@ -51,7 +51,7 @@ specified symmetric key.
     See section "Supported Public Object Algorithms" for a list
     of supported object algorithms.
 
-  * **-t**, **--iv**=_IV\_INPUT\_FILE_ : _IV\_OUTPUT\_FILE_:
+  * **-t**, **\--iv**=_IV\_INPUT\_FILE_ : _IV\_OUTPUT\_FILE_:
 
     Optional. The initialization vector to use. Defaults to 0's. The specification
   syntax allows for an input file and output file source to be specified. The input file

--- a/man/tpm2_evictcontrol.1.md
+++ b/man/tpm2_evictcontrol.1.md
@@ -17,7 +17,7 @@ be evicted.
 
 # OPTIONS
 
-  * **-a**, **--hierarchy**=_AUTH\_HIERARCHY\_:
+  * **-a**, **\--hierarchy**=_AUTH\_HIERARCHY\_:
 
     The authorization hierarchy used to authorize the commands. Defaults to the "owner" hierarchy.
     Supported options are:
@@ -25,7 +25,7 @@ be evicted.
       * **p** for **TPM_RH_PLATFORM**
       * **`<num>`** where a raw number can be used.
 
-  * **-c**, **--context**=_OBJECT_CONTEXT_:
+  * **-c**, **\--context**=_OBJECT_CONTEXT_:
 
     A context object specifier of a transient or persistent object.
     Either a file path of a context blob or a handle id. See section "Context Object Format".
@@ -37,11 +37,11 @@ be evicted.
     If the handle is for a persistent object, then the **-p** does not need to
     be provided since the handle must be the same for both options.
 
-  * **-p**, **--persistent**=_PERSISTENT\_HANDLE_:
+  * **-p**, **\--persistent**=_PERSISTENT\_HANDLE_:
 
     The persistent handle for the object handle specified via _HANDLE_.
 
-  * **-P**, **--auth-hierarchy**=_AUTH\_HIERARCHY_\VALUE_:
+  * **-P**, **\--auth-hierarchy**=_AUTH\_HIERARCHY_\VALUE_:
 
     Optional authorization value. Authorization values should follow the
     "authorization formatting standards", see section "Authorization Formatting".

--- a/man/tpm2_flushcontext.1.md
+++ b/man/tpm2_flushcontext.1.md
@@ -18,24 +18,24 @@ transient object, loaded session or saved session from the TPM.
 
 # OPTIONS
 
-  * **-c**, **--context**=_CONTEXT\_OBJECT_:
+  * **-c**, **\--context**=_CONTEXT\_OBJECT_:
 
     The handle or session file of an object, loaded session or saved session to be removed.
     See section "Context Object Format".
 
-  * **-t**, **--transient-object**:
+  * **-t**, **\--transient-object**:
 
     Remove all transient objects.
 
-  * **-l**, **--loaded-session**:
+  * **-l**, **\--loaded-session**:
 
     Remove all loaded sessions.
 
-  * **-s**, **--saved-session**:
+  * **-s**, **\--saved-session**:
 
     Remove all saved sessions.
 
-  * **-S**, **--session**=_SESSION\_FILE_:
+  * **-S**, **\--session**=_SESSION\_FILE_:
 
     Obtain handle to flush from a session file. A session file is generated from **tpm2_startauthsession**(1)'s **-S** option.
 
@@ -54,7 +54,7 @@ tpm2_flushcontext -c 0x80000000
 
 ## Flush all the transient objects loaded
 ```
-tpm2_flushcontext --transient-object
+tpm2_flushcontext \--transient-object
 ```
 
 ## Flush a context via a session file

--- a/man/tpm2_getcap.1.md
+++ b/man/tpm2_getcap.1.md
@@ -16,7 +16,7 @@
 
 # OPTIONS
 
-  * **-c**, **--capability**=_CAPABILITY\_NAME_:
+  * **-c**, **\--capability**=_CAPABILITY\_NAME_:
 
     The name of the capability group to query.
     Currently supported capability groups are:
@@ -60,7 +60,7 @@
     * **handles-saved-session**:
       Display handles about saved sessions.
 
-  * **-l**, **--list**:
+  * **-l**, **\--list**:
 
     List known supported capability names. These names can be
     supplied as the argument to the **-c** option. Output is in a
@@ -82,7 +82,7 @@
 
 ## To list the fixed properties of the TPM
 ```
-tpm2_getcap --capability properties-fixed
+tpm2_getcap \--capability properties-fixed
 ```
 
 ## To list the supported capability arguments to **-c**

--- a/man/tpm2_getmanufec.1.md
+++ b/man/tpm2_getmanufec.1.md
@@ -20,55 +20,55 @@ server.
 
 # OPTIONS
 
-  * **-e**, **--auth-endorse**=_ENDORSE\_AUTH_:
+  * **-e**, **\--auth-endorse**=_ENDORSE\_AUTH_:
 
     Specifies current endorsement authorization.
     Authorizations should follow the "authorization formatting standards", see
     section "Authorization Formatting".
 
-  * **-P**, **--auth-ek**=_EK\_AUTH_
+  * **-P**, **\--auth-ek**=_EK\_AUTH_
 
     Specifies the EK authorization when created.
     Same formatting as the endorse authorization value or **-e** option.
 
-  * **-w**, **--auth-owner**=_OWNER\_AUTH_
+  * **-w**, **\--auth-owner**=_OWNER\_AUTH_
 
     Specifies the current owner authorization.
     Same formatting as the endorse authorization value or **-e** option.
 
-  * **-H**, **--handle**=_HANDLE_:
+  * **-H**, **\--handle**=_HANDLE_:
 
     Specifies the handle used to make EK  persistent.
     If a value of **-** is passed the tool will find a vacant persistent handle
     to use and print out the automatically selected handle.
 
-  * **-G**, **--algorithm**=_ALGORITHM_:
+  * **-G**, **\--algorithm**=_ALGORITHM_:
 
     Specifies the algorithm type of EK.
     See section "Supported Public Object Algorithms" for a list of supported
     object algorithms. See section "Algorithm Specifiers" on how to specify
     an algorithm argument.
 
-  * **-o**, **--out-file**=_FILE_:
+  * **-o**, **\--out-file**=_FILE_:
 
     Specifies the file used to save the public portion of EK.
 
-  * **-N**, **--non-persistent**:
+  * **-N**, **\--non-persistent**:
 
     Specifies to readout the EK public without making it persistent.
 
-  * **-O**, **--offline**=_FILE_:
+  * **-O**, **\--offline**=_FILE_:
 
     Specifies the file that contains an EK retrieved from offline
     platform that needs to be provisioned.
 
-  * **-E**, **--ec-cert**=_EC\_CERT\_FILE_:
+  * **-E**, **\--ec-cert**=_EC\_CERT\_FILE_:
 
     Specifies the file used to save the Endorsement Credentials retrieved from
     the TPM manufacturer provisioning server. Defaults to stdout if not
     specified.
 
-  * **-U**, **--untrusted**:
+  * **-U**, **\--untrusted**:
 
     Specifies to attempt connecting with the TPM manufacturer provisioning server
     without verifying server certificate.

--- a/man/tpm2_getrandom.1.md
+++ b/man/tpm2_getrandom.1.md
@@ -23,12 +23,12 @@ Most TPMs do this, and thus the tool verifies that input size is bounded by prop
 
 # OPTIONS
 
-  * **-o**, **--out-file**=_FILE_
+  * **-o**, **\--out-file**=_FILE_
 
     Specifies the filename to output the raw bytes to. Defaults to stdout as a hex
     string.
 
-  * **-f**, **--force**
+  * **-f**, **\--force**
 
     Override checking that the:
     - Requested size is within the hash size limit of the TPM.

--- a/man/tpm2_hash.1.md
+++ b/man/tpm2_hash.1.md
@@ -20,7 +20,7 @@ sign.
 
 # OPTIONS
 
-  * **-a**, **--hierarchy**=_HIERARCHY_:
+  * **-a**, **\--hierarchy**=_HIERARCHY_:
 
     Hierarchy to use for the ticket. Defaults to **o**, **TPM_RH_OWNER**, when
     no value has been specified.
@@ -30,7 +30,7 @@ sign.
       * **e** for **TPM_RH_ENDORSEMENT**
       * **n** for **TPM_RH_NULL**
 
-  * **-g**, **--halg**=_HASH\_ALGORITHM_:
+  * **-g**, **\--halg**=_HASH\_ALGORITHM_:
 
     The hash algorithm to use.
     Algorithms should follow the "formatting standards", see section
@@ -38,11 +38,11 @@ sign.
     Also, see section "Supported Hash Algorithms" for a list of supported hash
     algorithms.
 
-  * **-o**, **--out-file**=_OUT\_FILE_
+  * **-o**, **\--out-file**=_OUT\_FILE_
 
     Optional file record of the hash result. Defaults to stdout in hex form.
 
-  * **-t**, **--ticket**=_TICKET\_FILE_
+  * **-t**, **\--ticket**=_TICKET\_FILE_
 
     Optional file record of the ticket result. Defaults to stdout in hex form.
 

--- a/man/tpm2_hmac.1.md
+++ b/man/tpm2_hmac.1.md
@@ -17,18 +17,18 @@ _FILE_ is not specified, then data is read from stdin.
 
 # OPTIONS
 
-  * **-C**, **--key-context**=_KEY\_CONTEXT\_OBJECT_:
+  * **-C**, **\--key-context**=_KEY\_CONTEXT\_OBJECT_:
 
     The context object of the symmetric signing key providing the HMAC key.
     Either a file or a handle number. See section "Context Object Format".
 
-  * **-P**, **--auth-key**=_KEY\_AUTH_:
+  * **-P**, **\--auth-key**=_KEY\_AUTH_:
 
     Optional authorization value to use the key specified by **-k**.
     Authorization values should follow the "authorization formatting standards",
     see section "Authorization Formatting".
 
-  * **-o**, **--out-file**=_OUT\_FILE_
+  * **-o**, **\--out-file**=_OUT\_FILE_
 
     Optional file record of the HMAC result. Defaults to stdout.
 

--- a/man/tpm2_import.1.md
+++ b/man/tpm2_import.1.md
@@ -20,14 +20,14 @@ key object created by the tpm2_duplicate tool.
 
 These options control the key importation process:
 
-  * **-G**, **--algorithm**=_ALGORITHM_:
+  * **-G**, **\--algorithm**=_ALGORITHM_:
 
     The algorithm used by the key to be imported. Supports:
     * **aes** - AES 128, 192 or 256 key.
     * **rsa** - RSA 1024 or 2048 key.
     * **ecc** - ECC NIST P192, P224, P256, P384 or P521 public and private key.
 
-  * **-g**, **--halg**=_ALGORITHM_:
+  * **-g**, **\--halg**=_ALGORITHM_:
 
     The hash algorithm for generating the objects name. This is optional
     and defaults to **sha256** when not specified. Algorithms should follow the
@@ -35,33 +35,31 @@ These options control the key importation process:
     Also, see section "Supported Hash Algorithms" for a list of supported
     hash algorithms.
 
-  * **-i**, **--infile**=_FILE_:
+  * **-i**, **\--infile**=_FILE_:
 
     Specifies the filename of symmetric key (128 bit data) to be imported. OR,
     Specifies the filename for the RSA2048 private key file in PEM and PKCS#1
     format. A typical file is generated with `openssl genrsa`.
 
-    When importing a duplicated object this specifies the filename of the 'duplicate' part
-
-  * **-C**, **--parent-key**=_PARENT\_CONTEXT_:
+  * **-C**, **\--parent-key**=_PARENT\_CONTEXT_:
 
     Specifies the context object for the parent key. Either a file or a handle number.
     See section "Context Object Format". The parent key **MUST** be an *RSA* key with an
     symmetric cipher of *aes128cfb*.
 
-  * **-K**, **--parent-pubkey**=_FILE_:
+  * **-K**, **\--parent-pubkey**=_FILE_:
 
     Optional. Specifies the parent key public data file input. This can be read with
     **tpm2_readpublic**(1) tool. If not specified, the tool invokes a tpm2_readpublic on the parent
     object.
 
-  * **-k**, **sym-alg-file**=_FILE_:
+  * **-k**, **\--sym-alg-file**=_FILE_:
 
     Optional. Specifies the file containing the symmetric algorithm key that was used for the
     inner wrapper. If the file is specified the tool assumes the algorithm is AES 128 in CFB mode
     otherwise none.
 
-  * **-r**, **--privfile**=_FILE_:
+  * **-r**, **\--privfile**=_FILE_:
 
     Specifies the file path required to save the encrypted private portion of
     the object imported as key.
@@ -69,38 +67,38 @@ These options control the key importation process:
     When importing a duplicated object this option specifies the file containing the
     private portion of the object to be imported.
 
-  * **-u**, **--pubfile**=_FILE_:
+  * **-u**, **\--pubfile**=_FILE_:
 
     Specifies the file path required to save the public portion of the object imported as key
 
     When importing a duplicated object this option specifies the file containing the
     public portion of the object to be imported.
 
-  * **-b**, **--object-attributes**=_ATTRIBUTES_:
+  * **-b**, **\--object-attributes**=_ATTRIBUTES_:
 
     The object attributes, optional.
 
-  * **-P**, **--auth-parent**=_PARENT\_KEY\_AUTH_:
+  * **-P**, **\--auth-parent**=_PARENT\_KEY\_AUTH_:
 
     The authorization value for using the parent key, optional.
     Authorization values should follow the "authorization formatting standards",
     see section "Authorization Formatting".
 
-  * **-p**, **--auth-key**=_KEY\_AUTH_:
+  * **-p**, **\--auth-key**=_KEY\_AUTH_:
 
     The authorization value for the key, optional.
     Follows the authorization formatting of the
     "password for parent key" option: **-P**.
 
-  * **-L**, **--policy-file**=_POLICY\_FILE_:
+  * **-L**, **\--policy-file**=_POLICY\_FILE_:
 
     The policy file.
 
-  * **-s**, **--seed**=_FILE_:
+  * **-s**, **\--seed**=_FILE_:
 
     Specifies the file containing the encrypted seed of the duplicated object.
 
-  * **--passin**=_OSSL\_PEM\_FILE\_PASSWORD_
+  * **\--passin**=_OSSL\_PEM\_FILE\_PASSWORD_
 
     An optional password for an Open SSL (OSSL) provided input file. It mirrors the -passin option of
     OSSL and is known to support the pass, file, env, fd and plain password formats of openssl.

--- a/man/tpm2_listpersistent.1.md
+++ b/man/tpm2_listpersistent.1.md
@@ -18,14 +18,14 @@
 
 These options for listing the persistent objects:
 
-  * **-g**, **--halg**=_ALGORITHM_:
+  * **-g**, **\--halg**=_ALGORITHM_:
 
     Only display persistent objects using this hash algorithm. Algorithms should
     follow the "formatting standards", see section "Algorithm Specifiers".
     Also, see section "Supported Hash Algorithms" for a list of supported
     hash algorithms.
 
-  * **-G**, **--kalg**=_KEY\_ALGORITHM_:
+  * **-G**, **\--kalg**=_KEY\_ALGORITHM_:
 
     Only display persistent objects using this key algorithm.
     See section "Supported Public Object Algorithms"

--- a/man/tpm2_load.1.md
+++ b/man/tpm2_load.1.md
@@ -20,30 +20,30 @@ defaults to *load.ctx* and can be specified with **-o**.
 
 # OPTIONS
 
-  * **-C**, **--context-parent**=_PARENT\_CONTEXT\_OBJECT_:
+  * **-C**, **\--context-parent**=_PARENT\_CONTEXT\_OBJECT_:
 
     Context object loaded object's parent. Either a file or a handle number.
     See section "Context Object Format".
 
-  * **-P**, **--auth-parent**=_KEY\_AUTH_:
+  * **-P**, **\--auth-parent**=_KEY\_AUTH_:
 
     Optional authorization value to use the parent object specified by **-C**.
     Authorization values should follow the "authorization formatting standards",
     see section "Authorization Formatting".
 
-  * **-u**, **--pubfile**=_PUBLIC\_OBJECT\_DATA\_FILE_:
+  * **-u**, **\--pubfile**=_PUBLIC\_OBJECT\_DATA\_FILE_:
 
     A file containing the public portion of the object.
 
-  * **-r**, **--privfile**=_PRIVATE\_OBJECT\_DATA\_FILE_:
+  * **-r**, **\--privfile**=_PRIVATE\_OBJECT\_DATA\_FILE_:
 
     A file containing the sensitive portion of the object.
 
-  * **-n**, **--name**=_NAME\_DATA\_FILE_:
+  * **-n**, **\--name**=_NAME\_DATA\_FILE_:
 
     An optional file to save the name structure of the object.
 
-  * **-o**, **--out-context**=_CONTEXT\_FILE\_NAME_:
+  * **-o**, **\--out-context**=_CONTEXT\_FILE\_NAME_:
 
     The file name of the saved object context, optional. If unspecified defaults
     to *object.ctx*.

--- a/man/tpm2_loadexternal.1.md
+++ b/man/tpm2_loadexternal.1.md
@@ -20,7 +20,7 @@ sensitive area.
 
 # OPTIONS
 
-  * **-a**, **--hierarchy**=_HIERARCHY_:
+  * **-a**, **\--hierarchy**=_HIERARCHY_:
 
     Hierarchy to use for the ticket, optional. Defaults to **n**, **null**.
     Supported options are:
@@ -29,14 +29,14 @@ sensitive area.
       * **e** for the **endorsement** hierarchy.
       * **n** for the **null** hierarchy.
 
-  * **-G**, **--key-alg**=_ALGORITHM_:
+  * **-G**, **\--key-alg**=_ALGORITHM_:
 
     The algorithm used by the key to be imported. Supports:
     * **aes** - AES 128,192 or 256 key.
     * **rsa** - RSA 1024 or 2048 key.
     * **ecc** - ECC NIST P192, P224, P256, P384 or P521 public and private key.
 
-  * **-u**, **--pubfile**=_PUBLIC\_FILE_:
+  * **-u**, **\--pubfile**=_PUBLIC\_FILE_:
 
     The public portion of the object, this can be one of the following file formats:
       * TSS - The TSS/TPM format. For example from option `-u` of command **tpm2_create**(1).
@@ -45,7 +45,7 @@ sensitive area.
       * ECC - OSSL PEM formats. For example `public.pem` from the command
         `openssl ec -in private.ecc.pem -out public.ecc.pem -pubout`
 
-  * **-r**, **--privfile**=_PRIVATE\_FILE_:
+  * **-r**, **\--privfile**=_PRIVATE\_FILE_:
 
     The sensitive portion of the object, optional. If one wishes to use the private portion
     of a key, this must be specified. Like option **-u**, this command takes files in the
@@ -57,18 +57,18 @@ sensitive area.
 
     *Note*: The private portion does not respect TSS formats as it's impossible to get a **TPM2B_SENSITIVE** output from a previous command.
 
-  * **-p**, **--auth-key**=_KEY\_AUTH_:
+  * **-p**, **\--auth-key**=_KEY\_AUTH_:
 
     The authorization value for the key, optional.
     Follows the authorization formatting of the
     "password for parent key" option: **-P**.
 
-  * **-L**, **--policy-file**=_POLICY\_FILE_:
+  * **-L**, **\--policy-file**=_POLICY\_FILE_:
 
     The input policy file, optional. A file containing the hash of a policy derived from
     `tpm2_createpolicy`.
 
-  * **-g**, **--halg**=_NAME\_ALGORITHM_:
+  * **-g**, **\--halg**=_NAME\_ALGORITHM_:
 
     The hash algorithm for generating the objects name. This is optional
     and defaults to sha256 when not specified. However, load external supports
@@ -78,7 +78,7 @@ sensitive area.
     Also, see section "Supported Hash Algorithms" for a list of supported
     hash algorithms.
 
-  * **-b**, **--object-attributes**=_ATTRIBUTES_:
+  * **-b**, **\--object-attributes**=_ATTRIBUTES_:
 
     The object attributes, optional. Object attributes follow the specifications
     as outlined in "object attribute specifiers". The default for created objects is:
@@ -89,17 +89,17 @@ sensitive area.
     *Note*: If specifying attributes, the TPM will reject certain attributes like
     **TPMA_OBJECT_FIXEDTPM**, as those guarantees cannot be made.
 
-  * **-o**, **--out-context**=_CONTEXT\_FILE_
+  * **-o**, **\--out-context**=_CONTEXT\_FILE_
 
     The file name of the saved object context, optional. If unspecified defaults
     to *external.ctx*.
 
-  * **-n**, **--name**=_NAME\_DATA\_FILE_:
+  * **-n**, **\--name**=_NAME\_DATA\_FILE_:
 
     An optional file to save the object name, which is in a binary hash format.
     The size of the hash is based on name algorithm or the **-g** option.
 
-  * **--passin**=_OSSL\_PEM\_FILE\_PASSWORD_
+  * **\--passin**=_OSSL\_PEM\_FILE\_PASSWORD_
 
     An optional password for an Open SSL (OSSL) provided input file.
     It mirrors the -passin option of OSSL and is known to support the pass,

--- a/man/tpm2_makecredential.1.md
+++ b/man/tpm2_makecredential.1.md
@@ -19,19 +19,19 @@ the **none** TCTI option.
 
 # OPTIONS
 
-  * **-e**, **--enckey**=_PUBLIC\_FILE_:
+  * **-e**, **\--enckey**=_PUBLIC\_FILE_:
 
     A TPM public key which was used to wrap the seed.
 
-  * **-s**, **--secret**=_SECRET\_DATA\_FILE_:
+  * **-s**, **\--secret**=_SECRET\_DATA\_FILE_:
 
     The secret which will be protected by the key derived from the random seed.
 
-  * **-n**, **--name**=_NAME_:
+  * **-n**, **\--name**=_NAME_:
 
     The name of the key for which certificate is to be created.
 
-  * **-o**, **--out-file**=_OUT\_FILE_:
+  * **-o**, **\--out-file**=_OUT\_FILE_:
 
     The output file path, recording the two structures output by
     tpm2_makecredential function.

--- a/man/tpm2_nvdefine.1.md
+++ b/man/tpm2_nvdefine.1.md
@@ -16,11 +16,11 @@
 
 # OPTIONS
 
-  * **-x**, **--index**=_NV\_INDEX_:
+  * **-x**, **\--index**=_NV\_INDEX_:
 
     Specifies the index to define the space at.
 
-  * **-a**, **--hierarchy**=_AUTH\_HIERARCHY_:
+  * **-a**, **\--hierarchy**=_AUTH\_HIERARCHY_:
 
     Specifies the handle used to authorize. Defaults to **o**, **TPM_RH_OWNER**,
     when no value has been specified.
@@ -29,30 +29,30 @@
       * **p** for **TPM_RH_PLATFORM**
       * **`<num>`** where a raw number can be used.
 
-  * **-s**, **--size**=_SIZE_:
+  * **-s**, **\--size**=_SIZE_:
 
     Specifies the size of data area in bytes. Defaults to **MAX_NV_INDEX_SIZE**
     which is typically 2048.
 
-  * **-b**, **--attributes**=_ATTRIBUTES_
+  * **-b**, **\--attributes**=_ATTRIBUTES_
 
     Specifies the attribute values for the nv region used when creating the
     entity. Either the raw bitfield mask or "nice-names" may be used. See
     section "NV Attributes" for more details.
 
-  * **-P**, **--auth-hierarchy**=_AUTH\_HIERARCHY\_VALUE_:
+  * **-P**, **\--auth-hierarchy**=_AUTH\_HIERARCHY\_VALUE_:
 
     Specifies the authorization value for the hierarchy. Authorization values
     should follow the "authorization formatting standards", see section
     "Authorization Formatting".
 
-  * **-p**, **--auth-index**=_INDEX\_PASSWORD_:
+  * **-p**, **\--auth-index**=_INDEX\_PASSWORD_:
 
     Specifies the password of NV Index when created.
     HMAC and Password authorization values should follow the "authorization
     formatting standards", see section "Authorization Formatting".
 
-  * **-L**, **--policy-file**=_POLICY\_FILE_:
+  * **-L**, **\--policy-file**=_POLICY\_FILE_:
 
     Specifies the policy digest file for policy based authorizations.
 

--- a/man/tpm2_nvincrement.1.md
+++ b/man/tpm2_nvincrement.1.md
@@ -16,11 +16,11 @@
 
 # OPTIONS
 
-  * **-x**, **--index**=_NV\_INDEX_:
+  * **-x**, **\--index**=_NV\_INDEX_:
 
     Specifies the index to define the space at.
 
-  * **-a**, **--hierarchy**=_AUTH_:
+  * **-a**, **\--hierarchy**=_AUTH_:
 
     Specifies the handle used to authorize. Defaults to **o**, **TPM_RH_OWNER**,
     when no value has been specified.
@@ -33,19 +33,19 @@
     authorize against the index. The index auth value is set via the
     **-p** option to **tpm2_nvdefine**(1).
 
-  * **-P**, **--auth-hierarchy**=_HIERARCHY\_AUTH_:
+  * **-P**, **\--auth-hierarchy**=_HIERARCHY\_AUTH_:
 
     Specifies the authorization value for the hierarchy. Authorization values
     should follow the "authorization formatting standards", see section
     "Authorization Formatting".
 
-  * **-L**, **--set-list**==_PCR\_SELECTION\_LIST_:
+  * **-L**, **\--set-list**==_PCR\_SELECTION\_LIST_:
 
     The list of PCR banks and selected PCRs' ids.
     _PCR\_SELECTION\_LIST_ values should follow the
     PCR bank specifiers standards, see section "PCR Bank Specifiers".
 
-  * **-F**,**--pcr-input-file**=_PCR\_INPUT\_FILE_
+  * **-F**,**\--pcr-input-file**=_PCR\_INPUT\_FILE_
 
     Optional path or name of the file containing expected PCR values for the specified index.
     Default is to read the current PCRs per the set list.

--- a/man/tpm2_nvread.1.md
+++ b/man/tpm2_nvread.1.md
@@ -16,11 +16,11 @@
 
 # OPTIONS
 
-  * **-x**, **--index**=_NV\_INDEX_:
+  * **-x**, **\--index**=_NV\_INDEX_:
 
     Specifies the index to define the space at.
 
-  * **-a**, **--hierarchy**=_AUTH_:
+  * **-a**, **\--hierarchy**=_AUTH_:
 
     Specifies the hierarchy used to authorize. Defaults to **o**, **TPM_RH_OWNER**,
     when no value has been specified.
@@ -33,34 +33,34 @@
     authorize against the index. The index auth value is set via the
     **-p** option to **tpm2_nvdefine**(1).
 
-  * **-o**, **--out-file**=_FILE_:
+  * **-o**, **\--out-file**=_FILE_:
 
     File to write data
 
-  * **-P**, **--auth-hierarchy**=_AUTH\_HIERARCHY\_VALUE__:
+  * **-P**, **\--auth-hierarchy**=_AUTH\_HIERARCHY\_VALUE__:
 
     Specifies the authorization value for the hierarchy. Authorization values
     should follow the "authorization formatting standards", see section
     "Authorization Formatting".
 
-  * **-s**, **--size**=_SIZE_:
+  * **-s**, **\--size**=_SIZE_:
 
     Specifies the size of data to be read in bytes, starting from 0 if
     offset is not specified. If not specified, the size of the data
     as reported by the public portion of the index will be used.
 
-  * **-L**, **--set-list**==_PCR\_SELECTION\_LIST_:
+  * **-L**, **\--set-list**==_PCR\_SELECTION\_LIST_:
 
     The list of PCR banks and selected PCRs' ids.
     _PCR\_SELECTION\_LIST_ values should follow the
     PCR bank specifiers standards, see section "PCR Bank Specifiers".
 
-  * **-F**,**--pcr-input-file=_PCR\_INPUT\_FILE_
+  * **-F**,**\--pcr-input-file=_PCR\_INPUT\_FILE_
 
     Optional Path or Name of the file containing expected PCR values for the specified index.
     Default is to read the current PCRs per the set list.
 
-  * **--offset**=_OFFSET_:
+  * **\--offset**=_OFFSET_:
 
     The offset within the NV index to start reading from.
 

--- a/man/tpm2_nvreadlock.1.md
+++ b/man/tpm2_nvreadlock.1.md
@@ -17,11 +17,11 @@ is released on subsequent restart of the machine.
 
 # OPTIONS
 
-  * **-x**, **--index**=_NV\_INDEX_:
+  * **-x**, **\--index**=_NV\_INDEX_:
 
     Specifies the index to define the space at.
 
-  * **-a**, **--hierarchy**=_AUTH_:
+  * **-a**, **\--hierarchy**=_AUTH_:
 
     Specifies the hierarchy used to authorize:
     * **o** for **TPM_RH_OWNER**
@@ -29,7 +29,7 @@ is released on subsequent restart of the machine.
     Defaults to **o**, **TPM_RH_OWNER**, when no value has been
     specified.
 
-  * **-P**, **--auth-hierarchy**=_AUTH\_HIERARCHY\_VALUE_:
+  * **-P**, **\--auth-hierarchy**=_AUTH\_HIERARCHY\_VALUE_:
 
     Specifies the authorization value for the hierarchy. Authorization values
     should follow the "authorization formatting standards", see section

--- a/man/tpm2_nvrelease.1.md
+++ b/man/tpm2_nvrelease.1.md
@@ -17,11 +17,11 @@ defined with **tpm2_nvdefine**(1).
 
 # OPTIONS
 
-  * **-x**, **--index**=_NV\_INDEX_:
+  * **-x**, **\--index**=_NV\_INDEX_:
 
     Specifies the index to release.
 
-  * **-a**, **--hierarchy**=_AUTH_:
+  * **-a**, **\--hierarchy**=_AUTH_:
 
     Specifies the hierarchy used to authorize.
     Supported options are:
@@ -29,7 +29,7 @@ defined with **tpm2_nvdefine**(1).
       * **p** for **TPM_RH_PLATFORM**
       * **`<num>`** where a raw number can be used.
 
-  * **-P**, **--auth-hierarchy**=_AUTH\_HIERARCHY\_VALUE_:
+  * **-P**, **\--auth-hierarchy**=_AUTH\_HIERARCHY\_VALUE_:
 
     Specifies the authorization value for the hierarchy. Authorization values
     should follow the "authorization formatting standards", see section

--- a/man/tpm2_nvwrite.1.md
+++ b/man/tpm2_nvwrite.1.md
@@ -17,11 +17,11 @@ If _FILE_ is not specified, it defaults to stdin.
 
 # OPTIONS
 
-  * **-x**, **--index**=_NV\_INDEX_:
+  * **-x**, **\--index**=_NV\_INDEX_:
 
     Specifies the index to define the space at.
 
-  * **-a**, **--hierarchy**=_AUTH_:
+  * **-a**, **\--hierarchy**=_AUTH_:
 
     Specifies the handle used to authorize. Defaults to **o**, **TPM_RH_OWNER**,
     when no value has been specified.
@@ -34,24 +34,24 @@ If _FILE_ is not specified, it defaults to stdin.
     authorize against the index. The index auth value is set via the
     **-p** option to **tpm2_nvdefine**(1).
 
-  * **-P**, **--auth-hierarchy**=_HIERARCHY\_AUTH_:
+  * **-P**, **\--auth-hierarchy**=_HIERARCHY\_AUTH_:
 
     Specifies the authorization value for the hierarchy. Authorization values
     should follow the "authorization formatting standards", see section
     "Authorization Formatting".
 
-  * **-L**, **--set-list**==_PCR\_SELECTION\_LIST_:
+  * **-L**, **\--set-list**==_PCR\_SELECTION\_LIST_:
 
     The list of PCR banks and selected PCRs' ids.
     _PCR\_SELECTION\_LIST_ values should follow the
     PCR bank specifiers standards, see section "PCR Bank Specifiers".
 
-  * **-F**,**--pcr-input-file**=_PCR\_INPUT\_FILE_
+  * **-F**,**\--pcr-input-file**=_PCR\_INPUT\_FILE_
 
     Optional Path or Name of the file containing expected PCR values for the specified index.
     Default is to read the current PCRs per the set list.
 
-  * **--offset**=_OFFSET_:
+  * **\--offset**=_OFFSET_:
 
     The offset within the NV index to start writing at.
 

--- a/man/tpm2_pcrallocate.1.md
+++ b/man/tpm2_pcrallocate.1.md
@@ -23,7 +23,7 @@ follow the pcr bank specifiers standards, see section "PCR Bank Specifiers".
 
 # OPTIONS
 
-  * **-P**, **--auth-platform**=_AUTH\_HIERARCHY_\VALUE_:
+  * **-P**, **\--auth-platform**=_AUTH\_HIERARCHY_\VALUE_:
 
     Optional authorization value. Authorization values should follow the
     "authorization formatting standards", see section "Authorization Formatting".

--- a/man/tpm2_pcrevent.1.md
+++ b/man/tpm2_pcrevent.1.md
@@ -31,12 +31,12 @@ See sections 23.1 and sections 17 of the [TPM2.0 Specification](https://trustedc
 
 These options control extending the pcr:
 
-  * **-x**, **--pcr-index**=_INDEX_:
+  * **-x**, **\--pcr-index**=_INDEX_:
 
     Not only compute the hash digests on _FILE_, also extend the PCR given by
     _INDEX_ for all supported hash algorithms.
 
-  * **-P**, **--auth-pcr**=_PCR\_AUTH_:
+  * **-P**, **\--auth-pcr**=_PCR\_AUTH_:
 
     Specifies the authorization value for PCR. Authorization values
     should follow the "authorization formatting standards", see section

--- a/man/tpm2_pcrlist.1.md
+++ b/man/tpm2_pcrlist.1.md
@@ -29,7 +29,7 @@ sha256 :
 
 # OPTIONS
 
-  * **-g**, **--halg**=_HASH\_ALGORITHM_:
+  * **-g**, **\--halg**=_HASH\_ALGORITHM_:
 
     Only output PCR banks with the given algorithm.
     Algorithms should follow the "formatting standards", see section
@@ -37,11 +37,11 @@ sha256 :
     Also, see section "Supported Hash Algorithms" for a list of supported hash
     algorithms.
 
-  * **-o**, **--out-file**=_FILE_:
+  * **-o**, **\--out-file**=_FILE_:
 
     The output file to write the PCR values in binary format, optional.
 
-  * **-L**, **--sel-list**=_PCR\_SELECTION\_LIST_:
+  * **-L**, **\--sel-list**=_PCR\_SELECTION\_LIST_:
 
     The list of PCR banks and selected PCRs' ids for each bank to display.
     _PCR\_SELECTION\_LIST_ values should follow the
@@ -49,7 +49,7 @@ sha256 :
 
     Also read **NOTES** section below.
 
-  * **-s**, **--algs**:
+  * **-s**, **\--algs**:
 
     Output the list of supported algorithms.
 

--- a/man/tpm2_policyauthorize.1.md
+++ b/man/tpm2_policyauthorize.1.md
@@ -28,30 +28,30 @@ in the policy digest.
 
 # OPTIONS
 
-  * **-o**, **--out-policy-file**=_POLICY\_FILE_:
+  * **-o**, **\--out-policy-file**=_POLICY\_FILE_:
 
     File to save the policy digest.
 
-  * **-S**, **--session**=_SESSION_FILE_:
+  * **-S**, **\--session**=_SESSION_FILE_:
 
     The policy session file generated via the **-S** option to
     **tpm2_startauthsession**(1).
 
-  * **-i**, **--in-policy-file**=_POLICY\_FILE_:
+  * **-i**, **\--in-policy-file**=_POLICY\_FILE_:
 
     The policy digest that has to be authorized.
 
-  * **-q**, **--qualify-data**=_DATA_FILE_:
+  * **-q**, **\--qualify-data**=_DATA_FILE_:
 
     The policy qualifier data signed in conjunction with the input policy digest.
     This is a unique data that the signer can choose to include in the signature.
 
-  * **-n**, **--name**=_NAME\_DATA\_FILE_:
+  * **-n**, **\--name**=_NAME\_DATA\_FILE_:
 
     File containing the name of the verifying public key. This ties the final
     policy digest with a signer. This can be retrieved with **tpm2_readpublic**(1)
 
-  * **-t**, **--ticket**=_TICKET\_FILE_:
+  * **-t**, **\--ticket**=_TICKET\_FILE_:
 
     The ticket file to record the validation structure. This is generated with
     **tpm2_verifysignature**(1).
@@ -120,7 +120,7 @@ tpm2_create -Q -g sha256 -u sealing_pubkey.pub -r sealing_prikey.pub -i- -C prim
 ```
 tpm2_verifysignature -c signing_key.ctx -g sha256 -m pcr.policy -s pcr.signature -t verification.tkt -f rsassa
 
-tpm2_startauthsession --policy-session -S session.ctx
+tpm2_startauthsession \--policy-session -S session.ctx
 
 tpm2_policypcr -Q -S session.ctx -L sha256:0 -o pcr.policy
 

--- a/man/tpm2_policycommandcode.1.md
+++ b/man/tpm2_policycommandcode.1.md
@@ -20,11 +20,11 @@ value. Requires support for extended sessions with resource manager.
 
 # OPTIONS
 
-  * **-S**, **--session**=_SESSION\_FILE_:
+  * **-S**, **\--session**=_SESSION\_FILE_:
 
     A session file from **tpm2_startauthsession**(1)'s **-S** option.
 
-  * **-o**, **--out-policy-file**=_POLICY\_FILE_:
+  * **-o**, **\--out-policy-file**=_POLICY\_FILE_:
 
     File to save the policy digest.
 
@@ -61,7 +61,7 @@ tpm2_create -C prim.ctx -u sealkey.pub -r sealkey.priv -L policy.dat \
 tpm2_load -C prim.ctx -u sealkey.pub -r sealkey.priv -n sealkey.name \
   -o sealkey.ctx
 
-tpm2_startauthsession --policy-session -S session.dat
+tpm2_startauthsession \--policy-session -S session.dat
 
 tpm2_policycommandcode -S session.dat -o policy.dat $TPM_CC_UNSEAL
 

--- a/man/tpm2_policyduplicationselect.1.md
+++ b/man/tpm2_policyduplicationselect.1.md
@@ -16,24 +16,24 @@
 
 # OPTIONS
 
-  * **-S**, **--session**=_SESSION_FILE_:
+  * **-S**, **\--session**=_SESSION_FILE_:
 
     The policy session file generated via the **-S** option to
     **tpm2_startauthsession**(1).
 
-  * **-n**, **--object-name**=_OBJ\_NAME\_FILE_:
+  * **-n**, **\--object-name**=_OBJ\_NAME\_FILE_:
 
     Input name file of the object to be duplicated.
 
-  * **-N**, **--new-parent-name**=_NP\_NAME\_FILE_:
+  * **-N**, **\--new-parent-name**=_NP\_NAME\_FILE_:
 
     Input name file of the new parent.
 
-  * **-o**, **--out-policy-file**=_POLICY\_FILE_:
+  * **-o**, **\--out-policy-file**=_POLICY\_FILE_:
 
     File to save the policy digest.
 
-  * **--include-object-if-exists**:
+  * **\--include-object-if-exists**:
 
     If exists, the object name will be included in the value in policy digest.
 

--- a/man/tpm2_policylocality.1.md
+++ b/man/tpm2_policylocality.1.md
@@ -20,11 +20,11 @@ value. Requires support for extended sessions with resource manager.
 
 # OPTIONS
 
-  * **-S**, **--session**=_SESSION\_FILE_:
+  * **-S**, **\--session**=_SESSION\_FILE_:
 
     A session file from **tpm2_startauthsession**(1)'s **-S** option.
 
-  * **-o**, **--out-policy-file**=_POLICY\_FILE_:
+  * **-o**, **\--out-policy-file**=_POLICY\_FILE_:
 
     File to save the policy digest.
 
@@ -61,7 +61,7 @@ tpm2_create -C prim.ctx -u sealkey.pub -r sealkey.priv -L policy.dat \
 tpm2_load -C prim.ctx -u sealkey.pub -r sealkey.priv -n sealkey.name \
   -o sealkey.ctx
 
-tpm2_startauthsession --policy-session -S session.dat
+tpm2_startauthsession \--policy-session -S session.dat
 
 tpm2_policylocality -S session.dat -o policy.dat $TPM_LOCALITY
 

--- a/man/tpm2_policyor.1.md
+++ b/man/tpm2_policyor.1.md
@@ -24,17 +24,17 @@ at least one of the policy events are true.
 
 # OPTIONS
 
-  * **-o**, **--out-policy-file**=_POLICY\_FILE_:
+  * **-o**, **\--out-policy-file**=_POLICY\_FILE_:
 
     File to save the compounded policy digest.
 
-  * **-L**, **--policy-list**=_POLICY\_FILE_\_LIST:
+  * **-L**, **\--policy-list**=_POLICY\_FILE_\_LIST:
 
     The list of files for the policy digests that has to be compounded resulting
     in individual policies being added to final policy digest that can
     authenticate the object. The list begins with the policy digest hash alg.
 
-  * **-S**, **--session**=_SESSION_FILE_:
+  * **-S**, **\--session**=_SESSION_FILE_:
 
     The policy session file generated via the **-S** option to
     **tpm2_startauthsession**(1).
@@ -97,7 +97,7 @@ tpm2_create -Q -g sha256 -u sealing_key.pub -r sealing_key.pub -i- -C prim.ctx -
 
 ## Satisfy the policy and unseal the secret
 ```
-tpm2_startauthsession --policy-session -S session.ctx
+tpm2_startauthsession \--policy-session -S session.ctx
 
 tpm2_policypcr -Q -S session.ctx -L sha1:0 -o o_set1_pcr0.policy
 

--- a/man/tpm2_policypassword.1.md
+++ b/man/tpm2_policypassword.1.md
@@ -23,11 +23,11 @@ If using a resource manager (RM), then one supporting extended sessions, like
 
 # OPTIONS
 
-  * **-o**, **--out-policy-file**=_POLICY\_FILE_:
+  * **-o**, **\--out-policy-file**=_POLICY\_FILE_:
 
     File to save the compounded policy digest.
 
-  * **-S**, **--session**=_SESSION_FILE_:
+  * **-S**, **\--session**=_SESSION_FILE_:
 
     The policy session file generated via the **-S** option to
     **tpm2_startauthsession**(1).
@@ -74,7 +74,7 @@ tpm2_encryptdecrypt -c key.ctx -o encrypt.out -i plain.txt -p text
 
 ## Authenticate with password and the policy
 ```
-tpm2_startauthsession --policy-session -S session.dat
+tpm2_startauthsession \--policy-session -S session.dat
 
 tpm2_policypassword -S session.dat -o policy.dat
 

--- a/man/tpm2_policypcr.1.md
+++ b/man/tpm2_policypcr.1.md
@@ -18,20 +18,20 @@ established via **tpm2_startauthsession**(1).
 
 # OPTIONS
 
-  * **-o**, **--out-policy-file**=_POLICY\_FILE_:
+  * **-o**, **\--out-policy-file**=_POLICY\_FILE_:
     
     File to save the policy digest.
 
-  * **-F**, **--pcr-input-file**=_PCR\_FILE_:
+  * **-F**, **\--pcr-input-file**=_PCR\_FILE_:
     
     Optional Path or Name of the file containing expected PCR values for the
     specified index. Default is to read the current PCRs per the set list.
 
-  * **-L**, **--set-list**=_PCR\_LIST_:
+  * **-L**, **\--set-list**=_PCR\_LIST_:
     
     The list of PCR banks and selected PCRs' ids for each bank.
 
-  * **-S**, **--session**=_SESSION_FILE_:
+  * **-S**, **\--session**=_SESSION_FILE_:
 
     The policy session file generated via the **-S** option to
     **tpm2_startauthsession**(1).
@@ -69,7 +69,7 @@ Then, it uses a *policy* session to unseal some data stored in the object.
     ```
 3. Create an actual policy session and using a policyPCR event, update the session policy hash.
     ```
-    handle=`tpm2_startauthsession --policy-session -S session.dat | cut -d' ' -f 2-2`
+    handle=`tpm2_startauthsession \--policy-session -S session.dat | cut -d' ' -f 2-2`
 
     tpm2_policypcr -Q -S session.dat -L "sha1:0,1,2,3" -F pcr.dat -o policy.dat
     ```

--- a/man/tpm2_policyrestart.1.md
+++ b/man/tpm2_policyrestart.1.md
@@ -21,7 +21,7 @@ state would still need to satisfy the policy
 
 # OPTIONS
 
-  * **-S**, **--session**=_SESSION\_FILE_:
+  * **-S**, **\--session**=_SESSION\_FILE_:
 
     Optional, A session file from **tpm2_startauthsession**(1)'s **-S** option.
     This session is used in lieu of starting a session and using the PCR policy options.
@@ -36,7 +36,7 @@ state would still need to satisfy the policy
 ## Start a *policy* session and restart it, unsealing some data.
 
 ```
-tpm2_startauthsession --policy-session
+tpm2_startauthsession \--policy-session
 
 tpm2_policypcr -Q -S session.dat -L "sha1:0,1,2,3" -F pcr.dat -o policy.dat
 

--- a/man/tpm2_policysecret.1.md
+++ b/man/tpm2_policysecret.1.md
@@ -19,7 +19,7 @@ a policy.
 
 # OPTIONS
 
-  * **-c**, **--context**=_OBJECT_CONTEXT_:
+  * **-c**, **\--context**=_OBJECT_CONTEXT_:
 
     A context object specifier of a transient/permanent/persistent object. Either
     a file path of a object context blob or a loaded/persistent/permanent handle
@@ -28,12 +28,12 @@ a policy.
     auth value from stdin. The argument follows the "authorization formatting
     standards", see section "Authorization Formatting".
 
-  * **-S**, **--session**=_SESSION_FILE_:
+  * **-S**, **\--session**=_SESSION_FILE_:
 
     The policy session file generated via the **-S** option to
     **tpm2_startauthsession**(1).
 
-  * **-o**, **--out-policy-file**=_POLICY\_FILE_:
+  * **-o**, **\--out-policy-file**=_POLICY\_FILE_:
 
     File to save the policy digest.
 
@@ -75,7 +75,7 @@ tpm2_load -C prim.ctx -u sealing_key.pub -r sealing_key.priv -n sealing_key.name
 
 ## Satisfy the policy and unseal the secret
 ```
-tpm2_startauthsession --policy-session -S session.ctx
+tpm2_startauthsession \--policy-session -S session.ctx
 
 tpm2_policysecret -S session.ctx -c $TPM_RH_OWNER -o secret.policy
 

--- a/man/tpm2_print.1.md
+++ b/man/tpm2_print.1.md
@@ -17,12 +17,12 @@ elements to stdout as YAML.
 
 # OPTIONS
 
-  * **-t**, **--type**:
+  * **-t**, **\--type**:
 
     Required. Type of data structure. Only **TPMS_ATTEST** and **TPMS_CONTEXT** are
     presently supported.
 
-  * **-i**, **--in-file**:
+  * **-i**, **\--in-file**:
 
     Optional. File containing TPM object. Reads from stdin if unspecified.
 
@@ -35,9 +35,9 @@ elements to stdout as YAML.
 ```
 tpm2_print -t TPMS_ATTEST -f /path/to/tpm/quote
 
-tpm2_print --type=TPMS_ATTEST --file=/path/to/tpm/quote
+tpm2_print \--type=TPMS_ATTEST \--file=/path/to/tpm/quote
 
-cat /path/to/tpm/quote | tpm2_print --type=TPMS_ATTEST
+cat /path/to/tpm/quote | tpm2_print \--type=TPMS_ATTEST
 ```
 
 # RETURNS

--- a/man/tpm2_quote.1.md
+++ b/man/tpm2_quote.1.md
@@ -16,22 +16,22 @@
 
 # OPTIONS
 
-  * **-C**, **--ak-context**=_AK\_CONTEXT\_OBJECT_:
+  * **-C**, **\--ak-context**=_AK\_CONTEXT\_OBJECT_:
 
     Context object for the existing AK's context. Either a file or a handle number.
     See section "Context Object Format".
 
-  * **-P**, **--auth-ak**=_AK\_AUTH_:
+  * **-P**, **\--auth-ak**=_AK\_AUTH_:
 
     Specifies the authorization value for AK specified by option **-C**.
     Authorization values should follow the "authorization formatting standards",
     see section "Authorization Formatting".
 
-  * **-l**, **--id-list**=_PCR\_ID\_LIST_
+  * **-l**, **\--id-list**=_PCR\_ID\_LIST_
 
     The comma separated list of selected PCRs' e.g. "4,5,6".
 
-  * **-L**, **--sel-list**=_PCR\_SELECTION\_LIST_:
+  * **-L**, **\--sel-list**=_PCR\_SELECTION\_LIST_:
 
     The list of PCR banks and selected PCRs' ids for each bank.
     _PCR\_SELECTION\_LIST_ values should follow the
@@ -39,33 +39,33 @@
 
     Also see **NOTES** section below.
 
-  * **-m**, **--message**:
+  * **-m**, **\--message**:
 
     Message output file, records the quote message that makes up the data that
     is signed by the TPM.
 
-  * **-s**, **--signature**:
+  * **-s**, **\--signature**:
 
     Signature output file, records the signature in the format specified via the **-f**
     option.
 
-  * **-f**, **--format**
+  * **-f**, **\--format**
 
     Format selection for the signature output file. See section "Signature Format Specifiers".
 
-  * **-p**, **--pcrs**:
+  * **-p**, **\--pcrs**:
 
     PCR output file, optional, records the list of PCR values as defined
     by **-l** or **-L**.  Note that only the digest of these values is stored in the
-    signed quote message -- these values themselves are not signed or
+    signed quote message \-- these values themselves are not signed or
     stored in the message.
 
-  * **-q**, **--qualify-data**:
+  * **-q**, **\--qualify-data**:
 
     Data given as a Hex string to qualify the  quote, optional. This is typically
     used to add a nonce against replay attacks.
 
-  * **-g**, **--halg**:
+  * **-g**, **\--halg**:
 
     Hash algorithm for signature. Required if **-p** is given.
 

--- a/man/tpm2_readpublic.1.md
+++ b/man/tpm2_readpublic.1.md
@@ -16,16 +16,16 @@
 
 # OPTIONS
 
-  * **-c**, **--context**=_OBJECT\_CONTEXT_:
+  * **-c**, **\--context**=_OBJECT\_CONTEXT_:
 
     Context object for the object to read. Either a file or a handle number.
     See section "Context Object Format".
 
-  * **-n**, **--name**=_NAME\_DATA\_FILE_:
+  * **-n**, **\--name**=_NAME\_DATA\_FILE_:
 
     An optional file to save the name structure of the object.
 
-  * **-o**, **--out-file**=_OUT\_FILE_:
+  * **-o**, **\--out-file**=_OUT\_FILE_:
 
     The output file path, recording the public portion of the object.
 

--- a/man/tpm2_rsadecrypt.1.md
+++ b/man/tpm2_rsadecrypt.1.md
@@ -22,27 +22,27 @@ The key referenced by key-context is **required** to be:
 
 # OPTIONS
 
-  * **-c**, **--key-context**=_KEY\_CONTEXT\_OBJECT_:
+  * **-c**, **\--key-context**=_KEY\_CONTEXT\_OBJECT_:
 
     Context object pointing to the the public portion of RSA key to use for
     decryption. Either a file or a handle number.
     See section "Context Object Format".
 
-  * **-p**, **--auth-key**=_KEY\_AUTH_:
+  * **-p**, **\--auth-key**=_KEY\_AUTH_:
 
     Optional authorization value to use the key specified by **-k**.
     Authorization values should follow the "authorization formatting standards",
     see section "Authorization Formatting".
 
-  * **-i**, **--in-file**=_INPUT\FILE_:
+  * **-i**, **\--in-file**=_INPUT\FILE_:
 
     Input file path, containing the data to be decrypted.
 
-  * **-o**, **--out-file**=_OUTPUT\_FILE_:
+  * **-o**, **\--out-file**=_OUTPUT\_FILE_:
 
     Output file path, record the decrypted data.
 
-  * **-g**, **--scheme**=_PADDING\_SCHEME_:
+  * **-g**, **\--scheme**=_PADDING\_SCHEME_:
 
     Optional, set the padding scheme (defaults to rsaes). 
     

--- a/man/tpm2_rsaencrypt.1.md
+++ b/man/tpm2_rsaencrypt.1.md
@@ -23,19 +23,19 @@ The key referenced by key-context is **required** to be:
 
 # OPTIONS
 
-  * **-c**, **--key-context**=_KEY\_CONTEXT\_OBJECT_:
+  * **-c**, **\--key-context**=_KEY\_CONTEXT\_OBJECT_:
 
     Context object pointing to the the public portion of RSA key to use for
     encryption. Either a file or a handle number.
     See section "Context Object Format".
 
-  * **-o**, **--out-file**=_OUTPUT\_FILE_:
+  * **-o**, **\--out-file**=_OUTPUT\_FILE_:
 
     Output file path, record the decrypted data. The default is to print an
     xxd compatible hexdump to stdout. If a file is specified, raw binary
     output is performed.
 
-  * **-g**, **--scheme**=_PADDING\_SCHEME_:
+  * **-g**, **\--scheme**=_PADDING\_SCHEME_:
 
     Optional, set the padding scheme (defaults to rsaes). 
     

--- a/man/tpm2_selftest.1.md
+++ b/man/tpm2_selftest.1.md
@@ -21,7 +21,7 @@ Self-test can be executed in two modes :
 
 # OPTIONS
 
-* **-f**, **--fulltest** : Run self-test in full mode
+* **-f**, **\--fulltest** : Run self-test in full mode
 
 [common options](common/options.md)
 

--- a/man/tpm2_send.1.md
+++ b/man/tpm2_send.1.md
@@ -22,7 +22,7 @@ program to decode and display the response in a human readable form.
 
 # OPTIONS
 
-  * **-o**, **--out-file**=_OUTPUT\_FILE_:
+  * **-o**, **\--out-file**=_OUTPUT\_FILE_:
 
     Output file to send response buffer to. Defaults to stdout.
 

--- a/man/tpm2_sign.1.md
+++ b/man/tpm2_sign.1.md
@@ -20,18 +20,18 @@ data and validation shall indicate that hashed data did not start with
 
 # OPTIONS
 
-  * **-c**, **--key-context**=_KEY\_CONTEXT\_OBJECT_:
+  * **-c**, **\--key-context**=_KEY\_CONTEXT\_OBJECT_:
 
     Context object pointing to the the key used for signing. Either a file or a
     handle number. See section "Context Object Format".
 
-  * **-p**, **--auth-key**=_KEY\_AUTH_:
+  * **-p**, **\--auth-key**=_KEY\_AUTH_:
 
     Optional authorization value to use the key specified by **-c**.
     Authorization values should follow the "authorization formatting standards",
     see section "Authorization Formatting".
 
-  * **-g**, **--halg**=_HASH\_ALGORITHM_:
+  * **-g**, **\--halg**=_HASH\_ALGORITHM_:
 
     The hash algorithm used to digest the message.
     Algorithms should follow the "formatting standards", see section
@@ -39,7 +39,7 @@ data and validation shall indicate that hashed data did not start with
     Also, see section "Supported Hash Algorithms" for a list of supported hash
     algorithms.
 
-  * **-s**, **--sig-scheme**=_SIGNING\_SCHEME_:
+  * **-s**, **\--sig-scheme**=_SIGNING\_SCHEME_:
 
     The signing scheme used to sign the message. Optional.
     Signing schemes should follow the "formatting standards", see section
@@ -50,11 +50,11 @@ data and validation shall indicate that hashed data did not start with
     If left unspecified, a default signature scheme for the key type will
      be used.
 
-  * **-m**, **--message**=_MSG\_FILE_:
+  * **-m**, **\--message**=_MSG\_FILE_:
 
     The message file, containing the content to be  digested.
 
-  * **-D**, **--digest**=_DIGEST\_FILE_:
+  * **-D**, **\--digest**=_DIGEST\_FILE_:
 
     The digest file that shall be computed using the correct hash
     algorithm. When this option is specified, a warning is generated and
@@ -63,15 +63,15 @@ data and validation shall indicate that hashed data did not start with
     You cannot use this option to sign a digest against a restricted
     signing key.
 
-  * **-t**, **--ticket**=_TICKET\_FILE_:
+  * **-t**, **\--ticket**=_TICKET\_FILE_:
 
     The ticket file, containing the validation structure, optional.
 
-  * **-o**, **--out-sig**=_SIGNATURE\_FILE_:
+  * **-o**, **\--out-sig**=_SIGNATURE\_FILE_:
 
     The signature file, records the signature structure.
 
-  * **-f**, **--format**
+  * **-f**, **\--format**
 
     Format selection for the signature output file. See section "Signature Format Specifiers".
 

--- a/man/tpm2_startauthsession.1.md
+++ b/man/tpm2_startauthsession.1.md
@@ -24,21 +24,21 @@ This will work with direct TPM access, but note that internally this calls a *Co
 
 # OPTIONS
 
-  * **--policy-session**:
+  * **\--policy-session**:
 
     Start a policy session of type **TPM_SE_POLICY**. Default without this option
     is **TPM_SE_TRIAL**.
     **NOTE**: A *trial* session is used when building a policy and a *policy*
     session is used when authenticating with a policy.
 
-  * **-g**, **--halg**=_HASH\_ALGORITHM_:
+  * **-g**, **\--halg**=_HASH\_ALGORITHM_:
 
     The hash algorithm used in computation of the policy digest. Algorithms
     should follow the "formatting standards", see section "Algorithm Specifiers".
     Also, see section "Supported Hash Algorithms" for a list of supported hash
     algorithms.
 
-  * **-S**, **--session**=_SESSION\_FILE\_NAME_:
+  * **-S**, **\--session**=_SESSION\_FILE\_NAME_:
 
     The name of the policy session file, optional. Defaults to *session.ctx*.
 
@@ -60,7 +60,7 @@ tpm2_startauthsession -S mysession.ctx
 
 ## Start a *policy* session and save the session data to a file
 ```
-tpm2_startauthsession --policy-session
+tpm2_startauthsession \--policy-session
 ```
 
 # RETURNS

--- a/man/tpm2_startup.1.md
+++ b/man/tpm2_startup.1.md
@@ -17,7 +17,7 @@
 
 # OPTIONS
 
-  * **-c**, **--clear**:
+  * **-c**, **\--clear**:
 
     Startup type sent will be **TPM_SU_CLEAR** instead of **TPM2_SU_STATE**.
 

--- a/man/tpm2_unseal.1.md
+++ b/man/tpm2_unseal.1.md
@@ -16,18 +16,18 @@
 
 # OPTIONS
 
-  * **-c**, **--context-object**=_CONTEXT\_OBJECT_:
+  * **-c**, **\--context-object**=_CONTEXT\_OBJECT_:
 
     Context object for the loaded object. Either a file or a handle number.
     See section "Context Object Format".
 
-  * **-p**, **--auth-key**=_KEY\_AUTH_:
+  * **-p**, **\--auth-key**=_KEY\_AUTH_:
 
     Optional authorization value to use the key specified by **-c**.
     Authorization values should follow the "authorization formatting standards",
     see section "Authorization Formatting".
 
-  * **-o**, **--out-file**=_OUT\_FILE_:
+  * **-o**, **\--out-file**=_OUT\_FILE_:
 
     Output file name, containing the unsealed data. Defaults to stdout if not specified.
 
@@ -36,14 +36,14 @@
   Options used for internally controlling sessions and policy events. These
   are exclusive of **-P**.
 
-  * **-L**, **--set-list**==_PCR\_SELECTION\_LIST_:
+  * **-L**, **\--set-list**==_PCR\_SELECTION\_LIST_:
 
     The list of PCR banks and selected PCRs' ids.
     _PCR\_SELECTION\_LIST_ values should follow the
     PCR bank specifiers standards, see section "PCR Bank Specifiers".
     **-S** is mutually exclusive of this option.
 
-  * **-F**,**--pcr-input-file**=_PCR\_INPUT\_FILE_
+  * **-F**,**\--pcr-input-file**=_PCR\_INPUT\_FILE_
 
     Optional Path or Name of the file containing expected PCR values for the specified index.
     Default is to read the current PCRs per the set list.
@@ -72,10 +72,10 @@ tpm2_unseal -c item.context -L sha1:0,1,2 -F out.dat
 
 # NOTES
 
-The **--set-list** and **--pcr-input-file** options should only be
+The **\--set-list** and **\--pcr-input-file** options should only be
 used for simple PCR authentication policies. For more complex policies the
 tools should be run in an execution environment that keeps the session context
-alive and pass that session using the **--input-session-handle** option.
+alive and pass that session using the **\--input-session-handle** option.
 
 # RETURNS
 

--- a/man/tpm2_verifysignature.1.md
+++ b/man/tpm2_verifysignature.1.md
@@ -21,12 +21,12 @@ symmetric key, both the public and private portions need to be loaded.
 
 # OPTIONS
 
-  * **-c**, **--key-context**=_KEY\_CONTEXT\_OBJECT_:
+  * **-c**, **\--key-context**=_KEY\_CONTEXT\_OBJECT_:
 
     Context object for the key context used for the operation. Either a file
     or a handle number. See section "Context Object Format".
 
-  * **-g**, **--halg**=_HASH\_ALGORITHM_:
+  * **-g**, **\--halg**=_HASH\_ALGORITHM_:
 
     The hash algorithm used to digest the message.
     Algorithms should follow the "formatting standards", see section
@@ -34,21 +34,21 @@ symmetric key, both the public and private portions need to be loaded.
     Also, see section "Supported Hash Algorithms" for a list of supported hash
     algorithms.
 
-  * **-m**, **--message**=_MSG\_FILE_:
+  * **-m**, **\--message**=_MSG\_FILE_:
 
     The message file, containing the content to be  digested.
 
-  * **-D**, **--digest**=_DIGEST\_FILE_:
+  * **-D**, **\--digest**=_DIGEST\_FILE_:
 
     The input hash file, containing the hash of the message. If this option is
     selected, then the message (**-m**) and algorithm (**-g**) options do not need
     to be specified.
 
-  * **-s**, **--sig**=_SIG\_FILE_:
+  * **-s**, **\--sig**=_SIG\_FILE_:
 
     The input signature file of the signature to be validated.
 
-  * **-f**, **--format**:
+  * **-f**, **\--format**:
 
     Set the input signature file to a specified format. The default is the tpm2.0 TPMT_SIGNATURE
     data format, however different schemes can be selected if the data came from an external
@@ -59,7 +59,7 @@ symmetric key, both the public and private portions need to be loaded.
     Also, see section "Supported Signing Schemes" for a list of supported hash
     algorithms.
 
-  * **-t**, **--ticket**=_TICKET\_FILE_:
+  * **-t**, **\--ticket**=_TICKET\_FILE_:
 
     The ticket file to record the validation structure.
 


### PR DESCRIPTION
Some point in time, pandoc behavior changed with how to deal
with - or -- dashed when converting from markdown to man. They
got changed from a double-dash to an en-dash.

Per https://github.com/jgm/pandoc/issues/5404

Correct this by escaping the dash.

Fixes: #1433

Signed-off-by: William Roberts <william.c.roberts@intel.com>