### PR TITLE
Disable dependency tracking.

### DIFF
--- a/.ci/coverity.run
+++ b/.ci/coverity.run
@@ -17,7 +17,7 @@ fi
 
 echo "Performing build with Coverity Scan"
 rm -fr $TRAVIS_BUILD_DIR/cov-int
-./bootstrap && ./configure && make clean
+./bootstrap && ./configure --disable-dependency-tracking && make clean
 cov-build --dir $TRAVIS_BUILD_DIR/cov-int make -j $(nproc)
 
 echo "Collecting Coverity data for submission"

--- a/.ci/docker.run
+++ b/.ci/docker.run
@@ -54,7 +54,7 @@ fi
 # Do a make distcheck in the root, clear it and than
 # cd to the variant directory.
 if [ "$CC" == "gcc" ]; then
-    ./configure
+    ./configure --disable-dependency-tracking
     make distcheck
     make distclean
 fi
@@ -66,14 +66,14 @@ pushd ./build
 # Run scan-build for gcc only.
 # Scan-build does not work with clang because of asan linking errors.
 if [[ "$CC" == gcc* ]]; then
-    scan-build ../configure --enable-unit $config_flags
+    scan-build ../configure --disable-dependency-tracking --enable-unit $config_flags
     scan-build --status-bugs make -j$(nproc)
 
     # scan-build causes test_tpm2_session to fail, so
     # rebuild after running scan-build.
 fi
 
-../configure --enable-unit $config_flags
+../configure --disable-dependency-tracking --enable-unit $config_flags
 make -j$(nproc)
 make -j$(nproc) check
 

--- a/.ci/download-deps.sh
+++ b/.ci/download-deps.sh
@@ -11,7 +11,7 @@ function get_deps() {
 		pushd tpm2-tss
 		echo "pwd build tss: `pwd`"
 		./bootstrap
-		./configure CFLAGS=-g
+		./configure --disable-dependency-tracking CFLAGS=-g
 		make -j4
 		make install
 		popd
@@ -26,7 +26,7 @@ function get_deps() {
 		pushd tpm2-abrmd
 		echo "pwd build abrmd: `pwd`"
 		./bootstrap
-		./configure CFLAGS=-g
+		./configure --disable-dependency-tracking CFLAGS=-g
 		make -j4
 		make install
 		popd


### PR DESCRIPTION
Since we only do one time builds with travis it is not useful to have dependency
tracking information. This should speed up travis builds.

Signed-off-by: Imran Desai <imran.desai@intel.com>