### PR TITLE
test_tpm2_auth_util.c: Remove foobar file created as part of tpm2_auth_util unit test run

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -204,7 +204,12 @@ test_unit_test_pcr_LDADD    = $(CMOCKA_LIBS) $(LDADD)
 
 test_unit_test_tpm2_auth_util_CFLAGS   = $(AM_CFLAGS) $(CMOCKA_CFLAGS)
 test_unit_test_tpm2_auth_util_LDFLAGS  = -Wl,--wrap=Esys_TR_SetAuth \
-                                         -Wl,--wrap=Esys_StartAuthSession
+                                         -Wl,--wrap=Esys_StartAuthSession \
+                                         -Wl,--wrap=fopen \
+                                         -Wl,--wrap=fread \
+                                         -Wl,--wrap=fseek \
+                                         -Wl,--wrap=ftell \
+                                         -Wl,--wrap=fclose
 test_unit_test_tpm2_auth_util_LDADD    = $(CMOCKA_LIBS) $(LDADD)
 
 test_unit_test_tpm2_errata_CFLAGS   = $(AM_CFLAGS) $(CMOCKA_CFLAGS)

--- a/test/unit/test_tpm2_auth_util.c
+++ b/test/unit/test_tpm2_auth_util.c
@@ -100,7 +100,6 @@ const char *mocked_file_data = "sekretpasswrd";
 FILE * __real_fopen(const char *path, const char *mode);
 FILE * __wrap_fopen(const char *path, const char *mode) {
     if (strcmp (path, "test_tpm2_auth_util_foobar")) {
-        printf("REAL CALLED\n");
         return __real_fopen(path, mode);
     }
     return mock_ptr_type(FILE*);

--- a/test/unit/test_tpm2_auth_util.c
+++ b/test/unit/test_tpm2_auth_util.c
@@ -110,7 +110,6 @@ size_t __wrap_fread(void *ptr, size_t size, size_t nmemb, FILE *stream) {
     if (stream != &mocked_file_stream) {
         return __real_fread(ptr,size,nmemb,stream);
     }
-    UNUSED(stream);
     memcpy(ptr, mocked_file_data, size * nmemb);
     return mock_type (size_t);
 }
@@ -120,7 +119,6 @@ long __wrap_ftell(FILE *stream) {
     if (stream != &mocked_file_stream) {
         return __real_ftell(stream);
     }
-    UNUSED(stream);
     return mock_type (long);
 }
 
@@ -129,9 +127,6 @@ int __wrap_fseek(FILE *stream, long offset, int whence) {
     if (stream != &mocked_file_stream) {
         return __real_fseek(stream, offset, whence);
     }
-    UNUSED(stream);
-    UNUSED(offset);
-    UNUSED(whence);
     return 0;
 }
 
@@ -140,7 +135,6 @@ int __wrap_fclose(FILE *stream) {
     if (stream != &mocked_file_stream) {
         return __real_fclose(stream);
     }
-    UNUSED(stream);
     return 0;
 }
 

--- a/test/unit/test_tpm2_auth_util.c
+++ b/test/unit/test_tpm2_auth_util.c
@@ -99,7 +99,7 @@ const char *mocked_file_data = "sekretpasswrd";
 
 FILE * __real_fopen(const char *path, const char *mode);
 FILE * __wrap_fopen(const char *path, const char *mode) {
-    if (strcmp (path, "test_tpm2_auth_util_foobar")) {
+    if (strcmp(path, "test_tpm2_auth_util_foobar")) {
         return __real_fopen(path, mode);
     }
     return mock_ptr_type(FILE*);
@@ -111,7 +111,7 @@ size_t __wrap_fread(void *ptr, size_t size, size_t nmemb, FILE *stream) {
         return __real_fread(ptr,size,nmemb,stream);
     }
     memcpy(ptr, mocked_file_data, size * nmemb);
-    return mock_type (size_t);
+    return mock_type(size_t);
 }
 
 long __real_ftell(FILE *stream);
@@ -119,7 +119,7 @@ long __wrap_ftell(FILE *stream) {
     if (stream != &mocked_file_stream) {
         return __real_ftell(stream);
     }
-    return mock_type (long);
+    return mock_type(long);
 }
 
 int __real_fseek(FILE *stream, long offset, int whence);

--- a/test/unit/test_tpm2_auth_util.c
+++ b/test/unit/test_tpm2_auth_util.c
@@ -94,27 +94,77 @@ static void test_tpm2_password_util_from_optarg_str_escaped_hex_prefix(void **st
     tpm2_session_close(&session);
 }
 
+FILE mocked_file_stream;
+const char *mocked_file_data = "sekretpasswrd";
+
+FILE * __real_fopen(const char *path, const char *mode);
+FILE * __wrap_fopen(const char *path, const char *mode) {
+    if (strcmp (path, "test_tpm2_auth_util_foobar")) {
+        printf("REAL CALLED\n");
+        return __real_fopen(path, mode);
+    }
+    return mock_ptr_type(FILE*);
+}
+
+size_t __real_fread(void *ptr, size_t size, size_t nmemb, FILE *stream);
+size_t __wrap_fread(void *ptr, size_t size, size_t nmemb, FILE *stream) {
+    if (stream != &mocked_file_stream) {
+        return __real_fread(ptr,size,nmemb,stream);
+    }
+    UNUSED(stream);
+    memcpy(ptr, mocked_file_data, size * nmemb);
+    return mock_type (size_t);
+}
+
+long __real_ftell(FILE *stream);
+long __wrap_ftell(FILE *stream) {
+    if (stream != &mocked_file_stream) {
+        return __real_ftell(stream);
+    }
+    UNUSED(stream);
+    return mock_type (long);
+}
+
+int __real_fseek(FILE *stream, long offset, int whence);
+int __wrap_fseek(FILE *stream, long offset, int whence) {
+    if (stream != &mocked_file_stream) {
+        return __real_fseek(stream, offset, whence);
+    }
+    UNUSED(stream);
+    UNUSED(offset);
+    UNUSED(whence);
+    return 0;
+}
+
+int __real_fclose(FILE *stream);
+int __wrap_fclose(FILE *stream) {
+    if (stream != &mocked_file_stream) {
+        return __real_fclose(stream);
+    }
+    UNUSED(stream);
+    return 0;
+}
+
 static void test_tpm2_password_util_from_optarg_file(void **state) {
     UNUSED(state);
 
-    const char *secret = "sekretpasswrd";
-
     tpm2_session *session;
 
-    int fd = open("foobar", O_CREAT | O_WRONLY, S_IRUSR | S_IWUSR);
-    assert_int_not_equal(fd, -1);
+    will_return(__wrap_fopen, &mocked_file_stream);
 
-    int wrok = write(fd, secret, strlen(secret));
-    assert_int_not_equal(wrok, -1);
-    close(fd);
+    will_return(__wrap_fread, (size_t)strlen(mocked_file_data));
 
-    bool res = tpm2_auth_util_from_optarg(NULL, "file:foobar", &session, true);
+    will_return(__wrap_ftell, (long)strlen(mocked_file_data));
+    will_return(__wrap_ftell, (long)strlen(mocked_file_data));
+
+    bool res = tpm2_auth_util_from_optarg(NULL,
+        "file:test_tpm2_auth_util_foobar", &session, true);
     assert_true(res);
 
     const TPM2B_AUTH *auth = tpm2_session_get_auth_value(session);
 
-    assert_int_equal(auth->size, wrok);
-    assert_memory_equal(auth->buffer, secret, wrok);
+    assert_int_equal(auth->size, strlen(mocked_file_data));
+    assert_memory_equal(auth->buffer, mocked_file_data, strlen(mocked_file_data));
 
     tpm2_session_close(&session);
 }


### PR DESCRIPTION

A foobar file is created but not cleaned at end of tpm2_auth_util unit test. 
This fixes the issue #1496 
Signed-off-by: Imran Desai <imran.desai@intel.com>