### PR TITLE
 tpm2_alg_util: add CMAC algorithm

### DIFF
--- a/lib/tpm2_alg_util.c
+++ b/lib/tpm2_alg_util.c
@@ -57,6 +57,7 @@ static void tpm2_alg_util_for_each_alg(alg_iter iterator, void *userdata) {
         // Keyed hash
         { .name = "hmac", .id = TPM2_ALG_HMAC, tpm2_alg_util_flags_keyedhash | tpm2_alg_util_flags_sig },
         { .name = "xor", .id = TPM2_ALG_XOR, tpm2_alg_util_flags_keyedhash },
+        { .name = "cmac", .id = TPM2_ALG_CMAC, .flags = tpm2_alg_util_flags_sig },
 
         // Mask Generation Functions
         { .name = "mgf1", .id = TPM2_ALG_MGF1, .flags = tpm2_alg_util_flags_mgf },

--- a/test/integration/tests/incrementalselftest.sh
+++ b/test/integration/tests/incrementalselftest.sh
@@ -52,8 +52,8 @@ hashalgs="$(populate_algs "details['hash'] and not details['method'] \
                                         and not details['signing'] \
                                         and not details['symmetric'] \
                                         and alg is not None")"
-eccmethods="$(populate_algs "details['signing'] and not details['hash'] and \"rsa\" not in alg")"
-rsamethods="$(populate_algs "details['signing'] and not details['hash'] and \"ec\" not in alg")"
+eccmethods="$(populate_algs "details['signing'] and not details['hash'] and \"ec\" in alg")"
+rsamethods="$(populate_algs "details['signing'] and not details['hash'] and \"rsa\" in alg")"
 
 # Check testing of AES modes
 tpm2_incrementalselftest ${aesmodes} | grep -q "complete"


### PR DESCRIPTION
Add CMAC to the list of known algorithms. This PR requires https://github.com/tpm2-software/tpm2-tss/pull/1437 to be merged first so that `TPM2_ALG_CMAC` is defined. The new algorithm is also accidentally included in `eccmethods` and `rsamethods` in `incrementalselftest.sh`, rework the conditions to avoid that.

These are the minimal changes to fix the test suite for the most recent TPM simulator version 1332, please advise if there are more places within tpm2-tools where the new algorithm needs to be added.

Fixes: #1532