### PR TITLE
exit codes: plumb through tools

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -361,6 +361,7 @@ MARKDOWN_COMMON_DEPS = \
 	man/common/object-alg.md \
 	man/common/options.md \
 	man/common/pubkey.md \
+	man/common/returns.md \
 	man/common/sign-alg.md \
 	man/common/signature.md \
 	man/common/signschemes.md \
@@ -397,6 +398,8 @@ man/man1/%.1 : man/%.1.md $(MARKDOWN_COMMON_DEPS)
 	    -e '/\[object attribute specifiers\]/d' \
 	    -e '/\[supported signing schemes\]/r $(top_srcdir)/man/common/signschemes.md' \
 	    -e '/\[supported signing schemes\]/d' \
+	    -e '/\[returns\]/r $(top_srcdir)/man/common/returns.md' \
+	    -e '/\[returns\]/d' \
 	    -e '/\[footer\]/r $(top_srcdir)/man/common/footer.md' \
 	    -e '/\[footer\]/d' \
 	    < $< | pandoc -s -t man > $@

--- a/Makefile.am
+++ b/Makefile.am
@@ -343,14 +343,6 @@ if HAVE_MAN_PAGES
     man/man1/tpm2_verifysignature.1
 endif
 
-if !HAVE_PANDOC
-# If pandoc is not enabled, we want to complain that you need pandoc for make dist,
-# so hook the target and complain.
-dist-hook:
-	@(>&2 echo "You do not have pandoc, a requirement for the distribution of manpages")
-	@exit 1
-endif
-
 MARKDOWN_COMMON_DEPS = \
 	man/common/alg.md \
 	man/common/authorizations.md \
@@ -425,3 +417,9 @@ dist-hook:
 	for f in $(EXTRA_DIST_IGNORE); do \
 		rm -rf `find $(distdir) -name $$f`; \
 	done;
+if !HAVE_PANDOC
+# If pandoc is not enabled, we want to complain that you need pandoc for make dist,
+# so hook the target and complain.
+	@(>&2 echo "You do not have pandoc, a requirement for the distribution of manpages")
+	@exit 1
+endif

--- a/lib/tpm2.c
+++ b/lib/tpm2.c
@@ -97,3 +97,32 @@ tool_rc tpm2_nv_readpublic(
 
     return tool_rc_success;
 }
+
+tool_rc tpm2_getcap(
+        ESYS_CONTEXT *esysContext,
+        ESYS_TR shandle1,
+        ESYS_TR shandle2,
+        ESYS_TR shandle3,
+        TPM2_CAP capability,
+        UINT32 property,
+        UINT32 propertyCount,
+        TPMI_YES_NO *moreData,
+        TPMS_CAPABILITY_DATA **capabilityData) {
+
+    TSS2_RC rval =  Esys_GetCapability(
+        esysContext,
+        shandle1,
+        shandle2,
+        shandle3,
+        capability,
+        property,
+        propertyCount,
+        moreData,
+        capabilityData);
+    if (rval != TSS2_RC_SUCCESS) {
+        LOG_PERR(Esys_NV_ReadPublic, rval);
+        return tool_rc_from_tpm(rval);
+    }
+
+    return tool_rc_success;
+}

--- a/lib/tpm2.c
+++ b/lib/tpm2.c
@@ -1,0 +1,33 @@
+/* SPDX-License-Identifier: BSD-3-Clause */
+
+#include <tss2/tss2_esys.h>
+
+#include "log.h"
+#include "tpm2.h"
+#include "tpm2_tool.h"
+#include "tpm2_util.h"
+
+tool_rc tpm2_readpublic(ESYS_CONTEXT *esysContext,
+        ESYS_TR objectHandle,
+        ESYS_TR shandle1,
+        ESYS_TR shandle2,
+        ESYS_TR shandle3,
+        TPM2B_PUBLIC **outPublic,
+        TPM2B_NAME **name,
+        TPM2B_NAME **qualifiedName) {
+
+    TSS2_RC rval = Esys_ReadPublic(esysContext,
+            objectHandle,
+            shandle1,
+            shandle2,
+            shandle3,
+            outPublic,
+            name,
+            qualifiedName);
+    if (rval != TPM2_RC_SUCCESS) {
+        LOG_PERR(Esys_ReadPublic, rval);
+        return tool_rc_from_tpm(rval);
+    }
+
+    return tool_rc_success;
+}

--- a/lib/tpm2.c
+++ b/lib/tpm2.c
@@ -126,3 +126,32 @@ tool_rc tpm2_getcap(
 
     return tool_rc_success;
 }
+
+tool_rc tpm2_nv_read(
+        ESYS_CONTEXT *esysContext,
+        ESYS_TR authHandle,
+        ESYS_TR nvIndex,
+        ESYS_TR shandle1,
+        ESYS_TR shandle2,
+        ESYS_TR shandle3,
+        UINT16 size,
+        UINT16 offset,
+        TPM2B_MAX_NV_BUFFER **data) {
+
+    TSS2_RC rval = Esys_NV_Read(
+        esysContext,
+        authHandle,
+        nvIndex,
+        shandle1,
+        shandle2,
+        shandle3,
+        size,
+        offset,
+        data);
+    if (rval != TSS2_RC_SUCCESS) {
+        LOG_PERR(Esys_NV_Read, rval);
+        return tool_rc_from_tpm(rval);
+    }
+
+    return tool_rc_success;
+}

--- a/lib/tpm2.c
+++ b/lib/tpm2.c
@@ -7,7 +7,8 @@
 #include "tpm2_tool.h"
 #include "tpm2_util.h"
 
