### PR TITLE
Rename the tool tpm2_clearlock to tpm2_clearcontrol to match spec TPM command name

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -34,7 +34,7 @@ bin_PROGRAMS = \
     tools/tpm2_certify \
     tools/tpm2_changeauth \
     tools/tpm2_clear \
-    tools/tpm2_clearlock \
+    tools/tpm2_clearcontrol \
     tools/tpm2_create \
     tools/tpm2_createak \
     tools/tpm2_createek \
@@ -103,7 +103,7 @@ tools_misc_tpm2_print_SOURCES = tools/misc/tpm2_print.c $(TOOL_SRC)
 tools_misc_tpm2_rc_decode_SOURCES = tools/misc/tpm2_rc_decode.c $(TOOL_SRC)
 
 tools_tpm2_clear_SOURCES = tools/tpm2_clear.c $(TOOL_SRC)
-tools_tpm2_clearlock_SOURCES = tools/tpm2_clearlock.c $(TOOL_SRC)
+tools_tpm2_clearcontrol_SOURCES = tools/tpm2_clearcontrol.c $(TOOL_SRC)
 tools_tpm2_create_SOURCES = tools/tpm2_create.c $(TOOL_SRC)
 tools_tpm2_createprimary_SOURCES = tools/tpm2_createprimary.c $(TOOL_SRC)
 tools_tpm2_getcap_SOURCES = tools/tpm2_getcap.c $(TOOL_SRC)
@@ -277,7 +277,7 @@ if HAVE_MAN_PAGES
     man/man1/tpm2_changeauth.1 \
     man/man1/tpm2_checkquote.1 \
     man/man1/tpm2_clear.1 \
-    man/man1/tpm2_clearlock.1 \
+    man/man1/tpm2_clearcontrol.1 \
     man/man1/tpm2_create.1 \
     man/man1/tpm2_createak.1 \
     man/man1/tpm2_createek.1 \

--- a/man/tpm2_clearcontrol.1.md
+++ b/man/tpm2_clearcontrol.1.md
@@ -1,18 +1,18 @@
-% tpm2_clearlock(1) tpm2-tools | General Commands Manual
+% tpm2_clearcontrol(1) tpm2-tools | General Commands Manual
 %
 % DECEMBER 2017
 
 # NAME
 
-**tpm2_clearlock**(1) - Lock/unlock access to the clear operation.
+**tpm2_clearcontrol**(1) - Lock/unlock access to the clear operation.
 
 # SYNOPSIS
 
-**tpm2_clearlock** [OPTIONS]
+**tpm2_clearcontrol** [OPTIONS]
 
 # DESCRIPTION
 
-**tpm2_clearlock**(1) - Allow a user to enable (unlock) or disable (lock)
+**tpm2_clearcontrol**(1) - Allow a user to enable (unlock) or disable (lock)
 access to the **tpm2_clear** operation. If the lockout password option
 is missing, assume NULL.
 
@@ -48,12 +48,12 @@ is missing, assume NULL.
 
 ## Enable the clear command on the platform hierarchy
 ```
-tpm2_clearlock -c -p -L lockoutpasswd
+tpm2_clearcontrol -c -p -L lockoutpasswd
 ```
 
 ## Disable the clear command on the lockout hierarchy
 ```
-tpm2_clearlock
+tpm2_clearcontrol
 ```
 
 # RETURNS

--- a/scripts/utils/analyze.py
+++ b/scripts/utils/analyze.py
@@ -143,7 +143,7 @@ class ToolConflictor(object):
             },
             {
                 "gname": "hierarchy",
-                "tools-in-group": ["tpm2_clear", "tpm2_clearlock"],
+                "tools-in-group": ["tpm2_clear", "tpm2_clearcontrol"],
                 "tools": [],
                 "conflict": None,
                 "ignore": set(['c', 'clear'])

--- a/test/integration/tests/clearcontrol.sh
+++ b/test/integration/tests/clearcontrol.sh
@@ -4,7 +4,7 @@
 source helpers.sh
 
 cleanup() {
-    tpm2_clearlock -c -p
+    tpm2_clearcontrol -c -p
 
     shut_down
 }
@@ -12,9 +12,9 @@ trap cleanup EXIT
 
 start_up
 
-tpm2_clearlock
+tpm2_clearcontrol
 
-tpm2_clearlock -c -p
+tpm2_clearcontrol -c -p
 
 tpm2_clear
 

--- a/tools/tpm2_clearcontrol.c
+++ b/tools/tpm2_clearcontrol.c
@@ -9,8 +9,8 @@
 #include "tpm2_tool.h"
 #include "tpm2_util.h"
 
-typedef struct clearlock_ctx clearlock_ctx;
-struct clearlock_ctx {
+typedef struct clearcontrol_ctx clearcontrol_ctx;
+struct clearcontrol_ctx {
     bool clear;
     bool platform;
 
@@ -20,9 +20,9 @@ struct clearlock_ctx {
     } auth;
 };
 
-static clearlock_ctx ctx;
+static clearcontrol_ctx ctx;
 
-static bool clearlock(ESYS_CONTEXT *ectx) {
+static bool clearcontrol(ESYS_CONTEXT *ectx) {
 
     ESYS_TR rh = ctx.platform ? ESYS_TR_RH_PLATFORM : ESYS_TR_RH_LOCKOUT;
     TPMI_YES_NO disable = ctx.clear ? 0 : 1;
@@ -87,5 +87,5 @@ int tpm2_tool_onrun(ESYS_CONTEXT *ectx, tpm2_option_flags flags) {
         return 1;
     }
 
-    return clearlock(ectx) != true;
+    return clearcontrol(ectx) != true;
 }


### PR DESCRIPTION
This PR commit simply renames the tool from tpm2_clearlock to tpm2_clearcontrol.

It partially addresses issue #1147. Need to add more commits for sanitizing tool options.