### PR TITLE
LICENSE: Switch to BSD3

### DIFF
--- a/.ci/coveralls-upload.sh
+++ b/.ci/coveralls-upload.sh
@@ -1,11 +1,5 @@
 #!/usr/bin/env bash
 # SPDX-License-Identifier: BSD-3-Clause
-#;**********************************************************************;
-#
-# Copyright (c) 2017, Intel Corporation
-# All rights reserved.
-#
-#;**********************************************************************;
 
 if [ "$ENABLE_COVERAGE" != "true" ]; then
   echo "ENABLE_COVERAGE not true, got "$ENABLE_COVERAGE""

--- a/.ci/coverity.run
+++ b/.ci/coverity.run
@@ -1,11 +1,5 @@
 #!/usr/bin/env bash
 # SPDX-License-Identifier: BSD-3-Clause
-#;**********************************************************************;
-#
-# Copyright (c) 2017, Intel Corporation
-# All rights reserved.
-#
-#;**********************************************************************;
 
 source $TRAVIS_BUILD_DIR/.ci/docker-prelude.sh
 

--- a/.ci/docker-prelude.sh
+++ b/.ci/docker-prelude.sh
@@ -1,11 +1,5 @@
 #!/usr/bin/env bash
 # SPDX-License-Identifier: BSD-3-Clause
-#;**********************************************************************;
-#
-# Copyright (c) 2017, Intel Corporation
-# All rights reserved.
-#
-#;**********************************************************************;
 
 # all command failures are fatal
 set -e

--- a/.ci/docker.run
+++ b/.ci/docker.run
@@ -1,11 +1,5 @@
 #!/usr/bin/env bash
 # SPDX-License-Identifier: BSD-3-Clause
-#;**********************************************************************;
-#
-# Copyright (c) 2017, Intel Corporation
-# All rights reserved.
-#
-#;**********************************************************************;
 
 set -e
 

--- a/.ci/download-deps.sh
+++ b/.ci/download-deps.sh
@@ -1,11 +1,5 @@
 #!/usr/bin/env bash
 # SPDX-License-Identifier: BSD-3-Clause
