### PR TITLE
Fix whitespace errors

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -92,7 +92,7 @@ Some distros have the dependencies already packaged, you can simply install the 
 ```
 $ sudo dnf builddep tpm2-tools
 
-```   
+```
 
 The package installed above contains all the dependencies for tpm2-tools included the projects mentioned at the beginning of this section (tpm2-tss and tpm2-abrmd)
 

--- a/lib/pcr.c
+++ b/lib/pcr.c
@@ -145,10 +145,10 @@ bool pcr_print_pcr_struct(TPML_PCR_SELECTION *pcrSelect, tpm2_pcrs *pcrs) {
 
     tpm2_tool_output("pcrs:\n");
 
-    // Loop through all PCR/hash banks 
+    // Loop through all PCR/hash banks
     for (i = 0; i < pcrSelect->count; i++) {
         const char *alg_name = tpm2_alg_util_algtostr(
-                pcrSelect->pcrSelections[i].hash, 
+                pcrSelect->pcrSelections[i].hash,
                 tpm2_alg_util_flags_hash);
 
         tpm2_tool_output("  %s:\n", alg_name);
@@ -205,7 +205,7 @@ bool pcr_print_pcr_selections(TPML_PCR_SELECTION *pcr_selections) {
         if (halgstr != NULL) {
             tpm2_tool_output("  - %s: [", halgstr);
         } else {
-            LOG_ERR("Unsupported hash algorithm 0x%08x", 
+            LOG_ERR("Unsupported hash algorithm 0x%08x",
                     pcr_selections->pcrSelections[i].hash);
             return false;
         }
@@ -329,7 +329,7 @@ bool pcr_get_banks(ESYS_CONTEXT *esys_context, TPMS_CAPABILITY_DATA *capability_
         LOG_PERR(Esys_GetCapability, rval);
         return false;
     }
-    
+
     *capability_data = *capdata_ret;
 
     unsigned i;
@@ -338,8 +338,8 @@ bool pcr_get_banks(ESYS_CONTEXT *esys_context, TPMS_CAPABILITY_DATA *capability_
     // able to manage, throw an error
     if (capability_data->data.assignedPCR.count > sizeof(algs->alg)) {
         LOG_ERR("Current implementation does not support more than %zu banks, "
-                "got %" PRIu32 " banks supported by TPM", 
-                sizeof(algs->alg), 
+                "got %" PRIu32 " banks supported by TPM",
+                sizeof(algs->alg),
                 capability_data->data.assignedPCR.count);
         free(capdata_ret);
         return false;

--- a/lib/tpm2_alg_util.c
+++ b/lib/tpm2_alg_util.c
@@ -936,4 +936,3 @@ bool tpm2_alg_util_is_aes_size_valid(UINT16 size_in_bytes) {
         return false;
     }
 }
-

--- a/lib/tpm2_error.c
+++ b/lib/tpm2_error.c
@@ -479,7 +479,7 @@ static const char *tpm2_err_handler_fmt0(TSS2_RC rc) {
         // 0x2D - TPM2_RC_UPGRADE
         "For all commands, other than TPM2_FieldUpgradeData, "
         "this code indicates that the TPM is in field upgrade mode. "
-        "For TPM2_FieldUpgradeData, this code indicates that the TPM " 
+        "For TPM2_FieldUpgradeData, this code indicates that the TPM "
         "is not in field upgrade mode",
         // 0x2E - TPM2_RC_TOO_MANY_CONTEXTS
         "context ID counter is at maximum",

--- a/lib/tpm2_identity_util.c
+++ b/lib/tpm2_identity_util.c
@@ -225,10 +225,10 @@ bool tpm2_identity_util_encrypt_seed_with_public_key(TPM2B_DIGEST *protection_se
         TPM2B_ENCRYPTED_SECRET *encrypted_protection_seed) {
     bool result = false;
     TPMI_ALG_PUBLIC alg = parent_pub->publicArea.type;
-    
+
     switch (alg) {
     case TPM2_ALG_RSA:
-        result = encrypt_seed_with_tpm2_rsa_public_key(protection_seed, 
+        result = encrypt_seed_with_tpm2_rsa_public_key(protection_seed,
                 parent_pub, label, labelLen, encrypted_protection_seed);
         break;
     case TPM2_ALG_ECC:
@@ -241,7 +241,7 @@ bool tpm2_identity_util_encrypt_seed_with_public_key(TPM2B_DIGEST *protection_se
             tpm2_alg_util_flags_any));
         return false;
     }
-    
+
     return result;
 }
 
@@ -369,9 +369,9 @@ static void hmac_outer_integrity(
 }
 
 bool tpm2_identity_util_calculate_inner_integrity(
-        TPMI_ALG_HASH name_alg, 
-        TPM2B_SENSITIVE *sensitive, 
-        TPM2B_NAME *pubname, 
+        TPMI_ALG_HASH name_alg,
+        TPM2B_SENSITIVE *sensitive,
+        TPM2B_NAME *pubname,
         TPM2B_DATA *enc_sensitive_key,
         TPMT_SYM_DEF_OBJECT *sym_alg,
         TPM2B_MAX_BUFFER *encrypted_inner_integrity) {
@@ -416,9 +416,9 @@ bool tpm2_identity_util_calculate_inner_integrity(
     return aes_encrypt_buffers(
             sym_alg,
             enc_sensitive_key->buffer,
-            marshalled_sensitive_and_name_digest, 
+            marshalled_sensitive_and_name_digest,
             hash_size + digest_size_info,
-            buffer_marshalled_sensitiveArea, 
+            buffer_marshalled_sensitiveArea,
             marshalled_sensitive_size_info + marshalled_sensitive_size,
             encrypted_inner_integrity);
 }
@@ -450,7 +450,7 @@ void tpm2_identity_util_calculate_outer_integrity(
             encrypted_duplicate_sensitive->buffer,
             encrypted_duplicate_sensitive->size,
             pubname->name,
-            pubname->size, 
+            pubname->size,
             protection_hmac_key->buffer,
             outer_hmac);
 }

--- a/lib/tpm2_nv_util.h
+++ b/lib/tpm2_nv_util.h
@@ -44,7 +44,7 @@ static inline bool tpm2_util_nv_read_public(ESYS_CONTEXT *context,
     }
 
     rval = Esys_NV_ReadPublic(context, tr_object,
-                              ESYS_TR_NONE, ESYS_TR_NONE, ESYS_TR_NONE, 
+                              ESYS_TR_NONE, ESYS_TR_NONE, ESYS_TR_NONE,
                               nv_public, NULL);
     if (rval != TSS2_RC_SUCCESS) {
         LOG_PERR(Esys_NV_ReadPublic, rval);
@@ -144,7 +144,7 @@ static inline bool tpm2_util_nv_read(
     // later
     TPM2B_NV_PUBLIC *nv_public = NULL;
     rval = Esys_NV_ReadPublic(ectx, nv_handle,
-                              ESYS_TR_NONE, ESYS_TR_NONE, ESYS_TR_NONE, 
+                              ESYS_TR_NONE, ESYS_TR_NONE, ESYS_TR_NONE,
                               &nv_public, NULL);
     if (rval != TSS2_RC_SUCCESS) {
         LOG_PERR(Esys_NV_ReadPublic, rval);

--- a/lib/tpm2_openssl.c
+++ b/lib/tpm2_openssl.c
@@ -184,8 +184,8 @@ out:
 }
 
 // show all PCR banks according to g_pcrSelection & g_pcrs->
-bool tpm2_openssl_hash_pcr_banks(TPMI_ALG_HASH hashAlg, 
-                TPML_PCR_SELECTION *pcrSelect, 
+bool tpm2_openssl_hash_pcr_banks(TPMI_ALG_HASH hashAlg,
+                TPML_PCR_SELECTION *pcrSelect,
                 tpm2_pcrs *pcrs, TPM2B_DIGEST *digest) {
 
     UINT32 vi = 0, di = 0, i;
@@ -208,7 +208,7 @@ bool tpm2_openssl_hash_pcr_banks(TPMI_ALG_HASH hashAlg,
         goto out;
     }
 
-    // Loop through all PCR/hash banks 
+    // Loop through all PCR/hash banks
     for (i = 0; i < pcrSelect->count; i++) {
 
         // Loop through all PCRs in this bank

--- a/lib/tpm2_openssl.h
+++ b/lib/tpm2_openssl.h
@@ -113,8 +113,8 @@ bool tpm2_openssl_hash_pcr_values(TPMI_ALG_HASH halg,
  * @return
  *  true on success, false on error.
  */
-bool tpm2_openssl_hash_pcr_banks(TPMI_ALG_HASH hashAlg, 
-        TPML_PCR_SELECTION *pcrSelect, 
+bool tpm2_openssl_hash_pcr_banks(TPMI_ALG_HASH hashAlg,
+        TPML_PCR_SELECTION *pcrSelect,
         tpm2_pcrs *pcrs, TPM2B_DIGEST *digest);
 
 /**

--- a/lib/tpm2_policy.c
+++ b/lib/tpm2_policy.c
@@ -450,7 +450,7 @@ static bool tpm2_policy_populate_digest_list(char *buf, TPML_DIGEST *policy_list
         }
 
         uint16_t policy_digest_size = hash_len;
-        retval = files_load_bytes_from_path(buf, 
+        retval = files_load_bytes_from_path(buf,
             policy_list->digests[policy_list->count].buffer, &policy_digest_size);
         if (!retval) {
             return false;
@@ -489,7 +489,7 @@ bool tpm2_policy_parse_policy_list(char *str, TPML_DIGEST *policy_list) {
             if (subtoken == NULL) {
                 break;
             }
-            
+
             //Expecting one policy digest of same hash alg type for all policies
             if (j == 1) {
                 hash = tpm2_alg_util_from_optarg(subtoken, tpm2_alg_util_flags_hash);

--- a/lib/tpm2_policy.h
+++ b/lib/tpm2_policy.h
@@ -61,9 +61,9 @@ bool tpm2_policy_build_policyauthorize(
  *
  * @param ectx
  *   The Enhanced system api context
- * @param policy_session 
+ * @param policy_session
  *   The policy session into which the policy digest is extended into
- * @param policy_list 
+ * @param policy_list
  *   The list of policy policy digests
  *
  * @return

--- a/lib/tpm2_util.c
+++ b/lib/tpm2_util.c
@@ -104,7 +104,7 @@ bool tpm2_util_get_digest_from_quote(TPM2B_ATTEST *quoted, TPM2B_DIGEST *digest,
         pcrSelCount = tpm2_util_endian_swap_32(pcrSelCount);
     }
     for (j = 0; j < pcrSelCount; j++) {
-        // Hash 
+        // Hash
         if (i+2 >= quoted->size) {
             LOG_ERR("Malformed TPMS_PCR_SELECTION value");
             return false;

--- a/man/tpm2_activatecredential.1.md
+++ b/man/tpm2_activatecredential.1.md
@@ -14,8 +14,8 @@ key.
 # DESCRIPTION
 
 **tpm2_activatecredential**(1) -  Verify that the given content is protected
-with given key handle for given handle, and then decrypt and return the secret, 
-if any password option is missing, assume NULL. Currently only support using 
+with given key handle for given handle, and then decrypt and return the secret,
+if any password option is missing, assume NULL. Currently only support using
 TCG profile compliant EK as the key handle.
 
 # OPTIONS

--- a/man/tpm2_getrandom.1.md
+++ b/man/tpm2_getrandom.1.md
@@ -15,10 +15,10 @@
 **tpm2_getrandom**(1) - Returns the next _SIZE_ octets from the random number
 generator. The _SIZE_ parameter is expected as the only argument to the tool.
 
-Note that the TPM specification recommends that TPM's fix the number of 
-available entry to the maximum size of a hash algorithm output in bytes. 
+Note that the TPM specification recommends that TPM's fix the number of
+available entry to the maximum size of a hash algorithm output in bytes.
 
-Most TPMs do this, and thus the tool verifies that input size is bounded by property 
+Most TPMs do this, and thus the tool verifies that input size is bounded by property
 **TPM2_PT_MAX_DIGEST** and issues an error if it is too large.
 
 # OPTIONS

--- a/man/tpm2_gettestresult.1.md
+++ b/man/tpm2_gettestresult.1.md
@@ -44,7 +44,7 @@ This command is the one of the few commands authorized to be submitted to TPM wh
 
 # RETURNS
 
-- 0 on success 
+- 0 on success
 - 1 on failure
 - 2 on testing
 - 3 on TPM failure

--- a/man/tpm2_pcrreset.1.md
+++ b/man/tpm2_pcrreset.1.md
@@ -19,7 +19,7 @@ The reset value is manufacturer-dependent and is either sequence of 00 or FF
 on the length of the hash algorithm for each supported bank
 
 _PCR\_INDEX_ is a space separated list of PCR indexes to be reset when issuing
-the command. 
+the command.
 
 # OPTIONS
 

--- a/man/tpm2_policypcr.1.md
+++ b/man/tpm2_policypcr.1.md
@@ -19,16 +19,16 @@ established via **tpm2_startauthsession**(1).
 # OPTIONS
 
   * **-o**, **\--out-policy-file**=_POLICY\_FILE_:
-    
+
     File to save the policy digest.
 
   * **-F**, **\--pcr-input-file**=_PCR\_FILE_:
-    
+
     Optional Path or Name of the file containing expected PCR values for the
     specified index. Default is to read the current PCRs per the set list.
 
   * **-L**, **\--set-list**=_PCR\_LIST_:
-    
+
     The list of PCR banks and selected PCRs' ids for each bank.
 
   * **-S**, **\--session**=_SESSION_FILE_:

--- a/man/tpm2_rsadecrypt.1.md
+++ b/man/tpm2_rsadecrypt.1.md
@@ -44,12 +44,12 @@ The key referenced by key-context is **required** to be:
 
   * **-g**, **\--scheme**=_PADDING\_SCHEME_:
 
-    Optional, set the padding scheme (defaults to rsaes). 
-    
+    Optional, set the padding scheme (defaults to rsaes).
+
     * null  - TPM_ALG_NULL
     * rsaes - TPM_ALG_RSAES
     * oaep  - TPM_ALG_OAEP
-    
+
 [common options](common/options.md)
 
 [common tcti options](common/tcti.md)

--- a/man/tpm2_rsaencrypt.1.md
+++ b/man/tpm2_rsaencrypt.1.md
@@ -37,8 +37,8 @@ The key referenced by key-context is **required** to be:
 
   * **-g**, **\--scheme**=_PADDING\_SCHEME_:
 
-    Optional, set the padding scheme (defaults to rsaes). 
-    
+    Optional, set the padding scheme (defaults to rsaes).
+
     * null  - TPM_ALG_NULL
     * rsaes - TPM_ALG_RSAES
     * oaep  - TPM_ALG_OAEP

--- a/misc/coding_standard_c.txt
+++ b/misc/coding_standard_c.txt
@@ -56,7 +56,7 @@ Abbreviated words in variable names should be avoided.  Exceptions are:
 “pos” = position
 “rem” = remainder
 
-Function names should follow the naming conventions of variables and clearly imply not only what the function does, but also the nature of what it returns (if anything).  Functions that return boolean integers should be named to reflect the true condition... even if they are created to detect false conditions. Functions should never be hidden in conditional statements, with the exception of loops where it makes the code simpler. 
+Function names should follow the naming conventions of variables and clearly imply not only what the function does, but also the nature of what it returns (if anything).  Functions that return boolean integers should be named to reflect the true condition... even if they are created to detect false conditions. Functions should never be hidden in conditional statements, with the exception of loops where it makes the code simpler.
 
 bool is_number_prime = is_prime(i);
 if(is_number_prime) {

--- a/test/integration/tests/checkquote.sh
+++ b/test/integration/tests/checkquote.sh
@@ -66,4 +66,3 @@ tpm2_quote -C $handle_ak -L sha256:15,16,22 -q $loaded_randomness -m $output_quo
 tpm2_checkquote -u $output_ak_pub_pem -m $output_quote -s $output_quotesig -F $output_quotepcr -g $digestAlg -q $loaded_randomness
 
 exit 0
-

--- a/test/integration/tests/rc_decode.sh
+++ b/test/integration/tests/rc_decode.sh
@@ -51,8 +51,8 @@ for key in "${!codes[@]}"; do
     value="$(printf '0x%03x' "$(eval echo ${codes[$key]%%:*})")"
     expected_msg="${codes[$key]##*:}"
     received_msg="$(tpm2_rc_decode ${value} | cut -d':' -f3)"
-    
-    if ! grep -iq "${received_msg# }" <<< "${expected_msg}"; then  
+
+    if ! grep -iq "${received_msg# }" <<< "${expected_msg}"; then
         echo "$value raised an invalid error message"
         echo "      - Expected : ${expected_msg}"
         echo "      - Seen     : ${received_msg# }"

--- a/test/integration/tests/toggle_options.sh
+++ b/test/integration/tests/toggle_options.sh
@@ -15,7 +15,7 @@ toolsdir="$(readlink -e "${srcdir}"/../../../tools)"
 #
 # On failure, the function will print the information
 # linked : toggle, filename, getopts string and case
-# 
+#
 # Line header help in guessing what is wrong :
 #   - <Y,!> : Getopt string is OK but no "case" was found
 #   - <!,Y> : Getopt string do not contain toggle but "case" exist
@@ -31,12 +31,12 @@ function check_toggle() {
         exit 254
     fi
 
-    for i in $(grep -R "'${toggle}'[[:space:]]*}" | sed "s%[[:space:]]*%%g"); do 
+    for i in $(grep -R "'${toggle}'[[:space:]]*}" | sed "s%[[:space:]]*%%g"); do
         optionnotfound=0
         casenotfound=0
 
-        filename=${i%%:*}; 
-        match=${i##*:}; 
+        filename=${i%%:*};
+        match=${i##*:};
         option="$(sed -r "s%.*'([^'])'.*%\1%g" <<< "${match}")"
         optionlist="$(grep -R "tpm2_options_new" "${filename}" | sed -r 's%.*("[^"]+").*%\1%g')"
         getcase="$(grep "case '${option}'" "${filename}" | sed "s%[[:space:]]*%%g")"
@@ -70,7 +70,7 @@ function check_toggle() {
 fail=0
 
 # For each detected option toggle, check if it is actually declared to be used
-for i in $(grep -rn "case '.'" "${toolsdir}"/*.c | cut -d"'" -f2-2 | sort | uniq); do 
+for i in $(grep -rn "case '.'" "${toolsdir}"/*.c | cut -d"'" -f2-2 | sort | uniq); do
     check_toggle "${i}"
 done
 

--- a/tools/tpm2_certify.c
+++ b/tools/tpm2_certify.c
@@ -135,7 +135,7 @@ static bool certify_and_save_data(ESYS_CONTEXT *ectx) {
     TPM2B_ATTEST *certify_info;
     TPMT_SIGNATURE *signature;
 
-    ESYS_TR shandle1 = tpm2_auth_util_get_shandle(ectx, 
+    ESYS_TR shandle1 = tpm2_auth_util_get_shandle(ectx,
                             ctx.object.object.tr_handle,
                             ctx.object.session);
     if (shandle1 == ESYS_TR_NONE) {

--- a/tools/tpm2_clearlock.c
+++ b/tools/tpm2_clearlock.c
@@ -32,7 +32,7 @@ static bool clearlock(ESYS_CONTEXT *ectx) {
             ctx.platform ? "TPM2_RH_PLATFORM" : "TPM2_RH_LOCKOUT");
 
     ESYS_TR shandle = tpm2_auth_util_get_shandle(ectx, rh, ctx.auth.session);
-    
+
     TSS2_RC rval = Esys_ClearControl(ectx, rh,
                 shandle, ESYS_TR_NONE, ESYS_TR_NONE, disable);
     if (rval != TPM2_RC_SUCCESS && rval != TPM2_RC_INITIALIZE) {

--- a/tools/tpm2_createpolicy.c
+++ b/tools/tpm2_createpolicy.c
@@ -187,7 +187,7 @@ int tpm2_tool_onrun(ESYS_CONTEXT *ectx, tpm2_option_flags flags) {
         return 1;
     }
 
-    return 0; 
+    return 0;
 }
 
 void tpm2_onexit(void) {

--- a/tools/tpm2_getcap.c
+++ b/tools/tpm2_getcap.c
@@ -824,7 +824,7 @@ dump_handles (TPM2_HANDLE     handles[],
               UINT32         count)
 {
     UINT32 i;
-    
+
     for (i = 0; i < count; ++i)
          tpm2_tool_output ("- 0x%X\n", handles[i]);
 }

--- a/tools/tpm2_gettestresult.c
+++ b/tools/tpm2_gettestresult.c
@@ -77,4 +77,3 @@ int tpm2_tool_onrun(ESYS_CONTEXT *ectx, tpm2_option_flags flags) {
     UNUSED(flags);
     return tpm_gettestresult(ectx);
 }
-

--- a/tools/tpm2_incrementalselftest.c
+++ b/tools/tpm2_incrementalselftest.c
@@ -34,7 +34,7 @@ static bool tpm_incrementalselftest(ESYS_CONTEXT *ectx) {
     print_yaml_indent(1);
 
     /*
-    * According to TSS2 ESAPI, toTest is callee-allocated and 
+    * According to TSS2 ESAPI, toTest is callee-allocated and
     * might be empty but not NULL
     */
     if(ctx.totest == NULL){

--- a/tools/tpm2_makecredential.c
+++ b/tools/tpm2_makecredential.c
@@ -96,7 +96,7 @@ static bool make_external_credential_and_save() {
     TPMI_ALG_HASH name_alg = ctx.public.publicArea.nameAlg;
 
 
-    /* 
+    /*
      * Generate and encrypt seed
      */
     TPM2B_DIGEST seed = TPM2B_TYPE_INIT(TPM2B_DIGEST, buffer);
@@ -113,7 +113,7 @@ static bool make_external_credential_and_save() {
         return false;
     }
 
-    /* 
+    /*
      * Perform identity structure calculations (off of the TPM)
      */
     TPM2B_MAX_BUFFER hmac_key;
@@ -126,7 +126,7 @@ static bool make_external_credential_and_save() {
             &enc_key);
 
     /*
-     * The ctx.credential needs to be marshalled into struct with 
+     * The ctx.credential needs to be marshalled into struct with
      * both size and contents together (to be encrypted as a block)
      */
     TPM2B_MAX_BUFFER marshalled_inner_integrity = TPM2B_EMPTY_INIT;

--- a/tools/tpm2_nvdefine.c
+++ b/tools/tpm2_nvdefine.c
@@ -62,7 +62,7 @@ static int nv_space_define(ESYS_CONTEXT *ectx) {
         if(!files_load_bytes_from_path(ctx.policy_file, public_info.nvPublic.authPolicy.buffer, &public_info.nvPublic.authPolicy.size )) {
             return false;
         }
-    } 
+    }
 
     public_info.nvPublic.dataSize = ctx.size;
 

--- a/tools/tpm2_nvlist.c
+++ b/tools/tpm2_nvlist.c
@@ -56,7 +56,7 @@ static bool nv_list(ESYS_CONTEXT *context) {
 
     TPMS_CAPABILITY_DATA *capabilityData;
     UINT32 property = tpm2_util_hton_32(TPM2_HT_NV_INDEX);
-    TSS2_RC rval = Esys_GetCapability(context, 
+    TSS2_RC rval = Esys_GetCapability(context,
                                       ESYS_TR_NONE, ESYS_TR_NONE, ESYS_TR_NONE,
                                       TPM2_CAP_HANDLES, property,
                                       TPM2_PT_NV_INDEX_MAX,

--- a/tools/tpm2_pcrallocate.c
+++ b/tools/tpm2_pcrallocate.c
@@ -54,7 +54,7 @@ static bool pcr_allocate(ESYS_CONTEXT *ectx) {
 
     pcr_print_pcr_selections(&ctx.pcrSelection);
 
-    rval = Esys_PCR_Allocate(ectx, ESYS_TR_RH_PLATFORM, 
+    rval = Esys_PCR_Allocate(ectx, ESYS_TR_RH_PLATFORM,
                              shandle1, ESYS_TR_NONE, ESYS_TR_NONE,
                              &ctx.pcrSelection, &allocationSuccess,
                              &maxPCR, &sizeNeeded, &sizeAvailable);
@@ -103,7 +103,7 @@ bool tpm2_tool_onstart(tpm2_options **opts) {
     const struct option topts[] = {
         { "auth-platform",     required_argument, NULL, 'P' },
     };
- 
+
     *opts = tpm2_options_new("P:", ARRAY_LEN(topts), topts, on_option, on_arg,
                              0);
 
@@ -119,7 +119,7 @@ int tpm2_tool_onrun(ESYS_CONTEXT *ectx, tpm2_option_flags flags) {
         LOG_ERR("Invalid platform authorization format");
         return 1;
     }
-    
+
     result = pcr_allocate(ectx);
 
     result &= tpm2_session_close(&ctx.auth.session);

--- a/tools/tpm2_pcrreset.c
+++ b/tools/tpm2_pcrreset.c
@@ -55,7 +55,7 @@ static bool on_arg(int argc, char** argv){
     uint32_t pcr;
 
     memset(ctx.pcr_list, 0, TPM2_MAX_PCRS);
-    
+
     if (argc < 1) {
         LOG_ERR("Expected at least one PCR index"
                 "ie: <pcr index>, got: 0");

--- a/tools/tpm2_policyor.c
+++ b/tools/tpm2_policyor.c
@@ -102,7 +102,7 @@ int tpm2_tool_onrun(ESYS_CONTEXT *ectx, tpm2_option_flags flags) {
     }
 
     /* Policy digest hash alg should match that of the session */
-    if (ctx.policy_list.digests[0].size != 
+    if (ctx.policy_list.digests[0].size !=
         tpm2_alg_util_get_hash_size(tpm2_session_get_authhash(s))) {
         LOG_ERR("Policy digest hash alg should match that of the session.");
         return rc;

--- a/tools/tpm2_policypassword.c
+++ b/tools/tpm2_policypassword.c
@@ -89,7 +89,7 @@ int tpm2_tool_onrun(ESYS_CONTEXT *ectx, tpm2_option_flags flags) {
 
     tpm2_util_hexdump(policy_digest->buffer, policy_digest->size);
     tpm2_tool_output("\n");
-   
+
     if (ctx.out_policy_dgst_path) {
         result = files_save_bytes_to_file(ctx.out_policy_dgst_path,
                     policy_digest->buffer, policy_digest->size);

--- a/tools/tpm2_rsadecrypt.c
+++ b/tools/tpm2_rsadecrypt.c
@@ -91,7 +91,7 @@ static bool on_option(char key, char *value) {
         break;
     }
     case 'g':
-        ctx.scheme.scheme = tpm2_alg_util_from_optarg(value, 
+        ctx.scheme.scheme = tpm2_alg_util_from_optarg(value,
                 tpm2_alg_util_flags_rsa_scheme);
         if (ctx.scheme.scheme == TPM2_ALG_ERROR) {
             return false;

--- a/tools/tpm2_rsaencrypt.c
+++ b/tools/tpm2_rsaencrypt.c
@@ -69,7 +69,7 @@ static bool on_option(char key, char *value) {
         ctx.output_path = value;
         break;
     case 'g':
-        ctx.scheme.scheme = tpm2_alg_util_from_optarg(value, 
+        ctx.scheme.scheme = tpm2_alg_util_from_optarg(value,
                 tpm2_alg_util_flags_rsa_scheme);
         if (ctx.scheme.scheme == TPM2_ALG_ERROR) {
             return false;


### PR DESCRIPTION
Following the discussion in #1482, fix all whitespace errors reported by
```
git diff --check $(git hash-object -t tree /dev/null)
```
We have to be a bit careful with Markdown files because [two trailing spaces at the end of a line are considered as a line break](https://meta.stackexchange.com/questions/40976/what-is-the-reason-for-the-top-secret-two-space-newline-markdown-weirdness), but luckily this feature is not used here.