### PR TITLE
pcr policy: drop -L and -F options and move to policy lang

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## Changelog
 ### next
+  * tpm2_nvincrement: -L and -F pcr policy options go away, replaced with pcr password minilanguage.
+  * tpm2_nvwrite: -L and -F pcr policy options go away, replaced with pcr password minilanguage.
+  * tpm2_nvread: -L and -F pcr policy options go away, replaced with pcr password minilanguage.
+  * tpm2_unseal: -L and -F pcr policy options go away, replaced with pcr password minilanguage.
   * tpm2_evictcontrol: support serializing ESYS_TR handle to disk.
   * tpm2_readpublic: support serializing ESYS_TR handle to disk.
   * tpm2_startauthsession: support encrypted and bound sessions.

--- a/man/common/authorizations.md
+++ b/man/common/authorizations.md
@@ -39,6 +39,11 @@ in the **Passwords** section.
 
 ### Examples
 
+To satisfy a PCR policy of sha256 on banks 0, 1, 2 and 3 use a specifier of:
+```
+pcr:sha256:0,1,2,3
+```
+
 To use a session context file called *session.ctx*.
 ```
 session:session.ctx

--- a/man/common/authorizations.md
+++ b/man/common/authorizations.md
@@ -47,6 +47,21 @@ The `raw-pcr-file` is an **optional** the output of the raw PCR contents as retu
 
 ### Examples
 
+To use the password `mypassword`:
+```
+mypassword
+```
+
+To use a raw binary password of 0x112233 in hex string format:
+```
+hex:112233
+```
+
+To use a password of `hex:` use the str escape:
+```
+str:hex:
+```
+
 To satisfy a PCR policy of sha256 on banks 0, 1, 2 and 3 use a specifier of:
 ```
 pcr:sha256:0,1,2,3

--- a/man/common/authorizations.md
+++ b/man/common/authorizations.md
@@ -25,10 +25,6 @@ with special prefix values, they are:
   * file: - Used when specifying a password stored in a file. Useful to prevent leaking the
          password to UNIX utilities (such as ps).
 
-## HMAC
-
-HMAC tickets can be presented as hex escaped passwords.
-
 ## Sessions
 
 When using a policy session to authorize the use of an object, prefix the option argument
@@ -36,6 +32,18 @@ with the *session* keyword.  Then indicate a path to a session file that was cre
 with tpm2_startauthsession(1). Optionally, if the session requires an auth value to be
 sent with the session handle (eg policy password), then append a + and a string as described
 in the **Passwords** section.
+
+## PCR Authorizations
+
+You can satisfy a PCR policy using the "pcr:" prefix and the PCR minilanguage. The PCR
+minilanguage is as follows:
+`<pcr-spec>+<raw-pcr-file>`
+
+The PCR spec is documented in in the section "PCR bank specifiers".
+
+The `raw-pcr-file` is an **optional** the output of the raw PCR contents as returned by *tpm2_pcrlist(1)*.
+
+[PCR bank specifiers](common/pcr.md)
 
 ### Examples
 

--- a/man/tpm2_nvincrement.1.md
+++ b/man/tpm2_nvincrement.1.md
@@ -39,17 +39,6 @@
     should follow the "authorization formatting standards", see section
     "Authorization Formatting".
 
-  * **-L**, **\--set-list**=_PCR\_SELECTION\_LIST_:
-
-    The list of PCR banks and selected PCRs' ids.
-    _PCR\_SELECTION\_LIST_ values should follow the
-    PCR bank specifiers standards, see section "PCR Bank Specifiers".
-
-  * **-F**, **\--pcr-input-file**=_PCR\_INPUT\_FILE_:
-
-    Optional path or name of the file containing expected PCR values for the specified index.
-    Default is to read the current PCRs per the set list.
-
 [common options](common/options.md)
 
 [common tcti options](common/tcti.md)

--- a/man/tpm2_nvread.1.md
+++ b/man/tpm2_nvread.1.md
@@ -49,17 +49,6 @@
     offset is not specified. If not specified, the size of the data
     as reported by the public portion of the index will be used.
 
-  * **-L**, **\--set-list**=_PCR\_SELECTION\_LIST_:
-
-    The list of PCR banks and selected PCRs' ids.
-    _PCR\_SELECTION\_LIST_ values should follow the
-    PCR bank specifiers standards, see section "PCR Bank Specifiers".
-
-  * **-F**, **\--pcr-input-file=_PCR\_INPUT\_FILE_:
-
-    Optional Path or Name of the file containing expected PCR values for the specified index.
-    Default is to read the current PCRs per the set list.
-
   * **\--offset**=_OFFSET_:
 
     The offset within the NV index to start reading from.

