### PR TITLE
Default file fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## Changelog
 ### next
+  * tpm2_createak: remove -k persistant option. Use tpm2_evictcontrol.
   * tpm2_nvincrement: -L and -F pcr policy options go away, replaced with pcr password minilanguage.
   * tpm2_nvwrite: -L and -F pcr policy options go away, replaced with pcr password minilanguage.
   * tpm2_nvread: -L and -F pcr policy options go away, replaced with pcr password minilanguage.

--- a/lib/.gitignore
+++ b/lib/.gitignore
@@ -3,3 +3,4 @@
 !.gitignore
 !*.c
 !*.h
+config.h

--- a/man/tpm2_createak.1.md
+++ b/man/tpm2_createak.1.md
@@ -61,10 +61,7 @@ loaded-key:
   * **-c**, **\--context**=_CONTEXT\_FILE\_NAME_:
 
     Optional, specifies a path to save the context of the AK handle. If the AK
-    is not persisted to a handle (via **-k**) the tool defaults to saving a
-    context file to *ak.ctx* unless an alternative is specified here.
-    If one saves the context file via this option and the public key via the
-    **-p** option, the AK can be restored via a call to **tpm2_loadexternal**(1).
+    is not persisted to a handle (via **-k**) then this option is required.
 
   * **-G**, **\--algorithm**=_ALGORITHM_:
 

--- a/man/tpm2_createak.1.md
+++ b/man/tpm2_createak.1.md
@@ -42,21 +42,10 @@ loaded-key:
     Specifies the AK authorization when created.
     Same formatting as the endorse authorization value or **-e** option.
 
-  * **-w**, **\--auth-owner**=_OWNER\_AUTH_
-
-    Specifies the current owner authorization.
-    Same formatting as the endorse password value or **-e** option.
-
   * **-C**, **\--ek-context**=_EK\_CONTEXT\_OBJECT_:
 
     Specifies the object context of the EK. Either a file or a handle number.
     See section "Context Object Format".
-
-  * **-k**, **\--ak-handle**=_AK\_HANDLE_:
-
-    Specifies the handle used to make AK persistent.
-    If a value of **-** is passed the tool will find a vacant persistent handle
-    to use and print out the automatically selected handle.
 
   * **-c**, **\--context**=_CONTEXT\_FILE\_NAME_:
 
@@ -127,52 +116,15 @@ when using a RM, moving the created EK to persistent memory is
 required.
 
 ### Create an Attestation Key and make it persistent
+
+Create an Endorsement Key (EK) and persist it to handle
+0x81010002.
+
 ```
-# create an Endorsement Key (EK)
 tpm2_createek -c 0x81010001 -G rsa -p ek.pub
 # create an Attestation Key (AK) passing the EK handle
-tpm2_createak -C 0x81010001 -k 0x81010002 -p ak.pub -n ak.name
-```
-
-## Without a Resource Manager (RM)
-
-The following examples will not work when an RM is in use, as the RM will
-flush the TPM context when the tool exits. In these scenarios, the created
-AK is in transient memory and thus will be flushed.
-
-### Create a transient Attestation Key, evict it, and reload it
-```
-# AK needs an Endorsement Key (primary object)
-tpm2_createek
-transient-object-context: ek.ctx
-
-# Now create a transient AK
-tpm2_createak -C ek.ctx -w ak.ctx -p ak.pub -n ak.name
-loaded-key:
-  name: 000b8052c63861b1855c91edd63bca2eb3ea3ad304bb9798a9445ada12d5b5bb36e0
-
-tpm2_createek -G rsa -p ek.pub -c ek.ctx
-
-# Check that the AK is loaded in transient memory
-# Note the AK is at handle 0x80000001
-tpm2_getcap -c handles-transient
-- 0x80000000
-- 0x80000001
-
-# Flush the AK handle
-tpm2_flushcontext -H 0x80000000
-
-# Note that it is flushed
-tpm2_getcap -c handles-transient
-- 0x80000000
-
-# Reload it via loadexternal
-tpm2_loadexternal -a o -u ak.pub -o ak.ctx
-
-# Check that it is re-loaded in transient memory
-$ tpm2_getcap -c handles-transient
-- 0x80000000
-- 0x80000001
+tpm2_createak -C 0x81010001 -k ak.ctx -p ak.pub -n ak.name
+tpm2_evictcontrol -c 0x81010002 -o ek.handle
 ```
 
 # RETURNS

