### PR TITLE
Remove duplicated output of persistent handle

### DIFF
--- a/tools/tpm2_evictcontrol.c
+++ b/tools/tpm2_evictcontrol.c
@@ -156,8 +156,6 @@ int tpm2_tool_onrun(ESYS_CONTEXT *ectx, tpm2_option_flags flags) {
         goto out;
     }
 
-    tpm2_tool_output("persistentHandle: 0x%x\n", ctx.persist_handle);
-
     ESYS_TR out_tr;
     ESYS_TR hierarchy = tpm2_tpmi_hierarchy_to_esys_tr(ctx.hierarchy);
     result = tpm2_ctx_mgmt_evictcontrol(ectx,


### PR DESCRIPTION
With commit 9c3e6387 ("tpm2_evictcontrol: support saving ESYS_TR") the
persistent handle is printed twice, with two different names
('persistentHandle' vs 'persistent-handle').
Only one of them is needed, and the latter is closer to other similar
outputs.

Signed-off-by: Peter Huewe <peter.huewe@infineon.com>