### PR TITLE
policypassword: Fix policypassword integration test and revert it from XFAIL list

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -184,9 +184,6 @@ check_PROGRAMS = \
 
 TESTS += $(ALL_SYSTEM_TESTS)
 
-XFAIL_TESTS = \
-    test/integration/tests/tcti/abrmd/policypassword.sh
-
 test_unit_test_string_bytes_CFLAGS   = $(AM_CFLAGS) $(CMOCKA_CFLAGS)
 test_unit_test_string_bytes_LDADD    = $(CMOCKA_LIBS) $(LDADD)
 

--- a/test/integration/tests/tcti/abrmd/policypassword.sh
+++ b/test/integration/tests/tcti/abrmd/policypassword.sh
@@ -46,17 +46,10 @@ tpm2_create -g sha256 -G aes -u $key_pub -r $key_priv -C $primary_key_ctx \
 tpm2_load -C $primary_key_ctx -u $key_pub -r $key_priv -o $key_ctx
 tpm2_encryptdecrypt -c $key_ctx -o $encrypted_txt -i $plain_txt -p $testpswd
 
-tpm2_startauthsession -V --policy-session -S $session_ctx
-tpm2_policypassword -V -S $session_ctx -o $policypassword
-
-trap - err
-tpm2_encryptdecrypt -V -c $key_ctx -i $encrypted_txt -o $decrypted_txt -D \
+tpm2_startauthsession --policy-session -S $session_ctx
+tpm2_policypassword -S $session_ctx -o $policypassword
+tpm2_encryptdecrypt -c $key_ctx -i $encrypted_txt -o $decrypted_txt -D \
   -p session:$session_ctx+$testpswd
-
-echo "tpm2_getcap -c handles-saved-session"
-tpm2_getcap -c handles-saved-session
-exit 1
-
 tpm2_flushcontext -S $session_ctx
 rm $session_ctx
 


### PR DESCRIPTION
For it to work, This change is contingent on an ESAPI change in the PR below
esys_iutil.c: Update session attribute in cmdauths structure for policy sessions #1407

Signed-off-by: Imran Desai <imran.desai@intel.com>