### PR TITLE
man/tpm2_changeauth: Fix typo

### DIFF
--- a/man/tpm2_changeauth.1.md
+++ b/man/tpm2_changeauth.1.md
@@ -88,12 +88,12 @@ tpm2_changeauth -w neww -e newe -l newl
 
 ## Set owner, endorsement and lockout authorizations to a new value
 ```
-tpm2_changeauth -w neww -e newe -l newl -O oldw -E olde -L oldl
+tpm2_changeauth -w neww -e newe -l newl -W oldw -E olde -L oldl
 ```
 
 ## Unset/Clear owner authorization which was previously set to value newo
 ```
-tpm2_changeauth -O newo
+tpm2_changeauth -W neww
 ```
 
 ## Modify authorization for a loadable transient object

--- a/man/tpm2_changeauth.1.md
+++ b/man/tpm2_changeauth.1.md
@@ -104,7 +104,7 @@ tpm2_create -Q -g sha256 -G aes -u key.pub -r key.priv -C prim.ctx
 
 tpm2_load -C prim.ctx -u key.pub -r key.priv -n key.name -o key.ctx
 
-tpm2_changeauth -p newkeyauth -c key.ctx -a prim.ctx -r key.priv
+tpm2_changeauth -p newkeyauth -c key.ctx -C prim.ctx -r key.priv
 ```
 
 ## Modify authorization for a NV Index - Requires Extended Session Support

--- a/man/tpm2_changeauth.1.md
+++ b/man/tpm2_changeauth.1.md
@@ -83,12 +83,12 @@ see section "Authorization Formatting".
 
 ## Set owner, endorsement and lockout authorizations
 ```
-tpm2_changeauth -o newo -e newe -l newl
+tpm2_changeauth -w neww -e newe -l newl
 ```
 
 ## Set owner, endorsement and lockout authorizations to a new value
 ```
-tpm2_changeauth -o newo -e newe -l newl -O oldo -E olde -L oldl
+tpm2_changeauth -w neww -e newe -l newl -O oldw -E olde -L oldl
 ```
 
 ## Unset/Clear owner authorization which was previously set to value newo

--- a/man/tpm2_create.1.md
+++ b/man/tpm2_create.1.md
@@ -106,7 +106,7 @@ These options for creating the TPM entity:
 
 [algorithm specifiers](common/alg.md)
 
-[object attribute specifiers](common/object-attrs.md)
+[object attribute specifiers](common/obj-attrs.md)
 
 # EXAMPLES
 


### PR DESCRIPTION
Based on 9f4d93f7945ef9e1aa797afb8535556e4414e3fb, the option changed.
Need to update man page too.

