### PR TITLE
tpm2_tcti_ldr: safe print option string

### DIFF
--- a/lib/tpm2_tcti_ldr.c
+++ b/lib/tpm2_tcti_ldr.c
@@ -71,7 +71,7 @@ TSS2_TCTI_CONTEXT *tpm2_tcti_ldr_load(const char *path, const char *opts) {
 
         handle = tpm2_tcti_ldr_dlopen(path);
         if (!handle) {
-            LOG_ERR("Could not dlopen library: \"%s\"", path);
+            LOG_ERR("Could not dlopen library: \"%s\"", PSTR(path));
             return NULL;
         }
     }
@@ -91,7 +91,7 @@ TSS2_TCTI_CONTEXT *tpm2_tcti_ldr_load(const char *path, const char *opts) {
     TSS2_RC rc = init(NULL, &size, opts);
     if (rc != TPM2_RC_SUCCESS) {
         LOG_ERR("tcti init setup routine failed for library: \"%s\""
-                " options: \"%s\"", path, opts);
+                " options: \"%s\"", path, PSTR(opts));
         goto err;
     }
 
@@ -104,7 +104,7 @@ TSS2_TCTI_CONTEXT *tpm2_tcti_ldr_load(const char *path, const char *opts) {
     rc = init(tcti_ctx, &size, opts);
     if (rc != TPM2_RC_SUCCESS) {
         LOG_ERR("tcti init allocation routine failed for library: \"%s\""
-                " options: \"%s\"", path, opts);
+                " options: \"%s\"", path, PSTR(opts));
         goto err;
     }
 

--- a/lib/tpm2_util.h
+++ b/lib/tpm2_util.h
@@ -24,6 +24,8 @@
 
 #define ARRAY_LEN(x) (sizeof(x)/sizeof(x[0]))
 
+#define PSTR(x) x ? x : "(null)"
+
 #define BUFFER_SIZE(type, field) (sizeof((((type *)NULL)->field)))
 
 #define TSS2_APP_RC_LAYER TSS2_RC_LAYER(5)


### PR DESCRIPTION
The TCTI option string is allowed to remain NULL, and thus
passing it as an argument to printf("%s") is not portable.
GLIBC will print (null) but some systems will crash.

Define a macro that will return the string "(null)" when the
string is NULL so other LIBC's have the same behavior as
GLIBC.

Fixes: #1241

Signed-off-by: William Roberts <william.c.roberts@intel.com>