### PR TITLE
Fix an issue where credential activation fails if Ak password is set

### DIFF
--- a/test/integration/tests/activecredential.sh
+++ b/test/integration/tests/activecredential.sh
@@ -24,7 +24,8 @@ echo "12345678" > secret.data
 
 tpm2_createek -Q -c 0x81010009 -G rsa -p ek.pub
 
-tpm2_createak -C 0x81010009 -c ak.ctx -G rsa -D sha256 -s rsassa -p ak.pub -n ak.name > ak.out
+tpm2_createak -C 0x81010009 -c ak.ctx -G rsa -D sha256 -s rsassa -p ak.pub\
+	-n ak.name -P akpass> ak.out
 
 # Capture the yaml output and verify that its the same as the name output
 loaded_key_name_yaml=`python << pyscript
@@ -45,6 +46,7 @@ test "$loaded_key_name_yaml" == "$loaded_key_name"
 
 tpm2_makecredential -Q -e ek.pub  -s secret.data -n $loaded_key_name -o mkcred.out
 
-tpm2_activatecredential -Q -c ak.ctx -C 0x81010009 -i mkcred.out -o actcred.out
+tpm2_activatecredential -Q -c ak.ctx -C 0x81010009 -i mkcred.out -o actcred.out\
+	-P akpass
 
 exit 0

--- a/tools/tpm2_activatecredential.c
+++ b/tools/tpm2_activatecredential.c
@@ -155,7 +155,7 @@ static bool activate_credential_and_output(ESYS_CONTEXT *ectx) {
     }
 
     ESYS_TR key_shandle = tpm2_auth_util_get_shandle(ectx,
-                            ctx.key_ctx_obj.tr_handle,
+                            ctx.ctx_obj.tr_handle,
                             ctx.key.session);
     if (key_shandle == ESYS_TR_NONE) {
         goto out_session;


### PR DESCRIPTION
This solves issue #1453.

Thanks @dgptha for raising the issue and also proposing the fix going into this commit.