### PR TITLE
continue work on exit codes and update tpm2_create to a new interface

### DIFF
--- a/lib/object.c
+++ b/lib/object.c
@@ -1,0 +1,87 @@
+#include <stdbool.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include <tss2/tss2_esys.h>
+
+#include "files.h"
+#include "log.h"
+#include "object.h"
+#include "tpm2_auth_util.h"
+
+#define FILE_PREFIX "file:"
+#define FILE_PREFIX_LEN (sizeof(FILE_PREFIX) - 1)
+
+#define NULL_OBJECT "null"
+#define NULL_OBJECT_LEN (sizeof(NULL_OBJECT) - 1)
+
+static tool_rc tpm2_util_object_load2(
+            ESYS_CONTEXT *ctx,
+            const char *objectstr,
+            const char *auth,
+            bool do_auth,
+            tpm2_loaded_object *outobject) {
+
+    if (do_auth) {
+        tpm2_session *s = NULL;
+        tool_rc rc = tpm2_auth_util_from_optarg(ctx, auth, &s, false);
+        if (rc != tool_rc_success) {
+            return rc;
+        }
+
+        outobject->session = s;
+    }
+
+    // 0. If objecstr is NULL return error
+    if (!objectstr) {
+        LOG_ERR("tpm2_util_object_load called with empty objectstr parameter");
+        return tool_rc_general_error;
+    }
+
+    // 1. If the objectstr starts with a file: prefix, treat as a context file
+    bool starts_with_file = !strncmp(objectstr, FILE_PREFIX, FILE_PREFIX_LEN);
+    if (starts_with_file) {
+        outobject->handle = 0;
+        outobject->path = objectstr += FILE_PREFIX_LEN;
+        return files_load_tpm_context_from_path(ctx,
+                &outobject->tr_handle, outobject->path);
+    }
+
+    // 2. If the objstr is "null" set the handle to RH_NULL
+    bool is_rh_null = !strncmp(objectstr, NULL_OBJECT, NULL_OBJECT_LEN);
+    if (is_rh_null){
+        outobject->path = NULL;
+        outobject->tr_handle = ESYS_TR_RH_NULL;
+        outobject->handle = TPM2_RH_NULL;
+        return tool_rc_success;
+    }
+
+    // 3. Try to load objectstr as a TPM2_HANDLE
+    bool result = tpm2_util_string_to_uint32(objectstr,
+                    &outobject->handle);
+    if (result) {
+        outobject->path = NULL;
+        return tpm2_util_sys_handle_to_esys_handle(ctx, outobject->handle, &outobject->tr_handle);
+    }
+
+    // 4. we must assume the whole value is a file path
+    outobject->handle = 0;
+    outobject->path = objectstr;
+    return files_load_tpm_context_from_path(ctx,
+            &outobject->tr_handle, outobject->path);
+}
+
+tool_rc tpm2_util_object_load(ESYS_CONTEXT *ctx,
+            const char *objectstr, tpm2_loaded_object *outobject) {
+
+    return tpm2_util_object_load2(ctx, objectstr, NULL, false, outobject);
+}
+
+tool_rc tpm2_util_object_load_auth(
+            ESYS_CONTEXT *ctx,
+            const char *objectstr,
+            const char *auth,
+            tpm2_loaded_object *outobject) {
+
+    return tpm2_util_object_load2(ctx, objectstr, auth, true, outobject);
+}

--- a/lib/object.h
+++ b/lib/object.h
@@ -1,0 +1,60 @@
+#ifndef LIB_OBJECT_H_
+#define LIB_OBJECT_H_
+
+#include "tpm2_error.h"
+#include "tpm2_session.h"
+
+typedef struct tpm2_loaded_object tpm2_loaded_object;
+struct tpm2_loaded_object {
+    TPM2_HANDLE handle;
+    ESYS_TR tr_handle;
+    const char *path;
+    tpm2_session *session;
+};
+
+
+/**
+ * Parses a string representation of a context object, either a file or handle,
+ * and loads the context object ensuring the handle member of the out object is
+ * set.
+ * The objectstr will recognised as a context file when prefixed with "file:"
+ * or should the value not be parsable as a handle number (as understood by
+ * strtoul()).
+ * @param ctx
+ * a TSS ESAPI context.
+ * @param objectstr
+ * The string representation of the object to be loaded.
+ * @param outobject
+ * A *tpm2_loaded_object* with a loaded handle. The path member will also be
+ * set when the *objectstr* is a context file.
+ * @return
+ *  tool_rc indicating status.
+ *
+ */
+tool_rc tpm2_util_object_load(ESYS_CONTEXT *ctx,
+                        const char *objectstr, tpm2_loaded_object *outobject);
+
+/**
+ * Same as tpm2_util_object_load but allows the auth string value to be populated
+ * as a session associated with the object.
+ * @param ctx
+ * a TSS ESAPI context.
+ * @param objectstr
+ * The string representation of the object to be loaded.
+ * @param auth
+ * The auth string for the object.
+ * @param outobject
+ * A *tpm2_loaded_object* with a loaded handle. The path member will also be
+ * set when the *objectstr* is a context file.
+ * @return
+ *  tool_rc indicating status.
+ * @return
+ *  tool_rc indicating status
+ */
+tool_rc tpm2_util_object_load_auth(
+            ESYS_CONTEXT *ctx,
+            const char *objectstr,
+            const char *auth,
+            tpm2_loaded_object *outobject);
+
+#endif /* LIB_OBJECT_H_ */

