### PR TITLE
lib: convert files_save_tpm_context_to_file to tool_rc

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -218,11 +218,11 @@ test_unit_test_tpm2_errata_LDADD    = $(CMOCKA_LIBS) $(LDADD)
 
 test_unit_test_tpm2_session_CFLAGS   = $(AM_CFLAGS) $(CMOCKA_CFLAGS)
 test_unit_test_tpm2_session_LDFLAGS  = -Wl,--wrap=Esys_StartAuthSession \
-                                       -Wl,--wrap=Esys_ContextSave \
+                                       -Wl,--wrap=tpm2_context_save \
                                        -Wl,--wrap=Esys_ContextLoad \
                                        -Wl,--wrap=Esys_PolicyRestart \
                                        -Wl,--wrap=Esys_TR_GetName \
-                                       -Wl,--wrap=Esys_FlushContext
+                                       -Wl,--wrap=tpm2_flush_context
 
 test_unit_test_tpm2_session_LDADD    = $(CMOCKA_LIBS) $(LDADD)
 

--- a/lib/files.h
+++ b/lib/files.h
@@ -6,6 +6,8 @@
 #include <stdbool.h>
 #include <stdio.h>
 
+typedef enum tool_rc tool_rc;
+
 #include <tss2/tss2_esys.h>
 
 /**
@@ -68,9 +70,9 @@ bool files_save_bytes_to_file(const char *path, UINT8 *buf, UINT16 size);
  *  The output path of the file.
  *
  * @return
- *  True on success, False on error.
+ *  tool_rc indicating status.
  */
