### PR TITLE
configure/Makefile/helpers.sh: enable running tests without resource manager

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -26,7 +26,11 @@ To build and install the tpm2-tools software the following software is required:
   * To build the man pages you need [pandoc](https://github.com/jgm/pandoc)
   * To enable the new userspace resource manager, one must get tpm2-tabrmd
     (**recommended**).
-  * For the tests: tpm2-abrmd (must be on $PATH) and tpm_server
+  * When ./configure is invoked with --enable-unit or --enable-unit=abrmd,
+    the tests are run towards a resource manager, tpm2-abrmd, which must be on $PATH.
+  * When ./configure is invoked with --enable-unit=mssim, the tests are run directly
+    towards tpm_server, without resource manager.
+  * For the tests, with or without resource manager, tpm_server must be installed.
   * Some tests pass only if xxd, bash and python with PyYAML are available
 
 ### Typical Distro Dependency Installation

--- a/Makefile.am
+++ b/Makefile.am
@@ -247,11 +247,14 @@ test_unit_test_tpm2_error_CFLAGS   = $(AM_CFLAGS) $(CMOCKA_CFLAGS)
 test_unit_test_tpm2_error_LDADD    = $(CMOCKA_LIBS) $(LDADD)
 
 AM_TESTS_ENVIRONMENT =	\
-	TPM2_ABRMD=tpm2-abrmd; export TPM2_ABRMD; \
 	TPM2_SIM=tpm_server; export TPM2_SIM; \
 	PATH=$(abs_builddir)/tools:$(abs_builddir)/tools/misc:$(abs_top_srcdir)/test/integration:$(PATH); \
 	TPM2_TOOLS_TEST_FIXTURES=$(abs_top_srcdir)/test/integration/fixtures; \
 	export TPM2_TOOLS_TEST_FIXTURES;
+
+if UNIT_ABRMD
+AM_TESTS_ENVIRONMENT += TPM2_ABRMD=tpm2-abrmd; export TPM2_ABRMD;
+endif
 
 SH_LOG_COMPILER = dbus-run-session
 AM_SH_LOG_FLAGS = --

--- a/configure.ac
+++ b/configure.ac
@@ -63,10 +63,16 @@ esac
 AC_SUBST([LIBDL_LDFLAGS])
 
 AC_ARG_ENABLE([unit],
-            [AS_HELP_STRING([--enable-unit],
-                            [build cmocka unit tests])],,
+            [AS_HELP_STRING([--enable-unit=[abrmd|mssim]],
+                            [build cmocka unit tests (yes|no|*abrmd*|mssim)])],,
             [enable_unit=no])
+case "$enable_unit" in
+  yes) enable_unit=abrmd;;
+  no|mssim|abrmd) ;;
+  *) AC_MSG_ERROR([Invalid value for --enable-unit, use one of no, abrmd or mssim])
+esac
 AM_CONDITIONAL([UNIT], [test "x$enable_unit" != xno])
+AM_CONDITIONAL([UNIT_ABRMD], [test "$enable_unit" = abrmd])
 
 dnl macro that checks for specific modules in python
 AC_DEFUN([AC_PYTHON_MODULE],
@@ -83,14 +89,14 @@ AC_DEFUN([AC_PYTHON_MODULE],
 AS_IF([test "x$enable_unit" != xno], [
     PKG_CHECK_MODULES([CMOCKA],[cmocka])
 
-    AC_CHECK_PROG([tpm2_abrmd], [tpm2-abrmd],
-        [yes], [no])
-
     AC_CHECK_PROG([tpm_server], [tpm_server],
         [yes], [no])
 
-    AS_IF([test "$tpm2_abrmd" = no],
-          [AC_MSG_ERROR([Required executable tpm2_abrmd not found, try setting PATH])])
+    AS_IF([test "$enable_unit" = abrmd],
+          [AC_CHECK_PROG([tpm2_abrmd], [tpm2-abrmd], yes, no)
+           AS_IF([test "$tpm2_abrmd" = no],
+                 [AC_MSG_ERROR([Required executable tpm2-abrmd not found, try setting \$PATH])])
+          ])
 
     AS_IF([test "$tpm_server" = no],
           [AC_MSG_ERROR([Required executable tpm_server not found, try setting PATH])])

--- a/test/integration/helpers.sh
+++ b/test/integration/helpers.sh
@@ -195,13 +195,15 @@ function start_sim() {
     tpm2_sim_pid=$!
     sleep 1
     if kill -0 "$tpm2_sim_pid"; then
-        local name="com.intel.tss2.Tabrmd${tpm2_sim_port}"
-                    tpm2_tabrmd_opts="--session --dbus-name=$name --tcti=mssim:port=$tpm2_sim_port"
-        echo "tpm2_tabrmd_opts: $tpm2_tabrmd_opts"
+        if [ "${TPM2_ABRMD:+set}" = set ]; then
+            local name="com.intel.tss2.Tabrmd${tpm2_sim_port}"
+            tpm2_tabrmd_opts="--session --dbus-name=$name --tcti=mssim:port=$tpm2_sim_port"
+            echo "tpm2_tabrmd_opts: $tpm2_tabrmd_opts"
 
-        tpm2_tcti_opts="abrmd:bus_type=session,bus_name=$name"
-        echo "tpm2_tcti_opts: $tpm2_tcti_opts"
-        echo "Started simulator in tmp dir: $tpm2_test_cwd"
+            tpm2_tcti_opts="abrmd:bus_type=session,bus_name=$name"
+            echo "tpm2_tcti_opts: $tpm2_tcti_opts"
+            echo "Started simulator in tmp dir: $tpm2_test_cwd"
+	fi
         return 0
     else
         echo "Could not start simulator at port: $tpm2_sim_port"
@@ -258,7 +260,7 @@ function start_up() {
         echo "Started the simulator"
     fi
 
-    if [ -n "$TPM2_ABRMD" ]; then
+    if [ "${TPM2_ABRMD:+set}" = set ]; then
         echo "Starting tpm2-abrmd"
         # Start tpm2-abrmd
         start_abrmd || exit 1


### PR DESCRIPTION
* When ./configure --enable-unit=mssim is invoked, run the tests towards tpm_server, skipping tpm2-abrmd
* When ./configure --enable-unit or ./configure --enable-unit=abrmd is called, run the tests over the resource manager
* When ./configure or ./configure --enable-unit=no or ./configure --disable-unit is called, do not run tests on “make check”.