-tool_rc tpm2_readpublic(ESYS_CONTEXT *esysContext,
+tool_rc tpm2_readpublic(
+        ESYS_CONTEXT *esysContext,
         ESYS_TR objectHandle,
         ESYS_TR shandle1,
         ESYS_TR shandle2,
@@ -16,7 +17,8 @@ tool_rc tpm2_readpublic(ESYS_CONTEXT *esysContext,
         TPM2B_NAME **name,
         TPM2B_NAME **qualifiedName) {
 
-    TSS2_RC rval = Esys_ReadPublic(esysContext,
+    TSS2_RC rval = Esys_ReadPublic(
+            esysContext,
             objectHandle,
             shandle1,
             shandle2,
@@ -26,6 +28,70 @@ tool_rc tpm2_readpublic(ESYS_CONTEXT *esysContext,
             qualifiedName);
     if (rval != TPM2_RC_SUCCESS) {
         LOG_PERR(Esys_ReadPublic, rval);
+        return tool_rc_from_tpm(rval);
+    }
+
+    return tool_rc_success;
+}
+
+tool_rc tpm2_from_tpm_public(
+            ESYS_CONTEXT *esysContext,
+            TPM2_HANDLE tpm_handle,
+            ESYS_TR optionalSession1,
+            ESYS_TR optionalSession2,
+            ESYS_TR optionalSession3,
+            ESYS_TR *object) {
+
+    TSS2_RC rval = Esys_TR_FromTPMPublic(
+            esysContext,
+            tpm_handle,
+            optionalSession1,
+            optionalSession2,
+            optionalSession3,
+            object);
+    if (rval != TSS2_RC_SUCCESS) {
+        LOG_PERR(Esys_TR_FromTPMPublic, rval);
+        return tool_rc_from_tpm(rval);
+    }
+
+    return tool_rc_success;
+}
+
+tool_rc tpm2_close(
+        ESYS_CONTEXT *esys_context,
+        ESYS_TR *rsrc_handle) {
+
+    TSS2_RC rval = Esys_TR_Close(
+        esys_context,
+        rsrc_handle);
+    if (rval != TSS2_RC_SUCCESS) {
+        LOG_PERR(Esys_TR_Close, rval);
+        return tool_rc_from_tpm(rval);
+    }
+
+    return tool_rc_success;
+}
+
+tool_rc tpm2_nv_readpublic(
+        ESYS_CONTEXT *esysContext,
+        ESYS_TR nvIndex,
+        ESYS_TR shandle1,
+        ESYS_TR shandle2,
+        ESYS_TR shandle3,
+        TPM2B_NV_PUBLIC **nvPublic,
+        TPM2B_NAME **nvName) {
+
+    TSS2_RC rval = Esys_NV_ReadPublic(
+        esysContext,
+        nvIndex,
+        shandle1,
+        shandle2,
+        shandle3,
+        nvPublic,
+        nvName);
+
+    if (rval != TSS2_RC_SUCCESS) {
+        LOG_PERR(Esys_NV_ReadPublic, rval);
         return tool_rc_from_tpm(rval);
     }
 

--- a/lib/tpm2.h
+++ b/lib/tpm2.h
@@ -7,6 +7,27 @@
 
 #include "tpm2_tool.h"
 
+tool_rc tpm2_from_tpm_public(
+            ESYS_CONTEXT *esysContext,
+            TPM2_HANDLE tpm_handle,
+            ESYS_TR optionalSession1,
+            ESYS_TR optionalSession2,
+            ESYS_TR optionalSession3,
+            ESYS_TR *object);
+
+tool_rc tpm2_close(
+        ESYS_CONTEXT *esys_context,
+        ESYS_TR *rsrc_handle);
+
+tool_rc tpm2_nv_readpublic(
+        ESYS_CONTEXT *esysContext,
+        ESYS_TR nvIndex,
+        ESYS_TR shandle1,
+        ESYS_TR shandle2,
+        ESYS_TR shandle3,
+        TPM2B_NV_PUBLIC **nvPublic,
+        TPM2B_NAME **nvName);
+
 tool_rc tpm2_readpublic(ESYS_CONTEXT *esysContext,
         ESYS_TR objectHandle,
         ESYS_TR shandle1,

--- a/lib/tpm2.h
+++ b/lib/tpm2.h
@@ -1,0 +1,19 @@
+/* SPDX-License-Identifier: BSD-3-Clause */
+
+#ifndef LIB_TPM2_H_
+#define LIB_TPM2_H_
+
+#include <tss2/tss2_esys.h>
+
+#include "tpm2_tool.h"
+
+tool_rc tpm2_readpublic(ESYS_CONTEXT *esysContext,
+        ESYS_TR objectHandle,
+        ESYS_TR shandle1,
+        ESYS_TR shandle2,
+        ESYS_TR shandle3,
+        TPM2B_PUBLIC **outPublic,
+        TPM2B_NAME **name,
+        TPM2B_NAME **qualifiedName);
+
+#endif /* LIB_TPM2_H_ */

--- a/lib/tpm2.h
+++ b/lib/tpm2.h
@@ -48,4 +48,15 @@ tool_rc tpm2_getcap(
         TPMI_YES_NO *moreData,
         TPMS_CAPABILITY_DATA **capabilityData);
 
+tool_rc tpm2_nv_read(
+        ESYS_CONTEXT *esysContext,
+        ESYS_TR authHandle,
+        ESYS_TR nvIndex,
+        ESYS_TR shandle1,
+        ESYS_TR shandle2,
+        ESYS_TR shandle3,
+        UINT16 size,
+        UINT16 offset,
+        TPM2B_MAX_NV_BUFFER **data);
+
 #endif /* LIB_TPM2_H_ */

--- a/lib/tpm2.h
+++ b/lib/tpm2.h
@@ -37,4 +37,15 @@ tool_rc tpm2_readpublic(ESYS_CONTEXT *esysContext,
         TPM2B_NAME **name,
         TPM2B_NAME **qualifiedName);
 
+tool_rc tpm2_getcap(
+        ESYS_CONTEXT *esysContext,
+        ESYS_TR shandle1,
+        ESYS_TR shandle2,
+        ESYS_TR shandle3,
+        TPM2_CAP capability,
+        UINT32 property,
+        UINT32 propertyCount,
+        TPMI_YES_NO *moreData,
+        TPMS_CAPABILITY_DATA **capabilityData);
+
 #endif /* LIB_TPM2_H_ */

--- a/lib/tpm2_error.c
+++ b/lib/tpm2_error.c
@@ -850,11 +850,13 @@ const char * tpm2_error_str(TSS2_RC rc) {
     return buf;
 }
 
+#define UNFMT1(x) (x - TPM2_RC_FMT1)
+
 static tool_rc flatten_fmt1(TSS2_RC rc) {
 
     UINT8 errnum = tpm2_rc_fmt1_error_get(rc);
     switch(errnum) {
-    case TPM2_RC_AUTH_FAIL:
+    case UNFMT1(TPM2_RC_AUTH_FAIL):
         return tool_rc_auth_error;
     default:
         return tool_rc_general_error;

--- a/lib/tpm2_error.c
+++ b/lib/tpm2_error.c
@@ -849,3 +849,24 @@ const char * tpm2_error_str(TSS2_RC rc) {
 
     return buf;
 }
+
+static tool_rc flatten_fmt1(TSS2_RC rc) {
+
+    UINT8 errnum = tpm2_rc_fmt1_error_get(rc);
+    switch(errnum) {
+    case TPM2_RC_AUTH_FAIL:
+        return tool_rc_auth_error;
+    default:
+        return tool_rc_general_error;
+    }
+}
+
+tool_rc tool_rc_from_tpm(TSS2_RC rc) {
+
+    bool is_fmt_1 = tss2_rc_layer_format_get(rc);
+    if (is_fmt_1) {
+        return flatten_fmt1(rc);
+    }
+
+    return tool_rc_general_error;
+}

--- a/lib/tpm2_error.h
+++ b/lib/tpm2_error.h
@@ -108,4 +108,29 @@ bool tpm2_error_set_handler(UINT8 layer, const char *name,
  */
 const char *tpm2_error_str(TSS2_RC rc);
 
+/* do not port to TSS below here */
+typedef enum tool_rc tool_rc;
+enum tool_rc {
+    /* do not reorder or change, part of returned codes to exit */
+    /* maps to common/returns.md */
+    tool_rc_success = 0,
+    tool_rc_general_error,
+    tool_rc_option_error,
+    tool_rc_auth_error,
+    tool_rc_tcti_error,
+    tool_rc_unsupported
+};
+
+/**
+ * Flattens a TSS generated RC into it's error component and converts it to a tool_rc suitable for tool return
+ * use.
+ * @note
+ *  Do not port me to TSS.
+ * @param rc
+ *  The rc to convert.
+ * @return
+ *  A valid tool_rc.
+ */
+tool_rc tool_rc_from_tpm(TSS2_RC rc);
+
 #endif /* LIB_TPM2_ERROR_H_ */

--- a/lib/tpm2_nv_util.h
+++ b/lib/tpm2_nv_util.h
@@ -61,30 +61,27 @@ static inline tool_rc tpm2_util_nv_read_public(ESYS_CONTEXT *context,
  * @param size
  *  The size of the buffer.
  * @return
- *  True on success, false otherwise.
+ *  tool_rc Indicating status.
  */
-static inline bool tpm2_util_nv_max_buffer_size(ESYS_CONTEXT *ectx,
+static inline tool_rc tpm2_util_nv_max_buffer_size(ESYS_CONTEXT *ectx,
         UINT32 *size) {
 
     /* Get the maximum read block size */
     TPMS_CAPABILITY_DATA *cap_data;
     TPMI_YES_NO more_data;
-    TSS2_RC rval = Esys_GetCapability(ectx,
+    tool_rc rc = tpm2_getcap(ectx,
                         ESYS_TR_NONE, ESYS_TR_NONE, ESYS_TR_NONE,
                         TPM2_CAP_TPM_PROPERTIES, TPM2_PT_NV_BUFFER_MAX,
                         1, &more_data, &cap_data);
-    if (rval != TPM2_RC_SUCCESS) {
-        LOG_PERR(Esys_GetCapability, rval);
-        LOG_ERR("Got size of %d",
-                cap_data->data.tpmProperties.tpmProperty[0].value);
-        return false;
+    if (rc != tool_rc_success) {
+        return rc;
     }
 
     *size = cap_data->data.tpmProperties.tpmProperty[0].value;
 
     free(cap_data);
 
-    return true;
+    return rc;
 }
 
 /**
@@ -171,8 +168,8 @@ static inline bool tpm2_util_nv_read(
     }
 
     UINT32 max_data_size;
-    res = tpm2_util_nv_max_buffer_size(ectx, &max_data_size);
-    if (!res) {
+    tool_rc rc = tpm2_util_nv_max_buffer_size(ectx, &max_data_size);
+    if (rc != tool_rc_success) {
         res = false;
         goto out;
     }

--- a/man/common/returns.md
+++ b/man/common/returns.md
@@ -1,0 +1,10 @@
+# Returns
+
+Tools can return any of the following codes:
+
+  - 0 - Success.
+  - 1 - General non-specific error.
+  - 2 - Error handling options.
+  - 3 - Authentication error.
+  - 4 - TCTI related error.
+  - 5 - Non supported scheme. Applicable to tpm2_testparams.

--- a/man/tpm2_activatecredential.1.md
+++ b/man/tpm2_activatecredential.1.md
@@ -73,8 +73,6 @@ tpm2_activatecredential -c ak.dat -C ek.dat -P abc123 -E abc123 -i <filePath> -o
 tpm2_activatecredential -c 0x81010002 -C 0x81010001 -P 123abc -E 1a1b1c  -i <filePath> -o <filePath>
 ```
 
-# RETURNS
-
-0 on success or 1 on failure.
+[returns](common/returns.md)
 
 [footer](common/footer.md)

--- a/man/tpm2_certify.1.md
+++ b/man/tpm2_certify.1.md
@@ -90,8 +90,6 @@ tpm2_certify -C obj.context -c key.context -P 0x0011 -p 0x00FF -g 0x00B -a <file
 tpm2_certify -H 0x81010002 -P 0011 -p 00FF  -g 0x00B -a <fileName> -s <fileName>
 ```
 
-# RETURNS
-
-0 on success or 1 on failure.
+[returns](common/returns.md)
 
 [footer](common/footer.md)

--- a/man/tpm2_changeauth.1.md
+++ b/man/tpm2_changeauth.1.md
@@ -124,8 +124,6 @@ tpm2_policycommandcode -S session.ctx -c $TPM2_NV_ChangeAuth -o policy.nvchange
 tpm2_changeauth -P session:session.ctx -p newindexauth -c $NVIndex
 ```
 
-# RETURNS
-
-0 on success or 1 on failure.
+[returns](common/returns.md)
 
 [footer](common/footer.md)

--- a/man/tpm2_checkquote.1.md
+++ b/man/tpm2_checkquote.1.md
@@ -87,8 +87,6 @@ tpm2_quote -C 0x8101000a -L sha256:15,16,22 -q abc123 -m quote.out -s sig.out -p
 tpm2_checkquote -c akpub.pem -m quote.out -s sig.out -p pcrs.out -G sha256 -q abc123
 ```
 
-# RETURNS
-
-0 on success or 1 on failure.
+[returns](common/returns.md)
 
 [footer](common/footer.md)

--- a/man/tpm2_clear.1.md
+++ b/man/tpm2_clear.1.md
@@ -50,8 +50,6 @@ tpm2_clear -L oldlockoutpasswd
 tpm2_clear -p
 ```
 
-# RETURNS
-
-0 on success or 1 on failure.
+[returns](common/returns.md)
 
 [footer](common/footer.md)

--- a/man/tpm2_clearcontrol.1.md
+++ b/man/tpm2_clearcontrol.1.md
@@ -58,8 +58,6 @@ tpm2_clearcontrol -a l s
 tpm2_clearcontrol -a p c
 ```
 
-# RETURNS
-
-0 on success or 1 on failure.
+[returns](common/returns.md)
 
 [footer](common/footer.md)

--- a/man/tpm2_create.1.md
+++ b/man/tpm2_create.1.md
@@ -125,8 +125,6 @@ tpm2_create -C parent.ctx  -K def456 -G keyedhash -i seal.dat -u obj.pub -r obj.
 tpm2_create -C primary.ctx -G rsa2048 -u obj.pub -r obj.priv -o obj.ctx
 ```
 
-# RETURNS
-
-0 on success or 1 on failure.
+[returns](common/returns.md)
 
 [footer](common/footer.md)

--- a/man/tpm2_createak.1.md
+++ b/man/tpm2_createak.1.md
@@ -127,8 +127,6 @@ tpm2_createak -C 0x81010001 -k ak.ctx -p ak.pub -n ak.name
 tpm2_evictcontrol -c 0x81010002 -o ek.handle
 ```
 
-# RETURNS
-
-0 on success or 1 on failure.
+[returns](common/returns.md)
 
 [footer](common/footer.md)

--- a/man/tpm2_createek.1.md
+++ b/man/tpm2_createek.1.md
@@ -131,8 +131,6 @@ tpm2_getcap -c handles-transient
 
 ```
 
-# RETURNS
-
-0 on success or 1 on failure.
+[returns](common/returns.md)
 
 [footer](common/footer.md)

--- a/man/tpm2_createpolicy.1.md
+++ b/man/tpm2_createpolicy.1.md
@@ -67,8 +67,6 @@ These options control creating the policy authorization session:
 tpm2_createpolicy \--policy-pcr -L 0x4:0 -o policy.file -F pcr0.bin
 ```
 
-# RETURNS
-
-0 on success or 1 on failure.
+[returns](common/returns.md)
 
 [footer](common/footer.md)

--- a/man/tpm2_createprimary.1.md
+++ b/man/tpm2_createprimary.1.md
@@ -116,8 +116,6 @@ tpm2_createprimary -a o -G rsa2048:aes128cfb -g sha256 -o prim.ctx \
 ```
 
 
-# RETURNS
-
-0 on success or 1 on failure.
+[returns](common/returns.md)
 
 [footer](common/footer.md)

--- a/man/tpm2_dictionarylockout.1.md
+++ b/man/tpm2_dictionarylockout.1.md
@@ -62,8 +62,6 @@ tpm2_dictionarylockout -c -p passwd
 tpm2_dictionarylockout -s -n 5 -t 6 -l 7 -p passwd
 ```
 
-# RETURNS
-
-0 on success or 1 on failure.
+[returns](common/returns.md)
 
 [footer](common/footer.md)

--- a/man/tpm2_duplicate.1.md
+++ b/man/tpm2_duplicate.1.md
@@ -77,8 +77,6 @@ tpm2_duplicate -C new_parent.ctxt -c key.ctxt -G null -p "session:session.dat" -
 tpm2_flushcontext -S session.dat
 ```
 
-# RETURNS
-
-0 on success or 1 on failure.
+[returns](common/returns.md)
 
 [footer](common/footer.md)

--- a/man/tpm2_encryptdecrypt.1.md
+++ b/man/tpm2_encryptdecrypt.1.md
@@ -76,8 +76,6 @@ tpm2_encryptdecrypt -C key.dat -p abc123 -i <filePath> -o <filePath>
 tpm2_encryptdecrypt -C 0x81010001 -p 123abca  -i <filePath> -o <filePath>
 ```
 
-# RETURNS
-
-0 on success or 1 on failure.
+[returns](common/returns.md)
 
 [footer](common/footer.md)

--- a/man/tpm2_evictcontrol.1.md
+++ b/man/tpm2_evictcontrol.1.md
@@ -90,8 +90,6 @@ tpm2_createprimary -o primary.ctx
 tpm2_evictcontrol -a o -c primary.ctx -o primary.handle
 ```
 
-# RETURNS
-
-0 on success or 1 on failure.
+[returns](common/returns.md)
 
 [footer](common/footer.md)

--- a/man/tpm2_flushcontext.1.md
+++ b/man/tpm2_flushcontext.1.md
@@ -68,8 +68,6 @@ tpm2_flushcontext -S session.dat
 
 If multiple options are specified (**-t**, **-s** or **-l**), only the last option will be taken into account.
 
-# RETURNS
-
-0 on success or 1 on failure.
+[returns](common/returns.md)
 
 [footer](common/footer.md)

--- a/man/tpm2_getcap.1.md
+++ b/man/tpm2_getcap.1.md
@@ -90,8 +90,6 @@ tpm2_getcap \--capability properties-fixed
 tpm2_getcap -l
 ```
 
-# RETURNS
-
-0 on success or 1 on failure.
+[returns](common/returns.md)
 
 [footer](common/footer.md)

--- a/man/tpm2_getmanufec.1.md
+++ b/man/tpm2_getmanufec.1.md
@@ -99,8 +99,6 @@ tpm2_getmanufec -e abc123 -w abc123 -P passwd -H 0x81010001 -G rsa -O -N -U -E E
 tpm2_getmanufec -e 1a1b1c -w 1a1b1c -P 123abc -H 0x81010001 -G rsa -O -N -U -E ECcert.bin -o ek.bin https://tpm.manufacturer.com/ekcertserver/
 ```
 
-# RETURNS
-
-0 on success or 1 on failure.
+[returns](common/returns.md)
 
 [footer](common/footer.md)

--- a/man/tpm2_getrandom.1.md
+++ b/man/tpm2_getrandom.1.md
@@ -50,8 +50,6 @@ tpm2_getrandom -o random.out 20
 tpm2_getrandom 8
 ```
 
-# RETURNS
-
-0 on success or 1 on failure.
+[returns](common/returns.md)
 
 [footer](common/footer.md)

--- a/man/tpm2_gettestresult.1.md
+++ b/man/tpm2_gettestresult.1.md
@@ -42,11 +42,6 @@ tpm2_gettestresult
 
 This command is the one of the few commands authorized to be submitted to TPM when in failure mode.
 
-# RETURNS
-
-- 0 on success
-- 1 on failure
-- 2 on testing
-- 3 on TPM failure
+[returns](common/returns.md)
 
 [footer](common/footer.md)

--- a/man/tpm2_hash.1.md
+++ b/man/tpm2_hash.1.md
@@ -61,8 +61,6 @@ sign.
 tpm2_hash -H e -g sha1 -o hash.bin -t ticket.bin data.txt
 ```
 
-# RETURNS
-
-0 on success or 1 on failure.
+[returns](common/returns.md)
 
 [footer](common/footer.md)

--- a/man/tpm2_hmac.1.md
+++ b/man/tpm2_hmac.1.md
@@ -61,8 +61,6 @@ tpm2_hmac -C key.context -P abc123 -o hash.out << data.in
 cat data.in | tpm2_hmac -C 0x81010002 -o hash.out
 ```
 
-# RETURNS
-
-0 on success or 1 on failure.
+[returns](common/returns.md)
 
 [footer](common/footer.md)

--- a/man/tpm2_import.1.md
+++ b/man/tpm2_import.1.md
@@ -153,8 +153,6 @@ tpm2_import -C parent.ctx -i key.dup -u key.pub -r key.priv -L policy.dat
   * Parents with a SHA1 hash algorithm currently fail. See bug
     [#119](https://github.com/tpm2-software/tpm2-tools/issues/1119) for details.
 
-# RETURNS
-
-0 on success or 1 on failure.
+[returns](common/returns.md)
 
 [footer](common/footer.md)

--- a/man/tpm2_incrementalselftest.1.md
+++ b/man/tpm2_incrementalselftest.1.md
@@ -34,6 +34,13 @@ algorithms that remains to be tested. This list contains algorithms scheduled fo
 AND algorithms that remains to be tested and not yet scheduled. This can occur for
 instance if all AES mode have not been already tested yet.
 
+# Output
+List of algorithms to be tested (implying scheduled) or remain to be tested (not scheduled) is
+also printed in YAML format.
+
+If none of the specified algorithm is printed, that means both that they are already tested
+AND that these algorithms won't be tested again.
+
 # OPTIONS
 
 This tool accepts no tool specific options.
@@ -69,14 +76,6 @@ also test complete AES mode list AND test ctr mode.
 If an algorithm has already been tested, this command won't permit re-executing the test. Only
 issuing **tpm2_selftest**(1) in full-test mode enabled will force retesting.
 
-# RETURNS
-
-0 on success or 1 on failure.
-
-List of algorithms to be tested (implying scheduled) or remain to be tested (not scheduled) is
-also printed in YAML format.
-
-If none of the specified algorithm is printed, that means both that they are already tested
-AND that these algorithms won't be tested again.
+[returns](common/returns.md)
 
 [footer](common/footer.md)

--- a/man/tpm2_listpersistent.1.md
+++ b/man/tpm2_listpersistent.1.md
@@ -49,8 +49,6 @@ tpm2_listpersistent
 tpm2_listpersistent -g sha256 -G ecc
 ```
 
-# RETURNS
-
-0 on success or 1 on failure.
+[returns](common/returns.md)
 
 [footer](common/footer.md)

--- a/man/tpm2_load.1.md
+++ b/man/tpm2_load.1.md
@@ -64,8 +64,6 @@ tpm2_load  -C parent.ctx -P "hex:123abc" -u <pubKeyFileName> -r <privKeyFileName
 
 ```
 
-# RETURNS
-
-0 on success or 1 on failure.
+[returns](common/returns.md)
 
 [footer](common/footer.md)

--- a/man/tpm2_loadexternal.1.md
+++ b/man/tpm2_loadexternal.1.md
@@ -167,8 +167,6 @@ dd if=/dev/urandom of=sym.key bs=1 count=16
 tpm2_loadexternal -a n -Gaes -r sym.key
 ```
 
-# RETURNS
-
-0 on success or 1 on failure.
+[returns](common/returns.md)
 
 [footer](common/footer.md)

--- a/man/tpm2_makecredential.1.md
+++ b/man/tpm2_makecredential.1.md
@@ -46,8 +46,6 @@ the **none** TCTI option.
 tpm2_makecredential -e <keyFile> -s <secFile> -n <hexString> -o <outFile>
 ```
 
-# RETURNS
-
-0 on success or 1 on failure.
+[returns](common/returns.md)
 
 [footer](common/footer.md)

--- a/man/tpm2_nvdefine.1.md
+++ b/man/tpm2_nvdefine.1.md
@@ -72,8 +72,6 @@ tpm2_nvdefine -x 0x1500016 -a 0x40000001 -s 32 -b 0x2000A
 tpm2_nvdefine -x 0x1500016 -a 0x40000001 -s 32 -b ownerread|ownerwrite|policywrite -p 1a1b1c
 ```
 
-# RETURNS
-
-0 on success or 1 on failure.
+[returns](common/returns.md)
 
 [footer](common/footer.md)

--- a/man/tpm2_nvincrement.1.md
+++ b/man/tpm2_nvincrement.1.md
@@ -55,8 +55,6 @@
 tpm2_nvincrement -x 0x1500016 -P "index"
 ```
 
-# RETURNS
-
-0 on success or 1 on failure.
+[returns](common/returns.md)
 
 [footer](common/footer.md)

--- a/man/tpm2_nvlist.1.md
+++ b/man/tpm2_nvlist.1.md
@@ -62,8 +62,6 @@ This tool takes no tool specific options.
 tpm2_nvlist
 ```
 
-# RETURNS
-
-0 on success or 1 on failure.
+[returns](common/returns.md)
 
 [footer](common/footer.md)

--- a/man/tpm2_nvread.1.md
+++ b/man/tpm2_nvread.1.md
@@ -68,8 +68,6 @@
 tpm2_nvread -x 0x1500016 -a 0x40000001 -s 32
 ```
 
-# RETURNS
-
-0 on success or 1 on failure.
+[returns](common/returns.md)
 
 [footer](common/footer.md)

--- a/man/tpm2_nvreadlock.1.md
+++ b/man/tpm2_nvreadlock.1.md
@@ -48,8 +48,6 @@ is released on subsequent restart of the machine.
 tpm2_nvreadlock -x 0x1500016 -a 0x40000001 -P passwd
 ```
 
-# RETURNS
-
-0 on success or 1 on failure.
+[returns](common/returns.md)
 
 [footer](common/footer.md)

--- a/man/tpm2_nvrelease.1.md
+++ b/man/tpm2_nvrelease.1.md
@@ -47,8 +47,6 @@ defined with **tpm2_nvdefine**(1).
 tpm2_nvrelease -x 0x1500016 -a 0x40000001 -P passwd
 ```
 
-# RETURNS
-
-0 on success or 1 on failure.
+[returns](common/returns.md)
 
 [footer](common/footer.md)

--- a/man/tpm2_nvwrite.1.md
+++ b/man/tpm2_nvwrite.1.md
@@ -59,8 +59,6 @@ If _FILE_ is not specified, it defaults to stdin.
 tpm2_nvwrite -x 0x1500016 -P "index" -f nv.data
 ```
 
-# RETURNS
-
-0 on success or 1 on failure.
+[returns](common/returns.md)
 
 [footer](common/footer.md)

--- a/man/tpm2_pcrallocate.1.md
+++ b/man/tpm2_pcrallocate.1.md
@@ -50,8 +50,6 @@ tpm2_pcrallocate
 tpm2_pcrallocate -P abc sha1:7,8,9,10,16,17,18,19+sha256:all
 ```
 
-# RETURNS
-
-0 on success or 1 on failure.
+[returns](common/returns.md)
 
 [footer](common/footer.md)

--- a/man/tpm2_pcrevent.1.md
+++ b/man/tpm2_pcrevent.1.md
@@ -60,8 +60,6 @@ tpm2_pcrevent data
 tpm2_pcrevent -x 8 data
 ```
 
-# RETURNS
-
-0 on success or 1 on failure.
+[returns](common/returns.md)
 
 [footer](common/footer.md)

--- a/man/tpm2_pcrextend.1.md
+++ b/man/tpm2_pcrextend.1.md
@@ -63,8 +63,6 @@ tpm2_pcrextend 4:sha=f1d2d2f924e986ac86fdf7b36c94bcdf32beec15,sha256:b5bb9d8014a
 tpm2_pcrextend 4:sha=f1d2d2f924e986ac86fdf7b36c94bcdf32beec15 7:sha256:b5bb9d8014a0f9b1d61e21e796d78dccdf1352f23cd32812f4850b878ae4944c
 ```
 
-# RETURNS
-
-0 on success or 1 on failure.
+[returns](common/returns.md)
 
 [footer](common/footer.md)

--- a/man/tpm2_pcrlist.1.md
+++ b/man/tpm2_pcrlist.1.md
@@ -93,8 +93,6 @@ with the maximum length of a bank.
 On most TPMs, it means that this tool can dump up to 24 PCRs
 at once.
 
-# RETURNS
-
-0 on success or 1 on failure.
+[returns](common/returns.md)
 
 [footer](common/footer.md)

--- a/man/tpm2_pcrreset.1.md
+++ b/man/tpm2_pcrreset.1.md
@@ -51,8 +51,6 @@ PCR 0 to 15 are not resettable (being part of SRTM). PCR 16 to 22 are mostly
 reserved for DRTM or dedicated to specific localities and might not
 be resettable depending on current TPM locality.
 
-# RETURNS
-
-0 on success or 1 on failure.
+[returns](common/returns.md)
 
 [footer](common/footer.md)

--- a/man/tpm2_policyauthorize.1.md
+++ b/man/tpm2_policyauthorize.1.md
@@ -135,8 +135,6 @@ echo $unsealed
 tpm2_flushcontext -S session.ctx
 ```
 
-# RETURNS
-
-0 on success or 1 on failure.
+[returns](common/returns.md)
 
 [footer](common/footer.md)

--- a/man/tpm2_policycommandcode.1.md
+++ b/man/tpm2_policycommandcode.1.md
@@ -81,8 +81,6 @@ if [ $? != 0 ]; then
 fi
 ```
 
-# RETURNS
-
-0 on success or 1 on failure.
+[returns](common/returns.md)
 
 [footer](common/footer.md)

--- a/man/tpm2_policyduplicationselect.1.md
+++ b/man/tpm2_policyduplicationselect.1.md
@@ -49,8 +49,6 @@ is recommended.
 * This command will set the policy session's command code to **TPM_CC_Duplicate** which enables duplication role of
 the policy.
 
-# RETURNS
-
-0 on success or 1 on failure.
+[returns](common/returns.md)
 
 [footer](common/footer.md)

--- a/man/tpm2_policylocality.1.md
+++ b/man/tpm2_policylocality.1.md
@@ -95,8 +95,6 @@ locality for a discrete nor firmware TPM.
 As for TPM simulator, there is no [tpm2-abrmd](https://github.com/tpm2-software/tpm2-abrmd) interface to change locality.
 For now, one can set locality with TPM simulator, without [tpm2-abrmd](https://github.com/tpm2-software/tpm2-abrmd).
 
-# RETURNS
-
-0 on success or 1 on failure.
+[returns](common/returns.md)
 
 [footer](common/footer.md)

--- a/man/tpm2_policyor.1.md
+++ b/man/tpm2_policyor.1.md
@@ -108,8 +108,6 @@ unsealed=`tpm2_unseal -p"session:session.ctx" -c sealing_key.ctx
 tpm2_flushcontext -S session.ctx
 ```
 
-# RETURNS
-
-0 on success or 1 on failure.
+[returns](common/returns.md)
 
 [footer](common/footer.md)

--- a/man/tpm2_policypassword.1.md
+++ b/man/tpm2_policypassword.1.md
@@ -84,8 +84,6 @@ tpm2_encryptdecrypt -c key.ctx -o encrypt.out -i plain.txt \
 tpm2_flushcontext -S session.dat
 ```
 
-# RETURNS
-
-0 on success or 1 on failure.
+[returns](common/returns.md)
 
 [footer](common/footer.md)

--- a/man/tpm2_policypcr.1.md
+++ b/man/tpm2_policypcr.1.md
@@ -82,8 +82,6 @@ Then, it uses a *policy* session to unseal some data stored in the object.
     tpm2_flushcontext -H "$handle"
     ```
 
-# RETURNS
-
-0 on success or 1 on failure.
+[returns](common/returns.md)
 
 [footer](common/footer.md)

--- a/man/tpm2_policyrestart.1.md
+++ b/man/tpm2_policyrestart.1.md
@@ -52,8 +52,6 @@ tpm2_policypcr -Q -S session.dat -L "sha1:0,1,2,3" -F pcr.dat -o policy.dat
 tpm2_unseal -S session.dat -c unseal.key.ctx
 ```
 
-# RETURNS
-
-0 on success or 1 on failure.
+[returns](common/returns.md)
 
 [footer](common/footer.md)

--- a/man/tpm2_policysecret.1.md
+++ b/man/tpm2_policysecret.1.md
@@ -85,8 +85,6 @@ echo $unsealed
 tpm2_flushcontext -S session.ctx
 ```
 
-# RETURNS
-
-0 on success or 1 on failure.
+[returns](common/returns.md)
 
 [footer](common/footer.md)

--- a/man/tpm2_print.1.md
+++ b/man/tpm2_print.1.md
@@ -40,8 +40,6 @@ tpm2_print \--type=TPMS_ATTEST \--file=/path/to/tpm/quote
 cat /path/to/tpm/quote | tpm2_print \--type=TPMS_ATTEST
 ```
 
-# RETURNS
-
-0 on success or 1 on failure.
+[returns](common/returns.md)
 
 [footer](common/footer.md)

--- a/man/tpm2_quote.1.md
+++ b/man/tpm2_quote.1.md
@@ -103,8 +103,6 @@ with the maximum length of a bank.
 On most TPMs, it means that this tool can quote up to 24 PCRs
 at once.
 
-# RETURNS
-
-0 on success or 1 on failure.
+[returns](common/returns.md)
 
 [footer](common/footer.md)

--- a/man/tpm2_rc_decode.1.md
+++ b/man/tpm2_rc_decode.1.md
@@ -27,8 +27,6 @@ This tool takes no tool specific options.
 tpm2_rc_decode 0x100
 ```
 
-# RETURNS
-
-0 on success or 1 on failure.
+[returns](common/returns.md)
 
 [footer](common/footer.md)

--- a/man/tpm2_readpublic.1.md
+++ b/man/tpm2_readpublic.1.md
@@ -84,8 +84,6 @@ tpm2_startauthsession --policy-session -S session.ctx -k primary.handle
 
 For new objects, its best to use all serialized handles.
 
-# RETURNS
-
-0 on success or 1 on failure.
+[returns](common/returns.md)
 
 [footer](common/footer.md)

--- a/man/tpm2_rsadecrypt.1.md
+++ b/man/tpm2_rsadecrypt.1.md
@@ -64,8 +64,6 @@ The key referenced by key-context is **required** to be:
 tpm2_rsadecrypt -C 0x81010001 -i encrypted.in -o plain.out
 ```
 
-# RETURNS
-
-0 on success or 1 on failure.
+[returns](common/returns.md)
 
 [footer](common/footer.md)

--- a/man/tpm2_rsaencrypt.1.md
+++ b/man/tpm2_rsaencrypt.1.md
@@ -55,8 +55,6 @@ The key referenced by key-context is **required** to be:
 tpm2_rsaencrypt -C 0x81010001 -o encrypted.out
 ```
 
-# RETURNS
-
-0 on success or 1 on failure.
+[returns](common/returns.md)
 
 [footer](common/footer.md)

--- a/man/tpm2_selftest.1.md
+++ b/man/tpm2_selftest.1.md
@@ -39,8 +39,6 @@ tpm2_selftest
 tpm2_selftest -f
 ```
 
-# RETURNS
-
-0 on success or 1 on failure.
+[returns](common/returns.md)
 
 [footer](common/footer.md)

--- a/man/tpm2_send.1.md
+++ b/man/tpm2_send.1.md
@@ -42,8 +42,6 @@ tpm2_send < tpm2-command.bin > tpm2-response.bin
 tpm2_send < tpm2-command.bin -o tpm2-response.bin
 ```
 
-# RETURNS
-
-0 on success or 1 on failure.
+[returns](common/returns.md)
 
 [footer](common/footer.md)

--- a/man/tpm2_sign.1.md
+++ b/man/tpm2_sign.1.md
@@ -128,8 +128,6 @@ tpm2_sign -Q -c key.ctx -g sha256 -D data.in.digest -f plain -s data.out.signed
 openssl dgst -verify public.ecc.pem -keyform pem -sha256 -signature data.out.signed data.in.raw
 ```
 
-# RETURNS
-
-0 on success or 1 on failure.
+[returns](common/returns.md)
 
 [footer](common/footer.md)

--- a/man/tpm2_startauthsession.1.md
+++ b/man/tpm2_startauthsession.1.md
@@ -77,8 +77,6 @@ tpm2_createprimary -o primary.ctx
 tpm2_startauthsession \--policy-session -k primary.ctx -S mysession.ctx
 ```
 
-# RETURNS
-
-0 on success or 1 on failure.
+[returns](common/returns.md)
 
 [footer](common/footer.md)

--- a/man/tpm2_startup.1.md
+++ b/man/tpm2_startup.1.md
@@ -38,8 +38,6 @@ tpm2_startup -c
 Typically a Resource Manager (like [tpm2-abrmd](https://github.com/tpm2-software/tpm2-abrmd)) or low-level/boot software will
 have already sent this command.
 
-# RETURNS
-
-0 on success or 1 on failure.
+[returns](common/returns.md)
 
 [footer](common/footer.md)

--- a/man/tpm2_stirrandom.1.md
+++ b/man/tpm2_stirrandom.1.md
@@ -65,8 +65,6 @@ As a consequence, it will just be considered as "additional input".
 The "additional input" is as defined in [NIST SP800-90A](
 https://nvlpubs.nist.gov/nistpubs/Legacy/SP/nistspecialpublication800-90.pdf)
 
-# RETURNS
-
-0 on success or 1 on failure.
+[returns](common/returns.md)
 
 [footer](common/footer.md)

--- a/man/tpm2_testparms.1.md
+++ b/man/tpm2_testparms.1.md
@@ -45,8 +45,6 @@ tpm2_testparms rsa
 tpm2_testparms ecc256:ecdsa:aes128ctr
 ```
 
-# RETURNS
-
-0 on success or 1 on failure.
+[returns](common/returns.md)
 
 [footer](common/footer.md)

--- a/man/tpm2_unseal.1.md
+++ b/man/tpm2_unseal.1.md
@@ -77,8 +77,6 @@ used for simple PCR authentication policies. For more complex policies the
 tools should be run in an execution environment that keeps the session context
 alive and pass that session using the **\--input-session-handle** option.
 
-# RETURNS
-
-0 on success or 1 on failure.
+[returns](common/returns.md)
 
 [footer](common/footer.md)

--- a/man/tpm2_verifysignature.1.md
+++ b/man/tpm2_verifysignature.1.md
@@ -120,8 +120,6 @@ openssl dgst -sha256 -sign private.ecc.pem -out data.out.signed data.in.raw
 tpm2_verifysignature -Q -c key.ctx -g sha256 -m data.in.raw -f ecdsa -s data.out.signed
 ```
 
-# RETURNS
-
-0 on success or 1 on failure.
+[returns](common/returns.md)
 
 [footer](common/footer.md)

--- a/tools/misc/tpm2_print.c
+++ b/tools/misc/tpm2_print.c
@@ -354,7 +354,7 @@ bool tpm2_tool_onstart(tpm2_options **opts) {
     return *opts != NULL;
 }
 
-int tpm2_tool_onrun(ESYS_CONTEXT *ectx, tpm2_option_flags flags) {
+tool_rc tpm2_tool_onrun(ESYS_CONTEXT *ectx, tpm2_option_flags flags) {
     UNUSED(ectx);
     UNUSED(flags);
 
@@ -369,7 +369,7 @@ int tpm2_tool_onrun(ESYS_CONTEXT *ectx, tpm2_option_flags flags) {
         break;
     default:
         LOG_ERR("Must specify a file type with -t option");
-        return 1;
+        return tool_rc_option_error;
     }
 
     FILE* fd = stdin;
@@ -379,7 +379,7 @@ int tpm2_tool_onrun(ESYS_CONTEXT *ectx, tpm2_option_flags flags) {
         fd = fopen(ctx.file.path, "rb");
         if(!fd) {
             LOG_ERR("Could not open file %s", ctx.file.path);
-            return 1;
+            return tool_rc_general_error;
         }
     }
     else {
@@ -394,5 +394,5 @@ int tpm2_tool_onrun(ESYS_CONTEXT *ectx, tpm2_option_flags flags) {
         fclose(fd);
     }
 
-    return res ? 0 : 1;
+    return res ? tool_rc_success : tool_rc_general_error;
 }

--- a/tools/misc/tpm2_rc_decode.c
+++ b/tools/misc/tpm2_rc_decode.c
@@ -54,7 +54,7 @@ bool tpm2_tool_onstart(tpm2_options **opts) {
     return *opts != NULL;
 }
 
-int tpm2_tool_onrun(ESYS_CONTEXT *ectx, tpm2_option_flags flags) {
+tool_rc tpm2_tool_onrun(ESYS_CONTEXT *ectx, tpm2_option_flags flags) {
 
     UNUSED(flags);
     UNUSED(ectx);
@@ -62,5 +62,5 @@ int tpm2_tool_onrun(ESYS_CONTEXT *ectx, tpm2_option_flags flags) {
     const char *e = tpm2_error_str(ctx.rc);
     tpm2_tool_output("%s\n", e);
 
-    return 0;
+    return tool_rc_success;
 }

--- a/tools/tpm2_certify.c
+++ b/tools/tpm2_certify.c
@@ -239,17 +239,17 @@ bool tpm2_tool_onstart(tpm2_options **opts) {
     return *opts != NULL;
 }
 
-int tpm2_tool_onrun(ESYS_CONTEXT *ectx, tpm2_option_flags flags) {
+tool_rc tpm2_tool_onrun(ESYS_CONTEXT *ectx, tpm2_option_flags flags) {
     UNUSED(flags);
 
-    int rc = 1;
+    tool_rc rc = tool_rc_general_error;
     bool result;
 
     if ((!ctx.object.context_arg)
         && (!ctx.key.context_arg)
         && (ctx.flags.g) && (ctx.flags.o)
         && (ctx.flags.s)) {
-        return -1;
+        return tool_rc_option_error;
     }
 
     /* Load input files */
@@ -288,13 +288,13 @@ int tpm2_tool_onrun(ESYS_CONTEXT *ectx, tpm2_option_flags flags) {
         goto out;
     }
 
-    rc = 0;
+    rc = tool_rc_success;
 out:
 
     result = tpm2_session_close(&ctx.key.session);
     result &= tpm2_session_close(&ctx.object.session);
     if (!result) {
-        rc = 1;
+        rc = tool_rc_general_error;
     }
 
     return rc;

--- a/tools/tpm2_changeauth.c
+++ b/tools/tpm2_changeauth.c
@@ -415,7 +415,7 @@ static bool is_input_option_args_valid(void) {
     return true;
 }
 
-int tpm2_tool_onrun(ESYS_CONTEXT *ectx, tpm2_option_flags flags) {
+tool_rc tpm2_tool_onrun(ESYS_CONTEXT *ectx, tpm2_option_flags flags) {
 
     UNUSED(flags);
 
@@ -425,7 +425,7 @@ int tpm2_tool_onrun(ESYS_CONTEXT *ectx, tpm2_option_flags flags) {
                 &ctx.tpm_handle_context_object);
         if (!result) {
             LOG_ERR("Invalid TPM object handle");
-            return -1;
+            return tool_rc_option_error;
         }
     }
 
@@ -434,13 +434,13 @@ int tpm2_tool_onrun(ESYS_CONTEXT *ectx, tpm2_option_flags flags) {
                 &ctx.tpm_handle_parent_context_object);
         if (!result) {
             LOG_ERR("Invalid TPM object handle parent");
-            return -1;
+            return tool_rc_option_error;
         }
     }
 
     result = is_input_option_args_valid();
     if (!result) {
-        return -1;
+        return tool_rc_option_error;
     }
 
     if (ctx.is_persistent || ctx.is_transient) {
@@ -456,6 +456,5 @@ int tpm2_tool_onrun(ESYS_CONTEXT *ectx, tpm2_option_flags flags) {
         result = process_change_hierarchy_auth(ectx);
     }
 
-    /* true is success, coerce to 0 for program success */
-    return result == false;
+    return result ? tool_rc_success : tool_rc_general_error;
 }

--- a/tools/tpm2_clear.c
+++ b/tools/tpm2_clear.c
@@ -74,7 +74,7 @@ bool tpm2_tool_onstart(tpm2_options **opts) {
     return *opts != NULL;
 }
 
-int tpm2_tool_onrun(ESYS_CONTEXT *ectx, tpm2_option_flags flags) {
+tool_rc tpm2_tool_onrun(ESYS_CONTEXT *ectx, tpm2_option_flags flags) {
 
     UNUSED(flags);
     bool result = false;
@@ -90,5 +90,5 @@ int tpm2_tool_onrun(ESYS_CONTEXT *ectx, tpm2_option_flags flags) {
 
     result &= tpm2_session_close(&ctx.auth.session);
 
-    return result == false;
+    return result ? tool_rc_success : tool_rc_general_error;
 }

--- a/tools/tpm2_clearcontrol.c
+++ b/tools/tpm2_clearcontrol.c
@@ -25,7 +25,7 @@ static clearcontrol_ctx ctx = {
     .disable_clear = 0,
 };
 
-static bool clearcontrol(ESYS_CONTEXT *ectx) {
+static tool_rc clearcontrol(ESYS_CONTEXT *ectx) {
 
     LOG_INFO ("Sending TPM2_ClearControl(%s) disableClear command with auth handle %s",
             ctx.disable_clear ? "SET" : "CLEAR",
@@ -37,11 +37,10 @@ static bool clearcontrol(ESYS_CONTEXT *ectx) {
                 shandle, ESYS_TR_NONE, ESYS_TR_NONE, ctx.disable_clear);
     if (rval != TPM2_RC_SUCCESS && rval != TPM2_RC_INITIALIZE) {
         LOG_PERR(Esys_ClearControl, rval);
-        return false;
+        return tool_rc_from_tpm(rval);
     }
 
-    LOG_INFO ("Success. TSS2_RC: 0x%x", rval);
-    return true;
+    return tool_rc_success;
 }
 
 static bool set_clearcontrol_auth_handle(const char *value) {
@@ -149,5 +148,5 @@ tool_rc tpm2_tool_onrun(ESYS_CONTEXT *ectx, tpm2_option_flags flags) {
         return tool_rc_general_error;
     }
 
-    return clearcontrol(ectx) ? tool_rc_success : tool_rc_general_error;
+    return clearcontrol(ectx);
 }

--- a/tools/tpm2_clearcontrol.c
+++ b/tools/tpm2_clearcontrol.c
@@ -131,7 +131,7 @@ bool tpm2_tool_onstart(tpm2_options **opts) {
     return *opts != NULL;
 }
 
-int tpm2_tool_onrun(ESYS_CONTEXT *ectx, tpm2_option_flags flags) {
+tool_rc tpm2_tool_onrun(ESYS_CONTEXT *ectx, tpm2_option_flags flags) {
 
     UNUSED(flags);
 
@@ -140,14 +140,14 @@ int tpm2_tool_onrun(ESYS_CONTEXT *ectx, tpm2_option_flags flags) {
     if (!res) {
         LOG_ERR("Invalid authorization, got\"%s\"",
             ctx.auth.auth_str);
-        return 1;
+        return tool_rc_general_error;
     }
 
     if (!ctx.disable_clear && ctx.rh == ESYS_TR_RH_LOCKOUT) {
         LOG_ERR("Only platform hierarchy handle can be specified"
             " for CLEAR operation on disableClear");
-        return 1;
+        return tool_rc_general_error;
     }
 
-    return clearcontrol(ectx) != true;
+    return clearcontrol(ectx) ? tool_rc_success : tool_rc_general_error;
 }

--- a/tools/tpm2_create.c
+++ b/tools/tpm2_create.c
@@ -240,24 +240,24 @@ static bool load_sensitive(void) {
             &ctx.in_sensitive.sensitive.data.size, ctx.in_sensitive.sensitive.data.buffer);
 }
 
-int tpm2_tool_onrun(ESYS_CONTEXT *ectx, tpm2_option_flags flags) {
+tool_rc tpm2_tool_onrun(ESYS_CONTEXT *ectx, tpm2_option_flags flags) {
 
     UNUSED(flags);
 
-    int rc = 1;
+    tool_rc rc = tool_rc_general_error;
     bool result;
 
     TPMA_OBJECT attrs = DEFAULT_ATTRS;
 
     if(!ctx.parent_ctx_path) {
         LOG_ERR("Must specify parent object via -C.");
-        return -1;
+        return tool_rc_option_error;
     }
 
     if (ctx.flags.i) {
         if (ctx.flags.G) {
             LOG_ERR("Cannot specify -G and -i together.");
-            return -1;
+            return tool_rc_option_error;
         }
 
         bool res = load_sensitive();
@@ -321,12 +321,12 @@ int tpm2_tool_onrun(ESYS_CONTEXT *ectx, tpm2_option_flags flags) {
         goto out;
     }
 
-    rc = 0;
+    rc = tool_rc_success;
 
 out:
     result = tpm2_session_close(&ctx.parent.session);
     if (!result) {
-        rc = 1;
+        rc = tool_rc_general_error;
     }
 
     return rc;

--- a/tools/tpm2_createek.c
+++ b/tools/tpm2_createek.c
@@ -354,12 +354,12 @@ static void set_default_hierarchy(void) {
     ctx.objdata.in.hierarchy = TPM2_RH_ENDORSEMENT;
 }
 
-int tpm2_tool_onrun(ESYS_CONTEXT *ectx, tpm2_option_flags flags) {
+tool_rc tpm2_tool_onrun(ESYS_CONTEXT *ectx, tpm2_option_flags flags) {
 
     UNUSED(flags);
 
     size_t i;
-    int rc = 1;
+    tool_rc rc = tool_rc_general_error;
 
     tpm2_session **sessions[] = {
        &ctx.auth.ek.session,
@@ -369,7 +369,7 @@ int tpm2_tool_onrun(ESYS_CONTEXT *ectx, tpm2_option_flags flags) {
 
     if (ctx.flags.f && !ctx.out_file_path) {
         LOG_ERR("Please specify an output file name when specifying a format");
-        return -1;
+        return tool_rc_option_error;
     }
 
     bool ret;
@@ -430,7 +430,7 @@ int tpm2_tool_onrun(ESYS_CONTEXT *ectx, tpm2_option_flags flags) {
         goto out;
     }
 
-    rc = 0;
+    rc = tool_rc_success;
 
 out:
 
@@ -438,7 +438,7 @@ out:
         tpm2_session *s = *sessions[i];
         result = tpm2_session_close(&s);
         if (!result) {
-            rc = 1;
+            rc = tool_rc_success;
         }
     }
 

--- a/tools/tpm2_createpolicy.c
+++ b/tools/tpm2_createpolicy.c
@@ -171,7 +171,7 @@ bool tpm2_tool_onstart(tpm2_options **opts) {
     return *opts != NULL;
 }
 
-int tpm2_tool_onrun(ESYS_CONTEXT *ectx, tpm2_option_flags flags) {
+tool_rc tpm2_tool_onrun(ESYS_CONTEXT *ectx, tpm2_option_flags flags) {
 
     UNUSED(flags);
 
@@ -179,15 +179,15 @@ int tpm2_tool_onrun(ESYS_CONTEXT *ectx, tpm2_option_flags flags) {
         pctx.common_policy_options.policy_session_type == TPM2_SE_TRIAL) {
         LOG_ERR("Provide the file name to store the resulting "
                 "policy digest");
-        return 1;
+        return tool_rc_option_error;
     }
 
     bool result = parse_policy_type_specific_command(ectx);
     if (!result) {
-        return 1;
+        return tool_rc_general_error;
     }
 
-    return 0;
+    return tool_rc_success;
 }
 
 void tpm2_onexit(void) {

--- a/tools/tpm2_createprimary.c
+++ b/tools/tpm2_createprimary.c
@@ -126,11 +126,11 @@ bool tpm2_tool_onstart(tpm2_options **opts) {
     return *opts != NULL;
 }
 
-int tpm2_tool_onrun(ESYS_CONTEXT *ectx, tpm2_option_flags flags) {
+tool_rc tpm2_tool_onrun(ESYS_CONTEXT *ectx, tpm2_option_flags flags) {
     UNUSED(flags);
 
     bool result;
-    int rc = 1;
+    tool_rc rc = tool_rc_general_error;
 
     if (!ctx.context_file || ctx.context_file[0] == '\0') {
         ctx.context_file = "primary.ctx";
@@ -175,12 +175,12 @@ int tpm2_tool_onrun(ESYS_CONTEXT *ectx, tpm2_option_flags flags) {
     }
     tpm2_tool_output("context-file: %s\n", ctx.context_file);
 
-    rc = 0;
+    rc = tool_rc_success;
 
 out:
     result = tpm2_session_close(&ctx.parent.session);
     if (!result) {
-        rc = 1;
+        rc = tool_rc_general_error;
     }
 
     return rc;

--- a/tools/tpm2_dictionarylockout.c
+++ b/tools/tpm2_dictionarylockout.c
@@ -134,16 +134,16 @@ bool tpm2_tool_onstart(tpm2_options **opts) {
     return *opts != NULL;
 }
 
-int tpm2_tool_onrun(ESYS_CONTEXT *ectx, tpm2_option_flags flags) {
+tool_rc tpm2_tool_onrun(ESYS_CONTEXT *ectx, tpm2_option_flags flags) {
 
     UNUSED(flags);
 
-    int rc = 1;
+    tool_rc rc = tool_rc_general_error;
     bool result;
 
     if (!ctx.clear_lockout && !ctx.setup_parameters) {
         LOG_ERR( "Invalid operational input: Neither Setup nor Clear lockout requested.");
-        return -1;
+        return tool_rc_option_error;
     }
 
     result = tpm2_auth_util_from_optarg(ectx, ctx.auth.auth_str,
@@ -151,7 +151,7 @@ int tpm2_tool_onrun(ESYS_CONTEXT *ectx, tpm2_option_flags flags) {
     if (!result) {
         LOG_ERR("Invalid lockout authorization, got\"%s\"",
             ctx.auth.auth_str);
-        return 1;
+        return rc;
     }
 
     result = dictionary_lockout_reset_and_parameter_setup(ectx);
@@ -159,12 +159,12 @@ int tpm2_tool_onrun(ESYS_CONTEXT *ectx, tpm2_option_flags flags) {
         goto out;
     }
 
-    rc = 0;
+    rc = tool_rc_success;
 
 out:
     result = tpm2_session_close(&ctx.auth.session);
     if (!result) {
-        rc = 1;
+        rc = tool_rc_general_error;
     }
 
     return rc;

--- a/tools/tpm2_duplicate.c
+++ b/tools/tpm2_duplicate.c
@@ -11,6 +11,7 @@
 #include "tpm2_alg_util.h"
 #include "tpm2_auth_util.h"
 #include "tpm2_options.h"
+#include "tpm2_tool.h"
 
 typedef struct tpm_duplicate_ctx tpm_duplicate_ctx;
 struct tpm_duplicate_ctx {
@@ -222,10 +223,10 @@ static bool set_key_algorithm(TPMI_ALG_PUBLIC alg, TPMT_SYM_DEF_OBJECT * obj) {
     return result;
 }
 
-int tpm2_tool_onrun(ESYS_CONTEXT *ectx, tpm2_option_flags flags) {
+tool_rc tpm2_tool_onrun(ESYS_CONTEXT *ectx, tpm2_option_flags flags) {
     UNUSED(flags);
 
-    int rc = 1;
+    tool_rc rc = tool_rc_general_error;
     bool result;
     TPMT_SYM_DEF_OBJECT sym_alg;
     TPM2B_DATA in_key;
@@ -313,7 +314,7 @@ int tpm2_tool_onrun(ESYS_CONTEXT *ectx, tpm2_option_flags flags) {
         goto free_out;
     }
 
-    rc = 0;
+    rc = tool_rc_success;
 
 free_out:
     free(out_key);
@@ -323,7 +324,7 @@ out:
 
     result = tpm2_session_close(&ctx.object.session);
     if (!result) {
-        rc = 1;
+        rc = tool_rc_general_error;
     }
 
     return rc;

--- a/tools/tpm2_encryptdecrypt.c
+++ b/tools/tpm2_encryptdecrypt.c
@@ -12,6 +12,7 @@
 
 #include "files.h"
 #include "log.h"
+#include "tpm2.h"
 #include "tpm2_alg_util.h"
 #include "tpm2_auth_util.h"
 #include "tpm2_options.h"
@@ -50,15 +51,9 @@ static tpm_encrypt_decrypt_ctx ctx = {
 
 static tool_rc readpub(ESYS_CONTEXT *ectx, TPM2B_PUBLIC **public) {
 
-    TSS2_RC rval = Esys_ReadPublic(ectx, ctx.object.context.tr_handle,
+    return tpm2_readpublic(ectx, ctx.object.context.tr_handle,
                       ESYS_TR_NONE, ESYS_TR_NONE, ESYS_TR_NONE,
                       public, NULL, NULL);
-    if (rval != TPM2_RC_SUCCESS) {
-        LOG_PERR(Esys_ReadPublic, rval);
-        return tool_rc_from_tpm(rval);
-    }
-
-    return tool_rc_success;
 }
 
 static tool_rc encrypt_decrypt(ESYS_CONTEXT *ectx, TPM2B_IV *iv_in) {

--- a/tools/tpm2_encryptdecrypt.c
+++ b/tools/tpm2_encryptdecrypt.c
@@ -182,23 +182,23 @@ bool tpm2_tool_onstart(tpm2_options **opts) {
     return *opts != NULL;
 }
 
-int tpm2_tool_onrun(ESYS_CONTEXT *ectx, tpm2_option_flags flags) {
+tool_rc tpm2_tool_onrun(ESYS_CONTEXT *ectx, tpm2_option_flags flags) {
 
     UNUSED(flags);
 
     bool result;
-    int rc = 1;
+    tool_rc rc = tool_rc_general_error;
 
     if (!ctx.object.context_arg) {
         LOG_ERR("Expected a context file or handle, got none.");
-        return -1;
+        return tool_rc_option_error;
     }
 
     ctx.data.size = sizeof(ctx.data.buffer);
     result = files_load_bytes_from_buffer_or_file_or_stdin(NULL,ctx.input_path,
         &ctx.data.size, ctx.data.buffer);
     if (!result) {
-        return false;
+        return rc;
     }
 
     result = tpm2_util_object_load(ectx, ctx.object.context_arg,
@@ -268,11 +268,11 @@ int tpm2_tool_onrun(ESYS_CONTEXT *ectx, tpm2_option_flags flags) {
         goto out;
     }
 
-    rc = 0;
+    rc = tool_rc_success;
 out:
     result = tpm2_session_close(&ctx.object.session);
     if (!result) {
-        rc = 1;
+        rc = tool_rc_general_error;
     }
 
     return rc;

--- a/tools/tpm2_evictcontrol.c
+++ b/tools/tpm2_evictcontrol.c
@@ -192,7 +192,7 @@ out:
         TSS2_RC rval = Esys_TR_Close(ectx, &out_tr);
         if (rval != TPM2_RC_SUCCESS) {
             LOG_PERR(Esys_TR_Close, rc);
-            rc = tool_rc_general_error;
+            rc = tool_rc_from_tpm(rval);
         }
     }
 

--- a/tools/tpm2_evictcontrol.c
+++ b/tools/tpm2_evictcontrol.c
@@ -98,11 +98,11 @@ bool tpm2_tool_onstart(tpm2_options **opts) {
     return *opts != NULL;
 }
 
-int tpm2_tool_onrun(ESYS_CONTEXT *ectx, tpm2_option_flags flags) {
+tool_rc tpm2_tool_onrun(ESYS_CONTEXT *ectx, tpm2_option_flags flags) {
 
     UNUSED(flags);
 
-    int rc = 1;
+    tool_rc rc = tool_rc_general_error;
     bool evicted = false;
 
     bool result = tpm2_util_object_load(ectx, ctx.context_arg,
@@ -184,7 +184,7 @@ int tpm2_tool_onrun(ESYS_CONTEXT *ectx, tpm2_option_flags flags) {
         }
     }
 
-    rc = 0;
+    rc = tool_rc_success;
 
 out:
 
@@ -192,13 +192,13 @@ out:
         TSS2_RC rval = Esys_TR_Close(ectx, &out_tr);
         if (rval != TPM2_RC_SUCCESS) {
             LOG_PERR(Esys_TR_Close, rc);
-            rc = 1;
+            rc = tool_rc_general_error;
         }
     }
 
     result = tpm2_session_close(&ctx.auth.session);
     if (!result) {
-        rc = 1;
+        rc = tool_rc_general_error;
     }
 
     return rc;

--- a/tools/tpm2_getcap.c
+++ b/tools/tpm2_getcap.c
@@ -932,19 +932,19 @@ bool tpm2_tool_onstart(tpm2_options **opts) {
     return *opts != NULL;
 }
 
-int tpm2_tool_onrun(ESYS_CONTEXT *context, tpm2_option_flags flags) {
+tool_rc tpm2_tool_onrun(ESYS_CONTEXT *context, tpm2_option_flags flags) {
 
     UNUSED(flags);
 
     if (options.list && options.capability_string) {
         LOG_ERR("Cannot specify -l with -c.");
-        return -1;
+        return tool_rc_option_error;
     }
 
     /* list known capabilities, ie -l option */
     if (options.list) {
         print_cap_map();
-        return 0;
+        return tool_rc_success;
     }
 
     /* List a capability, ie -c <arg> option */
@@ -954,13 +954,13 @@ int tpm2_tool_onrun(ESYS_CONTEXT *context, tpm2_option_flags flags) {
     ret = sanity_check_capability_opts();
     if (ret == 1) {
         LOG_ERR("Invalid capability string. See --help.\n");
-        return -1;
+        return tool_rc_option_error;
     }
     /* get requested capability from TPM, dump it to stdout */
     if (!get_tpm_capability_all(context, &capability_data))
-        return 1;
+        return tool_rc_general_error;
 
     bool result = dump_tpm_capability(&capability_data->data);
     free(capability_data);
-    return !result;
+    return result ? tool_rc_success : tool_rc_general_error;
 }

--- a/tools/tpm2_getmanufec.c
+++ b/tools/tpm2_getmanufec.c
@@ -496,9 +496,9 @@ bool tpm2_tool_onstart(tpm2_options **opts) {
     return *opts != NULL;
 }
 
-int tpm2_tool_onrun(ESYS_CONTEXT *ectx, tpm2_option_flags flags) {
+tool_rc tpm2_tool_onrun(ESYS_CONTEXT *ectx, tpm2_option_flags flags) {
 
-    int rc = 1;
+    tool_rc rc = tool_rc_general_error;
     bool result;
 
     if (!ctx.ek_server_addr) {
@@ -576,7 +576,7 @@ int tpm2_tool_onrun(ESYS_CONTEXT *ectx, tpm2_option_flags flags) {
         goto out;
     }
 
-    rc = 0;
+    rc = tool_rc_success;
 
 out:
     if (ctx.ec_cert_file) {
@@ -586,7 +586,7 @@ out:
     result = tpm2_session_close(&ctx.auth.owner.session);
     result &= tpm2_session_close(&ctx.auth.endorse.session);
     if (!result) {
-        rc = 1;
+        rc = tool_rc_general_error;
     }
 
     return rc;

--- a/tools/tpm2_getrandom.c
+++ b/tools/tpm2_getrandom.c
@@ -144,7 +144,7 @@ bool tpm2_tool_onstart(tpm2_options **opts) {
     return *opts != NULL;
 }
 
-int tpm2_tool_onrun(ESYS_CONTEXT *ectx, tpm2_option_flags flags) {
+tool_rc tpm2_tool_onrun(ESYS_CONTEXT *ectx, tpm2_option_flags flags) {
 
     UNUSED(flags);
 
@@ -161,7 +161,7 @@ int tpm2_tool_onrun(ESYS_CONTEXT *ectx, tpm2_option_flags flags) {
         UINT32 max = 0;
         bool res = get_max_random(ectx, &max);
         if (!res) {
-            return 1;
+            return tool_rc_general_error;
         }
 
         if (ctx.num_of_bytes > max) {
@@ -169,9 +169,9 @@ int tpm2_tool_onrun(ESYS_CONTEXT *ectx, tpm2_option_flags flags) {
                     "%"PRIu32"\n"
                     "Please lower your request (preferred) and try again or"
                     " use --force (advanced)", max);
-            return 1;
+            return tool_rc_general_error;
         }
     }
 
-    return get_random_and_save(ectx) != true;
+    return get_random_and_save(ectx) ? tool_rc_success : tool_rc_general_error;
 }

--- a/tools/tpm2_gettestresult.c
+++ b/tools/tpm2_gettestresult.c
@@ -38,7 +38,7 @@ tool_rc tpm2_tool_onrun(ESYS_CONTEXT *ectx, tpm2_option_flags flags) {
             ESYS_TR_NONE, &output, &status);
     if (rval != TSS2_RC_SUCCESS) {
         LOG_PERR(Esys_SelfTest, rval);
-        return tool_rc_general_error;
+        return tool_rc_from_tpm(rval);
     }
 
     tpm2_tool_output("status: ");

--- a/tools/tpm2_hash.c
+++ b/tools/tpm2_hash.c
@@ -147,23 +147,15 @@ bool tpm2_tool_onstart(tpm2_options **opts) {
     return *opts != NULL;
 }
 
-int tpm2_tool_onrun(ESYS_CONTEXT *context, tpm2_option_flags flags) {
+tool_rc tpm2_tool_onrun(ESYS_CONTEXT *context, tpm2_option_flags flags) {
 
     UNUSED(flags);
 
-    int rc = 1;
-
     bool res = hash_and_save(context);
-    if (!res) {
-        goto out;
-    }
 
-    rc = 0;
-
-out:
     if (ctx.input_file) {
         fclose(ctx.input_file);
     }
 
-    return rc;
+    return res ? tool_rc_success : tool_rc_general_error;
 }

--- a/tools/tpm2_hmac.c
+++ b/tools/tpm2_hmac.c
@@ -229,11 +229,11 @@ bool tpm2_tool_onstart(tpm2_options **opts) {
     return *opts != NULL;
 }
 
-int tpm2_tool_onrun(ESYS_CONTEXT *ectx, tpm2_option_flags flags) {
+tool_rc tpm2_tool_onrun(ESYS_CONTEXT *ectx, tpm2_option_flags flags) {
 
     UNUSED(flags);
 
-    int rc = 1;
+    tool_rc rc = tool_rc_general_error;
     bool result;
 
     /*
@@ -241,7 +241,7 @@ int tpm2_tool_onrun(ESYS_CONTEXT *ectx, tpm2_option_flags flags) {
      */
     if (!ctx.context_arg) {
         LOG_ERR("Must specify options C.");
-        return -1;
+        return tool_rc_option_error;
     }
 
     result = tpm2_auth_util_from_optarg(ectx, ctx.auth.auth_str,
@@ -263,7 +263,7 @@ int tpm2_tool_onrun(ESYS_CONTEXT *ectx, tpm2_option_flags flags) {
         goto out;
     }
 
-    rc = 0;
+    rc = tool_rc_success;
 
 out:
     if (ctx.input && ctx.input != stdin) {
@@ -272,7 +272,7 @@ out:
 
     result = tpm2_session_close(&ctx.auth.session);
     if (!result) {
-        rc = 1;
+        rc = tool_rc_general_error;
     }
 
     return rc;

--- a/tools/tpm2_import.c
+++ b/tools/tpm2_import.c
@@ -32,6 +32,7 @@
 
 #include "log.h"
 #include "files.h"
+#include "tpm2.h"
 #include "tpm2_alg_util.h"
 #include "tpm2_auth_util.h"
 #include "tpm2_kdfa.h"
@@ -70,19 +71,12 @@ static tpm_import_ctx ctx = {
     .input_key_file = NULL,
 };
 
-
-static tool_rc tpm2_readpublic(ESYS_CONTEXT *ectx, ESYS_TR handle,
+static tool_rc readpublic(ESYS_CONTEXT *ectx, ESYS_TR handle,
                 TPM2B_PUBLIC **public) {
 
-    TSS2_RC rval = Esys_ReadPublic(ectx, handle,
+    return tpm2_readpublic(ectx, handle,
                     ESYS_TR_NONE, ESYS_TR_NONE, ESYS_TR_NONE,
                     public, NULL, NULL);
-    if (rval != TPM2_RC_SUCCESS) {
-        LOG_PERR(Esys_ReadPublic, rval);
-        return tool_rc_from_tpm(rval);
-    }
-
-    return tool_rc_success;
 }
 
 static bool create_name(TPM2B_PUBLIC *public, TPM2B_NAME *pubname) {
@@ -441,7 +435,7 @@ static tool_rc openssl_import(ESYS_CONTEXT *ectx) {
         result = files_load_public(ctx.parent_key_public_file, &ppub);
         parent_pub = &ppub;
     } else {
-        tmp_rc = tpm2_readpublic(ectx, parent_ctx.tr_handle, &parent_pub);
+        tmp_rc = readpublic(ectx, parent_ctx.tr_handle, &parent_pub);
         free_ppub = true;
         result = tmp_rc == tool_rc_success;
     }

--- a/tools/tpm2_incrementalselftest.c
+++ b/tools/tpm2_incrementalselftest.c
@@ -21,14 +21,14 @@ struct tpm_incrementalselftest_ctx {
 
 static tpm_incrementalselftest_ctx ctx;
 
-static bool tpm_incrementalselftest(ESYS_CONTEXT *ectx) {
+static tool_rc tpm_incrementalselftest(ESYS_CONTEXT *ectx) {
 
     TPML_ALG *totest = NULL;
     TSS2_RC rval = Esys_IncrementalSelfTest(ectx, ESYS_TR_NONE, ESYS_TR_NONE,
             ESYS_TR_NONE, &(ctx.inputalgs), &totest);
     if (rval != TSS2_RC_SUCCESS) {
         LOG_PERR(Esys_SelfTest, rval);
-        return false;
+        return tool_rc_from_tpm(rval);
     }
 
     tpm2_tool_output("status: ");
@@ -52,7 +52,7 @@ static bool tpm_incrementalselftest(ESYS_CONTEXT *ectx) {
     }
 
     free(totest);
-    return true;
+    return tool_rc_success;
 }
 
 static bool on_arg(int argc, char **argv){
@@ -89,6 +89,5 @@ tool_rc tpm2_tool_onrun(ESYS_CONTEXT *ectx, tpm2_option_flags flags) {
 
     UNUSED(flags);
 
-    return tpm_incrementalselftest(ectx) ?
-            tool_rc_success : tool_rc_general_error;
+    return tpm_incrementalselftest(ectx);
 }

--- a/tools/tpm2_listpersistent.c
+++ b/tools/tpm2_listpersistent.c
@@ -11,6 +11,7 @@
 
 #include "files.h"
 #include "log.h"
+#include "tpm2.h"
 #include "tpm2_alg_util.h"
 #include "tpm2_attr_util.h"
 #include "tpm2_capability.h"
@@ -79,15 +80,9 @@ static tool_rc read_public(ESYS_CONTEXT *ectx,
         return tool_rc_from_tpm(rval);
     }
 
-    rval = Esys_ReadPublic(ectx, objHandle,
+    return tpm2_readpublic(ectx, objHandle,
                         ESYS_TR_NONE, ESYS_TR_NONE, ESYS_TR_NONE,
                         outPublic, NULL, NULL);
-    if (rval != TPM2_RC_SUCCESS) {
-        LOG_PERR(Esys_ReadPublic, rval);
-        return tool_rc_from_tpm(rval);
-    }
-
-    return tool_rc_success;
 }
 
 bool tpm2_tool_onstart(tpm2_options **opts) {

--- a/tools/tpm2_load.c
+++ b/tools/tpm2_load.c
@@ -141,21 +141,21 @@ bool tpm2_tool_onstart(tpm2_options **opts) {
     return *opts != NULL;
 }
 
-int tpm2_tool_onrun(ESYS_CONTEXT *ectx, tpm2_option_flags flags) {
+tool_rc tpm2_tool_onrun(ESYS_CONTEXT *ectx, tpm2_option_flags flags) {
 
     UNUSED(flags);
 
-    int rc = 1;
+    tool_rc rc = tool_rc_general_error;
     bool result;
 
     if ((!ctx.context_arg) || (!ctx.flags.u || !ctx.flags.r)) {
         LOG_ERR("Expected options C, u and r.");
-        return -1;
+        return tool_rc_option_error;
     }
 
     if (!ctx.context_file) {
         LOG_ERR("Expected option -o");
-        return -1;
+        return tool_rc_option_error;
     }
 
     result = tpm2_auth_util_from_optarg(ectx, ctx.parent_auth_str,
@@ -183,12 +183,12 @@ int tpm2_tool_onrun(ESYS_CONTEXT *ectx, tpm2_option_flags flags) {
         goto out;
     }
 
-    rc = 0;
+    rc = tool_rc_success;
 
 out:
     result = tpm2_session_close(&ctx.parent.session);
     if (!result) {
-        rc = 1;
+        rc = tool_rc_general_error;
     }
 
     return rc;

--- a/tools/tpm2_makecredential.c
+++ b/tools/tpm2_makecredential.c
@@ -262,20 +262,18 @@ bool tpm2_tool_onstart(tpm2_options **opts) {
     return *opts != NULL;
 }
 
-int tpm2_tool_onrun(ESYS_CONTEXT *ectx, tpm2_option_flags flags) {
+tool_rc tpm2_tool_onrun(ESYS_CONTEXT *ectx, tpm2_option_flags flags) {
 
     UNUSED(flags);
 
     if (!ctx.flags.e || !ctx.flags.n || !ctx.flags.o || !ctx.flags.s) {
         LOG_ERR("Expected options e, n, o and s.");
-        return -11;
+        return tool_rc_option_error;
     }
-
-    printf("make credential has ESAPI CTX: %p", ectx);
 
     // Run it outside of a TPM
     bool result = ectx ? make_credential_and_save(ectx) :
             make_external_credential_and_save();
 
-    return result != true;
+    return result ? tool_rc_success : tool_rc_general_error;
 }

--- a/tools/tpm2_nvdefine.c
+++ b/tools/tpm2_nvdefine.c
@@ -169,12 +169,12 @@ bool tpm2_tool_onstart(tpm2_options **opts) {
     return *opts != NULL;
 }
 
-int tpm2_tool_onrun(ESYS_CONTEXT *ectx, tpm2_option_flags flags) {
+tool_rc tpm2_tool_onrun(ESYS_CONTEXT *ectx, tpm2_option_flags flags) {
 
     UNUSED(flags);
 
     bool result;
-    int rc = 1;
+    tool_rc rc = tool_rc_general_error;
 
     result = tpm2_auth_util_from_optarg(ectx, ctx.hierarchy.auth_str,
             &ctx.hierarchy.session, false);
@@ -201,12 +201,12 @@ int tpm2_tool_onrun(ESYS_CONTEXT *ectx, tpm2_option_flags flags) {
         goto out;
     }
 
-    rc = 0;
+    rc = tool_rc_success;
 
 out:
     result = tpm2_session_close(&ctx.hierarchy.session);
     if (!result) {
-        rc = 1;
+        rc = tool_rc_general_error;
     }
 
     return rc;

--- a/tools/tpm2_nvincrement.c
+++ b/tools/tpm2_nvincrement.c
@@ -125,11 +125,11 @@ bool tpm2_tool_onstart(tpm2_options **opts) {
     return *opts != NULL;
 }
 
-int tpm2_tool_onrun(ESYS_CONTEXT *ectx, tpm2_option_flags flags) {
+tool_rc tpm2_tool_onrun(ESYS_CONTEXT *ectx, tpm2_option_flags flags) {
 
     UNUSED(flags);
 
-    int rc = 1;
+    tool_rc rc = tool_rc_general_error;
     bool result;
 
     /* If the users doesn't specify an authorisation hierarchy use the index
@@ -152,13 +152,13 @@ int tpm2_tool_onrun(ESYS_CONTEXT *ectx, tpm2_option_flags flags) {
         goto out;
     }
 
-    rc = 0;
+    rc = tool_rc_success;
 
 out:
 
     result = tpm2_session_close(&ctx.auth.session);
     if (!result) {
-        rc = 1;
+        rc = tool_rc_general_error;
     }
 
     return rc;

--- a/tools/tpm2_nvlist.c
+++ b/tools/tpm2_nvlist.c
@@ -73,11 +73,11 @@ static tool_rc nv_list(ESYS_CONTEXT *context) {
         tpm2_tool_output("0x%x:\n", index);
 
         TPM2B_NV_PUBLIC *nv_public;
-        bool res = tpm2_util_nv_read_public(context, index, &nv_public);
-        if (!res) {
+        tool_rc rc = tpm2_util_nv_read_public(context, index, &nv_public);
+        if (rc != tool_rc_success) {
             LOG_ERR("Failed to read the public part of NV index 0x%X", index);
             free(capabilityData);
-            return tool_rc_general_error;
+            return rc;
         }
         print_nv_public(nv_public);
         free(nv_public);

--- a/tools/tpm2_nvlist.c
+++ b/tools/tpm2_nvlist.c
@@ -52,7 +52,7 @@ static void print_nv_public(TPM2B_NV_PUBLIC *nv_public) {
     free(attrs);
 }
 
-static bool nv_list(ESYS_CONTEXT *context) {
+static tool_rc nv_list(ESYS_CONTEXT *context) {
 
     TPMS_CAPABILITY_DATA *capabilityData;
     UINT32 property = tpm2_util_hton_32(TPM2_HT_NV_INDEX);
@@ -63,7 +63,7 @@ static bool nv_list(ESYS_CONTEXT *context) {
                                       NULL, &capabilityData);
     if (rval != TPM2_RC_SUCCESS) {
         LOG_PERR(Esys_GetCapability, rval);
-        return false;
+        return tool_rc_from_tpm(rval);
     }
 
     UINT32 i;
@@ -77,7 +77,7 @@ static bool nv_list(ESYS_CONTEXT *context) {
         if (!res) {
             LOG_ERR("Failed to read the public part of NV index 0x%X", index);
             free(capabilityData);
-            return false;
+            return tool_rc_general_error;
         }
         print_nv_public(nv_public);
         free(nv_public);
@@ -85,7 +85,7 @@ static bool nv_list(ESYS_CONTEXT *context) {
     }
 
     free(capabilityData);
-    return true;
+    return tool_rc_success;
 }
 
 bool tpm2_tool_onstart(tpm2_options **opts) {
@@ -100,5 +100,5 @@ tool_rc tpm2_tool_onrun(ESYS_CONTEXT *context, tpm2_option_flags flags) {
 
     UNUSED(flags);
 
-    return nv_list(context) ? tool_rc_success : tool_rc_general_error;
+    return nv_list(context);
 }

--- a/tools/tpm2_nvlist.c
+++ b/tools/tpm2_nvlist.c
@@ -96,9 +96,9 @@ bool tpm2_tool_onstart(tpm2_options **opts) {
     return *opts != NULL;
 }
 
-int tpm2_tool_onrun(ESYS_CONTEXT *context, tpm2_option_flags flags) {
+tool_rc tpm2_tool_onrun(ESYS_CONTEXT *context, tpm2_option_flags flags) {
 
     UNUSED(flags);
 
-    return !nv_list(context);
+    return nv_list(context) ? tool_rc_success : tool_rc_general_error;
 }

--- a/tools/tpm2_nvread.c
+++ b/tools/tpm2_nvread.c
@@ -146,11 +146,11 @@ bool tpm2_tool_onstart(tpm2_options **opts) {
     return *opts != NULL;
 }
 
-int tpm2_tool_onrun(ESYS_CONTEXT *ectx, tpm2_option_flags flags) {
+tool_rc tpm2_tool_onrun(ESYS_CONTEXT *ectx, tpm2_option_flags flags) {
 
     UNUSED(flags);
 
-    int rc = 1;
+    tool_rc rc = 1;
     bool result;
 
     /* If the users doesn't specify an authorisation hierarchy use the index
@@ -165,7 +165,7 @@ int tpm2_tool_onrun(ESYS_CONTEXT *ectx, tpm2_option_flags flags) {
     if (!result) {
         LOG_ERR("Invalid handle authorization, got \"%s\"",
             ctx.auth.auth_str);
-        return false;
+        return tool_rc_general_error;
     }
 
     result = nv_read(ectx, flags);
@@ -173,13 +173,13 @@ int tpm2_tool_onrun(ESYS_CONTEXT *ectx, tpm2_option_flags flags) {
         goto out;
     }
 
-    rc = 0;
+    rc = tool_rc_success;
 
 out:
 
     result = tpm2_session_close(&ctx.auth.session);
     if (!result) {
-        rc = 1;
+        rc = tool_rc_general_error;
     }
 
     return rc;

--- a/tools/tpm2_nvreadlock.c
+++ b/tools/tpm2_nvreadlock.c
@@ -111,11 +111,11 @@ bool tpm2_tool_onstart(tpm2_options **opts) {
     return *opts != NULL;
 }
 
-int tpm2_tool_onrun(ESYS_CONTEXT *ectx, tpm2_option_flags flags) {
+tool_rc tpm2_tool_onrun(ESYS_CONTEXT *ectx, tpm2_option_flags flags) {
 
     UNUSED(flags);
 
-    int rc = 1;
+    int rc = tool_rc_general_error;
     bool result;
 
     result = tpm2_auth_util_from_optarg(ectx, ctx.auth.auth_str,
@@ -131,12 +131,12 @@ int tpm2_tool_onrun(ESYS_CONTEXT *ectx, tpm2_option_flags flags) {
         goto out;
     }
 
-    rc = 0;
+    rc = tool_rc_success;
 
 out:
     result = tpm2_session_close(&ctx.auth.session);
     if (!result) {
-        rc = 1;
+        rc = tool_rc_general_error;
     }
 
     return rc;

--- a/tools/tpm2_nvrelease.c
+++ b/tools/tpm2_nvrelease.c
@@ -111,11 +111,11 @@ bool tpm2_tool_onstart(tpm2_options **opts) {
     return *opts != NULL;
 }
 
-int tpm2_tool_onrun(ESYS_CONTEXT *ectx, tpm2_option_flags flags) {
+tool_rc tpm2_tool_onrun(ESYS_CONTEXT *ectx, tpm2_option_flags flags) {
 
     UNUSED(flags);
 
-    int rc = 1;
+    int rc = tool_rc_general_error;
     bool result;
 
     result = tpm2_auth_util_from_optarg(ectx, ctx.auth.auth_str,
@@ -131,12 +131,12 @@ int tpm2_tool_onrun(ESYS_CONTEXT *ectx, tpm2_option_flags flags) {
         goto out;
     }
 
-    rc = 0;
+    rc = tool_rc_success;
 
 out:
     result = tpm2_session_close(&ctx.auth.session);
     if (!result) {
-        rc = 1;
+        rc = tool_rc_general_error;
     }
 
     return rc;

--- a/tools/tpm2_nvwrite.c
+++ b/tools/tpm2_nvwrite.c
@@ -57,12 +57,12 @@ static tool_rc nv_write(ESYS_CONTEXT *ectx) {
      * from being partially written to the index.
      */
     TPM2B_NV_PUBLIC *nv_public = NULL;
-    bool res = tpm2_util_nv_read_public(ectx, ctx.nv_index, &nv_public);
-    if (!res) {
+    tool_rc rc = tpm2_util_nv_read_public(ectx, ctx.nv_index, &nv_public);
+    if (rc != tool_rc_success) {
         LOG_ERR("Failed to write NVRAM public area at index 0x%X",
                 ctx.nv_index);
         free(nv_public);
-        return tool_rc_general_error;
+        return rc;
     }
 
     if (ctx.offset + ctx.data_size > nv_public->nvPublic.dataSize) {
@@ -75,7 +75,7 @@ static tool_rc nv_write(ESYS_CONTEXT *ectx) {
     free(nv_public);
 
     UINT32 max_data_size;
-    res = tpm2_util_nv_max_buffer_size(ectx, &max_data_size);
+    bool res = tpm2_util_nv_max_buffer_size(ectx, &max_data_size);
     if (!res) {
         return tool_rc_general_error;
     }

--- a/tools/tpm2_nvwrite.c
+++ b/tools/tpm2_nvwrite.c
@@ -216,11 +216,11 @@ bool tpm2_tool_onstart(tpm2_options **opts) {
     return *opts != NULL;
 }
 
-int tpm2_tool_onrun(ESYS_CONTEXT *ectx, tpm2_option_flags flags) {
+tool_rc tpm2_tool_onrun(ESYS_CONTEXT *ectx, tpm2_option_flags flags) {
 
     UNUSED(flags);
 
-    int rc = 1;
+    tool_rc rc = tool_rc_general_error;
     bool result;
 
     /* If the users doesn't specify an authorisation hierarchy use the index
@@ -284,13 +284,13 @@ int tpm2_tool_onrun(ESYS_CONTEXT *ectx, tpm2_option_flags flags) {
         goto out;
     }
 
-    rc = 0;
+    rc = tool_rc_success;
 
 out:
 
     result = tpm2_session_close(&ctx.auth.session);
     if (!result) {
-        rc = 1;
+        rc = tool_rc_general_error;
     }
 
     return rc;

--- a/tools/tpm2_nvwrite.c
+++ b/tools/tpm2_nvwrite.c
@@ -75,9 +75,9 @@ static tool_rc nv_write(ESYS_CONTEXT *ectx) {
     free(nv_public);
 
     UINT32 max_data_size;
-    bool res = tpm2_util_nv_max_buffer_size(ectx, &max_data_size);
-    if (!res) {
-        return tool_rc_general_error;
+    rc = tpm2_util_nv_max_buffer_size(ectx, &max_data_size);
+    if (rc != tool_rc_success) {
+        return rc;
     }
 
     if (max_data_size > TPM2_MAX_NV_BUFFER_SIZE) {

--- a/tools/tpm2_pcrallocate.c
+++ b/tools/tpm2_pcrallocate.c
@@ -110,19 +110,19 @@ bool tpm2_tool_onstart(tpm2_options **opts) {
     return *opts != NULL;
 }
 
-int tpm2_tool_onrun(ESYS_CONTEXT *ectx, tpm2_option_flags flags) {
+tool_rc tpm2_tool_onrun(ESYS_CONTEXT *ectx, tpm2_option_flags flags) {
     UNUSED(flags);
 
     bool result = tpm2_auth_util_from_optarg(ectx, ctx.auth.auth_str,
                 &ctx.auth.session, false);
     if (!result) {
         LOG_ERR("Invalid platform authorization format");
-        return 1;
+        return tool_rc_general_error;
     }
 
     result = pcr_allocate(ectx);
 
     result &= tpm2_session_close(&ctx.auth.session);
 
-    return (result == true)? 0 : 1;
+    return result ? tool_rc_success : tool_rc_general_error;
 }

--- a/tools/tpm2_pcrevent.c
+++ b/tools/tpm2_pcrevent.c
@@ -272,11 +272,11 @@ bool tpm2_tool_onstart(tpm2_options **opts) {
     return *opts != NULL;
 }
 
-int tpm2_tool_onrun(ESYS_CONTEXT *ectx, tpm2_option_flags flags) {
+tool_rc tpm2_tool_onrun(ESYS_CONTEXT *ectx, tpm2_option_flags flags) {
 
     UNUSED(flags);
 
-    int rc = 1;
+    tool_rc rc = tool_rc_general_error;
 
     ctx.input = ctx.input ? ctx.input : stdin;
 
@@ -293,13 +293,13 @@ int tpm2_tool_onrun(ESYS_CONTEXT *ectx, tpm2_option_flags flags) {
         goto out;
     }
 
-    rc = 0;
+    rc = tool_rc_success;
 
 out:
 
     result = tpm2_session_close(&ctx.auth.session);
     if (!result) {
-        rc = 1;
+        rc = tool_rc_general_error;
     }
 
     return rc;

--- a/tools/tpm2_pcrextend.c
+++ b/tools/tpm2_pcrextend.c
@@ -75,11 +75,12 @@ bool tpm2_tool_onstart(tpm2_options **opts) {
     return *opts != NULL;
 }
 
-int tpm2_tool_onrun(ESYS_CONTEXT *ectx, tpm2_option_flags flags) {
+tool_rc tpm2_tool_onrun(ESYS_CONTEXT *ectx, tpm2_option_flags flags) {
 
     UNUSED(flags);
 
-    return pcr_extend(ectx) != true;
+    return pcr_extend(ectx) ?
+            tool_rc_success : tool_rc_general_error;
 }
 
 void tpm2_tool_onexit(void) {

--- a/tools/tpm2_pcrlist.c
+++ b/tools/tpm2_pcrlist.c
@@ -186,7 +186,7 @@ bool tpm2_tool_onstart(tpm2_options **opts) {
     return *opts != NULL;
 }
 
-int tpm2_tool_onrun(ESYS_CONTEXT *esys_context, tpm2_option_flags flags) {
+tool_rc tpm2_tool_onrun(ESYS_CONTEXT *esys_context, tpm2_option_flags flags) {
 
     UNUSED(flags);
 
@@ -199,7 +199,7 @@ int tpm2_tool_onrun(ESYS_CONTEXT *esys_context, tpm2_option_flags flags) {
                 ctx.flags.L ? "-L" : "",
                 ctx.flags.s ? "-s" : ""
         );
-        return -1;
+        return tool_rc_option_error;
     }
 
     if (ctx.flags.o) {
@@ -231,6 +231,5 @@ error:
         fclose(ctx.output_file);
     }
 
-    /* 0 on success 1 otherwise */
-    return !success;
+    return success ? tool_rc_success : tool_rc_general_error;
 }

--- a/tools/tpm2_pcrreset.c
+++ b/tools/tpm2_pcrreset.c
@@ -78,11 +78,11 @@ bool tpm2_tool_onstart(tpm2_options **opts) {
     return *opts != NULL;
 }
 
-int tpm2_tool_onrun(ESYS_CONTEXT *ectx, tpm2_option_flags flags) {
+tool_rc tpm2_tool_onrun(ESYS_CONTEXT *ectx, tpm2_option_flags flags) {
 
     UNUSED(flags);
 
-    return pcr_reset(ectx) != true;
+    return pcr_reset(ectx) ? tool_rc_success : tool_rc_general_error;
 }
 
 void tpm2_tool_onexit(void) {

--- a/tools/tpm2_policyauthorize.c
+++ b/tools/tpm2_policyauthorize.c
@@ -92,17 +92,17 @@ bool is_check_input_options_ok(void) {
     return true;
 }
 
-int tpm2_tool_onrun(ESYS_CONTEXT *ectx, tpm2_option_flags flags) {
+tool_rc tpm2_tool_onrun(ESYS_CONTEXT *ectx, tpm2_option_flags flags) {
 
     UNUSED(flags);
 
     TPM2B_DIGEST *policy_digest = NULL;
 
     if (!is_check_input_options_ok()) {
-        return -1;
+        return tool_rc_option_error;
     }
 
-    int rc = 1;
+    int rc = tool_rc_general_error;
 
     tpm2_session *s = tpm2_session_restore(ectx, ctx.session_path, false);
     if (!s) {
@@ -136,12 +136,12 @@ int tpm2_tool_onrun(ESYS_CONTEXT *ectx, tpm2_option_flags flags) {
         }
     }
 
-    rc = 0;
+    rc = tool_rc_success;
 
 out:
     result = tpm2_session_close(&s);
     if (!result) {
-        rc = 1;
+        rc = tool_rc_general_error;
     }
 
     free(policy_digest);

--- a/tools/tpm2_policycommandcode.c
+++ b/tools/tpm2_policycommandcode.c
@@ -85,17 +85,17 @@ bool tpm2_tool_onstart(tpm2_options **opts) {
     return *opts != NULL;
 }
 
-int tpm2_tool_onrun(ESYS_CONTEXT *ectx, tpm2_option_flags flags) {
+tool_rc tpm2_tool_onrun(ESYS_CONTEXT *ectx, tpm2_option_flags flags) {
 
     UNUSED(flags);
 
     TPM2B_DIGEST *policy_digest = NULL;
     bool retval = is_input_option_args_valid();
     if (!retval) {
-        return -1;
+        return tool_rc_option_error;
     }
 
-    int rc = 1;
+    tool_rc rc = tool_rc_general_error;
     tpm2_session *s = tpm2_session_restore(ectx, ctx.session_path, false);
     if (!s) {
         return rc;
@@ -127,14 +127,14 @@ int tpm2_tool_onrun(ESYS_CONTEXT *ectx, tpm2_option_flags flags) {
         }
     }
 
-    rc = 0;
+    rc = tool_rc_success;
 
 out:
     free(policy_digest);
 
     result = tpm2_session_close(&s);
     if (!result) {
-        rc = 1;
+        rc = tool_rc_general_error;
     }
 
     return rc;

--- a/tools/tpm2_policyduplicationselect.c
+++ b/tools/tpm2_policyduplicationselect.c
@@ -86,7 +86,7 @@ bool tpm2_tool_onstart(tpm2_options **opts) {
     return *opts != NULL;
 }
 
-int tpm2_tool_onrun(ESYS_CONTEXT *ectx, tpm2_option_flags flags) {
+tool_rc tpm2_tool_onrun(ESYS_CONTEXT *ectx, tpm2_option_flags flags) {
 
     UNUSED(flags);
 
@@ -96,7 +96,7 @@ int tpm2_tool_onrun(ESYS_CONTEXT *ectx, tpm2_option_flags flags) {
         return -1;
     }
 
-    int rc = 1;
+    tool_rc rc = tool_rc_general_error;
     tpm2_session *s = tpm2_session_restore(ectx, ctx.session_path, false);
     if (!s) {
         return rc;
@@ -128,14 +128,14 @@ int tpm2_tool_onrun(ESYS_CONTEXT *ectx, tpm2_option_flags flags) {
         }
     }
 
-    rc = 0;
+    rc = tool_rc_success;
 
 out:
     free(policy_digest);
 
     result = tpm2_session_close(&s);
     if (!result) {
-        rc = 1;
+        rc = tool_rc_general_error;
     }
 
     return rc;

--- a/tools/tpm2_policylocality.c
+++ b/tools/tpm2_policylocality.c
@@ -85,17 +85,17 @@ bool tpm2_tool_onstart(tpm2_options **opts) {
     return *opts != NULL;
 }
 
-int tpm2_tool_onrun(ESYS_CONTEXT *ectx, tpm2_option_flags flags) {
+tool_rc tpm2_tool_onrun(ESYS_CONTEXT *ectx, tpm2_option_flags flags) {
 
     UNUSED(flags);
 
     TPM2B_DIGEST *policy_digest = NULL;
     bool retval = is_input_option_args_valid();
     if (!retval) {
-        return -1;
+        return tool_rc_option_error;
     }
 
-    int rc = 1;
+    tool_rc rc = tool_rc_general_error;
     tpm2_session *s = tpm2_session_restore(ectx, ctx.session_path, false);
     if (!s) {
         return rc;
@@ -127,14 +127,14 @@ int tpm2_tool_onrun(ESYS_CONTEXT *ectx, tpm2_option_flags flags) {
         }
     }
 
-    rc = 0;
+    rc = tool_rc_success;
 
 out:
     free(policy_digest);
 
     result = tpm2_session_close(&s);
     if (!result) {
-        rc = 1;
+        rc = tool_rc_general_error;
     }
 
     return rc;

--- a/tools/tpm2_policyor.c
+++ b/tools/tpm2_policyor.c
@@ -82,7 +82,7 @@ bool is_input_option_args_valid(void) {
     return true;
 }
 
-int tpm2_tool_onrun(ESYS_CONTEXT *ectx, tpm2_option_flags flags) {
+tool_rc tpm2_tool_onrun(ESYS_CONTEXT *ectx, tpm2_option_flags flags) {
 
     UNUSED(flags);
 
@@ -90,11 +90,11 @@ int tpm2_tool_onrun(ESYS_CONTEXT *ectx, tpm2_option_flags flags) {
 
     bool retval = is_input_option_args_valid();
     if (!retval) {
-        return -1;
+        return tool_rc_option_error;
     }
 
 
-    int rc = 1;
+    tool_rc rc = tool_rc_general_error;
 
     tpm2_session *s = tpm2_session_restore(ectx, ctx.session_path, false);
     if (!s) {
@@ -133,12 +133,12 @@ int tpm2_tool_onrun(ESYS_CONTEXT *ectx, tpm2_option_flags flags) {
         }
     }
 
-    rc = 0;
+    rc = tool_rc_success;
 
 out:
     result = tpm2_session_close(&s);
     if (!result) {
-        rc = 1;
+        rc = tool_rc_general_error;
     }
 
     free(policy_digest);

--- a/tools/tpm2_policypassword.c
+++ b/tools/tpm2_policypassword.c
@@ -59,17 +59,17 @@ bool is_input_option_args_valid(void) {
     return true;
 }
 
-int tpm2_tool_onrun(ESYS_CONTEXT *ectx, tpm2_option_flags flags) {
+tool_rc tpm2_tool_onrun(ESYS_CONTEXT *ectx, tpm2_option_flags flags) {
 
     UNUSED(flags);
 
     TPM2B_DIGEST *policy_digest = NULL;
     bool retval = is_input_option_args_valid();
     if (!retval) {
-        return -1;
+        return tool_rc_option_error;
     }
 
-    int rc = 1;
+    tool_rc rc = tool_rc_general_error;
     tpm2_session *s = tpm2_session_restore(ectx, ctx.session_path, false);
     if (!s) {
         return rc;
@@ -100,13 +100,13 @@ int tpm2_tool_onrun(ESYS_CONTEXT *ectx, tpm2_option_flags flags) {
         }
     }
 
-    rc = 0;
+    rc = tool_rc_success;
 
 out:
 
     result = tpm2_session_close(&s);
     if (!result) {
-        rc = 1;
+        rc = tool_rc_general_error;
     }
 
     free(policy_digest);

--- a/tools/tpm2_policypcr.c
+++ b/tools/tpm2_policypcr.c
@@ -66,26 +66,26 @@ bool tpm2_tool_onstart(tpm2_options **opts) {
     return *opts != NULL;
 }
 
-int tpm2_tool_onrun(ESYS_CONTEXT *ectx, tpm2_option_flags flags) {
+tool_rc tpm2_tool_onrun(ESYS_CONTEXT *ectx, tpm2_option_flags flags) {
 
     UNUSED(flags);
 
-    int rc = 1;
+    tool_rc rc = tool_rc_general_error;
     tpm2_session *s = NULL;
 
-    bool fail = false;
+    bool option_fail = false;
     if (!ctx.session_path) {
         LOG_ERR("Must specify -S session file.");
-        fail = true;
+        option_fail = true;
     }
 
     if (!ctx.pcr_selection.count) {
         LOG_ERR("Must specify -L pcr selection list.");
-        fail = true;
+        option_fail = true;
     }
 
-    if (fail) {
-        return -1;
+    if (option_fail) {
+        return tool_rc_general_error;
     }
 
     s = tpm2_session_restore(ectx, ctx.session_path, false);
@@ -128,14 +128,14 @@ int tpm2_tool_onrun(ESYS_CONTEXT *ectx, tpm2_option_flags flags) {
         }
     }
 
-    rc = 0;
+    rc = tool_rc_success;
 
 out_policy:
     free(policy_digest);
 out:
     result = tpm2_session_close(&s);
     if (!result) {
-        rc = 1;
+        rc = tool_rc_general_error;
     }
 
     return rc;

--- a/tools/tpm2_policyrestart.c
+++ b/tools/tpm2_policyrestart.c
@@ -49,11 +49,11 @@ bool tpm2_tool_onstart(tpm2_options **opts) {
     return *opts != NULL;
 }
 
-int tpm2_tool_onrun(ESYS_CONTEXT *ectx, tpm2_option_flags flags) {
+tool_rc tpm2_tool_onrun(ESYS_CONTEXT *ectx, tpm2_option_flags flags) {
 
     UNUSED(flags);
 
-    int rc = 1;
+    tool_rc rc = tool_rc_general_error;
     bool result;
 
     tpm2_session *s = tpm2_session_restore(ectx, ctx.session.path, false);
@@ -66,12 +66,12 @@ int tpm2_tool_onrun(ESYS_CONTEXT *ectx, tpm2_option_flags flags) {
         goto out;
     }
 
-    rc = 0;
+    rc = tool_rc_success;
 
 out:
     result = tpm2_session_close(&s);
     if (!result) {
-        rc = 1;
+        rc = tool_rc_general_error;
     }
 
     return rc;

--- a/tools/tpm2_policysecret.c
+++ b/tools/tpm2_policysecret.c
@@ -98,7 +98,7 @@ bool is_input_option_args_valid(void) {
     return true;
 }
 
-int tpm2_tool_onrun(ESYS_CONTEXT *ectx, tpm2_option_flags flags) {
+tool_rc tpm2_tool_onrun(ESYS_CONTEXT *ectx, tpm2_option_flags flags) {
 
     UNUSED(flags);
 
@@ -106,7 +106,7 @@ int tpm2_tool_onrun(ESYS_CONTEXT *ectx, tpm2_option_flags flags) {
 
     bool result = is_input_option_args_valid();
     if (!result) {
-        return -1;
+        return tool_rc_option_error;
     }
 
     int rc = 1;
@@ -158,14 +158,14 @@ int tpm2_tool_onrun(ESYS_CONTEXT *ectx, tpm2_option_flags flags) {
         }
     }
 
-    rc = 0;
+    rc = tool_rc_success;
 
 out:
     free(policy_digest);
 
     result = tpm2_session_close(&s);
     if (!result) {
-        rc = 1;
+        rc = tool_rc_general_error;
     }
 
     return rc;

--- a/tools/tpm2_quote.c
+++ b/tools/tpm2_quote.c
@@ -296,17 +296,17 @@ bool tpm2_tool_onstart(tpm2_options **opts) {
     return *opts != NULL;
 }
 
-int tpm2_tool_onrun(ESYS_CONTEXT *ectx, tpm2_option_flags flags) {
+tool_rc tpm2_tool_onrun(ESYS_CONTEXT *ectx, tpm2_option_flags flags) {
 
     UNUSED(flags);
 
-    int rc = 1;
+    tool_rc rc = tool_rc_general_error;
     bool result;
 
     /* TODO this whole file needs to be re-done, especially the option validation */
     if (!ctx.flags.l && !ctx.flags.L) {
         LOG_ERR("Expected either -l or -L to be specified.");
-        return -1;
+        return tool_rc_option_error;
     }
 
     result = tpm2_auth_util_from_optarg(ectx, ctx.ak.auth_str,
@@ -319,7 +319,7 @@ int tpm2_tool_onrun(ESYS_CONTEXT *ectx, tpm2_option_flags flags) {
     if (ctx.flags.p) {
         if (!ctx.flags.G) {
             LOG_ERR("Must specify -G if -p is requested.");
-            return -1;
+            return tool_rc_option_error;
         }
         ctx.pcr_output = fopen(ctx.pcr_path, "wb+");
         if (!ctx.pcr_output) {
@@ -345,7 +345,7 @@ int tpm2_tool_onrun(ESYS_CONTEXT *ectx, tpm2_option_flags flags) {
         goto out;
     }
 
-    rc = 0;
+    rc = tool_rc_success;
 
 out:
     if (ctx.pcr_output) {
@@ -354,7 +354,7 @@ out:
 
     result = tpm2_session_close(&ctx.ak.session);
     if (!result) {
-        rc = 1;
+        rc = tool_rc_general_error;
     }
 
     return rc;

--- a/tools/tpm2_readpublic.c
+++ b/tools/tpm2_readpublic.c
@@ -150,14 +150,15 @@ static bool init(ESYS_CONTEXT *context) {
     return true;
 }
 
-int tpm2_tool_onrun(ESYS_CONTEXT *context, tpm2_option_flags flags) {
+tool_rc tpm2_tool_onrun(ESYS_CONTEXT *context, tpm2_option_flags flags) {
 
     UNUSED(flags);
 
     bool result = init(context);
     if (!result) {
-        return 1;
+        return tool_rc_general_error;
     }
 
-    return read_public_and_save(context) != true;
+    return read_public_and_save(context) ?
+           tool_rc_success : tool_rc_general_error;
 }

--- a/tools/tpm2_readpublic.c
+++ b/tools/tpm2_readpublic.c
@@ -32,7 +32,7 @@ static tpm_readpub_ctx ctx = {
     .format = pubkey_format_tss,
 };
 
-static int read_public_and_save(ESYS_CONTEXT *ectx) {
+static tool_rc read_public_and_save(ESYS_CONTEXT *ectx) {
 
     TPM2B_PUBLIC *public;
     TPM2B_NAME *name;
@@ -43,7 +43,7 @@ static int read_public_and_save(ESYS_CONTEXT *ectx) {
                     &public, &name, &qualified_name);
     if (rval != TPM2_RC_SUCCESS) {
         LOG_PERR(Eys_ReadPublic, rval);
-        return false;
+        return tool_rc_from_tpm(rval);
     }
 
     tpm2_tool_output("name: ");
@@ -86,7 +86,7 @@ out:
     free(name);
     free(qualified_name);
 
-    return ret;
+    return ret ? tool_rc_success : tool_rc_general_error;
 }
 
 static bool on_option(char key, char *value) {
@@ -159,6 +159,5 @@ tool_rc tpm2_tool_onrun(ESYS_CONTEXT *context, tpm2_option_flags flags) {
         return tool_rc_general_error;
     }
 
-    return read_public_and_save(context) ?
-           tool_rc_success : tool_rc_general_error;
+    return read_public_and_save(context);
 }

--- a/tools/tpm2_readpublic.c
+++ b/tools/tpm2_readpublic.c
@@ -9,6 +9,7 @@
 #include "tpm2_convert.h"
 #include "files.h"
 #include "log.h"
+#include "tpm2.h"
 #include "tpm2_alg_util.h"
 #include "tpm2_attr_util.h"
 #include "tpm2_options.h"
@@ -38,12 +39,11 @@ static tool_rc read_public_and_save(ESYS_CONTEXT *ectx) {
     TPM2B_NAME *name;
     TPM2B_NAME *qualified_name;
 
-    TSS2_RC rval = Esys_ReadPublic(ectx, ctx.context_object.tr_handle,
+    tool_rc rc = tpm2_readpublic(ectx, ctx.context_object.tr_handle,
                     ESYS_TR_NONE, ESYS_TR_NONE, ESYS_TR_NONE,
                     &public, &name, &qualified_name);
-    if (rval != TPM2_RC_SUCCESS) {
-        LOG_PERR(Eys_ReadPublic, rval);
-        return tool_rc_from_tpm(rval);
+    if (rc != tool_rc_success) {
+        return rc;
     }
 
     tpm2_tool_output("name: ");

--- a/tools/tpm2_rsadecrypt.c
+++ b/tools/tpm2_rsadecrypt.c
@@ -129,11 +129,11 @@ static bool init(ESYS_CONTEXT *ectx) {
                                 &ctx.key.object);
 }
 
-int tpm2_tool_onrun(ESYS_CONTEXT *ectx, tpm2_option_flags flags) {
+tool_rc tpm2_tool_onrun(ESYS_CONTEXT *ectx, tpm2_option_flags flags) {
 
     UNUSED(flags);
 
-    int rc = 1;
+    tool_rc rc = tool_rc_general_error;
     bool result = init(ectx);
     if (!result) {
         goto out;
@@ -151,12 +151,12 @@ int tpm2_tool_onrun(ESYS_CONTEXT *ectx, tpm2_option_flags flags) {
         goto out;
     }
 
-    rc = 0;
+    rc = tool_rc_success;
 out:
 
     result = tpm2_session_close(&ctx.key.session);
     if (!result) {
-        rc = 1;
+        rc = tool_rc_general_error;
     }
 
     return rc;

--- a/tools/tpm2_rsaencrypt.c
+++ b/tools/tpm2_rsaencrypt.c
@@ -29,7 +29,7 @@ static tpm_rsaencrypt_ctx ctx = {
     .scheme = { .scheme = TPM2_ALG_RSAES }
 };
 
-static bool rsa_encrypt_and_save(ESYS_CONTEXT *context) {
+static tool_rc rsa_encrypt_and_save(ESYS_CONTEXT *context) {
 
     bool ret = true;
     // Inputs
@@ -44,7 +44,7 @@ static bool rsa_encrypt_and_save(ESYS_CONTEXT *context) {
                         &ctx.message, &ctx.scheme, &label, &out_data);
     if (rval != TPM2_RC_SUCCESS) {
         LOG_PERR(Esys_RSA_Encrypt, rval);
-        return false;
+        return tool_rc_from_tpm(rval);
     }
 
     if (ctx.output_path) {
@@ -56,7 +56,7 @@ static bool rsa_encrypt_and_save(ESYS_CONTEXT *context) {
 
     free(out_data);
 
-    return ret;
+    return ret ? tool_rc_success : tool_rc_general_error;
 }
 
 static bool on_option(char key, char *value) {
@@ -132,6 +132,5 @@ tool_rc tpm2_tool_onrun(ESYS_CONTEXT *context, tpm2_option_flags flags) {
         return tool_rc_general_error;
     }
 
-    return rsa_encrypt_and_save(context) ?
-            tool_rc_success : tool_rc_general_error;
+    return rsa_encrypt_and_save(context);
 }

--- a/tools/tpm2_rsaencrypt.c
+++ b/tools/tpm2_rsaencrypt.c
@@ -123,14 +123,15 @@ static bool init(ESYS_CONTEXT *context) {
         &ctx.message.size, ctx.message.buffer);
 }
 
-int tpm2_tool_onrun(ESYS_CONTEXT *context, tpm2_option_flags flags) {
+tool_rc tpm2_tool_onrun(ESYS_CONTEXT *context, tpm2_option_flags flags) {
 
     UNUSED(flags);
 
     bool result = init(context);
     if (!result) {
-        return 1;
+        return tool_rc_general_error;
     }
 
-    return rsa_encrypt_and_save(context) != true;
+    return rsa_encrypt_and_save(context) ?
+            tool_rc_success : tool_rc_general_error;
 }

--- a/tools/tpm2_selftest.c
+++ b/tools/tpm2_selftest.c
@@ -57,11 +57,12 @@ bool tpm2_tool_onstart(tpm2_options **opts) {
     return *opts != NULL;
 }
 
-int tpm2_tool_onrun(ESYS_CONTEXT *ectx, tpm2_option_flags flags) {
+tool_rc tpm2_tool_onrun(ESYS_CONTEXT *ectx, tpm2_option_flags flags) {
 
     UNUSED(flags);
 
-    return tpm_selftest(ectx) != true;
+    return tpm_selftest(ectx) ?
+            tool_rc_success : tool_rc_general_error;
 }
 
 void tpm2_tool_onexit(void) {

--- a/tools/tpm2_selftest.c
+++ b/tools/tpm2_selftest.c
@@ -20,15 +20,15 @@ struct tpm_selftest_ctx {
 
 static tpm_selftest_ctx ctx;
 
-static bool tpm_selftest(ESYS_CONTEXT *ectx) {
+static tool_rc tpm_selftest(ESYS_CONTEXT *ectx) {
     TSS2_RC rval = Esys_SelfTest(ectx, ESYS_TR_NONE, ESYS_TR_NONE, ESYS_TR_NONE, ctx.fulltest);
     if (rval != TSS2_RC_SUCCESS) {
         LOG_ERR("TPM SelfTest failed !");
         LOG_PERR(Esys_SelfTest, rval);
-        return false;
+        return tool_rc_from_tpm(rval);
     }
 
-    return true;
+    return tool_rc_success;
 }
 
 static bool on_option(char key, char *value) {
@@ -61,8 +61,7 @@ tool_rc tpm2_tool_onrun(ESYS_CONTEXT *ectx, tpm2_option_flags flags) {
 
     UNUSED(flags);
 
-    return tpm_selftest(ectx) ?
-            tool_rc_success : tool_rc_general_error;
+    return tpm_selftest(ectx);
 }
 
 void tpm2_tool_onexit(void) {

--- a/tools/tpm2_send.c
+++ b/tools/tpm2_send.c
@@ -148,7 +148,7 @@ tool_rc tpm2_tool_onrun(ESYS_CONTEXT *context, tpm2_option_flags flags) {
 
     UNUSED(flags);
 
-    tool_rc ret = tool_rc_general_error;
+    tool_rc rc = tool_rc_general_error;
 
     UINT32 size;
     tpm2_command_header *command;
@@ -162,6 +162,7 @@ tool_rc tpm2_tool_onrun(ESYS_CONTEXT *context, tpm2_option_flags flags) {
     TSS2_RC rval = Esys_GetTcti(context, &tcti_context);
     if (rval != TPM2_RC_SUCCESS) {
         LOG_PERR(Esys_GetTctiContext, rval);
+        rc = tool_rc_from_tpm(rval);
         goto out;
     }
 
@@ -176,6 +177,7 @@ tool_rc tpm2_tool_onrun(ESYS_CONTEXT *context, tpm2_option_flags flags) {
     rval = Tss2_Tcti_Receive(tcti_context, &rsize, rbuf, TSS2_TCTI_TIMEOUT_BLOCK);
     if (rval != TPM2_RC_SUCCESS) {
         LOG_ERR("tss2_tcti_receive failed: 0x%x", rval);
+        rc = tool_rc_from_tpm(rval);
         goto out;
     }
 
@@ -188,7 +190,7 @@ tool_rc tpm2_tool_onrun(ESYS_CONTEXT *context, tpm2_option_flags flags) {
         LOG_ERR("Failed writing response to output file.");
     }
 
-    ret = tool_rc_success;
+    rc = tool_rc_success;
 
 out:
     free(command);
@@ -197,5 +199,5 @@ out_files:
     close_file(ctx.input);
     close_file(ctx.output);
 
-    return ret;
+    return rc;
 }

--- a/tools/tpm2_send.c
+++ b/tools/tpm2_send.c
@@ -144,11 +144,11 @@ bool tpm2_tool_onstart(tpm2_options **opts) {
  * in network byte order (big-endian). We output the response in the same
  * form.
  */
-int tpm2_tool_onrun(ESYS_CONTEXT *context, tpm2_option_flags flags) {
+tool_rc tpm2_tool_onrun(ESYS_CONTEXT *context, tpm2_option_flags flags) {
 
     UNUSED(flags);
 
-    int ret = 1;
+    tool_rc ret = tool_rc_general_error;
 
     UINT32 size;
     tpm2_command_header *command;
@@ -188,7 +188,7 @@ int tpm2_tool_onrun(ESYS_CONTEXT *context, tpm2_option_flags flags) {
         LOG_ERR("Failed writing response to output file.");
     }
 
-    ret = 0;
+    ret = tool_rc_success;
 
 out:
     free(command);

--- a/tools/tpm2_sign.c
+++ b/tools/tpm2_sign.c
@@ -270,7 +270,7 @@ bool tpm2_tool_onstart(tpm2_options **opts) {
     return *opts != NULL;
 }
 
-int tpm2_tool_onrun(ESYS_CONTEXT *ectx, tpm2_option_flags flags) {
+tool_rc tpm2_tool_onrun(ESYS_CONTEXT *ectx, tpm2_option_flags flags) {
 
     UNUSED(flags);
 
@@ -292,12 +292,12 @@ int tpm2_tool_onrun(ESYS_CONTEXT *ectx, tpm2_option_flags flags) {
         goto out;
     }
 
-    rc = 0;
+    rc = tool_rc_success;
 out:
 
     result = tpm2_session_close(&ctx.key.session);
     if (!result) {
-        rc = 1;
+        rc = tool_rc_general_error;
     }
 
     return rc;

--- a/tools/tpm2_startauthsession.c
+++ b/tools/tpm2_startauthsession.c
@@ -78,11 +78,11 @@ bool tpm2_tool_onstart(tpm2_options **opts) {
     return *opts != NULL;
 }
 
-int tpm2_tool_onrun(ESYS_CONTEXT *ectx, tpm2_option_flags flags) {
+tool_rc tpm2_tool_onrun(ESYS_CONTEXT *ectx, tpm2_option_flags flags) {
 
     UNUSED(flags);
 
-    int rc = 1;
+    tool_rc rc = tool_rc_general_error;
 
     tpm2_session *s = NULL;
 
@@ -95,7 +95,7 @@ int tpm2_tool_onrun(ESYS_CONTEXT *ectx, tpm2_option_flags flags) {
 
     if (!ctx.output.path) {
         LOG_ERR("Expected option -S");
-        return -1;
+        return tool_rc_option_error;
     }
 
     if (ctx.session.key_context_arg_str) {
@@ -158,5 +158,6 @@ int tpm2_tool_onrun(ESYS_CONTEXT *ectx, tpm2_option_flags flags) {
         return rc;
     }
 
-    return tpm2_session_close(&s) != true;
+    return tpm2_session_close(&s) ?
+            tool_rc_success : tool_rc_general_error;
 }

--- a/tools/tpm2_startup.c
+++ b/tools/tpm2_startup.c
@@ -48,7 +48,7 @@ bool tpm2_tool_onstart(tpm2_options **opts) {
     return *opts != NULL;
 }
 
-int tpm2_tool_onrun(ESYS_CONTEXT *context, tpm2_option_flags flags) {
+tool_rc tpm2_tool_onrun(ESYS_CONTEXT *context, tpm2_option_flags flags) {
 
     UNUSED(flags);
 
@@ -60,9 +60,9 @@ int tpm2_tool_onrun(ESYS_CONTEXT *context, tpm2_option_flags flags) {
     TSS2_RC rval = Esys_Startup (context, startup_type);
     if (rval != TPM2_RC_SUCCESS && rval != TPM2_RC_INITIALIZE) {
         LOG_PERR(Esys_Startup, rval);
-        return 1;
+        return tool_rc_general_error;
     }
 
     LOG_INFO ("Success. TSS2_RC: 0x%x", rval);
-    return 0;
+    return tool_rc_success;
 }

--- a/tools/tpm2_startup.c
+++ b/tools/tpm2_startup.c
@@ -60,7 +60,7 @@ tool_rc tpm2_tool_onrun(ESYS_CONTEXT *context, tpm2_option_flags flags) {
     TSS2_RC rval = Esys_Startup (context, startup_type);
     if (rval != TPM2_RC_SUCCESS && rval != TPM2_RC_INITIALIZE) {
         LOG_PERR(Esys_Startup, rval);
-        return tool_rc_general_error;
+        return tool_rc_from_tpm(rval);
     }
 
     LOG_INFO ("Success. TSS2_RC: 0x%x", rval);

--- a/tools/tpm2_stirrandom.c
+++ b/tools/tpm2_stirrandom.c
@@ -79,13 +79,14 @@ static bool load_sensitive(void) {
     return true;
 }
 
-int tpm2_tool_onrun(ESYS_CONTEXT *ectx, tpm2_option_flags flags) {
+tool_rc tpm2_tool_onrun(ESYS_CONTEXT *ectx, tpm2_option_flags flags) {
 
     UNUSED(flags);
 
     if (!load_sensitive()) {
-        return 1;
+        return tool_rc_general_error;
     }
 
-    return do_stirrandom(ectx) != true;
+    return do_stirrandom(ectx) ?
+            tool_rc_success : tool_rc_general_error;
 }

--- a/tools/tpm2_stirrandom.c
+++ b/tools/tpm2_stirrandom.c
@@ -25,7 +25,7 @@ struct tpm_stirrandom_ctx {
 
 static tpm_stirrandom_ctx ctx;
 
-static bool do_stirrandom(ESYS_CONTEXT *ectx) {
+static tool_rc do_stirrandom(ESYS_CONTEXT *ectx) {
 
     TSS2_RC rval = Esys_StirRandom(ectx, ESYS_TR_NONE, ESYS_TR_NONE,
                                    ESYS_TR_NONE, &ctx.in_data);
@@ -33,10 +33,10 @@ static bool do_stirrandom(ESYS_CONTEXT *ectx) {
         LOG_ERR("Error while injecting specified additionnal data into TPM "
                 "random pool");
         LOG_PERR(Esys_StirRandom, rval);
-        return false;
+        return tool_rc_from_tpm(rval);
     }
 
-    return true;
+    return tool_rc_success;
 }
 
 static bool on_args(int argc, char **argv) {
@@ -87,6 +87,5 @@ tool_rc tpm2_tool_onrun(ESYS_CONTEXT *ectx, tpm2_option_flags flags) {
         return tool_rc_general_error;
     }
 
-    return do_stirrandom(ectx) ?
-            tool_rc_success : tool_rc_general_error;
+    return do_stirrandom(ectx);
 }

--- a/tools/tpm2_testparms.c
+++ b/tools/tpm2_testparms.c
@@ -21,7 +21,8 @@ struct tpm_testparms_ctx {
 
 static tpm_testparms_ctx ctx;
 
-static int tpm_testparms(ESYS_CONTEXT *ectx) {
+static tool_rc tpm_testparms(ESYS_CONTEXT *ectx) {
+
     TSS2_RC rval = Esys_TestParms(ectx, ESYS_TR_NONE, ESYS_TR_NONE, ESYS_TR_NONE, &(ctx.inputalg));
     if (rval != TSS2_RC_SUCCESS) {
         if ((rval & (TPM2_RC_P | TPM2_RC_1)) == (TPM2_RC_P | TPM2_RC_1)){
@@ -59,13 +60,13 @@ static int tpm_testparms(ESYS_CONTEXT *ectx) {
                     LOG_ERR("Unsupported algorithm specification");
                     break;
             }
-            return 2;
+            return tool_rc_unsupported;
         }
         LOG_PERR(Esys_TestParms, rval);
-        return 1;
+        return tool_rc_general_error;
     }
 
-    return 0;
+    return tool_rc_success;
 }
 
 static bool on_arg(int argc, char **argv){
@@ -93,7 +94,7 @@ bool tpm2_tool_onstart(tpm2_options **opts) {
     return *opts != NULL;
 }
 
-int tpm2_tool_onrun(ESYS_CONTEXT *ectx, tpm2_option_flags flags) {
+tool_rc tpm2_tool_onrun(ESYS_CONTEXT *ectx, tpm2_option_flags flags) {
 
     UNUSED(flags);
 

--- a/tools/tpm2_testparms.c
+++ b/tools/tpm2_testparms.c
@@ -24,6 +24,9 @@ static tpm_testparms_ctx ctx;
 static tool_rc tpm_testparms(ESYS_CONTEXT *ectx) {
 
     TSS2_RC rval = Esys_TestParms(ectx, ESYS_TR_NONE, ESYS_TR_NONE, ESYS_TR_NONE, &(ctx.inputalg));
+    /*
+     * TODO: this is a good candidate for flatten support via tool_rc_from_tpm(rval);
+     */
     if (rval != TSS2_RC_SUCCESS) {
         if ((rval & (TPM2_RC_P | TPM2_RC_1)) == (TPM2_RC_P | TPM2_RC_1)){
             rval &= ~(TPM2_RC_P | TPM2_RC_1);

--- a/tools/tpm2_tool.h
+++ b/tools/tpm2_tool.h
@@ -8,6 +8,18 @@
 
 #include "tpm2_options.h"
 
+typedef enum tool_rc tool_rc;
+enum tool_rc {
+    /* do not reorder or change, part of returned codes to exit */
+    /* maps to common/returns.md */
+    tool_rc_success = 0,
+    tool_rc_general_error,
+    tool_rc_option_error,
+    tool_rc_auth_error,
+    tool_rc_tcti_error,
+    tool_rc_unsupported
+};
+
 extern bool output_enabled;
 
 /**
@@ -31,11 +43,9 @@ bool tpm2_tool_onstart(tpm2_options **opts) __attribute__((weak));
  * @param flags
  *  Flags that tools may wish to respect.
  * @return
- *  0 on success
- *  1 on failure
- * -1 to show usage
+ *  A tool_rc indicating status.
  */
-int tpm2_tool_onrun (ESYS_CONTEXT *ectx, tpm2_option_flags flags) __attribute__((weak));
+tool_rc tpm2_tool_onrun(ESYS_CONTEXT *ectx, tpm2_option_flags flags) __attribute__((weak));
 
 /**
  * Called when the tool is exiting, useful for cleanup.

--- a/tools/tpm2_tool.h
+++ b/tools/tpm2_tool.h
@@ -6,19 +6,8 @@
 #include <tss2/tss2_esys.h>
 #include <stdbool.h>
 
+#include "tpm2_error.h"
 #include "tpm2_options.h"
-
-typedef enum tool_rc tool_rc;
-enum tool_rc {
-    /* do not reorder or change, part of returned codes to exit */
-    /* maps to common/returns.md */
-    tool_rc_success = 0,
-    tool_rc_general_error,
-    tool_rc_option_error,
-    tool_rc_auth_error,
-    tool_rc_tcti_error,
-    tool_rc_unsupported
-};
 
 extern bool output_enabled;
 

--- a/tools/tpm2_unseal.c
+++ b/tools/tpm2_unseal.c
@@ -122,11 +122,11 @@ bool tpm2_tool_onstart(tpm2_options **opts) {
     return *opts != NULL;
 }
 
-int tpm2_tool_onrun(ESYS_CONTEXT *ectx, tpm2_option_flags flags) {
+tool_rc tpm2_tool_onrun(ESYS_CONTEXT *ectx, tpm2_option_flags flags) {
 
     UNUSED(flags);
 
-    int rc = 1;
+    tool_rc rc = tool_rc_general_error;
     bool result = init(ectx);
     if (!result) {
         goto out;
@@ -138,12 +138,12 @@ int tpm2_tool_onrun(ESYS_CONTEXT *ectx, tpm2_option_flags flags) {
         goto out;
     }
 
-    rc = 0;
+    rc = tool_rc_success;
 out:
 
     result = tpm2_session_close(&ctx.session);
     if (!result) {
-        rc = 1;
+        rc = tool_rc_general_error;
     }
 
     return rc;

--- a/tools/tpm2_verifysignature.c
+++ b/tools/tpm2_verifysignature.c
@@ -246,23 +246,23 @@ bool tpm2_tool_onstart(tpm2_options **opts) {
     return *opts != NULL;
 }
 
-int tpm2_tool_onrun(ESYS_CONTEXT *context, tpm2_option_flags flags) {
+tool_rc tpm2_tool_onrun(ESYS_CONTEXT *context, tpm2_option_flags flags) {
 
 	UNUSED(flags);
 
     /* initialize and process */
     bool res = init(context);
     if (!res) {
-        return 1;
+        return tool_rc_general_error;
     }
 
     res = verify_signature(context);
     if (!res) {
         LOG_ERR("Verify signature failed!");
-        return 1;
+        return tool_rc_general_error;
     }
 
-    return 0;
+    return tool_rc_success;
 }
 
 void tpm2_tool_onexit(void) {


### PR DESCRIPTION
This makes progress on #1193. It plumbs all the tools that directly call ESAPI routines to return a flattened RC known as a "tool_rc" that can be standardized and directly consumed on the command line.

Work still needs to be done to follow up with calls to ESAPI hidden in the lib folder, but that will be less pervasive and less likely to conflict and thus merge this now and ill follow up with the lib changes soon.