### PR TITLE
[3.X] build: link against tss2-mu

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -22,8 +22,7 @@ AM_CONDITIONAL([HAVE_PANDOC],[test "x${PANDOC}" = "xyes"])
 AM_CONDITIONAL(
     [HAVE_MAN_PAGES],
     [test -d "${srcdir}/man/man1" -o "x${PANDOC}" = "xyes"])
-PKG_CHECK_MODULES([SAPI],[tss2-sys >= 2.0 tss2-sys < 3.0])
-PKG_CHECK_MODULES([SAPI],[tss2-mu >= 2.0 tss2-sys < 3.0])
+PKG_CHECK_MODULES([SAPI],[tss2-sys >= 2.0 tss2-sys < 3.0 tss2-mu >= 2.0 tss2-mu < 3.0])
 PKG_CHECK_MODULES([CRYPTO], [libcrypto >= 1.0.2g])
 PKG_CHECK_MODULES([CURL],[libcurl])
 AC_ARG_ENABLE([unit],


### PR DESCRIPTION
Backport #1512 to 3.X: existence of tss2-mu was already checked, albeit in a separate `PKG_CHECK_MODULES` call, which means that `SAPI_LIBS` only contains `-ltss2-sys` from the first call. Make sure that it contains `-ltss2-mu` as well by using only a single `PKG_CHECK_MODULES` for both libraries.

As per https://github.com/tpm2-software/tpm2-tss/pull/1417#issuecomment-494036214, this should go into the 3.2 release so that building works correctly for tss2-sys ≩ 2.3.