-#;**********************************************************************;
-#
-# Copyright (c) 2017, Intel Corporation
-# All rights reserved.
-#
-#;**********************************************************************;
 
 function get_deps() {
 

--- a/LICENSE
+++ b/LICENSE
@@ -1,24 +1,24 @@
-Copyright (c) 2015, Intel Corporation
+Redistribution and use in source and binary forms, with or without modification,
+are permitted provided that the following conditions are met:
 
-Redistribution and use in source and binary forms, with or without
-modification, are permitted provided that the following conditions are met:
+1. Redistributions of source code must retain the above copyright notice, this
+   list of conditions and the following disclaimer.
 
-    * Redistributions of source code must retain the above copyright notice,
-      this list of conditions and the following disclaimer.
-    * Redistributions in binary form must reproduce the above copyright
-      notice, this list of conditions and the following disclaimer in the
-      documentation and/or other materials provided with the distribution.
-    * Neither the name of Intel Corporation nor the names of its contributors
-      may be used to endorse or promote products derived from this software
-      without specific prior written permission.
+2. Redistributions in binary form must reproduce the above copyright notice,
+  this list of conditions and the following disclaimer in the documentation
+  and/or other materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its contributors
+   may be used to endorse or promote products derived from this software
+   without specific prior written permission.
 
 THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
 AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
-IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
-DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE
-FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
-DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
-SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
-CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
-OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
-OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE
+GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT
+OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/Makefile.am
+++ b/Makefile.am
@@ -1,10 +1,4 @@
 # SPDX-License-Identifier: BSD-3-Clause
-#;**********************************************************************;
-#
-# Copyright (c) 2018, Intel Corporation
-# All rights reserved.
-#
-#;**********************************************************************;
 
 # ax_code_coverage
 if AUTOCONF_CODE_COVERAGE_2019_01_06

--- a/bootstrap
+++ b/bootstrap
@@ -1,11 +1,5 @@
 #!/bin/sh
 # SPDX-License-Identifier: BSD-3-Clause
-#;**********************************************************************;
-#
-# Copyright (c) 2018, Intel Corporation
-# All rights reserved.
-#
-#;**********************************************************************;
 
 set -e
 

--- a/lib/files.c
+++ b/lib/files.c
@@ -1,9 +1,5 @@
 /* SPDX-License-Identifier: BSD-3-Clause */
-//**********************************************************************;
-// Copyright (c) 2017, Intel Corporation
-// All rights reserved.
-//
-//**********************************************************************;
+
 #include <errno.h>
 #include <inttypes.h>
 #include <libgen.h>

--- a/lib/files.h
+++ b/lib/files.h
@@ -1,9 +1,5 @@
 /* SPDX-License-Identifier: BSD-3-Clause */
-//**********************************************************************;
-// Copyright (c) 2017, Intel Corporation
-// All rights reserved.
-//
-//**********************************************************************;
+
 #ifndef FILES_H
 #define FILES_H
 

--- a/lib/log.c
+++ b/lib/log.c
@@ -1,9 +1,5 @@
 /* SPDX-License-Identifier: BSD-3-Clause */
-//**********************************************************************;
-// Copyright (c) 2017, Intel Corporation
-// All rights reserved.
-//
-//**********************************************************************;
+
 #include <stdarg.h>
 #include <stdbool.h>
 #include <stdio.h>

--- a/lib/log.h
+++ b/lib/log.h
@@ -1,9 +1,5 @@
 /* SPDX-License-Identifier: BSD-3-Clause */
-//**********************************************************************;
-// Copyright (c) 2017, Intel Corporation
-// All rights reserved.
-//
-//**********************************************************************;
+
 #ifndef SRC_LOG_H_
 #define SRC_LOG_H_
 

--- a/lib/pcr.c
+++ b/lib/pcr.c
@@ -1,9 +1,5 @@
 /* SPDX-License-Identifier: BSD-3-Clause */
-//**********************************************************************;
-// Copyright (c) 2017, Intel Corporation
-// All rights reserved.
-//
-//**********************************************************************;
+
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>

--- a/lib/pcr.h
+++ b/lib/pcr.h
@@ -1,9 +1,5 @@
 /* SPDX-License-Identifier: BSD-3-Clause */
-//**********************************************************************;
-// Copyright (c) 2017, Intel Corporation
-// All rights reserved.
-//
-//**********************************************************************;
+
 #ifndef SRC_PCR_H_
 #define SRC_PCR_H_
 

--- a/lib/tpm2_alg_util.c
+++ b/lib/tpm2_alg_util.c
@@ -1,9 +1,5 @@
 /* SPDX-License-Identifier: BSD-3-Clause */
-//**********************************************************************;
-// Copyright (c) 2017, Intel Corporation
-// All rights reserved.
-//
-//**********************************************************************;
+
 #include <stdbool.h>
 #include <stdlib.h>
 #include <string.h>

--- a/lib/tpm2_alg_util.h
+++ b/lib/tpm2_alg_util.h
@@ -1,9 +1,5 @@
 /* SPDX-License-Identifier: BSD-3-Clause */
-//**********************************************************************;
-// Copyright (c) 2017, Intel Corporation
-// All rights reserved.
-//
-//**********************************************************************;
+
 #ifndef LIB_TPM2_ALG_UTIL_H_
 #define LIB_TPM2_ALG_UTIL_H_
 

--- a/lib/tpm2_attr_util.c
+++ b/lib/tpm2_attr_util.c
@@ -1,9 +1,5 @@
 /* SPDX-License-Identifier: BSD-3-Clause */
-//**********************************************************************;
-// Copyright (c) 2017, Intel Corporation
-// All rights reserved.
-//
-//**********************************************************************;
+
 #include <stdbool.h>
 #include <stdlib.h>
 #include <string.h>

--- a/lib/tpm2_attr_util.h
+++ b/lib/tpm2_attr_util.h
@@ -1,9 +1,5 @@
 /* SPDX-License-Identifier: BSD-3-Clause */
-//**********************************************************************;
-// Copyright (c) 2017, Intel Corporation
-// All rights reserved.
-//
-//**********************************************************************;
+
 #ifndef LIB_TPM2_ATTR_UTIL_H_
 #define LIB_TPM2_ATTR_UTIL_H_
 

--- a/lib/tpm2_auth_util.c
+++ b/lib/tpm2_auth_util.c
@@ -1,9 +1,5 @@
 /* SPDX-License-Identifier: BSD-3-Clause */
-//**********************************************************************;
-// Copyright (c) 2017-2018, Intel Corporation
-// All rights reserved.
-//
-//**********************************************************************;
+
 #include <errno.h>
 #include <limits.h>
 #include <stdbool.h>

--- a/lib/tpm2_auth_util.h
+++ b/lib/tpm2_auth_util.h
@@ -1,9 +1,5 @@
 /* SPDX-License-Identifier: BSD-3-Clause */
-//**********************************************************************;
-// Copyright (c) 2017, Intel Corporation
-// All rights reserved.
-//
-//**********************************************************************;
+
 #ifndef SRC_PASSWORD_UTIL_H_
 #define SRC_PASSWORD_UTIL_H_
 

--- a/lib/tpm2_capability.c
+++ b/lib/tpm2_capability.c
@@ -1,9 +1,4 @@
 /* SPDX-License-Identifier: BSD-3-Clause */
-//**********************************************************************;
-// Copyright (c) 2018, Intel Corporation
-// All rights reserved.
-//
-//**********************************************************************;
 
 #include <stdbool.h>
 #include <stdlib.h>

--- a/lib/tpm2_capability.h
+++ b/lib/tpm2_capability.h
@@ -1,9 +1,4 @@
 /* SPDX-License-Identifier: BSD-3-Clause */
-//**********************************************************************;
-// Copyright (c) 2018, Intel Corporation
-// All rights reserved.
-//
-//**********************************************************************;
 
 #ifndef LIB_TPM2_CAPABILITY_H_
 #define LIB_TPM2_CAPABILITY_H_

--- a/lib/tpm2_convert.c
+++ b/lib/tpm2_convert.c
@@ -1,10 +1,4 @@
 /* SPDX-License-Identifier: BSD-3-Clause */
-//**********************************************************************;
-// Copyright (c) 2017, SUSE Linux GmbH
-// Copyright (c) 2018, Intel Corporation
-// All rights reserved.
-//
-//**********************************************************************;
 
 #include <string.h>
 #include <errno.h>

--- a/lib/tpm2_convert.h
+++ b/lib/tpm2_convert.h
@@ -1,10 +1,4 @@
 /* SPDX-License-Identifier: BSD-3-Clause */
-//**********************************************************************;
-// Copyright (c) 2017, SUSE GmbH
-// Copyright (c) 2018, Intel Corporation
-// All rights reserved.
-//
-//**********************************************************************;
 
 #ifndef CONVERSION_H
 #define CONVERSION_H

--- a/lib/tpm2_convert.h
+++ b/lib/tpm2_convert.h
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: BSD-2-Clause */
+/* SPDX-License-Identifier: BSD-3-Clause */
 //**********************************************************************;
 // Copyright (c) 2017, SUSE GmbH
 // Copyright (c) 2018, Intel Corporation

--- a/lib/tpm2_errata.c
+++ b/lib/tpm2_errata.c
@@ -1,9 +1,5 @@
 /* SPDX-License-Identifier: BSD-3-Clause */
-//**********************************************************************;
-// Copyright (c) 2017, Alibaba Group
-// All rights reserved.
-//
-//**********************************************************************;
+
 #include <stdarg.h>
 #include <stdbool.h>
 #include <stdlib.h>

--- a/lib/tpm2_errata.h
+++ b/lib/tpm2_errata.h
@@ -1,9 +1,5 @@
 /* SPDX-License-Identifier: BSD-3-Clause */
-//**********************************************************************;
-// Copyright (c) 2017, Alibaba Group
-// All rights reserved.
-//
-//**********************************************************************;
+
 #ifndef TPM2_ERRATA_H
 #define TPM2_ERRATA_H
 

--- a/lib/tpm2_error.c
+++ b/lib/tpm2_error.c
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: BSD-2-Clause */
+/* SPDX-License-Identifier: BSD-3-Clause */
 //**********************************************************************;
 // Copyright (c) 2018, Intel Corporation
 // All rights reserved.

--- a/lib/tpm2_error.c
+++ b/lib/tpm2_error.c
@@ -1,9 +1,4 @@
 /* SPDX-License-Identifier: BSD-3-Clause */
-//**********************************************************************;
-// Copyright (c) 2018, Intel Corporation
-// All rights reserved.
-//
-//**********************************************************************;
 
 #include <stdarg.h>
 #include <stdbool.h>

--- a/lib/tpm2_error.h
+++ b/lib/tpm2_error.h
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: BSD-2-Clause */
+/* SPDX-License-Identifier: BSD-3-Clause */
 //**********************************************************************;
 // Copyright (c) 2018, Intel Corporation
 // All rights reserved.

--- a/lib/tpm2_error.h
+++ b/lib/tpm2_error.h
@@ -1,9 +1,4 @@
 /* SPDX-License-Identifier: BSD-3-Clause */
-//**********************************************************************;
-// Copyright (c) 2018, Intel Corporation
-// All rights reserved.
-//
-//**********************************************************************;
 
 #ifndef LIB_TPM2_ERROR_H_
 #define LIB_TPM2_ERROR_H_

--- a/lib/tpm2_hash.c
+++ b/lib/tpm2_hash.c
@@ -1,9 +1,5 @@
 /* SPDX-License-Identifier: BSD-3-Clause */
-//**********************************************************************;
-// Copyright (c) 2017, Intel Corporation
-// All rights reserved.
-//
-//**********************************************************************;
+
 #include <errno.h>
 #include <string.h>
 

--- a/lib/tpm2_hash.h
+++ b/lib/tpm2_hash.h
@@ -1,9 +1,5 @@
 /* SPDX-License-Identifier: BSD-3-Clause */
-//**********************************************************************;
-// Copyright (c) 2017, Intel Corporation
-// All rights reserved.
-//
-//**********************************************************************;
+
 #ifndef SRC_TPM_HASH_H_
 #define SRC_TPM_HASH_H_
 

--- a/lib/tpm2_header.h
+++ b/lib/tpm2_header.h
@@ -1,9 +1,5 @@
 /* SPDX-License-Identifier: BSD-3-Clause */
-/*
- * Copyright (c) 2016, Intel Corporation
- * All rights reserved.
- *
- */
+
 #ifndef TPM2_HEADER_H
 #define TPM2_HEADER_H
 

--- a/lib/tpm2_hierarchy.c
+++ b/lib/tpm2_hierarchy.c
@@ -1,9 +1,4 @@
 /* SPDX-License-Identifier: BSD-3-Clause */
-//**********************************************************************;
-// Copyright (c) 2018, Intel Corporation
-// All rights reserved.
-//
-//**********************************************************************;
 
 #include <stdbool.h>
 #include <stdlib.h>

--- a/lib/tpm2_hierarchy.h
+++ b/lib/tpm2_hierarchy.h
@@ -1,9 +1,4 @@
 /* SPDX-License-Identifier: BSD-3-Clause */
-//**********************************************************************;
-// Copyright (c) 2018, Intel Corporation
-// All rights reserved.
-//
-//**********************************************************************;
 
 #ifndef TOOLS_TPM2_HIERARCHY_H_
 #define TOOLS_TPM2_HIERARCHY_H_

--- a/lib/tpm2_identity_util.c
+++ b/lib/tpm2_identity_util.c
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: BSD-2-Clause */
+/* SPDX-License-Identifier: BSD-3-Clause */
 //**********************************************************************;
 // Copyright (c) 2017, Intel Corporation
 // Copyright (c) 2019 Massachusetts Institute of Technology

--- a/lib/tpm2_identity_util.c
+++ b/lib/tpm2_identity_util.c
@@ -1,10 +1,4 @@
 /* SPDX-License-Identifier: BSD-3-Clause */
-//**********************************************************************;
-// Copyright (c) 2017, Intel Corporation
-// Copyright (c) 2019 Massachusetts Institute of Technology
-// All rights reserved.
-//
-//**********************************************************************
 
 #include <errno.h>
 #include <stdint.h>

--- a/lib/tpm2_identity_util.h
+++ b/lib/tpm2_identity_util.h
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: BSD-2-Clause */
+/* SPDX-License-Identifier: BSD-3-Clause */
 //**********************************************************************;
 // Copyright (c) 2017, Intel Corporation
 // Copyright (c) 2019 Massachusetts Institute of Technology

--- a/lib/tpm2_identity_util.h
+++ b/lib/tpm2_identity_util.h
@@ -1,10 +1,4 @@
 /* SPDX-License-Identifier: BSD-3-Clause */
-//**********************************************************************;
-// Copyright (c) 2017, Intel Corporation
-// Copyright (c) 2019 Massachusetts Institute of Technology
-// All rights reserved.
-//
-//**********************************************************************
 
 #ifndef LIB_TPM2_IDENTITY_UTIL_H_
 #define LIB_TPM2_IDENTITY_UTIL_H_

--- a/lib/tpm2_kdfa.c
+++ b/lib/tpm2_kdfa.c
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: BSD-2-Clause */
+/* SPDX-License-Identifier: BSD-3-Clause */
 //**********************************************************************;
 // Copyright (c) 2015, Intel Corporation
 // All rights reserved.

--- a/lib/tpm2_kdfa.c
+++ b/lib/tpm2_kdfa.c
@@ -1,9 +1,4 @@
 /* SPDX-License-Identifier: BSD-3-Clause */
-//**********************************************************************;
-// Copyright (c) 2015, Intel Corporation
-// All rights reserved.
-//
-//**********************************************************************;
 
 #include <tss2/tss2_sys.h>
 

--- a/lib/tpm2_kdfa.h
+++ b/lib/tpm2_kdfa.h
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: BSD-2-Clause */
+/* SPDX-License-Identifier: BSD-3-Clause */
 //**********************************************************************;
 // Copyright (c) 2015, Intel Corporation
 // All rights reserved.

--- a/lib/tpm2_kdfa.h
+++ b/lib/tpm2_kdfa.h
@@ -1,9 +1,4 @@
 /* SPDX-License-Identifier: BSD-3-Clause */
-//**********************************************************************;
-// Copyright (c) 2015, Intel Corporation
-// All rights reserved.
-//
-//**********************************************************************;
 
 #ifndef SRC_TPM_KDFA_H_
 #define SRC_TPM_KDFA_H_

--- a/lib/tpm2_nv_util.h
+++ b/lib/tpm2_nv_util.h
@@ -1,9 +1,5 @@
 /* SPDX-License-Identifier: BSD-3-Clause */
-//**********************************************************************;
-// Copyright (c) 2017, Intel Corporation
-// All rights reserved.
-//
-//**********************************************************************;
+
 #ifndef LIB_TPM2_NV_UTIL_H_
 #define LIB_TPM2_NV_UTIL_H_
 

--- a/lib/tpm2_openssl.c
+++ b/lib/tpm2_openssl.c
@@ -1,9 +1,4 @@
 /* SPDX-License-Identifier: BSD-3-Clause */
-//**********************************************************************;
-// Copyright (c) 2017, Intel Corporation
-// All rights reserved.
-//
-//**********************************************************************
 
 #include <errno.h>
 #include <stdint.h>

--- a/lib/tpm2_openssl.c
+++ b/lib/tpm2_openssl.c
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: BSD-2-Clause */
+/* SPDX-License-Identifier: BSD-3-Clause */
 //**********************************************************************;
 // Copyright (c) 2017, Intel Corporation
 // All rights reserved.

--- a/lib/tpm2_openssl.h
+++ b/lib/tpm2_openssl.h
@@ -1,9 +1,4 @@
 /* SPDX-License-Identifier: BSD-3-Clause */
-//**********************************************************************;
-// Copyright (c) 2017, Intel Corporation
-// All rights reserved.
-//
-//**********************************************************************
 
 #ifndef LIB_TPM2_OPENSSL_H_
 #define LIB_TPM2_OPENSSL_H_

--- a/lib/tpm2_openssl.h
+++ b/lib/tpm2_openssl.h
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: BSD-2-Clause */
+/* SPDX-License-Identifier: BSD-3-Clause */
 //**********************************************************************;
 // Copyright (c) 2017, Intel Corporation
 // All rights reserved.

--- a/lib/tpm2_options.c
+++ b/lib/tpm2_options.c
@@ -1,9 +1,4 @@
 /* SPDX-License-Identifier: BSD-3-Clause */
-/*
- * Copyright (c) 2016-2018, Intel Corporation
- * All rights reserved.
- *
- */
 
 #include <errno.h>
 #include <stdbool.h>

--- a/lib/tpm2_options.h
+++ b/lib/tpm2_options.h
@@ -1,9 +1,5 @@
 /* SPDX-License-Identifier: BSD-3-Clause */
-/*
- * Copyright (c) 2016, Intel Corporation
- * All rights reserved.
- *
- */
+
 #ifndef OPTIONS_H
 #define OPTIONS_H
 

--- a/lib/tpm2_policy.c
+++ b/lib/tpm2_policy.c
@@ -1,9 +1,5 @@
 /* SPDX-License-Identifier: BSD-3-Clause */
-//**********************************************************************;
-// Copyright (c) 2017, Intel Corporation
-// All rights reserved.
-//
-//**********************************************************************;
+
 #include <stdbool.h>
 #include <stdio.h>
 #include <stdlib.h>

--- a/lib/tpm2_policy.h
+++ b/lib/tpm2_policy.h
@@ -1,9 +1,5 @@
 /* SPDX-License-Identifier: BSD-3-Clause */
-//**********************************************************************;
-// Copyright (c) 2017, Intel Corporation
-// All rights reserved.
-//
-//**********************************************************************;
+
 #ifndef TPM2_POLICY_H_
 #define TPM2_POLICY_H_
 

--- a/lib/tpm2_session.c
+++ b/lib/tpm2_session.c
@@ -1,9 +1,4 @@
 /* SPDX-License-Identifier: BSD-3-Clause */
-//**********************************************************************;
-// Copyright (c) 2015, Intel Corporation
-// All rights reserved.
-//
-//**********************************************************************;
 
 #include <errno.h>
 #include <stdbool.h>

--- a/lib/tpm2_session.c
+++ b/lib/tpm2_session.c
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: BSD-2-Clause */
+/* SPDX-License-Identifier: BSD-3-Clause */
 //**********************************************************************;
 // Copyright (c) 2015, Intel Corporation
 // All rights reserved.

--- a/lib/tpm2_session.h
+++ b/lib/tpm2_session.h
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: BSD-2-Clause */
+/* SPDX-License-Identifier: BSD-3-Clause */
 //**********************************************************************;
 // Copyright (c) 2015, Intel Corporation
 // All rights reserved.

--- a/lib/tpm2_session.h
+++ b/lib/tpm2_session.h
@@ -1,9 +1,4 @@
 /* SPDX-License-Identifier: BSD-3-Clause */
-//**********************************************************************;
-// Copyright (c) 2015, Intel Corporation
-// All rights reserved.
-//
-//**********************************************************************;
 
 #ifndef SRC_TPM2_SESSION_H_
 #define SRC_TPM2_SESSION_H_

--- a/lib/tpm2_tcti_ldr.c
+++ b/lib/tpm2_tcti_ldr.c
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: BSD-2-Clause */
+/* SPDX-License-Identifier: BSD-3-Clause */
 //**********************************************************************;
 // Copyright (c) 2018, Intel Corporation
 // All rights reserved.

--- a/lib/tpm2_tcti_ldr.c
+++ b/lib/tpm2_tcti_ldr.c
@@ -1,9 +1,4 @@
 /* SPDX-License-Identifier: BSD-3-Clause */
-//**********************************************************************;
-// Copyright (c) 2018, Intel Corporation
-// All rights reserved.
-//
-//**********************************************************************;
 
 #include <limits.h>
 #include <stdlib.h>

--- a/lib/tpm2_tcti_ldr.h
+++ b/lib/tpm2_tcti_ldr.h
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: BSD-2-Clause */
+/* SPDX-License-Identifier: BSD-3-Clause */
 //**********************************************************************;
 // Copyright (c) 2018, Intel Corporation
 // All rights reserved.

--- a/lib/tpm2_tcti_ldr.h
+++ b/lib/tpm2_tcti_ldr.h
@@ -1,9 +1,4 @@
 /* SPDX-License-Identifier: BSD-3-Clause */
-//**********************************************************************;
-// Copyright (c) 2018, Intel Corporation
-// All rights reserved.
-//
-//**********************************************************************;
 
 #include <tss2/tss2_sys.h>
 

--- a/lib/tpm2_util.c
+++ b/lib/tpm2_util.c
@@ -1,9 +1,5 @@
 /* SPDX-License-Identifier: BSD-3-Clause */
-//**********************************************************************;
-// Copyright (c) 2017-2018, Intel Corporation
-// All rights reserved.
-//
-//**********************************************************************;
+
 #include <ctype.h>
 #include <errno.h>
 #include <stdbool.h>

--- a/lib/tpm2_util.h
+++ b/lib/tpm2_util.h
@@ -1,9 +1,5 @@
 /* SPDX-License-Identifier: BSD-3-Clause */
-//**********************************************************************;
-// Copyright (c) 2017-2018, Intel Corporation
-// All rights reserved.
-//
-//**********************************************************************;
+
 #ifndef STRING_BYTES_H
 #define STRING_BYTES_H
 

--- a/scripts/utils/icert2pem.sh
+++ b/scripts/utils/icert2pem.sh
@@ -1,11 +1,5 @@
 #!/bin/sh
 # SPDX-License-Identifier: BSD-3-Clause
-#;**********************************************************************;
-#
-# Copyright (c) 2016, Intel Corporation
-# All rights reserved.
-#
-#;**********************************************************************;
 
 usage() {
 cat <<EOF

--- a/scripts/utils/tcgRSApub2PemDer.sh
+++ b/scripts/utils/tcgRSApub2PemDer.sh
@@ -1,11 +1,5 @@
 #!/bin/bash
 # SPDX-License-Identifier: BSD-3-Clause
-#;**********************************************************************;
-#
-# Copyright (c) 2016, Intel Corporation
-# All rights reserved.
-#
-#;**********************************************************************;
 
 echo 'MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEA' | base64 -d > header.bin
 echo '02 03' | xxd -r -p >mid-header.bin

--- a/test/integration/helpers.sh
+++ b/test/integration/helpers.sh
@@ -1,12 +1,5 @@
 #!/bin/bash
 # SPDX-License-Identifier: BSD-3-Clause
-#;**********************************************************************;
-#
-# Copyright (c) 2017, Alibaba Group
-# Copyright (c) 2018, Intel Corporation
-# All rights reserved.
-#
-#;**********************************************************************;
 
 function filter_algs_by() {
 

--- a/test/integration/tests/activecredential.sh
+++ b/test/integration/tests/activecredential.sh
@@ -1,11 +1,5 @@
 #!/bin/bash
 # SPDX-License-Identifier: BSD-3-Clause
-#;**********************************************************************;
-#
-# Copyright (c) 2016-2018, Intel Corporation
-# All rights reserved.
-#
-#;**********************************************************************;
 
 source helpers.sh
 

--- a/test/integration/tests/certify.sh
+++ b/test/integration/tests/certify.sh
@@ -1,11 +1,5 @@
 #!/bin/bash
 # SPDX-License-Identifier: BSD-3-Clause
-#;**********************************************************************;
-#
-# Copyright (c) 2016-2018, Intel Corporation
-# All rights reserved.
-#
-#;**********************************************************************;
 
 source helpers.sh
 

--- a/test/integration/tests/changeauth.sh
+++ b/test/integration/tests/changeauth.sh
@@ -1,11 +1,5 @@
 #!/bin/bash
 # SPDX-License-Identifier: BSD-3-Clause
-#;**********************************************************************;
-#
-# Copyright (c) 2016-2018, Intel Corporation
-# All rights reserved.
-#
-#;**********************************************************************;
 
 source helpers.sh
 

--- a/test/integration/tests/checkquote.sh
+++ b/test/integration/tests/checkquote.sh
@@ -1,11 +1,5 @@
 #!/bin/bash
 # SPDX-License-Identifier: BSD-3-Clause
-#;**********************************************************************;
-#
-# Copyright (c) 2019 Massachusetts Institute of Technology.
-# All rights reserved.
-#
-#;**********************************************************************;
 
 source helpers.sh
 

--- a/test/integration/tests/clearlock.sh
+++ b/test/integration/tests/clearlock.sh
@@ -1,12 +1,5 @@
 #!/bin/bash
 # SPDX-License-Identifier: BSD-3-Clause
-#;**********************************************************************;
-#
-# Copyright (c) 2017, Emmanuel Deloget <logout@free.fr>
-# Copyright (c) 2018, Intel Corporation
-# All rights reserved.
-#
-#;**********************************************************************;
 
 source helpers.sh
 

--- a/test/integration/tests/create.sh
+++ b/test/integration/tests/create.sh
@@ -1,11 +1,5 @@
 #!/bin/bash
 # SPDX-License-Identifier: BSD-3-Clause
-#;**********************************************************************;
-#
-# Copyright (c) 2016-2018, Intel Corporation
-# All rights reserved.
-#
-#;**********************************************************************;
 
 source helpers.sh
 

--- a/test/integration/tests/createak.sh
+++ b/test/integration/tests/createak.sh
@@ -1,11 +1,5 @@
 #!/bin/bash
 # SPDX-License-Identifier: BSD-3-Clause
-#;**********************************************************************;
-#
-# Copyright (c) 2016-2018, Intel Corporation
-# All rights reserved.
-#
-#;**********************************************************************;
 
 source helpers.sh
 

--- a/test/integration/tests/createek.sh
+++ b/test/integration/tests/createek.sh
@@ -1,11 +1,5 @@
 #!/bin/bash
 # SPDX-License-Identifier: BSD-3-Clause
-#;**********************************************************************;
-#
-# Copyright (c) 2016-2018, Intel Corporation
-# All rights reserved.
-#
-#;**********************************************************************;
 
 source helpers.sh
 

--- a/test/integration/tests/createpolicy.sh
+++ b/test/integration/tests/createpolicy.sh
@@ -1,11 +1,5 @@
 #!/bin/bash
 # SPDX-License-Identifier: BSD-3-Clause
-#;**********************************************************************;
-#
-# Copyright (c) 2016-2018, Intel Corporation
-# All rights reserved.
-#
-#;**********************************************************************;
 
 source helpers.sh
 

--- a/test/integration/tests/createprimary.sh
+++ b/test/integration/tests/createprimary.sh
@@ -1,11 +1,5 @@
 #!/bin/bash
 # SPDX-License-Identifier: BSD-3-Clause
-#;**********************************************************************;
-#
-# Copyright (c) 2016-2018, Intel Corporation
-# All rights reserved.
-#
-#;**********************************************************************;
 
 source helpers.sh
 

--- a/test/integration/tests/dictionarylockout.sh
+++ b/test/integration/tests/dictionarylockout.sh
@@ -1,11 +1,6 @@
 #!/bin/bash
 # SPDX-License-Identifier: BSD-3-Clause
-#;**********************************************************************;
-#
-# Copyright (c) 2016-2018, Intel Corporation
-# All rights reserved.
-#
-#;**********************************************************************;
+
 ###this script use for test the implementation tpm2_dictionarylockout
 
 source helpers.sh

--- a/test/integration/tests/duplicate.sh
+++ b/test/integration/tests/duplicate.sh
@@ -1,11 +1,5 @@
 #!/bin/bash
 # SPDX-License-Identifier: BSD-3-Clause
-#;**********************************************************************;
-#
-# Copyright (c) 2019, GlovePuppet
-# All rights reserved.
-#
-#;**********************************************************************;
 
 source helpers.sh
 

--- a/test/integration/tests/encryptdecrypt.sh
+++ b/test/integration/tests/encryptdecrypt.sh
@@ -1,11 +1,5 @@
 #!/bin/bash
 # SPDX-License-Identifier: BSD-3-Clause
-#;**********************************************************************;
-#
-# Copyright (c) 2016-2018, Intel Corporation
-# All rights reserved.
-#
-#;**********************************************************************;
 
 source helpers.sh
 

--- a/test/integration/tests/evictcontrol.sh
+++ b/test/integration/tests/evictcontrol.sh
@@ -1,11 +1,5 @@
 #!/bin/bash
 # SPDX-License-Identifier: BSD-3-Clause
-#;**********************************************************************;
-#
-# Copyright (c) 2016-2018, Intel Corporation
-# All rights reserved.
-#
-#;**********************************************************************;
 
 source helpers.sh
 

--- a/test/integration/tests/flushcontext.sh
+++ b/test/integration/tests/flushcontext.sh
@@ -1,12 +1,5 @@
 #!/bin/bash
 # SPDX-License-Identifier: BSD-3-Clause
-#;**********************************************************************;
-#
-# Copyright (c) 2017, Alibaba Group
-# Copyright (c) 2018, Intel Corporation
-# All rights reserved.
-#
-#;**********************************************************************;
 
 source helpers.sh
 

--- a/test/integration/tests/getcap.sh
+++ b/test/integration/tests/getcap.sh
@@ -1,11 +1,5 @@
 #!/bin/bash
 # SPDX-License-Identifier: BSD-3-Clause
-#;**********************************************************************;
-#
-# Copyright (c) 2016-2018, Intel Corporation
-# All rights reserved.
-#
-#;**********************************************************************;
 
 source helpers.sh
 

--- a/test/integration/tests/getmanufec.sh
+++ b/test/integration/tests/getmanufec.sh
@@ -1,11 +1,5 @@
 #!/bin/bash
 # SPDX-License-Identifier: BSD-3-Clause
-#;**********************************************************************;
-#
-# Copyright (c) 2016-2018, Intel Corporation
-# All rights reserved.
-#
-#;**********************************************************************;
 
 source helpers.sh
 

--- a/test/integration/tests/getrandom.sh
+++ b/test/integration/tests/getrandom.sh
@@ -1,11 +1,5 @@
 #!/bin/bash
 # SPDX-License-Identifier: BSD-3-Clause
-#;**********************************************************************;
-#
-# Copyright (c) 2016-2018, Intel Corporation
-# All rights reserved.
-#
-#;**********************************************************************;
 
 source helpers.sh
 

--- a/test/integration/tests/gettestresult.sh
+++ b/test/integration/tests/gettestresult.sh
@@ -1,11 +1,5 @@
 #!/bin/bash
 # SPDX-License-Identifier: BSD-3-Clause
-#;**********************************************************************;
-#
-# Copyright (c) 2019, Sebastien LE STUM
-# All rights reserved.
-#
-#;**********************************************************************;
 
 source helpers.sh
 

--- a/test/integration/tests/hash.sh
+++ b/test/integration/tests/hash.sh
@@ -1,11 +1,5 @@
 #!/bin/bash
 # SPDX-License-Identifier: BSD-3-Clause
-#;**********************************************************************;
-#
-# Copyright (c) 2016-2018, Intel Corporation
-# All rights reserved.
-#
-#;**********************************************************************;
 
 #this script is for hash case testing
 

--- a/test/integration/tests/hmac.sh
+++ b/test/integration/tests/hmac.sh
@@ -1,11 +1,5 @@
 #!/bin/bash
 # SPDX-License-Identifier: BSD-3-Clause
-#;**********************************************************************;
-#
-# Copyright (c) 2016-2018, Intel Corporation
-# All rights reserved.
-#
-#;**********************************************************************;
 
 source helpers.sh
 

--- a/test/integration/tests/import.sh
+++ b/test/integration/tests/import.sh
@@ -1,11 +1,5 @@
 #!/bin/bash
 # SPDX-License-Identifier: BSD-3-Clause
-#;**********************************************************************;
-#
-# Copyright (c) 2017-2018, Intel Corporation
-# All rights reserved.
-#
-#;**********************************************************************;
 
 source helpers.sh
 

--- a/test/integration/tests/incrementalselftest.sh
+++ b/test/integration/tests/incrementalselftest.sh
@@ -1,11 +1,5 @@
 #!/bin/bash
 # SPDX-License-Identifier: BSD-3-Clause
-#;**********************************************************************;
-#
-# Copyright (c) 2019, Sebastien LE STUM
-# All rights reserved.
-#
-#;**********************************************************************;
 
 source helpers.sh
 

--- a/test/integration/tests/listpersistent.sh
+++ b/test/integration/tests/listpersistent.sh
@@ -1,12 +1,5 @@
 #!/bin/bash
 # SPDX-License-Identifier: BSD-3-Clause
-#;**********************************************************************;
-#
-# Copyright (c) 2017, Red Hat, Inc.
-# Copyright (c) 2018, Intel Corporation
-# All rights reserved.
-#
-#;**********************************************************************;
 
 source helpers.sh
 

--- a/test/integration/tests/load.sh
+++ b/test/integration/tests/load.sh
@@ -1,11 +1,5 @@
 #!/bin/bash
 # SPDX-License-Identifier: BSD-3-Clause
-#;**********************************************************************;
-#
-# Copyright (c) 2016-2018, Intel Corporation
-# All rights reserved.
-#
-#;**********************************************************************;
 
 source helpers.sh
 

--- a/test/integration/tests/loadexternal.sh
+++ b/test/integration/tests/loadexternal.sh
@@ -1,11 +1,5 @@
 #!/bin/bash
 # SPDX-License-Identifier: BSD-3-Clause
-#;**********************************************************************;
-#
-# Copyright (c) 2016-2018, Intel Corporation
-# All rights reserved.
-#
-#;**********************************************************************;
 
 source helpers.sh
 

--- a/test/integration/tests/makecredential.sh
+++ b/test/integration/tests/makecredential.sh
@@ -1,11 +1,5 @@
 #!/bin/bash
 # SPDX-License-Identifier: BSD-3-Clause
-#;**********************************************************************;
-#
-# Copyright (c) 2016-2018, Intel Corporation
-# All rights reserved.
-#
-#;**********************************************************************;
 
 source helpers.sh
 

--- a/test/integration/tests/nv.sh
+++ b/test/integration/tests/nv.sh
@@ -1,11 +1,5 @@
 #!/bin/bash
 # SPDX-License-Identifier: BSD-3-Clause
-#;**********************************************************************;
-#
-# Copyright (c) 2016-2018, Intel Corporation
-# All rights reserved.
-#
-#;**********************************************************************;
 
 source helpers.sh
 

--- a/test/integration/tests/nvinc.sh
+++ b/test/integration/tests/nvinc.sh
@@ -1,11 +1,6 @@
 #!/bin/bash
 # SPDX-License-Identifier: BSD-3-Clause
 #;**********************************************************************;
-#
-# Copyright (c) 2016-2018, Intel Corporation
-# All rights reserved.
-#
-#;**********************************************************************;
 
 source helpers.sh
 

--- a/test/integration/tests/output_formats.sh
+++ b/test/integration/tests/output_formats.sh
@@ -1,12 +1,5 @@
 #!/bin/bash
 # SPDX-License-Identifier: BSD-3-Clause
-#;**********************************************************************;
-#
-# Copyright (c) 2017, SUSE Linux GmbH
-# Copyright (c) 2018, Intel Corporation
-# All rights reserved.
-#
-#;**********************************************************************;
 
 source helpers.sh
 

--- a/test/integration/tests/pcrallocate.sh
+++ b/test/integration/tests/pcrallocate.sh
@@ -1,12 +1,5 @@
 #!/bin/bash
 # SPDX-License-Identifier: BSD-3-Clause
-#;**********************************************************************;
-#
-# Copyright (c) 2016-2018, Intel Corporation
-# Copyright (c) 2019, Fraunhofer SIT
-# All rights reserved.
-#
-#;**********************************************************************;
 
 source helpers.sh
 

--- a/test/integration/tests/pcrevent.sh
+++ b/test/integration/tests/pcrevent.sh
@@ -1,11 +1,5 @@
 #!/bin/bash
 # SPDX-License-Identifier: BSD-3-Clause
-#;**********************************************************************;
-#
-# Copyright (c) 2017-2018, Intel Corporation
-# All rights reserved.
-#
-#;**********************************************************************;
 
 #this script is for hash case testing
 

--- a/test/integration/tests/pcrextend.sh
+++ b/test/integration/tests/pcrextend.sh
@@ -1,11 +1,5 @@
 #!/bin/bash
 # SPDX-License-Identifier: BSD-3-Clause
-#;**********************************************************************;
-#
-# Copyright (c) 2017-2018, Intel Corporation
-# All rights reserved.
-#
-#;**********************************************************************;
 
 source helpers.sh
 

--- a/test/integration/tests/pcrlist.sh
+++ b/test/integration/tests/pcrlist.sh
@@ -1,11 +1,5 @@
 #!/bin/bash
 # SPDX-License-Identifier: BSD-3-Clause
-#;**********************************************************************;
-#
-# Copyright (c) 2016-2018, Intel Corporation
-# All rights reserved.
-#
-#;**********************************************************************;
 
 source helpers.sh
 

--- a/test/integration/tests/pcrreset.sh
+++ b/test/integration/tests/pcrreset.sh
@@ -1,11 +1,5 @@
 #!/bin/bash
 # SPDX-License-Identifier: BSD-3-Clause
-#;**********************************************************************;
-#
-# Copyright (c) 2019, Sebastien LE STUM
-# All rights reserved.
-#
-#;**********************************************************************;
 
 source helpers.sh
 

--- a/test/integration/tests/print.sh
+++ b/test/integration/tests/print.sh
@@ -1,11 +1,5 @@
 #!/bin/bash
 # SPDX-License-Identifier: BSD-3-Clause
-#;**********************************************************************;
-#
-# Copyright (c) 2018, National Instruments
-# All rights reserved.
-#
-#;**********************************************************************;
 
 source helpers.sh
 

--- a/test/integration/tests/quote.sh
+++ b/test/integration/tests/quote.sh
@@ -1,11 +1,5 @@
 #!/bin/bash
 # SPDX-License-Identifier: BSD-3-Clause
-#;**********************************************************************;
-#
-# Copyright (c) 2016-2018, Intel Corporation
-# All rights reserved.
-#
-#;**********************************************************************;
 
 source helpers.sh
 

--- a/test/integration/tests/rc_decode.sh
+++ b/test/integration/tests/rc_decode.sh
@@ -1,11 +1,5 @@
 #!/bin/bash
 # SPDX-License-Identifier: BSD-3-Clause
-#;**********************************************************************;
-#
-# Copyright (c) 2016-2018, Intel Corporation
-# All rights reserved.
-#
-#;**********************************************************************;
 
 source helpers.sh
 

--- a/test/integration/tests/readpublic.sh
+++ b/test/integration/tests/readpublic.sh
@@ -1,11 +1,5 @@
 #!/bin/bash
 # SPDX-License-Identifier: BSD-3-Clause
-#;**********************************************************************;
-#
-# Copyright (c) 2016-2018, Intel Corporation
-# All rights reserved.
-#
-#;**********************************************************************;
 
 source helpers.sh
 

--- a/test/integration/tests/rsadecrypt.sh
+++ b/test/integration/tests/rsadecrypt.sh
@@ -1,11 +1,5 @@
 #!/bin/bash
 # SPDX-License-Identifier: BSD-3-Clause
-#;**********************************************************************;
-#
-# Copyright (c) 2016-2018, Intel Corporation
-# All rights reserved.
-#
-#;**********************************************************************;
 
 source helpers.sh
 

--- a/test/integration/tests/rsaencrypt.sh
+++ b/test/integration/tests/rsaencrypt.sh
@@ -1,11 +1,5 @@
 #!/bin/bash
 # SPDX-License-Identifier: BSD-3-Clause
-#;**********************************************************************;
-#
-# Copyright (c) 2016-2018, Intel Corporation
-# All rights reserved.
-#
-#;**********************************************************************;
 
 source helpers.sh
 

--- a/test/integration/tests/selftest.sh
+++ b/test/integration/tests/selftest.sh
@@ -1,11 +1,5 @@
 #!/bin/bash
 # SPDX-License-Identifier: BSD-3-Clause
-#;**********************************************************************;
-#
-# Copyright (c) 2019, Sebastien LE STUM
-# All rights reserved.
-#
-#;**********************************************************************;
 
 source helpers.sh
 

--- a/test/integration/tests/send.sh
+++ b/test/integration/tests/send.sh
@@ -1,11 +1,5 @@
 #!/bin/bash
 # SPDX-License-Identifier: BSD-3-Clause
-#;**********************************************************************;
-#
-# Copyright (c) 2016-2018, Intel Corporation
-# All rights reserved.
-#
-#;**********************************************************************;
 
 source helpers.sh
 

--- a/test/integration/tests/sign.sh
+++ b/test/integration/tests/sign.sh
@@ -1,11 +1,5 @@
 #!/bin/bash
 # SPDX-License-Identifier: BSD-3-Clause
-#;**********************************************************************;
-#
-# Copyright (c) 2016-2018, Intel Corporation
-# All rights reserved.
-#
-#;**********************************************************************;
 
 source helpers.sh
 

--- a/test/integration/tests/startup.sh
+++ b/test/integration/tests/startup.sh
@@ -1,11 +1,5 @@
 #!/bin/bash
 # SPDX-License-Identifier: BSD-3-Clause
-#;**********************************************************************;
-#
-# Copyright (c) 2016-2018, Intel Corporation
-# All rights reserved.
-#
-#;**********************************************************************;
 
 source helpers.sh
 

--- a/test/integration/tests/stirrandom.sh
+++ b/test/integration/tests/stirrandom.sh
@@ -1,11 +1,5 @@
 #!/bin/bash
 # SPDX-License-Identifier: BSD-3-Clause
-#;**********************************************************************;
-#
-# Copyright (c) 2019, Sebastien LE STUM
-# All rights reserved.
-#
-#;**********************************************************************;
 
 source helpers.sh
 

--- a/test/integration/tests/tcti/abrmd/extended-sessions.sh
+++ b/test/integration/tests/tcti/abrmd/extended-sessions.sh
@@ -1,11 +1,5 @@
 #!/bin/bash
 # SPDX-License-Identifier: BSD-3-Clause
-#;**********************************************************************;
-#
-# Copyright (c) 2018, Intel Corporation
-# All rights reserved.
-#
-#;**********************************************************************;
 
 source helpers.sh
 

--- a/test/integration/tests/tcti/abrmd/policyauthorize.sh
+++ b/test/integration/tests/tcti/abrmd/policyauthorize.sh
@@ -1,11 +1,5 @@
 #!/bin/bash
 # SPDX-License-Identifier: BSD-3-Clause
-#;**********************************************************************;
-#
-# Copyright (c) 2018, Intel Corporation
-# All rights reserved.
-#
-#;**********************************************************************;
 
 source helpers.sh
 

--- a/test/integration/tests/tcti/abrmd/policycommandcode.sh
+++ b/test/integration/tests/tcti/abrmd/policycommandcode.sh
@@ -1,11 +1,5 @@
 #!/bin/bash
 # SPDX-License-Identifier: BSD-3-Clause
-#;**********************************************************************;
-#
-# Copyright (c) 2018, Intel Corporation
-# All rights reserved.
-#
-#;**********************************************************************;
 
 source helpers.sh
 

--- a/test/integration/tests/tcti/abrmd/policyor.sh
+++ b/test/integration/tests/tcti/abrmd/policyor.sh
@@ -1,11 +1,5 @@
 #!/bin/bash
 # SPDX-License-Identifier: BSD-3-Clause
-#;**********************************************************************;
-#
-# Copyright (c) 2018, Intel Corporation
-# All rights reserved.
-#
-#;**********************************************************************;
 
 source helpers.sh
 

--- a/test/integration/tests/tcti/abrmd/policypassword.sh
+++ b/test/integration/tests/tcti/abrmd/policypassword.sh
@@ -1,11 +1,5 @@
 #!/bin/bash
 # SPDX-License-Identifier: BSD-3-Clause
-#;**********************************************************************;
-#
-# Copyright (c) 2018, Intel Corporation
-# All rights reserved.
-#
-#;**********************************************************************;
 
 source helpers.sh
 

--- a/test/integration/tests/tcti/abrmd/policysecret.sh
+++ b/test/integration/tests/tcti/abrmd/policysecret.sh
@@ -1,11 +1,5 @@
 #!/bin/bash
 # SPDX-License-Identifier: BSD-3-Clause
-#;**********************************************************************;
-#
-# Copyright (c) 2018, Intel Corporation
-# All rights reserved.
-#
-#;**********************************************************************;
 
 source helpers.sh
 

--- a/test/integration/tests/testparms.sh
+++ b/test/integration/tests/testparms.sh
@@ -1,11 +1,5 @@
 #!/bin/bash
 # SPDX-License-Identifier: BSD-3-Clause
-#;**********************************************************************;
-#
-# Copyright (c) 2019, Sebastien LE STUM
-# All rights reserved.
-#
-#;**********************************************************************;
 
 source helpers.sh
 

--- a/test/integration/tests/toggle_options.sh
+++ b/test/integration/tests/toggle_options.sh
@@ -1,11 +1,5 @@
 #!/bin/bash
 # SPDX-License-Identifier: BSD-3-Clause
-#;**********************************************************************;
-#
-# Copyright (c) 2019, Sebastien LE STUM
-# All rights reserved.
-#
-#;**********************************************************************;
 
 source helpers.sh
 

--- a/test/integration/tests/unseal.sh
+++ b/test/integration/tests/unseal.sh
@@ -1,11 +1,5 @@
 #!/bin/bash
 # SPDX-License-Identifier: BSD-3-Clause
-#;**********************************************************************;
-#
-# Copyright (c) 2016-2018, Intel Corporation
-# All rights reserved.
-#
-#;**********************************************************************;
 
 source helpers.sh
 

--- a/test/integration/tests/verifysignature.sh
+++ b/test/integration/tests/verifysignature.sh
@@ -1,11 +1,5 @@
 #!/bin/bash
 # SPDX-License-Identifier: BSD-3-Clause
-#;**********************************************************************;
-#
-# Copyright (c) 2016-2018, Intel Corporation
-# All rights reserved.
-#
-#;**********************************************************************;
 
 source helpers.sh
 

--- a/test/unit/test_files.c
+++ b/test/unit/test_files.c
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: BSD-2-Clause */
+/* SPDX-License-Identifier: BSD-3-Clause */
 //**********************************************************************;
 // Copyright (c) 2016, Intel Corporation
 // All rights reserved.

--- a/test/unit/test_files.c
+++ b/test/unit/test_files.c
@@ -1,9 +1,5 @@
 /* SPDX-License-Identifier: BSD-3-Clause */
-//**********************************************************************;
-// Copyright (c) 2016, Intel Corporation
-// All rights reserved.
-//
-//**********************************************************************;
+
 #include <errno.h>
 #include <stdarg.h>
 #include <stdbool.h>

--- a/test/unit/test_pcr.c
+++ b/test/unit/test_pcr.c
@@ -1,9 +1,5 @@
 /* SPDX-License-Identifier: BSD-3-Clause */
-//**********************************************************************;
-// Copyright (c) 2016, Intel Corporation
-// All rights reserved.
-//
-//**********************************************************************;
+
 #include <stdarg.h>
 #include <stdbool.h>
 #include <stddef.h>

--- a/test/unit/test_pcr.c
+++ b/test/unit/test_pcr.c
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: BSD-2-Clause */
+/* SPDX-License-Identifier: BSD-3-Clause */
 //**********************************************************************;
 // Copyright (c) 2016, Intel Corporation
 // All rights reserved.

--- a/test/unit/test_string_bytes.c
+++ b/test/unit/test_string_bytes.c
@@ -1,9 +1,5 @@
 /* SPDX-License-Identifier: BSD-3-Clause */
-//**********************************************************************;
-// Copyright (c) 2016, Intel Corporation
-// All rights reserved.
-//
-//**********************************************************************;
+
 #include <stdarg.h>
 #include <stddef.h>
 #include <setjmp.h>

--- a/test/unit/test_string_bytes.c
+++ b/test/unit/test_string_bytes.c
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: BSD-2-Clause */
+/* SPDX-License-Identifier: BSD-3-Clause */
 //**********************************************************************;
 // Copyright (c) 2016, Intel Corporation
 // All rights reserved.

--- a/test/unit/test_tpm2_alg_util.c
+++ b/test/unit/test_tpm2_alg_util.c
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: BSD-2-Clause */
+/* SPDX-License-Identifier: BSD-3-Clause */
 //**********************************************************************;
 // Copyright (c) 2016, Intel Corporation
 // All rights reserved.

--- a/test/unit/test_tpm2_alg_util.c
+++ b/test/unit/test_tpm2_alg_util.c
@@ -1,9 +1,5 @@
 /* SPDX-License-Identifier: BSD-3-Clause */
-//**********************************************************************;
-// Copyright (c) 2016, Intel Corporation
-// All rights reserved.
-//
-//**********************************************************************;
+
 #include <setjmp.h>
 #include <stdarg.h>
 #include <stdbool.h>

--- a/test/unit/test_tpm2_attr_util.c
+++ b/test/unit/test_tpm2_attr_util.c
@@ -1,9 +1,5 @@
 /* SPDX-License-Identifier: BSD-3-Clause */
-//**********************************************************************;
-// Copyright (c) 2016, Intel Corporation
-// All rights reserved.
-//
-//**********************************************************************;
+
 #include <stdarg.h>
 #include <stdbool.h>
 #include <stddef.h>

--- a/test/unit/test_tpm2_attr_util.c
+++ b/test/unit/test_tpm2_attr_util.c
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: BSD-2-Clause */
+/* SPDX-License-Identifier: BSD-3-Clause */
 //**********************************************************************;
 // Copyright (c) 2016, Intel Corporation
 // All rights reserved.

--- a/test/unit/test_tpm2_auth_util.c
+++ b/test/unit/test_tpm2_auth_util.c
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: BSD-2-Clause */
+/* SPDX-License-Identifier: BSD-3-Clause */
 //**********************************************************************;
 // Copyright (c) 2017, Intel Corporation
 // All rights reserved.

--- a/test/unit/test_tpm2_auth_util.c
+++ b/test/unit/test_tpm2_auth_util.c
@@ -1,9 +1,5 @@
 /* SPDX-License-Identifier: BSD-3-Clause */
-//**********************************************************************;
-// Copyright (c) 2017, Intel Corporation
-// All rights reserved.
-//
-//**********************************************************************;
+
 #include <errno.h>
 #include <fcntl.h>
 #include <setjmp.h>

--- a/test/unit/test_tpm2_errata.c
+++ b/test/unit/test_tpm2_errata.c
@@ -1,9 +1,4 @@
 /* SPDX-License-Identifier: BSD-3-Clause */
-//**********************************************************************;
-// Copyright (c) 2017, Intel Corporation
-// All rights reserved.
-//
-//**********************************************************************;
 
 #include <stdarg.h>
 #include <stddef.h>

--- a/test/unit/test_tpm2_errata.c
+++ b/test/unit/test_tpm2_errata.c
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: BSD-2-Clause */
+/* SPDX-License-Identifier: BSD-3-Clause */
 //**********************************************************************;
 // Copyright (c) 2017, Intel Corporation
 // All rights reserved.

--- a/test/unit/test_tpm2_error.c
+++ b/test/unit/test_tpm2_error.c
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: BSD-2-Clause */
+/* SPDX-License-Identifier: BSD-3-Clause */
 //**********************************************************************;
 // Copyright (c) 2018, Intel Corporation
 // All rights reserved.

--- a/test/unit/test_tpm2_error.c
+++ b/test/unit/test_tpm2_error.c
@@ -1,9 +1,4 @@
 /* SPDX-License-Identifier: BSD-3-Clause */
-//**********************************************************************;
-// Copyright (c) 2018, Intel Corporation
-// All rights reserved.
-//
-//**********************************************************************;
 
 #include <stdarg.h>
 #include <stddef.h>

--- a/test/unit/test_tpm2_header.c
+++ b/test/unit/test_tpm2_header.c
@@ -1,9 +1,5 @@
 /* SPDX-License-Identifier: BSD-3-Clause */
-//**********************************************************************;
-// Copyright (c) 2016, Intel Corporation
-// All rights reserved.
-//
-//**********************************************************************;
+
 #include <stdarg.h>
 #include <stddef.h>
 #include <setjmp.h>

--- a/test/unit/test_tpm2_header.c
+++ b/test/unit/test_tpm2_header.c
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: BSD-2-Clause */
+/* SPDX-License-Identifier: BSD-3-Clause */
 //**********************************************************************;
 // Copyright (c) 2016, Intel Corporation
 // All rights reserved.

--- a/test/unit/test_tpm2_hierarchy.c
+++ b/test/unit/test_tpm2_hierarchy.c
@@ -1,9 +1,5 @@
 /* SPDX-License-Identifier: BSD-3-Clause */
-//**********************************************************************;
-// Copyright (c) 2018, Intel Corporation
-// All rights reserved.
-//
-//**********************************************************************;
+
 #include <stdarg.h>
 #include <stdio.h>
 #include <stddef.h>

--- a/test/unit/test_tpm2_hierarchy.c
+++ b/test/unit/test_tpm2_hierarchy.c
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: BSD-2-Clause */
+/* SPDX-License-Identifier: BSD-3-Clause */
 //**********************************************************************;
 // Copyright (c) 2018, Intel Corporation
 // All rights reserved.

--- a/test/unit/test_tpm2_policy.c
+++ b/test/unit/test_tpm2_policy.c
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: BSD-2-Clause */
+/* SPDX-License-Identifier: BSD-3-Clause */
 //**********************************************************************;
 // Copyright (c) 2017, Intel Corporation
 // All rights reserved.

--- a/test/unit/test_tpm2_policy.c
+++ b/test/unit/test_tpm2_policy.c
@@ -1,9 +1,4 @@
 /* SPDX-License-Identifier: BSD-3-Clause */
-//**********************************************************************;
-// Copyright (c) 2017, Intel Corporation
-// All rights reserved.
-//
-//**********************************************************************;
 
 #include <errno.h>
 #include <setjmp.h>

--- a/test/unit/test_tpm2_session.c
+++ b/test/unit/test_tpm2_session.c
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: BSD-2-Clause */
+/* SPDX-License-Identifier: BSD-3-Clause */
 //**********************************************************************;
 // Copyright (c) 2017, Intel Corporation
 // All rights reserved.

--- a/test/unit/test_tpm2_session.c
+++ b/test/unit/test_tpm2_session.c
@@ -1,9 +1,4 @@
 /* SPDX-License-Identifier: BSD-3-Clause */
-//**********************************************************************;
-// Copyright (c) 2017, Intel Corporation
-// All rights reserved.
-//
-//**********************************************************************;
 
 #include <errno.h>
 #include <setjmp.h>

--- a/tools/misc/tpm2_checkquote.c
+++ b/tools/misc/tpm2_checkquote.c
@@ -1,9 +1,4 @@
 /* SPDX-License-Identifier: BSD-3-Clause */
-//**********************************************************************;
-// Copyright (c) 2019 Massachusetts Institute of Technology.
-// All rights reserved.
-//
-//**********************************************************************;
 
 #include <stdlib.h>
 #include <stdio.h>

--- a/tools/misc/tpm2_print.c
+++ b/tools/misc/tpm2_print.c
@@ -1,9 +1,4 @@
 /* SPDX-License-Identifier: BSD-3-Clause */
-//**********************************************************************;
-// Copyright (c) 2017, National Instruments
-// All rights reserved.
-//
-//**********************************************************************;
 
 #include <stdio.h>
 #include <string.h>

--- a/tools/misc/tpm2_rc_decode.c
+++ b/tools/misc/tpm2_rc_decode.c
@@ -1,9 +1,4 @@
 /* SPDX-License-Identifier: BSD-3-Clause */
-//**********************************************************************;
-// Copyright (c) 2016, Intel Corporation
-// All rights reserved.
-//
-//**********************************************************************;
 
 #include <inttypes.h>
 #include <stdbool.h>

--- a/tools/misc/tpm2_rc_decode.c
+++ b/tools/misc/tpm2_rc_decode.c
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: BSD-2-Clause */
+/* SPDX-License-Identifier: BSD-3-Clause */
 //**********************************************************************;
 // Copyright (c) 2016, Intel Corporation
 // All rights reserved.

--- a/tools/tpm2_activatecredential.c
+++ b/tools/tpm2_activatecredential.c
@@ -1,9 +1,4 @@
 /* SPDX-License-Identifier: BSD-3-Clause */
-//**********************************************************************;
-// Copyright (c) 2015-2018, Intel Corporation
-// All rights reserved.
-//
-//**********************************************************************;
 
 #include <errno.h>
 #include <inttypes.h>

--- a/tools/tpm2_certify.c
+++ b/tools/tpm2_certify.c
@@ -1,9 +1,4 @@
 /* SPDX-License-Identifier: BSD-3-Clause */
-//**********************************************************************;
-// Copyright (c) 2015-2018, Intel Corporation
-// All rights reserved.
-//
-//**********************************************************************;
 
 #include <limits.h>
 #include <stdbool.h>

--- a/tools/tpm2_changeauth.c
+++ b/tools/tpm2_changeauth.c
@@ -1,9 +1,4 @@
 /* SPDX-License-Identifier: BSD-3-Clause */
-//**********************************************************************;
-// Copyright (c) 2015-2018, Intel Corporation
-// All rights reserved.
-//
-//**********************************************************************;
 
 #include <stdbool.h>
 #include <stdlib.h>

--- a/tools/tpm2_clear.c
+++ b/tools/tpm2_clear.c
@@ -1,9 +1,5 @@
 /* SPDX-License-Identifier: BSD-3-Clause */
-/*
- * Copyright (c) 2017-2018, Intel Corporation
- * All rights reserved.
- *
- */
+
 #include <stdbool.h>
 #include <stdlib.h>
 

--- a/tools/tpm2_clearlock.c
+++ b/tools/tpm2_clearlock.c
@@ -1,10 +1,5 @@
 /* SPDX-License-Identifier: BSD-3-Clause */
-/*
- * Copyright (c) 2017, Emmanuel Deloget <logout@free.fr>
- * Copyright (c) 2018, Intel Corporation
- * All rights reserved.
- *
- */
+
 #include <stdbool.h>
 #include <stdlib.h>
 

--- a/tools/tpm2_create.c
+++ b/tools/tpm2_create.c
@@ -1,9 +1,4 @@
 /* SPDX-License-Identifier: BSD-3-Clause */
-//**********************************************************************;
-// Copyright (c) 2015-2018, Intel Corporation
-// All rights reserved.
-//
-//**********************************************************************;
 
 #include <ctype.h>
 #include <errno.h>

--- a/tools/tpm2_createak.c
+++ b/tools/tpm2_createak.c
@@ -1,9 +1,4 @@
 /* SPDX-License-Identifier: BSD-3-Clause */
-//**********************************************************************;
-// Copyright (c) 2015-2018, Intel Corporation
-// All rights reserved.
-//
-//**********************************************************************;
 
 #include <stdbool.h>
 #include <stdlib.h>

--- a/tools/tpm2_createek.c
+++ b/tools/tpm2_createek.c
@@ -1,9 +1,4 @@
 /* SPDX-License-Identifier: BSD-3-Clause */
-//**********************************************************************;
-// Copyright (c) 2015-2018, Intel Corporation
-// All rights reserved.
-//
-//**********************************************************************;
 
 #include <stdbool.h>
 #include <stdlib.h>

--- a/tools/tpm2_createpolicy.c
+++ b/tools/tpm2_createpolicy.c
@@ -1,9 +1,5 @@
 /* SPDX-License-Identifier: BSD-3-Clause */
-//**********************************************************************;
-// Copyright (c) 2015-2018, Intel Corporation
-// All rights reserved.
-//
-//**********************************************************************;
+
 #include <limits.h>
 #include <string.h>
 #include <stdio.h>

--- a/tools/tpm2_createprimary.c
+++ b/tools/tpm2_createprimary.c
@@ -1,9 +1,4 @@
 /* SPDX-License-Identifier: BSD-3-Clause */
-//**********************************************************************;
-// Copyright (c) 2015-2018, Intel Corporation
-// All rights reserved.
-//
-//**********************************************************************;
 
 #include <ctype.h>
 #include <limits.h>

--- a/tools/tpm2_dictionarylockout.c
+++ b/tools/tpm2_dictionarylockout.c
@@ -1,9 +1,4 @@
 /* SPDX-License-Identifier: BSD-3-Clause */
-//**********************************************************************;
-// Copyright (c) 2015-2018, Intel Corporation
-// All rights reserved.
-//
-//**********************************************************************;
 
 #include <stdbool.h>
 #include <stdlib.h>

--- a/tools/tpm2_duplicate.c
+++ b/tools/tpm2_duplicate.c
@@ -1,9 +1,5 @@
 /* SPDX-License-Identifier: BSD-3-Clause */
-//**********************************************************************;
-// Copyright (c) 2017-2018, Intel Corporation
-// All rights reserved.
-//
-//**********************************************************************;
+
 #include <errno.h>
 #include <stdlib.h>
 #include <string.h>

--- a/tools/tpm2_encryptdecrypt.c
+++ b/tools/tpm2_encryptdecrypt.c
@@ -1,9 +1,4 @@
 /* SPDX-License-Identifier: BSD-3-Clause */
-//**********************************************************************;
-// Copyright (c) 2015-2018, Intel Corporation
-// All rights reserved.
-//
-//**********************************************************************;
 
 #include <stdbool.h>
 #include <stdlib.h>

--- a/tools/tpm2_evictcontrol.c
+++ b/tools/tpm2_evictcontrol.c
@@ -1,9 +1,4 @@
 /* SPDX-License-Identifier: BSD-3-Clause */
-//**********************************************************************;
-// Copyright (c) 2015-2018, Intel Corporation
-// All rights reserved.
-//
-//**********************************************************************;
 
 #include <stdbool.h>
 #include <stdlib.h>

--- a/tools/tpm2_flushcontext.c
+++ b/tools/tpm2_flushcontext.c
@@ -1,9 +1,4 @@
 /* SPDX-License-Identifier: BSD-3-Clause */
-//**********************************************************************;
-// Copyright (c) 2017, Alibaba Group
-// All rights reserved.
-//
-//**********************************************************************;
 
 #include <inttypes.h>
 #include <stdbool.h>

--- a/tools/tpm2_getcap.c
+++ b/tools/tpm2_getcap.c
@@ -1,9 +1,5 @@
 /* SPDX-License-Identifier: BSD-3-Clause */
-/*
- * Copyright (c) 2016, Intel Corporation
- * All rights reserved.
- *
- */
+
 #include <ctype.h>
 #include <stdio.h>
 #include <stdlib.h>

--- a/tools/tpm2_getmanufec.c
+++ b/tools/tpm2_getmanufec.c
@@ -1,9 +1,5 @@
 /* SPDX-License-Identifier: BSD-3-Clause */
-//**********************************************************************;
-// Copyright (c) 2015-2018, Intel Corporation
-// All rights reserved.
-//
-//**********************************************************************;
+
 #include <ctype.h>
 #include <errno.h>
 #include <limits.h>

--- a/tools/tpm2_getrandom.c
+++ b/tools/tpm2_getrandom.c
@@ -1,9 +1,4 @@
 /* SPDX-License-Identifier: BSD-3-Clause */
-//**********************************************************************;
-// Copyright (c) 2015, Intel Corporation
-// All rights reserved.
-//
-//**********************************************************************;
 
 #include <inttypes.h>
 #include <stdbool.h>

--- a/tools/tpm2_gettestresult.c
+++ b/tools/tpm2_gettestresult.c
@@ -1,9 +1,4 @@
 /* SPDX-License-Identifier: BSD-3-Clause */
-//**********************************************************************;
-// Copyright (c) 2019, Sebastien LE STUM
-// All rights reserved.
-//
-//**********************************************************************;
 
 #include <ctype.h>
 #include <errno.h>

--- a/tools/tpm2_hash.c
+++ b/tools/tpm2_hash.c
@@ -1,9 +1,4 @@
 /* SPDX-License-Identifier: BSD-3-Clause */
-//**********************************************************************;
-// Copyright (c) 2015, Intel Corporation
-// All rights reserved.
-//
-//**********************************************************************;
 
 #include <errno.h>
 #include <stdlib.h>

--- a/tools/tpm2_hmac.c
+++ b/tools/tpm2_hmac.c
@@ -1,9 +1,4 @@
 /* SPDX-License-Identifier: BSD-3-Clause */
-//**********************************************************************;
-// Copyright (c) 2015-2018, Intel Corporation
-// All rights reserved.
-//
-//**********************************************************************;
 
 #include <errno.h>
 #include <stdbool.h>

--- a/tools/tpm2_import.c
+++ b/tools/tpm2_import.c
@@ -1,9 +1,4 @@
 /* SPDX-License-Identifier: BSD-3-Clause */
-//**********************************************************************;
-// Copyright (c) 2017-2018, Intel Corporation
-// All rights reserved.
-//
-//**********************************************************************;
 
 //**********************************************************************;
 // Copyright 1999-2018 The OpenSSL Project Authors. All Rights Reserved.

--- a/tools/tpm2_incrementalselftest.c
+++ b/tools/tpm2_incrementalselftest.c
@@ -1,9 +1,4 @@
 /* SPDX-License-Identifier: BSD-3-Clause */
-//**********************************************************************;
-// Copyright (c) 2019, Sebastien LE STUM
-// All rights reserved.
-//
-//**********************************************************************;
 
 #include <ctype.h>
 #include <errno.h>

--- a/tools/tpm2_listpersistent.c
+++ b/tools/tpm2_listpersistent.c
@@ -1,9 +1,4 @@
 /* SPDX-License-Identifier: BSD-3-Clause */
-//**********************************************************************;
-// Copyright (c) 2016, Intel Corporation
-// All rights reserved.
-//
-//**********************************************************************;
 
 #include <stdarg.h>
 

--- a/tools/tpm2_load.c
+++ b/tools/tpm2_load.c
@@ -1,9 +1,4 @@
 /* SPDX-License-Identifier: BSD-3-Clause */
-//**********************************************************************;
-// Copyright (c) 2015-2018, Intel Corporation
-// All rights reserved.
-//
-//**********************************************************************;
 
 #include <stdarg.h>
 

--- a/tools/tpm2_loadexternal.c
+++ b/tools/tpm2_loadexternal.c
@@ -1,9 +1,4 @@
 /* SPDX-License-Identifier: BSD-3-Clause */
-//**********************************************************************;
-// Copyright (c) 2015-2018, Intel Corporation
-// All rights reserved.
-//
-//**********************************************************************;
 
 #include <errno.h>
 #include <limits.h>

--- a/tools/tpm2_makecredential.c
+++ b/tools/tpm2_makecredential.c
@@ -1,10 +1,4 @@
 /* SPDX-License-Identifier: BSD-3-Clause */
-//**********************************************************************;
-// Copyright (c) 2015, Intel Corporation
-// Copyright (c) 2019 Massachusetts Institute of Technology
-// All rights reserved.
-//
-//**********************************************************************;
 
 #include <stdlib.h>
 #include <errno.h>

--- a/tools/tpm2_nvdefine.c
+++ b/tools/tpm2_nvdefine.c
@@ -1,9 +1,4 @@
 /* SPDX-License-Identifier: BSD-3-Clause */
-//**********************************************************************;
-// Copyright (c) 2015-2018, Intel Corporation
-// All rights reserved.
-//
-//**********************************************************************;
 
 #include <stdbool.h>
 #include <stdlib.h>

--- a/tools/tpm2_nvincrement.c
+++ b/tools/tpm2_nvincrement.c
@@ -1,9 +1,4 @@
 /* SPDX-License-Identifier: BSD-3-Clause */
-//**********************************************************************;
-// Copyright (c) 2015-2018, Intel Corporation
-// All rights reserved.
-//
-//**********************************************************************;
 
 #include <errno.h>
 #include <stdbool.h>

--- a/tools/tpm2_nvlist.c
+++ b/tools/tpm2_nvlist.c
@@ -1,9 +1,4 @@
 /* SPDX-License-Identifier: BSD-3-Clause */
-//**********************************************************************;
-// Copyright (c) 2015-2019, Intel Corporation
-// All rights reserved.
-//
-//**********************************************************************;
 
 #include <stdbool.h>
 #include <stdlib.h>

--- a/tools/tpm2_nvread.c
+++ b/tools/tpm2_nvread.c
@@ -1,9 +1,5 @@
 /* SPDX-License-Identifier: BSD-3-Clause */
-//**********************************************************************;
-// Copyright (c) 2015-2018, Intel Corporation
-// All rights reserved.
-//
-//**********************************************************************;
+
 #include <ctype.h>
 #include <stdbool.h>
 #include <stdlib.h>

--- a/tools/tpm2_nvreadlock.c
+++ b/tools/tpm2_nvreadlock.c
@@ -1,10 +1,4 @@
 /* SPDX-License-Identifier: BSD-3-Clause */
-//**********************************************************************;
-// Copyright (c) 2015-2018, Intel Corporation
-// Copyright (c) 2016, Atom Software Studios
-// All rights reserved.
-//
-//**********************************************************************;
 
 #include <stdbool.h>
 

--- a/tools/tpm2_nvrelease.c
+++ b/tools/tpm2_nvrelease.c
@@ -1,9 +1,4 @@
 /* SPDX-License-Identifier: BSD-3-Clause */
-//**********************************************************************;
-// Copyright (c) 2015-2018, Intel Corporation
-// All rights reserved.
-//
-//**********************************************************************;
 
 #include <stdbool.h>
 #include <stdlib.h>

--- a/tools/tpm2_nvwrite.c
+++ b/tools/tpm2_nvwrite.c
@@ -1,9 +1,4 @@
 /* SPDX-License-Identifier: BSD-3-Clause */
-//**********************************************************************;
-// Copyright (c) 2015-2018, Intel Corporation
-// All rights reserved.
-//
-//**********************************************************************;
 
 #include <errno.h>
 #include <stdbool.h>

--- a/tools/tpm2_pcrallocate.c
+++ b/tools/tpm2_pcrallocate.c
@@ -1,10 +1,4 @@
 /* SPDX-License-Identifier: BSD-3-Clause */
-//**********************************************************************;
-// Copyright (c) 2015-2018, Intel Corporation
-// Copyright (c) 2019, Fraunhofer SIT
-// All rights reserved.
-//
-//**********************************************************************;
 
 #include <ctype.h>
 #include <errno.h>

--- a/tools/tpm2_pcrevent.c
+++ b/tools/tpm2_pcrevent.c
@@ -1,9 +1,4 @@
 /* SPDX-License-Identifier: BSD-3-Clause */
-//**********************************************************************;
-// Copyright (c) 2015-2018, Intel Corporation
-// All rights reserved.
-//
-//**********************************************************************;
 
 #include <errno.h>
 #include <stdbool.h>

--- a/tools/tpm2_pcrextend.c
+++ b/tools/tpm2_pcrextend.c
@@ -1,9 +1,4 @@
 /* SPDX-License-Identifier: BSD-3-Clause */
-//**********************************************************************;
-// Copyright (c) 2017, Intel Corporation
-// All rights reserved.
-//
-//**********************************************************************;
 
 #include <stdlib.h>
 

--- a/tools/tpm2_pcrlist.c
+++ b/tools/tpm2_pcrlist.c
@@ -1,10 +1,4 @@
 /* SPDX-License-Identifier: BSD-3-Clause */
-//**********************************************************************;
-// Copyright (c) 2015, Intel Corporation
-// Copyright (c) 2018, Fraunhofer SIT
-// All rights reserved.
-//
-//**********************************************************************;
 
 #include <errno.h>
 #include <stdbool.h>

--- a/tools/tpm2_pcrreset.c
+++ b/tools/tpm2_pcrreset.c
@@ -1,9 +1,4 @@
 /* SPDX-License-Identifier: BSD-3-Clause */
-//**********************************************************************;
-// Copyright (c) 2019, Sebastien LE STUM
-// All rights reserved.
-//
-//**********************************************************************;
 
 #include <ctype.h>
 #include <errno.h>

--- a/tools/tpm2_policyauthorize.c
+++ b/tools/tpm2_policyauthorize.c
@@ -1,9 +1,4 @@
 /* SPDX-License-Identifier: BSD-3-Clause */
-//**********************************************************************;
-// Copyright (c) 2018, Intel Corporation
-// All rights reserved.
-//
-//**********************************************************************;
 
 #include <stdlib.h>
 

--- a/tools/tpm2_policycommandcode.c
+++ b/tools/tpm2_policycommandcode.c
@@ -1,9 +1,4 @@
 /* SPDX-License-Identifier: BSD-3-Clause */
-//**********************************************************************;
-// Copyright (c) 2018, Intel Corporation
-// All rights reserved.
-//
-//**********************************************************************;
 
 #include <errno.h>
 #include <stdlib.h>

--- a/tools/tpm2_policyduplicationselect.c
+++ b/tools/tpm2_policyduplicationselect.c
@@ -1,9 +1,4 @@
 /* SPDX-License-Identifier: BSD-3-Clause */
-//**********************************************************************;
-// Copyright (c) 2018, Intel Corporation
-// All rights reserved.
-//
-//**********************************************************************;
 
 #include <errno.h>
 #include <stdlib.h>

--- a/tools/tpm2_policylocality.c
+++ b/tools/tpm2_policylocality.c
@@ -1,9 +1,4 @@
 /* SPDX-License-Identifier: BSD-3-Clause */
-//**********************************************************************;
-// Copyright (c) 2018, Intel Corporation
-// All rights reserved.
-//
-//**********************************************************************;
 
 #include <errno.h>
 #include <stdlib.h>

--- a/tools/tpm2_policyor.c
+++ b/tools/tpm2_policyor.c
@@ -1,9 +1,4 @@
 /* SPDX-License-Identifier: BSD-3-Clause */
-//**********************************************************************;
-// Copyright (c) 2018, Intel Corporation
-// All rights reserved.
-//
-//**********************************************************************;
 
 #include <stdlib.h>
 

--- a/tools/tpm2_policypassword.c
+++ b/tools/tpm2_policypassword.c
@@ -1,9 +1,4 @@
 /* SPDX-License-Identifier: BSD-3-Clause */
-//**********************************************************************;
-// Copyright (c) 2018, Intel Corporation
-// All rights reserved.
-//
-//**********************************************************************;
 
 #include <stdlib.h>
 

--- a/tools/tpm2_policypcr.c
+++ b/tools/tpm2_policypcr.c
@@ -1,9 +1,4 @@
 /* SPDX-License-Identifier: BSD-3-Clause */
-//**********************************************************************;
-// Copyright (c) 2018, Intel Corporation
-// All rights reserved.
-//
-//**********************************************************************;
 
 #include <errno.h>
 #include <stdlib.h>

--- a/tools/tpm2_policyrestart.c
+++ b/tools/tpm2_policyrestart.c
@@ -1,9 +1,4 @@
 /* SPDX-License-Identifier: BSD-3-Clause */
-//**********************************************************************;
-// Copyright (c) 2018, Intel Corporation
-// All rights reserved.
-//
-//**********************************************************************;
 
 #include <errno.h>
 #include <stdlib.h>

--- a/tools/tpm2_policysecret.c
+++ b/tools/tpm2_policysecret.c
@@ -1,9 +1,5 @@
 /* SPDX-License-Identifier: BSD-3-Clause */
-//**********************************************************************;
-// Copyright (c) 2018, Intel Corporation
-// All rights reserved.
-//
-//**********************************************************************;
+
 #include <stdlib.h>
 #include <string.h>
 #include <tss2/tss2_esys.h>

--- a/tools/tpm2_quote.c
+++ b/tools/tpm2_quote.c
@@ -1,9 +1,4 @@
 /* SPDX-License-Identifier: BSD-3-Clause */
-//**********************************************************************;
-// Copyright (c) 2015-2018, Intel Corporation
-// All rights reserved.
-//
-//**********************************************************************;
 
 #include <stdbool.h>
 #include <stdlib.h>

--- a/tools/tpm2_readpublic.c
+++ b/tools/tpm2_readpublic.c
@@ -1,9 +1,4 @@
 /* SPDX-License-Identifier: BSD-3-Clause */
-//**********************************************************************;
-// Copyright (c) 2015-2018, Intel Corporation
-// All rights reserved.
-//
-//**********************************************************************;
 
 #include <stdbool.h>
 #include <stdlib.h>

--- a/tools/tpm2_rsadecrypt.c
+++ b/tools/tpm2_rsadecrypt.c
@@ -1,9 +1,4 @@
 /* SPDX-License-Identifier: BSD-3-Clause */
-//**********************************************************************;
-// Copyright (c) 2015-2018, Intel Corporation
-// All rights reserved.
-//
-//**********************************************************************;
 
 #include <stdbool.h>
 #include <stdlib.h>

--- a/tools/tpm2_rsaencrypt.c
+++ b/tools/tpm2_rsaencrypt.c
@@ -1,9 +1,4 @@
 /* SPDX-License-Identifier: BSD-3-Clause */
-//**********************************************************************;
-// Copyright (c) 2015-2018, Intel Corporation
-// All rights reserved.
-//
-//**********************************************************************;
 
 #include <errno.h>
 #include <stdbool.h>

--- a/tools/tpm2_selftest.c
+++ b/tools/tpm2_selftest.c
@@ -1,9 +1,4 @@
 /* SPDX-License-Identifier: BSD-3-Clause */
-//**********************************************************************;
-// Copyright (c) 2019, Sebastien LE STUM
-// All rights reserved.
-//
-//**********************************************************************;
 
 #include <ctype.h>
 #include <errno.h>

--- a/tools/tpm2_send.c
+++ b/tools/tpm2_send.c
@@ -1,9 +1,5 @@
 /* SPDX-License-Identifier: BSD-3-Clause */
-/*
- * Copyright (c) 2016, Intel Corporation
- * All rights reserved.
- *
- */
+
 #include <errno.h>
 #include <stdbool.h>
 #include <stdio.h>

--- a/tools/tpm2_sign.c
+++ b/tools/tpm2_sign.c
@@ -1,9 +1,4 @@
 /* SPDX-License-Identifier: BSD-3-Clause */
-//**********************************************************************;
-// Copyright (c) 2015-2018, Intel Corporation
-// All rights reserved.
-//
-//**********************************************************************;
 
 #include <limits.h>
 #include <stdbool.h>

--- a/tools/tpm2_startauthsession.c
+++ b/tools/tpm2_startauthsession.c
@@ -1,9 +1,4 @@
 /* SPDX-License-Identifier: BSD-3-Clause */
-//**********************************************************************;
-// Copyright (c) 2018, Intel Corporation
-// All rights reserved.
-//
-//**********************************************************************;
 
 #include <errno.h>
 #include <inttypes.h>

--- a/tools/tpm2_startup.c
+++ b/tools/tpm2_startup.c
@@ -1,9 +1,5 @@
 /* SPDX-License-Identifier: BSD-3-Clause */
-/*
- * Copyright (c) 2016, Intel Corporation
- * All rights reserved.
- *
- */
+
 #include <stdbool.h>
 #include <stdlib.h>
 

--- a/tools/tpm2_stirrandom.c
+++ b/tools/tpm2_stirrandom.c
@@ -1,9 +1,4 @@
 /* SPDX-License-Identifier: BSD-3-Clause */
-//**********************************************************************;
-// Copyright (c) 2019, Sebastien LE STUM
-// All rights reserved.
-//
-//**********************************************************************;
 
 #include <ctype.h>
 #include <errno.h>

--- a/tools/tpm2_testparms.c
+++ b/tools/tpm2_testparms.c
@@ -1,9 +1,4 @@
 /* SPDX-License-Identifier: BSD-3-Clause */
-//**********************************************************************;
-// Copyright (c) 2019, Sebastien LE STUM
-// All rights reserved.
-//
-//**********************************************************************;
 
 #include <ctype.h>
 #include <errno.h>

--- a/tools/tpm2_tool.c
+++ b/tools/tpm2_tool.c
@@ -1,9 +1,5 @@
 /* SPDX-License-Identifier: BSD-3-Clause */
-/*
- * Copyright (c) 2016, Intel Corporation
- * All rights reserved.
- *
- */
+
 #include <stdbool.h>
 #include <stdlib.h>
 

--- a/tools/tpm2_tool.h
+++ b/tools/tpm2_tool.h
@@ -1,9 +1,5 @@
 /* SPDX-License-Identifier: BSD-3-Clause */
-/*
- * Copyright (c) 2016, Intel Corporation
- * All rights reserved.
- *
- */
+
 #ifndef MAIN_H
 #define MAIN_H
 

--- a/tools/tpm2_unseal.c
+++ b/tools/tpm2_unseal.c
@@ -1,9 +1,4 @@
 /* SPDX-License-Identifier: BSD-3-Clause */
-//**********************************************************************;
-// Copyright (c) 2015-2018, Intel Corporation
-// All rights reserved.
-//
-//**********************************************************************;
 
 #include <stdbool.h>
 #include <stdlib.h>

--- a/tools/tpm2_verifysignature.c
+++ b/tools/tpm2_verifysignature.c
@@ -1,9 +1,4 @@
 /* SPDX-License-Identifier: BSD-3-Clause */
-//**********************************************************************;
-// Copyright (c) 2015-2018, Intel Corporation
-// All rights reserved.
-//
-//**********************************************************************;
 
 #include <stdlib.h>
 #include <stdio.h>


### PR DESCRIPTION
Switch all files to BSD3 and remove the copyright lines. The copyright lines are not legally binding and just serve as busy work and a maintenance burden.