-bool files_save_tpm_context_to_path(ESYS_CONTEXT *context, ESYS_TR handle,
+tool_rc files_save_tpm_context_to_path(ESYS_CONTEXT *context, ESYS_TR handle,
         const char *path);
 
 /**
@@ -82,9 +84,9 @@ bool files_save_tpm_context_to_path(ESYS_CONTEXT *context, ESYS_TR handle,
  * @param stream
  *  The FILE stream to save too.
  * @return
- *  True on success, False on error.
+ *  tool_rc indicating status.
  */
-bool files_save_tpm_context_to_file(ESYS_CONTEXT *context,
+tool_rc files_save_tpm_context_to_file(ESYS_CONTEXT *context,
         ESYS_TR handle,
         FILE *stream);
 

--- a/lib/tpm2.c
+++ b/lib/tpm2.c
@@ -155,3 +155,35 @@ tool_rc tpm2_nv_read(
 
     return tool_rc_success;
 }
+
+tool_rc tpm2_context_save(
+        ESYS_CONTEXT *esysContext,
+        ESYS_TR saveHandle,
+        TPMS_CONTEXT **context) {
+
+    TSS2_RC rval = Esys_ContextSave(
+            esysContext,
+            saveHandle,
+            context);
+    if (rval != TSS2_RC_SUCCESS) {
+        LOG_PERR(Esys_ContextSave, rval);
+        return tool_rc_from_tpm(rval);
+    }
+
+    return tool_rc_success;
+}
+
+tool_rc tpm2_flush_context(
+        ESYS_CONTEXT *esysContext,
+        ESYS_TR flushHandle) {
+
+    TSS2_RC rval = Esys_FlushContext(
+        esysContext,
+        flushHandle);
+    if (rval != TSS2_RC_SUCCESS) {
+        LOG_PERR(Esys_FlushContext, rval);
+        return tool_rc_from_tpm(rval);
+    }
+
+    return tool_rc_success;
+}

--- a/lib/tpm2.h
+++ b/lib/tpm2.h
@@ -59,4 +59,13 @@ tool_rc tpm2_nv_read(
         UINT16 offset,
         TPM2B_MAX_NV_BUFFER **data);
 
+tool_rc tpm2_context_save(
+        ESYS_CONTEXT *esysContext,
+        ESYS_TR saveHandle,
+        TPMS_CONTEXT **context);
+
+tool_rc tpm2_flush_context(
+        ESYS_CONTEXT *esysContext,
+        ESYS_TR flushHandle);
+
 #endif /* LIB_TPM2_H_ */

--- a/lib/tpm2_session.h
+++ b/lib/tpm2_session.h
@@ -10,6 +10,8 @@
 typedef struct tpm2_session_data tpm2_session_data;
 typedef struct tpm2_session tpm2_session;
 
+typedef enum tool_rc tool_rc;
+
 /**
  * Creates a new session data object, based around the inputs to
  * TPM2_StartAuthSession as listed in Section 11.1:
@@ -156,9 +158,9 @@ tpm2_session *tpm2_session_open(ESYS_CONTEXT *context,
  * @param session
  *  The session context to save
  * @return
- *  True on success, false otherwise.
+ *  tool_rc indicating status.
  */
-bool tpm2_session_close(tpm2_session **session);
+tool_rc tpm2_session_close(tpm2_session **session);
 
 /**
  * Restores a session saved with tpm2_session_save().

--- a/test/integration/tests/createprimary.sh
+++ b/test/integration/tests/createprimary.sh
@@ -66,7 +66,6 @@ tpm2_createprimary -Q -o context.out
 
 # Test that -o does not need to be specified.
 tpm2_createprimary -Q
-test -f primary.ctx
 
 # Test for session leaks
 BEFORE=$(tpm2_getcap -c handles-loaded-session; tpm2_getcap -c handles-saved-session)

--- a/test/unit/test_tpm2_session.c
+++ b/test/unit/test_tpm2_session.c
@@ -31,7 +31,7 @@ static void test_tpm2_create_dummy_context(TPMS_CONTEXT *context) {
     memset(context->contextBlob.buffer, '\0', context->contextBlob.size);
 }
 
-TSS2_RC __wrap_Esys_ContextSave(ESYS_CONTEXT *esysContext,
+tool_rc __wrap_tpm2_context_save(ESYS_CONTEXT *esysContext,
             ESYS_TR saveHandle, TPMS_CONTEXT **context) {
 
     UNUSED(esysContext);
@@ -43,7 +43,7 @@ TSS2_RC __wrap_Esys_ContextSave(ESYS_CONTEXT *esysContext,
     *context = dummy_context;
     _save_handle = saveHandle;
 
-    return TPM2_RC_SUCCESS;
+    return tool_rc_success;
 }
 
 TSS2_RC __wrap_Esys_ContextLoad(ESYS_CONTEXT *esysContext,
@@ -91,7 +91,7 @@ TSS2_RC __wrap_Esys_TR_GetName(ESYS_CONTEXT *esysContext, ESYS_TR handle,
     return rc;
 }
 
-TSS2_RC __wrap_Esys_FlushContext(ESYS_CONTEXT *esysContext, ESYS_TR flushHandle) {
+TSS2_RC __wrap_tpm2_flush_context(ESYS_CONTEXT *esysContext, ESYS_TR flushHandle) {
     UNUSED(esysContext);
     UNUSED(flushHandle);
 
@@ -214,8 +214,8 @@ static void test_tpm2_session_save(void **state) {
                     &tpm_handle1);
     assert_true(result);
 
-    result = tpm2_session_close(&s);
-    assert_true(result);
+    tool_rc rc = tpm2_session_close(&s);
+    assert_int_equal(rc, tool_rc_success);
     assert_null(s);
 
     s = tpm2_session_restore(NULL, (char *)*state, false);

--- a/tools/tpm2_activatecredential.c
+++ b/tools/tpm2_activatecredential.c
@@ -241,8 +241,6 @@ bool tpm2_tool_onstart(tpm2_options **opts) {
 
 tool_rc tpm2_tool_onrun(ESYS_CONTEXT *ectx, tpm2_option_flags flags) {
 
-    tool_rc rc = tool_rc_general_error;
-
     /* opts is unused, avoid compiler warning */
     UNUSED(flags);
 
@@ -276,20 +274,25 @@ tool_rc tpm2_tool_onrun(ESYS_CONTEXT *ectx, tpm2_option_flags flags) {
             &ctx.endorse.session, true);
     if (!res) {
         LOG_ERR("Invalid endorse authorization, got\"%s\"", ctx.endorse.auth_str);
-        goto out;
+        return tool_rc_general_error;
     }
 
-    rc = activate_credential_and_output(ectx);
+    return activate_credential_and_output(ectx);
+}
 
-out:
-    res = tpm2_session_close(&ctx.key.session);
-    if (!res) {
-        rc = tool_rc_general_error;
+tool_rc tpm2_tool_onstop(ESYS_CONTEXT *ectx) {
+    UNUSED(ectx);
+
+    tool_rc rc = tool_rc_success;
+
+    tool_rc tmp_rc = tpm2_session_close(&ctx.key.session);
+    if (tmp_rc != tool_rc_success) {
+        rc = tmp_rc;
     }
 
-    res = tpm2_session_close(&ctx.endorse.session);
-    if (!res) {
-        rc = tool_rc_general_error;
+    tmp_rc = tpm2_session_close(&ctx.endorse.session);
+    if (tmp_rc != tool_rc_success) {
+        rc = tmp_rc;
     }
 
     return rc;

--- a/tools/tpm2_clear.c
+++ b/tools/tpm2_clear.c
@@ -85,12 +85,11 @@ tool_rc tpm2_tool_onrun(ESYS_CONTEXT *ectx, tpm2_option_flags flags) {
         return tool_rc_general_error;
     }
 
-    tool_rc rc = clear(ectx);
+    return clear(ectx);
+}
 
-    result = tpm2_session_close(&ctx.auth.session);
-    if (!result) {
-        rc = tool_rc_general_error;
-    }
+tool_rc tpm2_tool_onstop(ESYS_CONTEXT *ectx) {
+    UNUSED(ectx);
 
-    return rc;
+    return tpm2_session_close(&ctx.auth.session);
 }

--- a/tools/tpm2_createak.c
+++ b/tools/tpm2_createak.c
@@ -244,8 +244,8 @@ static tool_rc create_ak(ESYS_CONTEXT *ectx) {
     }
     LOG_INFO("Esys_Create success");
 
-    result = tpm2_session_close(&session);
-    if (!result) {
+    rc = tpm2_session_close(&session);
+    if (rc != tool_rc_success) {
         goto out;
     }
 
@@ -299,8 +299,8 @@ static tool_rc create_ak(ESYS_CONTEXT *ectx) {
         goto nameout;
     }
 
-    result = tpm2_session_close(&session);
-    if (!result) {
+    rc = tpm2_session_close(&session);
+    if (rc != tool_rc_success) {
         goto out;
     }
 
@@ -322,9 +322,10 @@ static tool_rc create_ak(ESYS_CONTEXT *ectx) {
 
     // If the AK isn't persisted we always save a context file of the
     // transient AK handle for future tool interactions.
-    result = files_save_tpm_context_to_path(ectx,
+    tool_rc tmp_rc = files_save_tpm_context_to_path(ectx,
                 loaded_sha1_key_handle, ctx.ak.out.ctx_file);
-    if (!result) {
+    if (tmp_rc != tool_rc_success) {
+        rc = tmp_rc;
         LOG_ERR("Error saving tpm context for handle");
         goto nameout;
     }

--- a/tools/tpm2_createek.c
+++ b/tools/tpm2_createek.c
@@ -237,12 +237,12 @@ static tool_rc create_ek_handle(ESYS_CONTEXT *ectx) {
             }
         }
 
-        bool result = files_save_tpm_context_to_path(ectx,
+        tool_rc rc = files_save_tpm_context_to_path(ectx,
                 ctx.objdata.out.handle, filename);
         if (!result) {
             LOG_ERR("Error saving tpm context for handle");
             free(filename);
-            return tool_rc_general_error;
+            return rc;
         }
         tpm2_tool_output("transient-object-context: %s\n", filename);
         free(filename);
@@ -426,9 +426,9 @@ out:
 
     for(i=0; i < ARRAY_LEN(sessions); i++) {
         tpm2_session *s = *sessions[i];
-        bool result = tpm2_session_close(&s);
-        if (!result) {
-            rc = tool_rc_success;
+        tool_rc tmp_rc = tpm2_session_close(&s);
+        if (tmp_rc != tool_rc_success) {
+            rc = tmp_rc;
         }
     }
 

--- a/tools/tpm2_dictionarylockout.c
+++ b/tools/tpm2_dictionarylockout.c
@@ -138,28 +138,24 @@ tool_rc tpm2_tool_onrun(ESYS_CONTEXT *ectx, tpm2_option_flags flags) {
 
     UNUSED(flags);
 
-    tool_rc rc = tool_rc_general_error;
-    bool result;
-
     if (!ctx.clear_lockout && !ctx.setup_parameters) {
         LOG_ERR( "Invalid operational input: Neither Setup nor Clear lockout requested.");
         return tool_rc_option_error;
     }
 
-    result = tpm2_auth_util_from_optarg(ectx, ctx.auth.auth_str,
+    bool result = tpm2_auth_util_from_optarg(ectx, ctx.auth.auth_str,
             &ctx.auth.session, false);
     if (!result) {
         LOG_ERR("Invalid lockout authorization, got\"%s\"",
             ctx.auth.auth_str);
-        return rc;
+        return tool_rc_general_error;
     }
 
-    rc = dictionary_lockout_reset_and_parameter_setup(ectx);
+    return dictionary_lockout_reset_and_parameter_setup(ectx);
+}
 
-    result = tpm2_session_close(&ctx.auth.session);
-    if (!result) {
-        rc = tool_rc_general_error;
-    }
+tool_rc tpm2_tool_onstop(ESYS_CONTEXT *ectx) {
+    UNUSED(ectx);
 
-    return rc;
+    return tpm2_session_close(&ctx.auth.session);
 }

--- a/tools/tpm2_evictcontrol.c
+++ b/tools/tpm2_evictcontrol.c
@@ -196,10 +196,11 @@ out:
         }
     }
 
-    result = tpm2_session_close(&ctx.auth.session);
-    if (!result) {
-        rc = tool_rc_general_error;
-    }
-
     return rc;
+}
+
+tool_rc tpm2_tool_onstop(ESYS_CONTEXT *ectx) {
+    UNUSED(ectx);
+
+    return tpm2_session_close(&ctx.auth.session);
 }

--- a/tools/tpm2_hmac.c
+++ b/tools/tpm2_hmac.c
@@ -237,9 +237,6 @@ tool_rc tpm2_tool_onrun(ESYS_CONTEXT *ectx, tpm2_option_flags flags) {
 
     UNUSED(flags);
 
-    tool_rc rc = tool_rc_general_error;
-    bool result;
-
     /*
      * Option C must be specified.
      */
@@ -248,31 +245,29 @@ tool_rc tpm2_tool_onrun(ESYS_CONTEXT *ectx, tpm2_option_flags flags) {
         return tool_rc_option_error;
     }
 
-    result = tpm2_auth_util_from_optarg(ectx, ctx.auth.auth_str,
+    bool result = tpm2_auth_util_from_optarg(ectx, ctx.auth.auth_str,
             &ctx.auth.session, false);
     if (!result) {
         LOG_ERR("Invalid key handle authorization, got\"%s\"",
             ctx.auth.auth_str);
-        return rc;
+        return tool_rc_general_error;
     }
 
     result = tpm2_util_object_load(ectx, ctx.context_arg,
                                 &ctx.key_context_object);
     if (!result) {
-        goto out;
+        return tool_rc_general_error;
     }
 
-    rc = do_hmac_and_output(ectx);
+    return do_hmac_and_output(ectx);
+}
 
-out:
+tool_rc tpm2_tool_onstop(ESYS_CONTEXT *ectx) {
+    UNUSED(ectx);
+
     if (ctx.input && ctx.input != stdin) {
         fclose(ctx.input);
     }
 
-    result = tpm2_session_close(&ctx.auth.session);
-    if (!result) {
-        rc = tool_rc_general_error;
-    }
-
-    return rc;
+    return tpm2_session_close(&ctx.auth.session);
 }

--- a/tools/tpm2_loadexternal.c
+++ b/tools/tpm2_loadexternal.c
@@ -336,9 +336,10 @@ tool_rc tpm2_tool_onrun(ESYS_CONTEXT *ectx, tpm2_option_flags flags) {
         goto out;
     }
 
-    result = files_save_tpm_context_to_path(ectx, ctx.handle,
+    tmp_rc = files_save_tpm_context_to_path(ectx, ctx.handle,
                 ctx_file);
-    if (!result) {
+    if (tmp_rc != tool_rc_success) {
+        rc = tmp_rc;
         goto out;
     }
 

--- a/tools/tpm2_nvdefine.c
+++ b/tools/tpm2_nvdefine.c
@@ -173,14 +173,11 @@ tool_rc tpm2_tool_onrun(ESYS_CONTEXT *ectx, tpm2_option_flags flags) {
 
     UNUSED(flags);
 
-    bool result;
-    tool_rc rc = tool_rc_general_error;
-
-    result = tpm2_auth_util_from_optarg(ectx, ctx.hierarchy.auth_str,
+    bool result = tpm2_auth_util_from_optarg(ectx, ctx.hierarchy.auth_str,
             &ctx.hierarchy.session, false);
     if (!result) {
         LOG_ERR("Invalid handle authorization, got \"%s\"", ctx.hierarchy.auth_str);
-        goto out;
+        return tool_rc_general_error;
     }
 
     tpm2_session *tmp;
@@ -188,7 +185,7 @@ tool_rc tpm2_tool_onrun(ESYS_CONTEXT *ectx, tpm2_option_flags flags) {
             &tmp, true);
     if (!result) {
         LOG_ERR("Invalid index authorization, got\"%s\"", ctx.index_auth_str);
-        goto out;
+        return tool_rc_general_error;
     }
 
     const TPM2B_AUTH *auth = tpm2_session_get_auth_value(tmp);
@@ -196,13 +193,10 @@ tool_rc tpm2_tool_onrun(ESYS_CONTEXT *ectx, tpm2_option_flags flags) {
 
     tpm2_session_close(&tmp);
 
-    rc = nv_space_define(ectx);
+    return nv_space_define(ectx);
+}
 
-out:
-    result = tpm2_session_close(&ctx.hierarchy.session);
-    if (!result) {
-        rc = tool_rc_general_error;
-    }
-
-    return rc;
+tool_rc tpm2_tool_onstop(ESYS_CONTEXT *ectx) {
+    UNUSED(ectx);
+    return tpm2_session_close(&ctx.hierarchy.session);
 }

--- a/tools/tpm2_nvincrement.c
+++ b/tools/tpm2_nvincrement.c
@@ -128,9 +128,6 @@ tool_rc tpm2_tool_onrun(ESYS_CONTEXT *ectx, tpm2_option_flags flags) {
 
     UNUSED(flags);
 
-    tool_rc rc = tool_rc_general_error;
-    bool result;
-
     /* If the users doesn't specify an authorisation hierarchy use the index
      * passed to -x/--index for the authorisation index.
      */
@@ -138,21 +135,18 @@ tool_rc tpm2_tool_onrun(ESYS_CONTEXT *ectx, tpm2_option_flags flags) {
         ctx.hierarchy = ctx.nv_index;
     }
 
-    result = tpm2_auth_util_from_optarg(ectx, ctx.auth.auth_str,
+    bool result = tpm2_auth_util_from_optarg(ectx, ctx.auth.auth_str,
             &ctx.auth.session, false);
     if (!result) {
         LOG_ERR("Invalid handle authorization, got \"%s\"",
             ctx.auth.auth_str);
-        goto out;
+        return tool_rc_general_error;
     }
 
-    rc = nv_increment(ectx);
-out:
+    return nv_increment(ectx);
+}
 
-    result = tpm2_session_close(&ctx.auth.session);
-    if (!result) {
-        rc = tool_rc_general_error;
-    }
-
-    return rc;
+tool_rc tpm2_tool_onstop(ESYS_CONTEXT *ectx) {
+    UNUSED(ectx);
+    return tpm2_session_close(&ctx.auth.session);
 }

--- a/tools/tpm2_nvread.c
+++ b/tools/tpm2_nvread.c
@@ -148,9 +148,6 @@ tool_rc tpm2_tool_onrun(ESYS_CONTEXT *ectx, tpm2_option_flags flags) {
 
     UNUSED(flags);
 
-    tool_rc rc = 1;
-    bool result;
-
     /* If the users doesn't specify an authorisation hierarchy use the index
      * passed to -x/--index for the authorisation index.
      */
@@ -158,7 +155,7 @@ tool_rc tpm2_tool_onrun(ESYS_CONTEXT *ectx, tpm2_option_flags flags) {
         ctx.hierarchy = ctx.nv_index;
     }
 
-    result = tpm2_auth_util_from_optarg(ectx, ctx.auth.auth_str,
+    bool result = tpm2_auth_util_from_optarg(ectx, ctx.auth.auth_str,
             &ctx.auth.session, false);
     if (!result) {
         LOG_ERR("Invalid handle authorization, got \"%s\"",
@@ -166,12 +163,10 @@ tool_rc tpm2_tool_onrun(ESYS_CONTEXT *ectx, tpm2_option_flags flags) {
         return tool_rc_general_error;
     }
 
-    rc = nv_read(ectx, flags);
+    return nv_read(ectx, flags);
+}
 
-    result = tpm2_session_close(&ctx.auth.session);
-    if (!result) {
-        rc = tool_rc_general_error;
-    }
-
-    return rc;
+tool_rc tpm2_tool_onstop(ESYS_CONTEXT *ectx) {
+    UNUSED(ectx);
+    return tpm2_session_close(&ctx.auth.session);
 }

--- a/tools/tpm2_nvreadlock.c
+++ b/tools/tpm2_nvreadlock.c
@@ -115,23 +115,18 @@ tool_rc tpm2_tool_onrun(ESYS_CONTEXT *ectx, tpm2_option_flags flags) {
 
     UNUSED(flags);
 
-    tool_rc rc = tool_rc_general_error;
-
     bool result = tpm2_auth_util_from_optarg(ectx, ctx.auth.auth_str,
             &ctx.auth.session, false);
     if (!result) {
         LOG_ERR("Invalid handle authorization, got \"%s\"",
             ctx.auth.auth_str);
-       goto out;
+       return tool_rc_general_error;
     }
 
-    rc = nv_readlock(ectx);
+    return nv_readlock(ectx);
+}
 
-out:
-    result = tpm2_session_close(&ctx.auth.session);
-    if (!result) {
-        rc = tool_rc_general_error;
-    }
-
-    return rc;
+tool_rc tpm2_tool_onstop(ESYS_CONTEXT *ectx) {
+    UNUSED(ectx);
+    return tpm2_session_close(&ctx.auth.session);
 }

--- a/tools/tpm2_nvrelease.c
+++ b/tools/tpm2_nvrelease.c
@@ -115,24 +115,18 @@ tool_rc tpm2_tool_onrun(ESYS_CONTEXT *ectx, tpm2_option_flags flags) {
 
     UNUSED(flags);
 
-    int rc = tool_rc_general_error;
-    bool result;
-
-    result = tpm2_auth_util_from_optarg(ectx, ctx.auth.auth_str,
+    bool result = tpm2_auth_util_from_optarg(ectx, ctx.auth.auth_str,
             &ctx.auth.session, false);
     if (!result) {
         LOG_ERR("Invalid handle authorization, got \"%s\"",
             ctx.auth.auth_str);
-        goto out;
+        return tool_rc_general_error;
     }
 
-    rc = nv_space_release(ectx);
+    return nv_space_release(ectx);
+}
 
-out:
-    result = tpm2_session_close(&ctx.auth.session);
-    if (!result) {
-        rc = tool_rc_general_error;
-    }
-
-    return rc;
+tool_rc tpm2_tool_onstop(ESYS_CONTEXT *ectx) {
+    UNUSED(ectx);
+    return tpm2_session_close(&ctx.auth.session);
 }

--- a/tools/tpm2_pcrallocate.c
+++ b/tools/tpm2_pcrallocate.c
@@ -120,12 +120,10 @@ tool_rc tpm2_tool_onrun(ESYS_CONTEXT *ectx, tpm2_option_flags flags) {
         return tool_rc_general_error;
     }
 
-    tool_rc rc = pcr_allocate(ectx);
+    return pcr_allocate(ectx);
+}
 
-    result = tpm2_session_close(&ctx.auth.session);
-    if (!result) {
-        rc = tool_rc_general_error;
-    }
-
-    return rc;
+tool_rc tpm2_tool_onstop(ESYS_CONTEXT *ectx) {
+    UNUSED(ectx);
+    return tpm2_session_close(&ctx.auth.session);
 }

--- a/tools/tpm2_pcrevent.c
+++ b/tools/tpm2_pcrevent.c
@@ -279,8 +279,6 @@ tool_rc tpm2_tool_onrun(ESYS_CONTEXT *ectx, tpm2_option_flags flags) {
 
     UNUSED(flags);
 
-    tool_rc rc = tool_rc_general_error;
-
     ctx.input = ctx.input ? ctx.input : stdin;
 
     bool result = tpm2_auth_util_from_optarg(ectx, ctx.auth.auth_str,
@@ -288,19 +286,15 @@ tool_rc tpm2_tool_onrun(ESYS_CONTEXT *ectx, tpm2_option_flags flags) {
     if (!result) {
         LOG_ERR("Invalid key handle authorization, got\"%s\"",
             ctx.auth.auth_str);
-        goto out;
+        return tool_rc_general_error;
     }
 
-    rc = do_pcrevent_and_output(ectx);
+    return do_pcrevent_and_output(ectx);
+}
 
-out:
-
-    result = tpm2_session_close(&ctx.auth.session);
-    if (!result) {
-        rc = tool_rc_general_error;
-    }
-
-    return rc;
+tool_rc tpm2_tool_onstop(ESYS_CONTEXT *ectx) {
+    UNUSED(ectx);
+    return tpm2_session_close(&ctx.auth.session);
 }
 
 void tpm2_tool_onexit(void) {
@@ -308,5 +302,4 @@ void tpm2_tool_onexit(void) {
     if (ctx.input && ctx.input != stdin) {
         fclose(ctx.input);
     }
-
 }

--- a/tools/tpm2_policycommandcode.c
+++ b/tools/tpm2_policycommandcode.c
@@ -23,6 +23,8 @@ struct tpm2_policycommandcode_ctx {
    const char *session_path;
    TPM2_CC command_code;
    const char *out_policy_dgst_path;
+   TPM2B_DIGEST *policy_digest;
+   tpm2_session *session;
 };
 
 static tpm2_policycommandcode_ctx ctx;
@@ -89,53 +91,48 @@ tool_rc tpm2_tool_onrun(ESYS_CONTEXT *ectx, tpm2_option_flags flags) {
 
     UNUSED(flags);
 
-    TPM2B_DIGEST *policy_digest = NULL;
     bool retval = is_input_option_args_valid();
     if (!retval) {
         return tool_rc_option_error;
     }
 
-    tool_rc rc = tool_rc_general_error;
-    tpm2_session *s = tpm2_session_restore(ectx, ctx.session_path, false);
-    if (!s) {
-        return rc;
+    ctx.session = tpm2_session_restore(ectx, ctx.session_path, false);
+    if (!ctx.session) {
+        return tool_rc_general_error;
     }
 
-    bool result = tpm2_policy_build_policycommandcode(ectx, s,
+    bool result = tpm2_policy_build_policycommandcode(ectx, ctx.session,
         ctx.command_code);
     if (!result) {
         LOG_ERR("Could not build TPM policy_command_code");
-        goto out;
+        return tool_rc_general_error;
     }
 
-    result = tpm2_policy_get_digest(ectx, s, &policy_digest);
+    result = tpm2_policy_get_digest(ectx, ctx.session, &ctx.policy_digest);
     if (!result) {
         LOG_ERR("Could not build tpm policy");
-        goto out;
+        return tool_rc_general_error;
     }
 
-    tpm2_util_hexdump(policy_digest->buffer, policy_digest->size);
+    tpm2_util_hexdump(ctx.policy_digest->buffer, ctx.policy_digest->size);
     tpm2_tool_output("\n");
 
     if (ctx.out_policy_dgst_path) {
         result = files_save_bytes_to_file(ctx.out_policy_dgst_path,
-                    policy_digest->buffer, policy_digest->size);
+                ctx.policy_digest->buffer, ctx.policy_digest->size);
         if (!result) {
             LOG_ERR("Failed to save policy digest into file \"%s\"",
                     ctx.out_policy_dgst_path);
-            goto out;
+            return tool_rc_general_error;
         }
     }
 
-    rc = tool_rc_success;
+    return tool_rc_success;
 
-out:
-    free(policy_digest);
+}
 
-    result = tpm2_session_close(&s);
-    if (!result) {
-        rc = tool_rc_general_error;
-    }
-
-    return rc;
+tool_rc tpm2_tool_onstop(ESYS_CONTEXT *ectx) {
+    UNUSED(ectx);
+    free(ctx.policy_digest);
+    return tpm2_session_close(&ctx.session);
 }

--- a/tools/tpm2_policylocality.c
+++ b/tools/tpm2_policylocality.c
@@ -23,6 +23,8 @@ struct tpm2_policylocality_ctx {
    const char *session_path;
    TPMA_LOCALITY locality;
    const char *out_policy_dgst_path;
+   TPM2B_DIGEST *policy_digest;
+   tpm2_session *session;
 };
 
 static tpm2_policylocality_ctx ctx;
@@ -89,53 +91,47 @@ tool_rc tpm2_tool_onrun(ESYS_CONTEXT *ectx, tpm2_option_flags flags) {
 
     UNUSED(flags);
 
-    TPM2B_DIGEST *policy_digest = NULL;
     bool retval = is_input_option_args_valid();
     if (!retval) {
         return tool_rc_option_error;
     }
 
-    tool_rc rc = tool_rc_general_error;
-    tpm2_session *s = tpm2_session_restore(ectx, ctx.session_path, false);
-    if (!s) {
-        return rc;
+    ctx.session = tpm2_session_restore(ectx, ctx.session_path, false);
+    if (!ctx.session) {
+        return tool_rc_general_error;
     }
 
-    bool result = tpm2_policy_build_policylocality(ectx, s,
+    bool result = tpm2_policy_build_policylocality(ectx, ctx.session,
         ctx.locality);
     if (!result) {
         LOG_ERR("Could not build TPM policy_locality");
-        goto out;
+        return tool_rc_general_error;
     }
 
-    result = tpm2_policy_get_digest(ectx, s, &policy_digest);
+    result = tpm2_policy_get_digest(ectx, ctx.session, &ctx.policy_digest);
     if (!result) {
         LOG_ERR("Could not build tpm policy");
-        goto out;
+        return tool_rc_general_error;
     }
 
-    tpm2_util_hexdump(policy_digest->buffer, policy_digest->size);
+    tpm2_util_hexdump(ctx.policy_digest->buffer, ctx.policy_digest->size);
     tpm2_tool_output("\n");
 
     if (ctx.out_policy_dgst_path) {
         result = files_save_bytes_to_file(ctx.out_policy_dgst_path,
-                    policy_digest->buffer, policy_digest->size);
+                    ctx.policy_digest->buffer, ctx.policy_digest->size);
         if (!result) {
             LOG_ERR("Failed to save policy digest into file \"%s\"",
                     ctx.out_policy_dgst_path);
-            goto out;
+            return tool_rc_general_error;
         }
     }
 
-    rc = tool_rc_success;
+    return tool_rc_success;
+}
 
-out:
-    free(policy_digest);
-
-    result = tpm2_session_close(&s);
-    if (!result) {
-        rc = tool_rc_general_error;
-    }
-
-    return rc;
+tool_rc tpm2_tool_onstop(ESYS_CONTEXT *ectx) {
+    UNUSED(ectx);
+    free(ctx.policy_digest);
+    return tpm2_session_close(&ctx.session);
 }

--- a/tools/tpm2_policyor.c
+++ b/tools/tpm2_policyor.c
@@ -21,6 +21,9 @@ struct tpm2_policyor_ctx {
    TPML_DIGEST policy_list;
    //File path for storing the policy digest output
    const char *out_policy_dgst_path;
+
+   TPM2B_DIGEST *policy_digest;
+   tpm2_session *session;
 };
 
 static tpm2_policyor_ctx ctx;
@@ -86,62 +89,53 @@ tool_rc tpm2_tool_onrun(ESYS_CONTEXT *ectx, tpm2_option_flags flags) {
 
     UNUSED(flags);
 
-    TPM2B_DIGEST *policy_digest = NULL;
-
     bool retval = is_input_option_args_valid();
     if (!retval) {
         return tool_rc_option_error;
     }
 
-
-    tool_rc rc = tool_rc_general_error;
-
-    tpm2_session *s = tpm2_session_restore(ectx, ctx.session_path, false);
-    if (!s) {
-        return rc;
+    ctx.session = tpm2_session_restore(ectx, ctx.session_path, false);
+    if (!ctx.session) {
+        return tool_rc_general_error;
     }
 
     /* Policy digest hash alg should match that of the session */
     if (ctx.policy_list.digests[0].size !=
-        tpm2_alg_util_get_hash_size(tpm2_session_get_authhash(s))) {
+        tpm2_alg_util_get_hash_size(tpm2_session_get_authhash(ctx.session))) {
         LOG_ERR("Policy digest hash alg should match that of the session.");
-        return rc;
+        return tool_rc_general_error;
     }
 
-    bool result = tpm2_policy_build_policyor(ectx, s, ctx.policy_list);
+    bool result = tpm2_policy_build_policyor(ectx, ctx.session, ctx.policy_list);
     if (!result) {
         LOG_ERR("Could not build policyor TPM");
-        goto out;
+        return tool_rc_general_error;
     }
 
-    result = tpm2_policy_get_digest(ectx, s, &policy_digest);
+    result = tpm2_policy_get_digest(ectx, ctx.session, &ctx.policy_digest);
     if (!result) {
         LOG_ERR("Could not build tpm policy");
-        goto out;
+        return tool_rc_general_error;
     }
 
-    tpm2_util_hexdump(policy_digest->buffer, policy_digest->size);
+    tpm2_util_hexdump(ctx.policy_digest->buffer, ctx.policy_digest->size);
     tpm2_tool_output("\n");
 
     if (ctx.out_policy_dgst_path) {
         result = files_save_bytes_to_file(ctx.out_policy_dgst_path,
-                    policy_digest->buffer, policy_digest->size);
+                    ctx.policy_digest->buffer, ctx.policy_digest->size);
         if (!result) {
             LOG_ERR("Failed to save policy digest into file \"%s\"",
                     ctx.out_policy_dgst_path);
-            goto out;
+            return tool_rc_general_error;
         }
     }
 
-    rc = tool_rc_success;
+    return tool_rc_success;
+}
 
-out:
-    result = tpm2_session_close(&s);
-    if (!result) {
-        rc = tool_rc_general_error;
-    }
-
-    free(policy_digest);
-
-    return rc;
+tool_rc tpm2_tool_onstop(ESYS_CONTEXT *ectx) {
+    UNUSED(ectx);
+    free(ctx.policy_digest);
+    return tpm2_session_close(&ctx.session);
 }

--- a/tools/tpm2_policypassword.c
+++ b/tools/tpm2_policypassword.c
@@ -19,6 +19,9 @@ struct tpm2_policypassword_ctx {
    const char *session_path;
    //File path for storing the policy digest output
    const char *out_policy_dgst_path;
+
+   TPM2B_DIGEST *policy_digest;
+   tpm2_session *session;
 };
 
 static tpm2_policypassword_ctx ctx;
@@ -63,53 +66,46 @@ tool_rc tpm2_tool_onrun(ESYS_CONTEXT *ectx, tpm2_option_flags flags) {
 
     UNUSED(flags);
 
-    TPM2B_DIGEST *policy_digest = NULL;
     bool retval = is_input_option_args_valid();
     if (!retval) {
         return tool_rc_option_error;
     }
 
-    tool_rc rc = tool_rc_general_error;
-    tpm2_session *s = tpm2_session_restore(ectx, ctx.session_path, false);
-    if (!s) {
-        return rc;
+    ctx.session = tpm2_session_restore(ectx, ctx.session_path, false);
+    if (!ctx.session) {
+        return tool_rc_general_error;
     }
 
-    bool result = tpm2_policy_build_policypassword(ectx, s);
+    bool result = tpm2_policy_build_policypassword(ectx, ctx.session);
     if (!result) {
         LOG_ERR("Could not build policypassword TPM");
-        goto out;
+        return tool_rc_general_error;
     }
 
-    result = tpm2_policy_get_digest(ectx, s, &policy_digest);
+    result = tpm2_policy_get_digest(ectx, ctx.session, &ctx.policy_digest);
     if (!result) {
         LOG_ERR("Could not build tpm policy");
-        goto out;
+        return tool_rc_general_error;
     }
 
-    tpm2_util_hexdump(policy_digest->buffer, policy_digest->size);
+    tpm2_util_hexdump(ctx.policy_digest->buffer, ctx.policy_digest->size);
     tpm2_tool_output("\n");
 
     if (ctx.out_policy_dgst_path) {
         result = files_save_bytes_to_file(ctx.out_policy_dgst_path,
-                    policy_digest->buffer, policy_digest->size);
+                    ctx.policy_digest->buffer, ctx.policy_digest->size);
         if (!result) {
             LOG_ERR("Failed to save policy digest into file \"%s\"",
                     ctx.out_policy_dgst_path);
-            goto out;
+            return tool_rc_general_error;
         }
     }
 
-    rc = tool_rc_success;
+    return tool_rc_success;
+}
 
-out:
-
-    result = tpm2_session_close(&s);
-    if (!result) {
-        rc = tool_rc_general_error;
-    }
-
-    free(policy_digest);
-
-    return rc;
+tool_rc tpm2_tool_onstop(ESYS_CONTEXT *ectx) {
+    UNUSED(ectx);
+    free(ctx.policy_digest);
+    return tpm2_session_close(&ctx.session);
 }

--- a/tools/tpm2_rsadecrypt.c
+++ b/tools/tpm2_rsadecrypt.c
@@ -133,26 +133,22 @@ tool_rc tpm2_tool_onrun(ESYS_CONTEXT *ectx, tpm2_option_flags flags) {
 
     UNUSED(flags);
 
-    tool_rc rc = tool_rc_general_error;
     bool result = init(ectx);
     if (!result) {
-        goto out;
+        return tool_rc_general_error;
     }
 
     result = tpm2_auth_util_from_optarg(ectx, ctx.key.auth_str,
             &ctx.key.session, false);
     if (!result) {
         LOG_ERR("Invalid key authorization, got\"%s\"", ctx.key.auth_str);
-        goto out;
+        return tool_rc_general_error;
     }
 
-    rc = rsa_decrypt_and_save(ectx);
-out:
+    return rsa_decrypt_and_save(ectx);
+}
 
-    result = tpm2_session_close(&ctx.key.session);
-    if (!result) {
-        rc = tool_rc_general_error;
-    }
-
-    return rc;
+tool_rc tpm2_tool_onstop(ESYS_CONTEXT *ectx) {
+    UNUSED(ectx);
+    return tpm2_session_close(&ctx.key.session);
 }

--- a/tools/tpm2_sign.c
+++ b/tools/tpm2_sign.c
@@ -281,29 +281,24 @@ tool_rc tpm2_tool_onrun(ESYS_CONTEXT *ectx, tpm2_option_flags flags) {
 
     UNUSED(flags);
 
-    int rc = 1;
     bool result = init(ectx);
     if (!result) {
-        goto out;
+        return tool_rc_general_error;
     }
 
     result = tpm2_auth_util_from_optarg(ectx, ctx.key.auth_str,
             &ctx.key.session, false);
     if (!result) {
         LOG_ERR("Invalid key authorization, got\"%s\"", ctx.key.auth_str);
-        goto out;
+        return tool_rc_general_error;
     }
 
-    rc = sign_and_save(ectx);
+    return sign_and_save(ectx);
+}
 
-out:
-
-    result = tpm2_session_close(&ctx.key.session);
-    if (!result) {
-        rc = tool_rc_general_error;
-    }
-
-    return rc;
+tool_rc tpm2_tool_onstop(ESYS_CONTEXT *ectx) {
+    UNUSED(ectx);
+    return tpm2_session_close(&ctx.key.session);
 }
 
 void tpm2_tool_onexit(void) {

--- a/tools/tpm2_startauthsession.c
+++ b/tools/tpm2_startauthsession.c
@@ -158,6 +158,5 @@ tool_rc tpm2_tool_onrun(ESYS_CONTEXT *ectx, tpm2_option_flags flags) {
         return rc;
     }
 
-    return tpm2_session_close(&s) ?
-            tool_rc_success : tool_rc_general_error;
+    return tpm2_session_close(&s);
 }

--- a/tools/tpm2_tool.c
+++ b/tools/tpm2_tool.c
@@ -77,7 +77,7 @@ static ESYS_CONTEXT* ctx_init(TSS2_TCTI_CONTEXT *tcti_ctx) {
  */
 int main(int argc, char *argv[]) {
 
-    int ret = tool_rc_general_error;
+    tool_rc ret = tool_rc_general_error;
 
     tpm2_options *tool_opts = NULL;
     if (tpm2_tool_onstart) {
@@ -137,6 +137,11 @@ int main(int argc, char *argv[]) {
      * 'main'.
      */
     ret = tpm2_tool_onrun(ectx, flags);
+    if (tpm2_tool_onstop) {
+        tool_rc tmp_rc = tpm2_tool_onstop(ectx);
+        /* if onrun() passed, the error code should come from onstop() */
+        ret = ret == tool_rc_success ? tmp_rc : ret;
+    }
     switch(ret) {
         case tool_rc_success:
             /* nothing to do here */

--- a/tools/tpm2_tool.h
+++ b/tools/tpm2_tool.h
@@ -37,6 +37,15 @@ bool tpm2_tool_onstart(tpm2_options **opts) __attribute__((weak));
 tool_rc tpm2_tool_onrun(ESYS_CONTEXT *ectx, tpm2_option_flags flags) __attribute__((weak));
 
 /**
+ * Called after tpm2_tool_onrun() is invoked. ESAPI context is still valid during this call.
+ * @param ectx
+ *  The system/esapi api context.
+ * @return
+ *  A tool_rc indicating status.
+ */
+tool_rc tpm2_tool_onstop(ESYS_CONTEXT *ectx) __attribute__((weak));
+
+/**
  * Called when the tool is exiting, useful for cleanup.
  */
 void tpm2_tool_onexit(void) __attribute__((weak));

--- a/tools/tpm2_unseal.c
+++ b/tools/tpm2_unseal.c
@@ -126,25 +126,21 @@ tool_rc tpm2_tool_onrun(ESYS_CONTEXT *ectx, tpm2_option_flags flags) {
 
     UNUSED(flags);
 
-    tool_rc rc = tool_rc_general_error;
     bool result = init(ectx);
     if (!result) {
-        goto out;
+        return tool_rc_general_error;
     }
 
     result = unseal_and_save(ectx);
     if (!result) {
         LOG_ERR("Unseal failed!");
-        goto out;
+        return tool_rc_general_error;
     }
 
-    rc = tool_rc_success;
-out:
+    return tool_rc_success;
+}
 
-    result = tpm2_session_close(&ctx.session);
-    if (!result) {
-        rc = tool_rc_general_error;
-    }
-
-    return rc;
+tool_rc tpm2_tool_onstop(ESYS_CONTEXT *ectx) {
+    UNUSED(ectx);
+    return tpm2_session_close(&ctx.session);
 }


### PR DESCRIPTION
Convert files_save_tpm_context_to_file() and its companion
files_save_tpm_context_to_path() to return tool_rc's and move
ESYS_* routines to tpm2.c.

Also, the code code tricky to deal with tpm2_session_close(),
so to make this easier, implement issue #1523 and make a callback
that:
 * if onrun() is called, the callback is called.
 * ESAPI has not been torn down
 * records tool_rc issues to pass back to caller
  * onrun() error's take precedence.

Makes progress on: #1193 and #1520

Some small tweaks to make some code paths easier which uncovered
that issue #1457 still had some stragglers.

Fixes: #1523

Signed-off-by: William Roberts <william.c.roberts@intel.com>

Still some more lib work to continue after this:
```
$ grep -lrn Esys_ | grep .\[hc]$
files.c
tpm2_session.c
tpm2_capability.c
tpm2_alg_util.c
tpm2_hierarchy.c
tpm2_policy.h
tpm2_policy.c
files.h
tpm2_util.h
tpm2_util.c
tpm2_ctx_mgmt.c
tpm2_session.h
tpm2_hash.c
tpm2_auth_util.c
pcr.c
```