--- a/man/tpm2_nvwrite.1.md
+++ b/man/tpm2_nvwrite.1.md
@@ -40,17 +40,6 @@ If _FILE_ is not specified, it defaults to stdin.
     should follow the "authorization formatting standards", see section
     "Authorization Formatting".
 
-  * **-L**, **\--set-list**=_PCR\_SELECTION\_LIST_:
-
-    The list of PCR banks and selected PCRs' ids.
-    _PCR\_SELECTION\_LIST_ values should follow the
-    PCR bank specifiers standards, see section "PCR Bank Specifiers".
-
-  * **-F**, **\--pcr-input-file**=_PCR\_INPUT\_FILE_:
-
-    Optional Path or Name of the file containing expected PCR values for the specified index.
-    Default is to read the current PCRs per the set list.
-
   * **\--offset**=_OFFSET_:
 
     The offset within the NV index to start writing at.

--- a/test/integration/tests/nv.sh
+++ b/test/integration/tests/nv.sh
@@ -98,9 +98,9 @@ tpm2_createpolicy -Q --policy-pcr -L ${alg_pcr_policy}:${pcr_ids} -F $file_pcr_v
 tpm2_nvdefine -Q -x 0x1500016 -a 0x40000001 -s 32 -L $file_policy -b "policyread|policywrite"
 
 # Write with index authorization for now, since tpm2_nvwrite does not support pcr policy.
-echo -n "policy locked" | tpm2_nvwrite -Q -x 0x1500016 -a 0x1500016 -L ${alg_pcr_policy}:${pcr_ids} -F $file_pcr_value
+echo -n "policy locked" | tpm2_nvwrite -Q -x 0x1500016 -a 0x1500016 -P pcr:${alg_pcr_policy}:${pcr_ids}+$file_pcr_value
 
-str=`tpm2_nvread -x 0x1500016 -a 0x1500016 -L ${alg_pcr_policy}:${pcr_ids} -F $file_pcr_value -s 13`
+str=`tpm2_nvread -x 0x1500016 -a 0x1500016 -P pcr:${alg_pcr_policy}:${pcr_ids}+$file_pcr_value -s 13`
 
 test "policy locked" == "$str"
 

--- a/test/integration/tests/nvinc.sh
+++ b/test/integration/tests/nvinc.sh
@@ -71,9 +71,9 @@ tpm2_nvdefine -Q -x 0x1500016 -a 0x40000001 -s 8 -L $file_policy -b "policyread|
 echo -n -e '\x00\x00\x00\x00\x00\x00\x00\x03' > nv.test_inc
 
 # Counter is initialised to highest value previously seen (in this case 2) then incremented
-tpm2_nvincrement -Q -x 0x1500016 -a 0x1500016 -L ${alg_pcr_policy}:${pcr_ids} -F $file_pcr_value
+tpm2_nvincrement -Q -x 0x1500016 -a 0x1500016 -P pcr:${alg_pcr_policy}:${pcr_ids}+$file_pcr_value
 
-tpm2_nvread -x 0x1500016 -a 0x1500016 -L ${alg_pcr_policy}:${pcr_ids} -F $file_pcr_value -s 8 > cmp.dat
+tpm2_nvread -x 0x1500016 -a 0x1500016 -P pcr:${alg_pcr_policy}:${pcr_ids}+$file_pcr_value -s 8 > cmp.dat
 
 cmp nv.test_inc cmp.dat
 

--- a/test/integration/tests/unseal.sh
+++ b/test/integration/tests/unseal.sh
@@ -82,7 +82,7 @@ tpm2_create -Q -g $alg_create_obj -u $file_unseal_key_pub -r $file_unseal_key_pr
 
 tpm2_load -Q -C $file_primary_key_ctx  -u $file_unseal_key_pub  -r $file_unseal_key_priv -n $file_unseal_key_name -o $file_unseal_key_ctx
 
-unsealed=`tpm2_unseal --context-object $file_unseal_key_ctx -L ${alg_pcr_policy}:${pcr_ids} -F $file_pcr_value`
+unsealed=`tpm2_unseal -V --context-object $file_unseal_key_ctx -p pcr:${alg_pcr_policy}:${pcr_ids}+$file_pcr_value`
 
 test "$unsealed" == "$secret"
 
@@ -102,7 +102,7 @@ pcr_extend=$(echo $pcr_ids | cut -d ',' -f1)
 
 tpm2_pcrextend $pcr_extend:sha1=6c10289a8da7f774cf67bd2fc8502cd4b585346a
 
