### PR TITLE
test: aes256 key trunctuated in import.sh

### DIFF
--- a/test/integration/tests/import.sh
+++ b/test/integration/tests/import.sh
@@ -23,7 +23,7 @@ start_up
 
 run_aes_import_test() {
 
-	dd if=/dev/urandom of=sym.key bs=1 count=$2 2>/dev/null
+	dd if=/dev/urandom of=sym.key bs=1 count=$3 2>/dev/null
 
 	#Symmetric Key Import Test
 	echo "tpm2_import -Q -G aes -g "$name_alg" -i sym.key -C $1 -u import_key.pub -r import_key.priv"
@@ -38,8 +38,7 @@ run_aes_import_test() {
 
 	tpm2_encryptdecrypt -c import_key.ctx  -i plain.txt -o plain.enc
 
-	openssl enc -in plain.enc -out plain.dec.ssl -d -K `xxd -p sym.key` -iv 0 \
-	-aes-128-cfb
+	openssl enc -in plain.enc -out plain.dec.ssl -d -K `xxd -p sym.key` -iv 0 -$2
 
 	diff plain.txt plain.dec.ssl
 
@@ -138,9 +137,9 @@ run_test() {
 	tpm2_createprimary -Q -G "$parent_alg" -g "$name_alg" -a o -o parent.ctx
 
 	# 128 bit AES is 16 bytes
-	run_aes_import_test parent.ctx 16
+	run_aes_import_test parent.ctx aes-128-cfb 16
 	# 256 bit AES is 32 bytes
-	run_aes_import_test parent.ctx 32
+	run_aes_import_test parent.ctx aes-256-cfb 32
 
 	run_rsa_import_test parent.ctx 1024
     run_rsa_import_test parent.ctx 2048

--- a/test/integration/tests/import.sh
+++ b/test/integration/tests/import.sh
@@ -38,7 +38,7 @@ run_aes_import_test() {
 
 	tpm2_encryptdecrypt -c import_key.ctx  -i plain.txt -o plain.enc
 
-	openssl enc -in plain.enc -out plain.dec.ssl -d -K `xxd -p sym.key` -iv 0 -$2
+	openssl enc -in plain.enc -out plain.dec.ssl -d -K `xxd -c 256 -p sym.key` -iv 0 -$2
 
 	diff plain.txt plain.dec.ssl
 

--- a/test/integration/tests/import.sh
+++ b/test/integration/tests/import.sh
@@ -142,9 +142,9 @@ run_test() {
 	run_aes_import_test parent.ctx aes-256-cfb 32
 
 	run_rsa_import_test parent.ctx 1024
-    run_rsa_import_test parent.ctx 2048
+	run_rsa_import_test parent.ctx 2048
 
-    run_ecc_import_test parent.ctx prime256v1
+	run_ecc_import_test parent.ctx prime256v1
 }
 
 #


### PR DESCRIPTION
In the test `import.sh`, the decryption was broken due to two problems:

- `openssl enc` expects the ciphername as a parameter (either `-aes-128-cfb` or `-aes-256-cfb`). Previously we always passed `-aes-128-cfb` (which broke decryption for aes256)
- `xxd` is used to convert binary data into a hex string. However, `xxd` eventually breaks the line. To prevent this, `-c 256` is added to be able to convert to up to 256 chars without line break. Fixes #1146 

Also, a minor indentation issue is fixed.

Unfortunately, this test passed even if it was broken. This is due to the fact that bash traps are not inherited to bash functions. See #1535.