### PR TITLE
ci: check for whitespace errors against $TRAVIS_BRANCH

### DIFF
--- a/.ci/docker.run
+++ b/.ci/docker.run
@@ -83,7 +83,7 @@ popd
 # so people can verify the rest of their patch works in CI before dying.
 # git diff --check fails with a non-zero return code causing the shell to die
 # as it has a set -e executed.
-git diff --check origin/master
+git diff --check origin/${TRAVIS_BRANCH:-master}
 
 # upload coveralls results
 ./.ci/coveralls-upload.sh


### PR DESCRIPTION
Currently the whitespace error check is always performed against the master branch. Therefore it fails on different branches because Travis CI only does a shallow clone of the current branch. Replacing it with `$TRAVIS_BRANCH` allows to test against the correct base branch for pull requests and is a no-op if a branch is built directly. In case the CI scripts are used locally without Travis, use the master branch as a default for `$TRAVIS_BRANCH` to retain the current behaviour.

This fixes #1482, see https://travis-ci.org/diabonas/tpm2-tools/builds/533291219 for a successful build of a feature branch on a personal repository.