--- a/lib/tpm2.c
+++ b/lib/tpm2.c
@@ -691,6 +691,25 @@ tool_rc tpm2_mu_tpm2_handle_unmarshal(
     return tool_rc_success;
 }
 
+tool_rc tpm2_mu_tpmt_public_marshal(
+    TPMT_PUBLIC    const *src,
+    uint8_t        buffer[],
+    size_t         buffer_size,
+    size_t         *offset) {
+
+    TSS2_RC rval = Tss2_MU_TPMT_PUBLIC_Marshal(
+        src,
+        buffer,
+        buffer_size,
+        offset);
+    if (rval != TSS2_RC_SUCCESS) {
+        LOG_PERR(Tss2_MU_TPMT_PUBLIC_Marshal, rval);
+        return tool_rc_from_tpm(rval);
+    }
+
+    return tool_rc_success;
+}
+
 tool_rc tpm2_evictcontrol(
     ESYS_CONTEXT *esysContext,
     ESYS_TR auth,
@@ -835,6 +854,76 @@ tool_rc tpm2_tr_set_auth(
         authValue);
     if (rval != TSS2_RC_SUCCESS) {
         LOG_PERR(Esys_SequenceComplete, rval);
+        return tool_rc_from_tpm(rval);
+    }
+
+    return tool_rc_success;
+}
+
+tool_rc tpm2_create(
+        ESYS_CONTEXT *esysContext,
+        ESYS_TR parentHandle,
+        ESYS_TR shandle1,
+        ESYS_TR shandle2,
+        ESYS_TR shandle3,
+        const TPM2B_SENSITIVE_CREATE *inSensitive,
+        const TPM2B_PUBLIC *inPublic,
+        const TPM2B_DATA *outsideInfo,
+        const TPML_PCR_SELECTION *creationPCR,
+        TPM2B_PRIVATE **outPrivate,
+        TPM2B_PUBLIC **outPublic,
+        TPM2B_CREATION_DATA **creationData,
+        TPM2B_DIGEST **creationHash,
+        TPMT_TK_CREATION **creationTicket) {
+
+    TSS2_RC rval = Esys_Create(
+        esysContext,
+        parentHandle,
+        shandle1,
+        shandle2,
+        shandle3,
+        inSensitive,
+        inPublic,
+        outsideInfo,
+        creationPCR,
+        outPrivate,
+        outPublic,
+        creationData,
+        creationHash,
+        creationTicket);
+    if (rval != TSS2_RC_SUCCESS) {
+        LOG_PERR(Esys_Create, rval);
+        return tool_rc_from_tpm(rval);
+    }
+
+    return tool_rc_success;
+}
+
+tool_rc tpm2_create_loaded(
+            ESYS_CONTEXT *esysContext,
+            ESYS_TR parentHandle,
+            ESYS_TR shandle1,
+            ESYS_TR shandle2,
+            ESYS_TR shandle3,
+            const TPM2B_SENSITIVE_CREATE *inSensitive,
+            const TPM2B_TEMPLATE *inPublic,
+            ESYS_TR *objectHandle,
+            TPM2B_PRIVATE **outPrivate,
+            TPM2B_PUBLIC **outPublic) {
+
+    TSS2_RC rval = Esys_CreateLoaded(
+        esysContext,
+        parentHandle,
+        shandle1,
+        shandle2,
+        shandle3,
+        inSensitive,
+        inPublic,
+        objectHandle,
+        outPrivate,
+        outPublic);
+    if (rval != TSS2_RC_SUCCESS) {
+        LOG_PERR(Esys_CreateLoaded, rval);
         return tool_rc_from_tpm(rval);
     }
 

--- a/lib/tpm2.h
+++ b/lib/tpm2.h
@@ -5,7 +5,8 @@
 
 #include <tss2/tss2_esys.h>
 
-#include "tpm2_tool.h"
+#include "object.h"
+#include "tpm2_error.h"
 
 tool_rc tpm2_from_tpm_public(
             ESYS_CONTEXT *esysContext,
@@ -309,10 +310,7 @@ tool_rc tpm2_tr_set_auth(
 
 tool_rc tpm2_create(
     ESYS_CONTEXT *esysContext,
-    ESYS_TR parentHandle,
-    ESYS_TR shandle1,
-    ESYS_TR shandle2,
-    ESYS_TR shandle3,
+    tpm2_loaded_object *parent_obj,
     const TPM2B_SENSITIVE_CREATE *inSensitive,
     const TPM2B_PUBLIC *inPublic,
     const TPM2B_DATA *outsideInfo,
@@ -324,15 +322,12 @@ tool_rc tpm2_create(
     TPMT_TK_CREATION **creationTicket);
 
 tool_rc tpm2_create_loaded(
-            ESYS_CONTEXT *esysContext,
-            ESYS_TR parentHandle,
-            ESYS_TR shandle1,
-            ESYS_TR shandle2,
-            ESYS_TR shandle3,
-            const TPM2B_SENSITIVE_CREATE *inSensitive,
-            const TPM2B_TEMPLATE *inPublic,
-            ESYS_TR *objectHandle,
-            TPM2B_PRIVATE **outPrivate,
-            TPM2B_PUBLIC **outPublic);
+    ESYS_CONTEXT *esysContext,
+    tpm2_loaded_object *parent_obj,
+    const TPM2B_SENSITIVE_CREATE *inSensitive,
+    const TPM2B_TEMPLATE *inPublic,
+    ESYS_TR *objectHandle,
+    TPM2B_PRIVATE **outPrivate,
+    TPM2B_PUBLIC **outPublic);
 
 #endif /* LIB_TPM2_H_ */

--- a/lib/tpm2.h
+++ b/lib/tpm2.h
@@ -247,6 +247,12 @@ tool_rc tpm2_mu_tpm2_handle_unmarshal(
     size_t          *offset,
     TPM2_HANDLE     *out);
 
+tool_rc tpm2_mu_tpmt_public_marshal(
+    TPMT_PUBLIC    const *src,
+    uint8_t        buffer[],
+    size_t         buffer_size,
+    size_t         *offset);
+
 tool_rc tpm2_evictcontrol(
     ESYS_CONTEXT *esysContext,
     ESYS_TR auth,
@@ -300,5 +306,33 @@ tool_rc tpm2_tr_set_auth(
     ESYS_CONTEXT *esysContext,
     ESYS_TR handle,
     TPM2B_AUTH const *authValue);
+
+tool_rc tpm2_create(
+    ESYS_CONTEXT *esysContext,
+    ESYS_TR parentHandle,
+    ESYS_TR shandle1,
+    ESYS_TR shandle2,
+    ESYS_TR shandle3,
+    const TPM2B_SENSITIVE_CREATE *inSensitive,
+    const TPM2B_PUBLIC *inPublic,
+    const TPM2B_DATA *outsideInfo,
+    const TPML_PCR_SELECTION *creationPCR,
+    TPM2B_PRIVATE **outPrivate,
+    TPM2B_PUBLIC **outPublic,
+    TPM2B_CREATION_DATA **creationData,
+    TPM2B_DIGEST **creationHash,
+    TPMT_TK_CREATION **creationTicket);
+
+tool_rc tpm2_create_loaded(
+            ESYS_CONTEXT *esysContext,
+            ESYS_TR parentHandle,
+            ESYS_TR shandle1,
+            ESYS_TR shandle2,
+            ESYS_TR shandle3,
+            const TPM2B_SENSITIVE_CREATE *inSensitive,
+            const TPM2B_TEMPLATE *inPublic,
+            ESYS_TR *objectHandle,
+            TPM2B_PRIVATE **outPrivate,
+            TPM2B_PUBLIC **outPublic);
 
 #endif /* LIB_TPM2_H_ */

--- a/lib/tpm2_util.h
+++ b/lib/tpm2_util.h
@@ -10,6 +10,7 @@
 #include <tss2/tss2_esys.h>
 
 #include "tpm2_error.h"
+#include "tpm2_session.h"
 
 #if defined (__GNUC__)
 #define COMPILER_ATTR(...) __attribute__((__VA_ARGS__))
@@ -86,14 +87,6 @@ typedef struct {
     UINT16 size;
     BYTE buffer[0];
 } TPM2B;
-
-typedef struct tpm2_loaded_object tpm2_loaded_object;
-struct tpm2_loaded_object {
-    TPM2_HANDLE handle;
-    ESYS_TR tr_handle;
-    const char *path;
-};
-
 
 int tpm2_util_hex_to_byte_structure(const char *inStr, UINT16 *byteLength, BYTE *byteBuffer);
 
@@ -314,27 +307,6 @@ void tpm2_util_public_to_yaml(TPM2B_PUBLIC *public, char *indent);
  *  The level of indentation, can be NULL
  */
 void tpm2_util_tpma_object_to_yaml(TPMA_OBJECT obj, char *indent);
-
-/**
- * Parses a string representation of a context object, either a file or handle,
- * and loads the context object ensuring the handle member of the out object is
- * set.
- * The objectstr will recognised as a context file when prefixed with "file:"
- * or should the value not be parsable as a handle number (as understood by
- * strtoul()).
- * @param ctx
- * a TSS ESAPI context.
- * @param objectstr
- * The string representation of the object to be loaded.
- * @param outobject
- * A *tpm2_loaded_object* with a loaded handle. The path member will also be
- * set when the *objectstr* is a context file.
- * @return
- *  tool_rc indicating status.
- *
- */
-tool_rc tpm2_util_object_load(ESYS_CONTEXT *ctx,
-                        const char *objectstr, tpm2_loaded_object *outobject);
 
 /**
  * Calculates the unique public field. The unique public field is the digest, based on name algorithm

--- a/tools/misc/tpm2_checkquote.c
+++ b/tools/misc/tpm2_checkquote.c
@@ -11,6 +11,7 @@
 
 #include "files.h"
 #include "log.h"
+#include "object.h"
 #include "pcr.h"
 #include "tpm2_alg_util.h"
 #include "tpm2_convert.h"

--- a/tools/tpm2_activatecredential.c
+++ b/tools/tpm2_activatecredential.c
@@ -14,6 +14,7 @@
 
 #include "files.h"
 #include "log.h"
+#include "object.h"
 #include "tpm2_auth_util.h"
 #include "tpm2_error.h"
 #include "tpm2_options.h"

--- a/tools/tpm2_certify.c
+++ b/tools/tpm2_certify.c
@@ -10,6 +10,7 @@
 
 #include "files.h"
 #include "log.h"
+#include "object.h"
 #include "tpm2.h"
 #include "tpm2_alg_util.h"
 #include "tpm2_auth_util.h"

--- a/tools/tpm2_changeauth.c
+++ b/tools/tpm2_changeauth.c
@@ -8,6 +8,7 @@
 
 #include "files.h"
 #include "log.h"
+#include "object.h"
 #include "tpm2_auth_util.h"
 #include "tpm2_options.h"
 #include "tpm2_session.h"

--- a/tools/tpm2_createak.c
+++ b/tools/tpm2_createak.c
@@ -14,6 +14,7 @@
 #include "tpm2_auth_util.h"
 #include "files.h"
 #include "log.h"
+#include "object.h"
 #include "tpm2_util.h"
 #include "tpm2_session.h"
 #include "tpm2_alg_util.h"

--- a/tools/tpm2_duplicate.c
+++ b/tools/tpm2_duplicate.c
@@ -7,6 +7,7 @@
 #include <tss2/tss2_esys.h>
 
 #include "log.h"
+#include "object.h"
 #include "files.h"
 #include "tpm2_alg_util.h"
 #include "tpm2_auth_util.h"

--- a/tools/tpm2_encryptdecrypt.c
+++ b/tools/tpm2_encryptdecrypt.c
@@ -12,6 +12,7 @@
 
 #include "files.h"
 #include "log.h"
+#include "object.h"
 #include "tpm2.h"
 #include "tpm2_alg_util.h"
 #include "tpm2_auth_util.h"

--- a/tools/tpm2_evictcontrol.c
+++ b/tools/tpm2_evictcontrol.c
@@ -13,6 +13,7 @@
 
 #include "files.h"
 #include "log.h"
+#include "object.h"
 #include "tpm2_auth_util.h"
 #include "tpm2_capability.h"
 #include "tpm2_ctx_mgmt.h"

--- a/tools/tpm2_flushcontext.c
+++ b/tools/tpm2_flushcontext.c
@@ -7,6 +7,7 @@
 #include <tss2/tss2_esys.h>
 
 #include "log.h"
+#include "object.h"
 #include "tpm2_capability.h"
 #include "tpm2_options.h"
 #include "tpm2_session.h"

--- a/tools/tpm2_hmac.c
+++ b/tools/tpm2_hmac.c
@@ -12,6 +12,7 @@
 
 #include "files.h"
 #include "log.h"
+#include "object.h"
 #include "tpm2_alg_util.h"
 #include "tpm2_auth_util.h"
 #include "tpm2_options.h"

--- a/tools/tpm2_import.c
+++ b/tools/tpm2_import.c
@@ -30,8 +30,9 @@
 #include <tss2/tss2_esys.h>
 #include <tss2/tss2_mu.h>
 
-#include "log.h"
 #include "files.h"
+#include "log.h"
+#include "object.h"
 #include "tpm2.h"
 #include "tpm2_alg_util.h"
 #include "tpm2_auth_util.h"

--- a/tools/tpm2_load.c
+++ b/tools/tpm2_load.c
@@ -13,6 +13,7 @@
 
 #include "files.h"
 #include "log.h"
+#include "object.h"
 #include "tpm2_auth_util.h"
 #include "tpm2_options.h"
 #include "tpm2_session.h"

--- a/tools/tpm2_policysecret.c
+++ b/tools/tpm2_policysecret.c
@@ -6,6 +6,7 @@
 
 #include "files.h"
 #include "log.h"
+#include "object.h"
 #include "tpm2_auth_util.h"
 #include "tpm2_hierarchy.h"
 #include "tpm2_options.h"

--- a/tools/tpm2_quote.c
+++ b/tools/tpm2_quote.c
@@ -10,6 +10,7 @@
 #include "tpm2_convert.h"
 #include "files.h"
 #include "log.h"
+#include "object.h"
 #include "pcr.h"
 #include "tpm2_alg_util.h"
 #include "tpm2_auth_util.h"

--- a/tools/tpm2_readpublic.c
+++ b/tools/tpm2_readpublic.c
@@ -9,6 +9,7 @@
 #include "tpm2_convert.h"
 #include "files.h"
 #include "log.h"
+#include "object.h"
 #include "tpm2.h"
 #include "tpm2_alg_util.h"
 #include "tpm2_attr_util.h"

--- a/tools/tpm2_rsadecrypt.c
+++ b/tools/tpm2_rsadecrypt.c
@@ -8,6 +8,7 @@
 
 #include "files.h"
 #include "log.h"
+#include "object.h"
 #include "tpm2_auth_util.h"
 #include "tpm2_options.h"
 #include "tpm2_session.h"

--- a/tools/tpm2_rsaencrypt.c
+++ b/tools/tpm2_rsaencrypt.c
@@ -9,6 +9,7 @@
 
 #include "files.h"
 #include "log.h"
+#include "object.h"
 #include "tpm2_options.h"
 #include "tpm2_tool.h"
 #include "tpm2_util.h"

--- a/tools/tpm2_sign.c
+++ b/tools/tpm2_sign.c
@@ -11,6 +11,7 @@
 
 #include "files.h"
 #include "log.h"
+#include "object.h"
 #include "tpm2_auth_util.h"
 #include "tpm2_convert.h"
 #include "tpm2_hash.h"

--- a/tools/tpm2_startauthsession.c
+++ b/tools/tpm2_startauthsession.c
@@ -13,6 +13,7 @@
 
 #include "files.h"
 #include "log.h"
+#include "object.h"
 #include "tpm2_alg_util.h"
 #include "tpm2_options.h"
 #include "tpm2_session.h"

--- a/tools/tpm2_unseal.c
+++ b/tools/tpm2_unseal.c
@@ -9,6 +9,7 @@
 
 #include "files.h"
 #include "log.h"
+#include "object.h"
 #include "pcr.h"
 #include "tpm2_auth_util.h"
 #include "tpm2_hash.h"

--- a/tools/tpm2_verifysignature.c
+++ b/tools/tpm2_verifysignature.c
@@ -8,6 +8,7 @@
 
 #include "files.h"
 #include "log.h"
+#include "object.h"
 #include "tpm2_alg_util.h"
 #include "tpm2_convert.h"
 #include "tpm2_hash.h"


### PR DESCRIPTION
This PR continues work on plumbing back the Esys_ and TSS2_ calls to a flattened RC and moving the calls into tpm2.c so we can ensure consistent error logging and error returns across tooling (#1193). Additionally it starts looking at #1539 and places the tpm2_session data for an object in the object itself and moves the logic for converting these data structures to Esys ones inside the tpm2.c calls for create and createloaded.