### PR TITLE
Backport tpm2_flushcontext to 3.X

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -69,6 +69,7 @@ bin_PROGRAMS = \
     tools/tpm2_getcap \
     tools/tpm2_encryptdecrypt \
     tools/tpm2_evictcontrol \
+    tools/tpm2_flushcontext \
     tools/tpm2_getmanufec \
     tools/tpm2_getpubak \
     tools/tpm2_getpubek \
@@ -178,6 +179,7 @@ tools_tpm2_readpublic_SOURCES = tools/tpm2_readpublic.c $(TOOL_SRC)
 tools_tpm2_getrandom_SOURCES = tools/tpm2_getrandom.c $(TOOL_SRC)
 tools_tpm2_encryptdecrypt_SOURCES = tools/tpm2_encryptdecrypt.c $(TOOL_SRC)
 tools_tpm2_evictcontrol_SOURCES = tools/tpm2_evictcontrol.c $(TOOL_SRC)
+tools_tpm2_flushcontext_SOURCES = tools/tpm2_flushcontext.c $(TOOL_SRC)
 tools_tpm2_loadexternal_SOURCES = tools/tpm2_loadexternal.c $(TOOL_SRC)
 tools_tpm2_rsadecrypt_SOURCES = tools/tpm2_rsadecrypt.c $(TOOL_SRC)
 tools_tpm2_rsaencrypt_SOURCES = tools/tpm2_rsaencrypt.c $(TOOL_SRC)
@@ -269,6 +271,7 @@ if HAVE_MAN_PAGES
     man/man1/tpm2_getcap.1 \
     man/man1/tpm2_encryptdecrypt.1 \
     man/man1/tpm2_evictcontrol.1 \
+    man/man1/tpm2_flushcontext.1 \
     man/man1/tpm2_getmanufec.1 \
     man/man1/tpm2_getpubak.1 \
     man/man1/tpm2_getpubek.1 \

--- a/man/tpm2_flushcontext.1.md
+++ b/man/tpm2_flushcontext.1.md
@@ -1,0 +1,63 @@
+% tpm2_flushcontext(1) tpm2-tools | General Commands Manual
+%
+% NOVEMBER 2017
+
+# NAME
+
+**tpm2_flushcontext**(1) - Remove a specified handle, or all contexts associated with a
+transient object, loaded session or saved session from the TPM.
+
+# SYNOPSIS
+
+**tpm2_flushcontext** [*OPTIONS*]
+
+# DESCRIPTION
+
+**tpm2_flushcontext**(1) - Remove a specified handle, or all contexts associated with a
+transient object, loaded session or saved session from the TPM.
+
+# OPTIONS
+
+  * **-c**, **\--context**=_CONTEXT\_OBJECT_:
+
+    The handle of an object, loaded session or saved session to be removed.
+
+  * **-t**, **\--transient-object**:
+
+    Remove all transient objects.
+
+  * **-l**, **\--loaded-session**:
+
+    Remove all loaded sessions.
+
+  * **-s**, **\--saved-session**:
+
+    Remove all saved sessions.
+
+[common options](common/options.md)
+
+[common tcti options](common/tcti.md)
+
+[context object format](common/ctxobj.md)
+
+# EXAMPLES
+
+## Flushing a transient loaded context
+```
+tpm2_flushcontext -c 0x80000000
+```
+
+## Flush all the transient objects loaded
+```
+tpm2_flushcontext \--transient-object
+```
+
+# NOTES
+
+If multiple options are specified (**-t**, **-s** or **-l**), only the last option will be taken into account.
+
+# RETURNS
+
+0 on success or 1 on failure.
+
+[footer](common/footer.md)

--- a/test/system/test_tpm2_flushcontext.sh
+++ b/test/system/test_tpm2_flushcontext.sh
@@ -1,0 +1,43 @@
+#!/bin/bash
+# SPDX-License-Identifier: BSD-3-Clause
+#;**********************************************************************;
+#
+# Copyright (c) 2017, Alibaba Group
+# Copyright (c) 2018, Intel Corporation
+# All rights reserved.
+#
+#;**********************************************************************;
+
+onerror() {
+    echo "$BASH_COMMAND on line ${BASH_LINENO[0]} failed: $?"
+    exit 1
+}
+trap onerror ERR
+
+cleanup() {
+  rm -f primary.ctx decrypt.ctx key.pub key.priv key.name decrypt.out \
+        encrypt.out secret.dat key.ctx
+}
+trap cleanup EXIT
+
+cleanup
+
+# Test for flushing the specified handle
+tpm2_createprimary -Q -H o -g sha256 -G rsa
+# tpm2-abrmd may save the transient object and restore it when using
+res=`tpm2_getcap -c handles-transient`
+if [ -n "$res" ]; then
+    tpm2_flushcontext -Q -c 0x80000000
+fi
+
+# Test for flushing a transient object
+tpm2_createprimary -Q -H o -g sha256 -G rsa
+tpm2_flushcontext -Q -t
+
+# Test for flushing a loaded session
+tpm2_createpolicy -Q -L sha256:0 -F pcr.in -f policy.out
+tpm2_flushcontext -Q -l
+
+cleanup "no-shut-down"
+
+exit 0

