### PR TITLE
configure: use AX_CHECK_ENABLE_DEBUG([info])

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -3,7 +3,7 @@ AC_INIT([tpm2-tools],
 AC_CONFIG_MACRO_DIR([m4])
 
 AX_IS_RELEASE([dash-version])
-AX_CHECK_ENABLE_DEBUG([yes])
+AX_CHECK_ENABLE_DEBUG([info])
 
 AC_PROG_CC
 AC_PROG_LN_S


### PR DESCRIPTION
Currently trying to build the Git version of tpm2-tools fails with 
```
/usr/include/features.h:382:4: error: #warning _FORTIFY_SOURCE requires compiling with optimization (-O) [-Werror=cpp]
 #  warning _FORTIFY_SOURCE requires compiling with optimization (-O)
    ^~~~~~~
```
The reason is that `AX_CHECK_ENABLE_DEBUG([yes])` introduced by #1486 disables optimisation, but `_FORTIFY_SOURCE` set as part of the default hardening requires at least `-O1`. (The CI is not affected because it uses `--disable-hardening`.) According to the [Autoconf Archive manual](https://www.gnu.org/software/autoconf-archive/ax_check_enable_debug.html), the solution is to use `info` instead of `yes` to retain optimisation:

> Specifying ’yes’ adds ’-g -O0’ to the compilation flags for all languages. Specifying ’info’ adds ’-g’ to the compilation flags. Specifying ’profile’ adds ’-g -pg’ to the compilation flags and ’-pg’ to the linking flags. Otherwise, nothing is added. 