--- a/man/tpm2_createprimary.1.md
+++ b/man/tpm2_createprimary.1.md
@@ -63,8 +63,7 @@ interactions with the created primary.
 
   * **-o**, **\--out-context-name**=_CONTEXT\_FILE\_NAME_:
 
-    Optional file name to use for the returned object context, otherwise a
-    default of _primary.ctx_ is used.
+    File name to use for the returned object context, required.
 
   * **-L**, **\--policy-file**=_POLICY\_FILE_:
 

--- a/man/tpm2_load.1.md
+++ b/man/tpm2_load.1.md
@@ -15,8 +15,7 @@
 **tpm2_load**(1) - Load both the private and public portions of an object
 into the TPM.
 The tool outputs the name of the loaded object in a YAML format and saves a
-context file for future interactions with the object. The context file name
-defaults to *load.ctx* and can be specified with **-o**.
+context file for future interactions with the object.
 
 # OPTIONS
 
@@ -45,8 +44,7 @@ defaults to *load.ctx* and can be specified with **-o**.
 
   * **-o**, **\--out-context**=_CONTEXT\_FILE\_NAME_:
 
-    The file name of the saved object context, optional. If unspecified defaults
-    to *object.ctx*.
+    The file name of the saved object context, required.
 
 [common options](common/options.md)
 

--- a/man/tpm2_loadexternal.1.md
+++ b/man/tpm2_loadexternal.1.md
@@ -91,8 +91,7 @@ sensitive area.
 
   * **-o**, **\--out-context**=_CONTEXT\_FILE_
 
-    The file name of the saved object context, optional. If unspecified defaults
-    to *external.ctx*.
+    The file name of the saved object context, required.
 
   * **-n**, **\--name**=_NAME\_DATA\_FILE_:
 

--- a/man/tpm2_startauthsession.1.md
+++ b/man/tpm2_startauthsession.1.md
@@ -46,7 +46,7 @@ This will work with direct TPM access, but note that internally this calls a *Co
 
   * **-S**, **\--session**=_SESSION\_FILE\_NAME_:
 
-    The name of the policy session file, optional. Defaults to *session.ctx*.
+    The name of the policy session file, required.
 
 
 [common options](common/options.md)