--- a/tools/tpm2_flushcontext.c
+++ b/tools/tpm2_flushcontext.c
@@ -1,0 +1,130 @@
+/* SPDX-License-Identifier: BSD-3-Clause */
+//**********************************************************************;
+// Copyright (c) 2017, Alibaba Group
+// All rights reserved.
+//
+//**********************************************************************;
+
+#include <inttypes.h>
+#include <stdbool.h>
+#include <stdlib.h>
+
+#include <tss2/tss2_esys.h>
+
+#include "log.h"
+#include "tpm2_options.h"
+#include "tpm2_util.h"
+#include "tpm2_tool.h"
+
+struct tpm_flush_context_ctx {
+    UINT32 property;
+    TPM2_HANDLE handle;
+};
+
+static struct tpm_flush_context_ctx ctx = { 0, 0 };
+
+static const char *get_property_name(TPM2_HANDLE handle) {
+
+    switch (handle & TPM2_HR_RANGE_MASK) {
+        case TPM2_HR_TRANSIENT:
+            return "transient";
+        case TPM2_HT_LOADED_SESSION << TPM2_HR_SHIFT:
+            return "loaded session";
+        case TPM2_HT_SAVED_SESSION << TPM2_HR_SHIFT:
+            return "saved session";
+    }
+
+    return "invalid";
+}
+
+static bool flush_contexts_tpm2(TSS2_SYS_CONTEXT *sapi_context, TPM2_HANDLE handles[],
+                          UINT32 count) {
+
+    UINT32 i;
+
+    for (i = 0; i < count; ++i) {
+        TPM2_RC rval = TSS2_RETRY_EXP(Tss2_Sys_FlushContext(sapi_context, handles[i]));
+        if (rval != TPM2_RC_SUCCESS) {
+            LOG_ERR("Failed Flush Context for %s handle 0x%x",
+                    get_property_name(handles[i]), handles[i]);
+            return false;
+        }
+    }
+
+    return true;
+}
+
+static bool on_option(char key, char *value) {
+    (void)(value);
+
+    switch (key) {
+    case 'c':
+        if (!tpm2_util_string_to_uint32(value, &ctx.handle)) {
+            LOG_ERR("Could not convert handle to number, got: \"%s\"",
+                    value);
+            return false;
+        }
+        break;
+    case 't':
+        ctx.property = TPM2_TRANSIENT_FIRST;
+        break;
+    case 'l':
+        ctx.property = TPM2_LOADED_SESSION_FIRST;
+        break;
+    case 's':
+        ctx.property = TPM2_ACTIVE_SESSION_FIRST;
+        break;
+    }
+
+    return true;
+}
+
+bool tpm2_tool_onstart(tpm2_options **opts) {
+
+    static const struct option topts[] = {
+        { "context",          required_argument,  NULL, 'c' },
+        { "transient-object", no_argument,        NULL, 't' },
+        { "loaded-session",   no_argument,        NULL, 'l' },
+        { "saved-session",    no_argument,        NULL, 's' },
+    };
+
+    *opts = tpm2_options_new("c:tls", ARRAY_LEN(topts), topts,
+                             on_option, NULL, 0);
+
+    return *opts != NULL;
+}
+
+int tpm2_tool_onrun(TSS2_SYS_CONTEXT *sapi_context, tpm2_option_flags flags) {
+
+    UNUSED(flags);
+
+    if (ctx.property) {
+        TPMS_CAPABILITY_DATA capability_data;
+
+        TSS2_RC rc = TSS2_RETRY_EXP(Tss2_Sys_GetCapability (sapi_context,
+                                     NULL,
+                                     TPM2_CAP_HANDLES,
+                                     ctx.property,
+                                     TPM2_MAX_CAP_HANDLES,
+                                     NULL,
+                                     &capability_data,
+                                     NULL));
+        if (rc != TPM2_RC_SUCCESS) {
+            LOG_ERR("Failed to GetCapability: capability: TPM2_CAP_HANDLES");
+            return 1;
+        }
+
+        TPML_HANDLE *handles = &capability_data.data.handles;
+        int retval = flush_contexts_tpm2(sapi_context, handles->handle,
+                                    handles->count) != true;
+        if (retval) return retval;
+    }
+
+    if (ctx.handle) {
+        int retval = flush_contexts_tpm2(sapi_context, &ctx.handle,
+                                    1) != true;
+        if (retval) return retval;
+    }
+
+    return 0;
+}


### PR DESCRIPTION
Not the whole program was backported, because of the ESYS-SAPI conversion. Only flushing of all handles of a group and a particular handle are supported in this.

And since I'm completely unbeknown to the old SAPI conventions, please give this a deep review. Hope it works ok for addition.

Fixes: #1452 