-tpm2_unseal -c $file_unseal_key_ctx -L ${alg_pcr_policy}:${pcr_ids} -F $file_pcr_value 2> /dev/null
+tpm2_unseal -c $file_unseal_key_ctx -p pcr:${alg_pcr_policy}:${pcr_ids} 2> /dev/null
 if [ $? != 1 ]; then
   echo "tpm2_unseal didn't fail with a PCR state different than the policy!"
   exit 1

--- a/tools/tpm2_nvincrement.c
+++ b/tools/tpm2_nvincrement.c
@@ -37,11 +37,7 @@ struct tpm_nvincrement_ctx {
         tpm2_session *session;
     } auth;
 
-    char *raw_pcrs_file;
-    tpm2_session *policy_session;
-    TPML_PCR_SELECTION pcr_selection;
     struct {
-        UINT8 L : 1;
         UINT8 a : 1;
     } flags;
 };
@@ -114,15 +110,6 @@ static bool on_option(char key, char *value) {
     case 'P':
         ctx.auth.auth_str = value;
         break;
-    case 'L':
-        if (!pcr_parse_selections(value, &ctx.pcr_selection)) {
-            return false;
-        }
-        ctx.flags.L = 1;
-        break;
-    case 'F':
-        ctx.raw_pcrs_file = value;
-        break;
     }
 
     return true;
@@ -135,43 +122,13 @@ bool tpm2_tool_onstart(tpm2_options **opts) {
         { "index",                required_argument, NULL, 'x' },
         { "hierarchy",            required_argument, NULL, 'a' },
         { "auth-hierarchy",       required_argument, NULL, 'P' },
-        { "set-list",             required_argument, NULL, 'L' },
-        { "pcr-input-file",       required_argument, NULL, 'F' },
     };
 
-    *opts = tpm2_options_new("x:a:P:L:F:", ARRAY_LEN(topts), topts,
+    *opts = tpm2_options_new("x:a:P:", ARRAY_LEN(topts), topts,
                              on_option, NULL, 0);
 
     return *opts != NULL;
 }
-
-static bool start_auth_session(ESYS_CONTEXT *ectx) {
-
-    tpm2_session_data *session_data =
-            tpm2_session_data_new(TPM2_SE_POLICY);
-    if (!session_data) {
-        LOG_ERR("oom");
-        return false;
-    }
-
-    ctx.auth.session = tpm2_session_open(ectx,
-            session_data);
-    if (!ctx.auth.session) {
-        LOG_ERR("Could not start tpm session");
-        return false;
-    }
-
-    bool result = tpm2_policy_build_pcr(ectx, ctx.auth.session,
-            ctx.raw_pcrs_file,
-            &ctx.pcr_selection);
-    if (!result) {
-        LOG_ERR("Could not build a pcr policy");
-        return false;
-    }
-
-    return true;
-}
-
 
 int tpm2_tool_onrun(ESYS_CONTEXT *ectx, tpm2_option_flags flags) {
 
@@ -180,12 +137,6 @@ int tpm2_tool_onrun(ESYS_CONTEXT *ectx, tpm2_option_flags flags) {
     int rc = 1;
     bool result;
 
-    if (ctx.flags.L && ctx.auth.auth_str) {
-        LOG_ERR("Can only use either existing session or a new session,"
-                " not both!");
-        goto out;
-    }
-
     /* If the users doesn't specify an authorisation hierarchy use the index
      * passed to -x/--index for the authorisation index.
      */
@@ -193,19 +144,12 @@ int tpm2_tool_onrun(ESYS_CONTEXT *ectx, tpm2_option_flags flags) {
         ctx.hierarchy = ctx.nv_index;
     }
 
-    if (ctx.flags.L) {
-        result = start_auth_session(ectx);
-        if (!result) {
-            goto out;
-        }
-    } else {
-        result = tpm2_auth_util_from_optarg(ectx, ctx.auth.auth_str,
-                &ctx.auth.session, false);
-        if (!result) {
-            LOG_ERR("Invalid handle authorization, got \"%s\"",
-                ctx.auth.auth_str);
-            goto out;
-        }
+    result = tpm2_auth_util_from_optarg(ectx, ctx.auth.auth_str,
+            &ctx.auth.session, false);
+    if (!result) {
+        LOG_ERR("Invalid handle authorization, got \"%s\"",
+            ctx.auth.auth_str);
+        goto out;
     }
 
     result = nv_increment(ectx);


### PR DESCRIPTION
Drop the -F and -L options on nvread, nvwrite, nvincrement and unseal and support via a pcr authorization mini-language. By default, all tools will now support satisfying simple PCR policies via authorization strings.

Fixes: #1016 