--- a/test/integration/tests/activecredential.sh
+++ b/test/integration/tests/activecredential.sh
@@ -4,12 +4,11 @@
 source helpers.sh
 
 cleanup() {
-    rm -f secret.data ek.pub ak.pub ak.name mkcred.out actcred.out ak.out
+    rm -f secret.data ek.pub ak.pub ak.name mkcred.out actcred.out ak.out ak.ctx
 
     # Evict persistent handles, we want them to always succeed and never trip
     # the onerror trap.
-    tpm2_evictcontrol -Q -a o -c 0x81010009 2>/dev/null || true
-    tpm2_evictcontrol -Q -a o -c 0x8101000a 2>/dev/null || true
+	tpm2_evictcontrol -Q -a o -c 0x81010009 2>/dev/null || true
 
     if [ "$1" != "no-shut-down" ]; then
         shut_down
@@ -25,7 +24,7 @@ echo "12345678" > secret.data
 
 tpm2_createek -Q -c 0x81010009 -G rsa -p ek.pub
 
-tpm2_createak -C 0x81010009 -k 0x8101000a -G rsa -D sha256 -s rsassa -p ak.pub -n ak.name > ak.out
+tpm2_createak -C 0x81010009 -c ak.ctx -G rsa -D sha256 -s rsassa -p ak.pub -n ak.name > ak.out
 
 # Capture the yaml output and verify that its the same as the name output
 loaded_key_name_yaml=`python << pyscript
@@ -46,6 +45,6 @@ test "$loaded_key_name_yaml" == "$loaded_key_name"
 
 tpm2_makecredential -Q -e ek.pub  -s secret.data -n $loaded_key_name -o mkcred.out
 
-tpm2_activatecredential -Q -c 0x8101000a -C 0x81010009 -i mkcred.out -o actcred.out
+tpm2_activatecredential -Q -c ak.ctx -C 0x81010009 -i mkcred.out -o actcred.out
 
 exit 0

--- a/test/integration/tests/checkquote.sh
+++ b/test/integration/tests/checkquote.sh
@@ -13,6 +13,7 @@ ownerpw=ownerpass
 endorsepw=endorsepass
 ekpw=ekpass
 akpw=akpass
+ak_ctx=ak.ctx
 
 output_ek_pub_pem=ekpub.pem
 output_ak_pub_pem=akpub.pem
@@ -24,7 +25,8 @@ output_quotepcr=quotepcr.out
 cleanup() {
   rm -f $output_ek_pub_pem \
         $output_ak_pub_pem $output_ak_pub_name \
-        $output_quote $output_quotesig $output_quotepcr rand.out
+        $output_quote $output_quotesig $output_quotepcr rand.out \
+	    $ak_ctx
 
   tpm2_pcrreset 16
   tpm2_evictcontrol -a o -c $handle_ek -P "$ownerpw" 2>/dev/null || true
@@ -53,7 +55,8 @@ getrandom() {
 # Key generation
 tpm2_createek -c $handle_ek -G $ek_alg -p $output_ek_pub_pem -f pem -P "$ekpw"
 
-tpm2_createak -C $handle_ek -k $handle_ak -G $ak_alg -D $digestAlg -s $signAlg -p $output_ak_pub_pem -f pem -n $output_ak_pub_name -P "$akpw"
+tpm2_createak -C $handle_ek -c $ak_ctx -G $ak_alg -D $digestAlg -s $signAlg -p $output_ak_pub_pem -f pem -n $output_ak_pub_name -P "$akpw"
+tpm2_evictcontrol -Q -c $ak_ctx -p $handle_ak
 
 # Quoting
 getrandom 20

--- a/test/integration/tests/createak.sh
+++ b/test/integration/tests/createak.sh
@@ -26,17 +26,18 @@ cleanup "no-shut-down"
 
 tpm2_createek -Q -c 0x8101000b -G rsa -p ek.pub
 
-tpm2_createak -Q -C 0x8101000b -k 0x8101000c -G rsa -D sha256 -s rsassa -p ak.pub -n ak.name
+tpm2_createak -Q -C 0x8101000b -c ak.ctx -G rsa -D sha256 -s rsassa -p ak.pub -n ak.name
 
 # Find a vacant persistent handle
-tpm2_createak -C 0x8101000b -k - -G rsa -D sha256 -s rsassa -p ak.pub -n ak.name > ak.log
-phandle=`yaml_get_kv ak.log \"ak\-persistent\-handle\"`
+tpm2_createak -C 0x8101000b -c ak.ctx -G rsa -D sha256 -s rsassa -p ak.pub -n ak.name
+tpm2_evictcontrol -c ak.ctx > ak.log
+phandle=`yaml_get_kv ak.log \"persistent\-handle\"`
 tpm2_evictcontrol -Q -a o -c $phandle
 
 # Test tpm2_createak with endorsement password
 cleanup "no-shut-down"
 tpm2_changeauth -e endauth
 tpm2_createek -Q -e endauth -c 0x8101000b -G rsa -p ek.pub
-tpm2_createak -Q -e endauth -C 0x8101000b -k 0x8101000c -G rsa -p ak.pub -n ak.name
+tpm2_createak -Q -e endauth -C 0x8101000b -c ak.ctx -G rsa -p ak.pub -n ak.name
 
 exit 0

--- a/test/integration/tests/makecredential.sh
+++ b/test/integration/tests/makecredential.sh
@@ -4,7 +4,7 @@
 source helpers.sh
 
 handle_ek=0x81010007
-handle_ak=0x81010008
+ak_ctx=ak.ctx
 ek_alg=rsa
 ak_alg=rsa
 digestAlg=sha256
@@ -18,10 +18,9 @@ output_mkcredential=mkcredential.out
 
 cleanup() {
     rm -f $output_ek_pub $output_ak_pub $output_ak_pub_name $output_mkcredential \
-          $file_input_data output_ak grep.txt
+          $file_input_data output_ak grep.txt $ak_ctx
 
     tpm2_evictcontrol -Q -ao -c $handle_ek 2>/dev/null || true
-    tpm2_evictcontrol -Q -ao -c $handle_ak 2>/dev/null || true
 
     if [ "$1" != "no-shut-down" ]; then
           shut_down
@@ -37,7 +36,7 @@ echo "12345678" > $file_input_data
 
 tpm2_createek -Q -c $handle_ek -G $ek_alg -p $output_ek_pub
 
-tpm2_createak -Q -C $handle_ek  -k $handle_ak -G $ak_alg -D $digestAlg -s $signAlg -p $output_ak_pub -n $output_ak_pub_name
+tpm2_createak -Q -C $handle_ek -c $ak_ctx -G $ak_alg -D $digestAlg -s $signAlg -p $output_ak_pub -n $output_ak_pub_name
 
 # Use -c in xxd so there is no line wrapping
 file_size=`stat --printf="%s" $output_ak_pub_name`

--- a/test/integration/tests/print.sh
+++ b/test/integration/tests/print.sh
@@ -3,7 +3,7 @@
 
 source helpers.sh
 
-ak_handle=0x81010016
+ak_ctx=ak.ctx
 ek_handle=0x81010017
 
 ak_name_file=ak.name
@@ -15,7 +15,7 @@ print_file=quote.yaml
 
 cleanup() {
     rm -f $ak_name_file $ak_pubkey_file $ek_pubkey_file \
-          $quote_file $print_file
+          $quote_file $print_file $ak_ctx
 
     if [ "$1" != "no-shut-down" ]; then
        shut_down
@@ -31,10 +31,10 @@ tpm2_clear
 
 # Create signing key
 tpm2_createek -Q -G rsa -c $ek_handle -p $ek_pubkey_file
-tpm2_createak -Q -G rsa -D sha256 -s rsassa -C $ek_handle -k $ak_handle -p $ak_pubkey_file -n $ak_name_file
+tpm2_createak -Q -G rsa -D sha256 -s rsassa -C $ek_handle -c $ak_ctx -p $ak_pubkey_file -n $ak_name_file
 
 # Take PCR quote
-tpm2_quote -Q -C $ak_handle -L "sha256:0,2,4,9,10,11,12,17" -q "0f8beb45ac" -m $quote_file
+tpm2_quote -Q -C $ak_ctx -L "sha256:0,2,4,9,10,11,12,17" -q "0f8beb45ac" -m $quote_file
 
 # Print TPM's quote file
 tpm2_print -t TPMS_ATTEST -i $quote_file > $print_file

--- a/test/integration/tests/quote.sh
+++ b/test/integration/tests/quote.sh
@@ -20,6 +20,7 @@ file_quote_key_ctx=ctx_load_out_"$alg_primary_obj"_"$alg_primary_key"-"$alg_crea
 Handle_ak_quote=0x81010016
 Handle_ek_quote=0x81010017
 Handle_ak_quote2=0x81010018
+ak2_ctx=ak2.ctx
 
 out=out.yaml
 toss_out=junk.out
@@ -27,7 +28,7 @@ toss_out=junk.out
 cleanup() {
     rm -f $file_primary_key_ctx $file_quote_key_pub $file_quote_key_priv \
     $file_quote_key_name $file_quote_key_ctx ek.pub2 ak.pub2 ak.name_2 \
-    $out $toss_out
+    $out $toss_out $ak2_ctx
 
     tpm2_evictcontrol -Q -ao -c $Handle_ek_quote 2>/dev/null || true
     tpm2_evictcontrol -Q -ao -c $Handle_ak_quote 2>/dev/null || true
@@ -77,7 +78,8 @@ tpm2_quote -Q -C $Handle_ak_quote  -L $alg_quote:16,17,18+$alg_quote1:16,17,18 -
 #####AK
 tpm2_createek -Q -c $Handle_ek_quote -G 0x01 -p ek.pub2
 
-tpm2_createak -Q -C $Handle_ek_quote -k  $Handle_ak_quote2 -p ak.pub2 -n ak.name_2
+tpm2_createak -Q -C $Handle_ek_quote -c $ak2_ctx -p ak.pub2 -n ak.name_2
+tpm2_evictcontrol -Q -a o -c $ak2_ctx -p $Handle_ak_quote2
 
 tpm2_quote -Q -C $Handle_ak_quote -L $alg_quote:16,17,18 -l 16,17,18 -q $nonce -m $toss_out -s $toss_out -p $toss_out -g $alg_primary_obj
 

--- a/test/unit/test_files.c
+++ b/test/unit/test_files.c
@@ -240,43 +240,6 @@ static void test_file_exists_bad_args(void **state) {
     assert_false(res);
 }
 
-static void test_files_get_unique_name(void **state) {
-
-    test_file *tf = test_file_from_state(state);
-
-    char *unique = NULL;
-    bool ret = files_get_unique_name(tf->path, &unique);
-    assert_true(ret);
-    assert_non_null(unique);
-    assert_string_not_equal(tf->path, unique);
-    char *ext = rindex(unique, '.');
-    assert_string_equal(ext, ".test");
-    free(unique);
-    unique = NULL;
-
-    const char *multipath = "foo.bar.baz";
-    FILE *fi = fopen(multipath, "w+b");
-    fclose(fi);
-    ret = files_get_unique_name(multipath, &unique);
-    remove(multipath);
-    assert_true(ret);
-    assert_non_null(unique);
-    assert_string_equal("foo.bar1.baz", unique);
-    free(unique);
-    unique = NULL;
-
-    ret = files_get_unique_name("foo", &unique);
-    assert_true(ret);
-    assert_non_null(unique);
-    assert_string_equal("foo", unique);
-    free(unique);
-    unique = NULL;
-
-    ret = files_get_unique_name(NULL, &unique);
-    assert_false(ret);
-    assert_null(unique);
-}
-
 /* link required symbol, but tpm2_tool.c declares it AND main, which
  * we have a main below for cmocka tests.
  */
@@ -317,9 +280,6 @@ int main(int argc, char* argv[]) {
         cmocka_unit_test_setup_teardown(test_file_exists,
                 test_setup, test_teardown),
         cmocka_unit_test_setup_teardown(test_file_exists_bad_args,
-                test_setup, test_teardown),
-
-        cmocka_unit_test_setup_teardown(test_files_get_unique_name,
                 test_setup, test_teardown),
     };
 

--- a/tools/tpm2_load.c
+++ b/tools/tpm2_load.c
@@ -153,6 +153,11 @@ int tpm2_tool_onrun(ESYS_CONTEXT *ectx, tpm2_option_flags flags) {
         return -1;
     }
 
+    if (!ctx.context_file) {
+        LOG_ERR("Expected option -o");
+        return -1;
+    }
+
     result = tpm2_auth_util_from_optarg(ectx, ctx.parent_auth_str,
             &ctx.parent.session, false);
     if (!result) {
@@ -171,27 +176,12 @@ int tpm2_tool_onrun(ESYS_CONTEXT *ectx, tpm2_option_flags flags) {
         goto out;
     }
 
-    if (!ctx.context_file || ctx.context_file[0] == '\0') {
-        ctx.context_file = "object.ctx";
-    }
-
-    char *filename = NULL;
-    result = files_get_unique_name(ctx.context_file, &filename);
-    if (!result) {
-        LOG_ERR("Couldn't get unique version of %s", ctx.context_file);
-        goto out;
-    }
-
     result = files_save_tpm_context_to_path(ectx,
                 ctx.handle,
-                filename);
+                ctx.context_file);
     if (!result) {
-        free(filename);
         goto out;
     }
-
-    tpm2_tool_output("transient-context: %s\n", filename);
-    free(filename);
 
     rc = 0;
 

--- a/tools/tpm2_loadexternal.c
+++ b/tools/tpm2_loadexternal.c
@@ -152,6 +152,11 @@ int tpm2_tool_onrun(ESYS_CONTEXT *ectx, tpm2_option_flags flags) {
         return 1;
     }
 
+    if (!ctx.context_file_path) {
+        LOG_ERR("Expected -o option");
+        return 1;
+    }
+
     /*
      * We only load a TSS format for the public portion, so if
      * someone hands us a public file, we'll assume the TSS format when

--- a/tools/tpm2_startauthsession.c
+++ b/tools/tpm2_startauthsession.c
@@ -93,6 +93,11 @@ int tpm2_tool_onrun(ESYS_CONTEXT *ectx, tpm2_option_flags flags) {
      */
     bool has_key = false;
 
+    if (!ctx.output.path) {
+        LOG_ERR("Expected option -S");
+        return -1;
+    }
+
     if (ctx.session.key_context_arg_str) {
         bool result = tpm2_util_object_load(ectx, ctx.session.key_context_arg_str,
                                     &ctx.session.key_context_object);
@@ -153,27 +158,5 @@ int tpm2_tool_onrun(ESYS_CONTEXT *ectx, tpm2_option_flags flags) {
         return rc;
     }
 
-    if (!ctx.output.path || ctx.output.path[0] == '\0') {
-        ctx.output.path = "session.ctx";
-    }
-
-    char *ctx_file = NULL;
-    bool result = files_get_unique_name(ctx.output.path, &ctx_file);
-    if (!result) {
-        goto out;
-    }
-
-    tpm2_tool_output("session-context: %s\n", ctx_file);
-
-    rc = 0;
-
-out:
-    free(ctx_file);
-
-    result = tpm2_session_close(&s);
-    if (!result) {
-        rc = 1;
-    }
-
-    return rc;
+    return tpm2_session_close(&s) != true;
 }


### PR DESCRIPTION
- get rid of the default file names and make them required options.
- update gitignore file to ignore config.h
- get rid of the persistent option in tpm2_createak, that can be done with tpm2_evictcontrol.