### PR TITLE
Tests might not fail since traps are not inherited to bash functions

### DIFF
--- a/man/tpm2_loadexternal.1.md
+++ b/man/tpm2_loadexternal.1.md
@@ -137,7 +137,7 @@ name: 0x000b44e59fa5658ab443834a069a488ecc1f6d7deb47c40c6ec49871ef57d7036b43
 
 # EXAMPLES
 
-## Load a TPM generateed public key into the *owner* hierarchy
+## Load a TPM generated public key into the *owner* hierarchy
 ```
 tpm2_create -G rsa -u pub.dat -r priv.dat
 

--- a/test/integration/helpers.sh
+++ b/test/integration/helpers.sh
@@ -87,12 +87,11 @@ pyscript
 #
 # Given a file as argument 1, prints the value of the key
 # provided as argument 2 and optionally argument 3 (for nested maps).
-# Note that if key is a string, pass the quotes. This allows lookups
-# on string or numerical keys.
+# Note that all names and values are parsed as strings.
 #
 function yaml_get_kv() {
 
-    third_arg=\"\"
+    third_arg=""
     if [ $# -eq 3 ]; then
         third_arg=$3
     fi
@@ -105,11 +104,11 @@ import yaml
 
 with open("$1") as f:
     try:
-        y = yaml.safe_load(f)
+        y = yaml.load(f, Loader=yaml.BaseLoader)
         if $# == 3:
-            print(y[$2][$third_arg])
+            print(y["$2"]["$third_arg"])
         else:
-            print(y[$2])
+            print(y["$2"])
     except yaml.YAMLError as exc:
         sys.exit(exc)
 pyscript

--- a/test/integration/helpers.sh
+++ b/test/integration/helpers.sh
@@ -337,13 +337,18 @@ onerror() {
 }
 trap onerror ERR
 
+#
+# print 0 if the list of arguments 1 to n-1 contains the last argument n
+# print 1 otherwise
+#
 function ina() {
     local n=$#
     local value=${!n}
     for ((i=1;i < $#;i++)) {
         if [ "${!i}" == "${value}" ]; then
-            return 0
+            echo 0
+            return
         fi
     }
-    return 1
+    echo 1
 }

--- a/test/integration/helpers.sh
+++ b/test/integration/helpers.sh
@@ -1,6 +1,8 @@
 #!/bin/bash
 # SPDX-License-Identifier: BSD-3-Clause
 
+set -E
+
 function filter_algs_by() {
 
 python << pyscript

--- a/test/integration/tests/activecredential.sh
+++ b/test/integration/tests/activecredential.sh
@@ -8,7 +8,7 @@ cleanup() {
 
     # Evict persistent handles, we want them to always succeed and never trip
     # the onerror trap.
-	tpm2_evictcontrol -Q -a o -c 0x81010009 2>/dev/null || true
+    tpm2_evictcontrol -Q -a o -c 0x81010009 2>/dev/null || true
 
     if [ "$1" != "no-shut-down" ]; then
         shut_down
@@ -25,7 +25,7 @@ echo "12345678" > secret.data
 tpm2_createek -Q -c 0x81010009 -G rsa -p ek.pub
 
 tpm2_createak -C 0x81010009 -c ak.ctx -G rsa -D sha256 -s rsassa -p ak.pub\
-	-n ak.name -P akpass> ak.out
+    -n ak.name -P akpass> ak.out
 
 # Capture the yaml output and verify that its the same as the name output
 loaded_key_name_yaml=`python << pyscript
@@ -47,6 +47,6 @@ test "$loaded_key_name_yaml" == "$loaded_key_name"
 tpm2_makecredential -Q -e ek.pub  -s secret.data -n $loaded_key_name -o mkcred.out
 
 tpm2_activatecredential -Q -c ak.ctx -C 0x81010009 -i mkcred.out -o actcred.out\
-	-P akpass
+    -P akpass
 
 exit 0

--- a/test/integration/tests/attestation.sh
+++ b/test/integration/tests/attestation.sh
@@ -45,8 +45,7 @@ cleanup() {
 
   tpm2_changeauth -Q -W "$ownerpw" -E "$endorsepw" 2>/dev/null || true
 
-  ina "$@" "no-shut-down"
-  if [ $? -ne 0 ]; then
+  if [ $(ina "$@" "no-shut-down") -ne 0 ]; then
     shut_down
   fi
 }

--- a/test/integration/tests/checkquote.sh
+++ b/test/integration/tests/checkquote.sh
@@ -26,7 +26,7 @@ cleanup() {
   rm -f $output_ek_pub_pem \
         $output_ak_pub_pem $output_ak_pub_name \
         $output_quote $output_quotesig $output_quotepcr rand.out \
-	    $ak_ctx
+        $ak_ctx
 
   tpm2_pcrreset 16
   tpm2_evictcontrol -a o -c $handle_ek -P "$ownerpw" 2>/dev/null || true

--- a/test/integration/tests/checkquote.sh
+++ b/test/integration/tests/checkquote.sh
@@ -34,8 +34,7 @@ cleanup() {
 
   tpm2_changeauth -W "$ownerpw" -E "$endorsepw" 2>/dev/null || true
 
-  ina "$@" "no-shut-down"
-  if [ $? -ne 0 ]; then
+  if [ $(ina "$@" "no-shut-down") -ne 0 ]; then
     shut_down
     echo "shutdown"
   fi

--- a/test/integration/tests/create.sh
+++ b/test/integration/tests/create.sh
@@ -6,15 +6,13 @@ source helpers.sh
 cleanup() {
   rm -f key.pub key.priv policy.bin out.pub key.ctx
 
-  ina "$@" "keep-context"
-  if [ $? -ne 0 ]; then
+  if [ $(ina "$@" "keep-context") -ne 0 ]; then
     rm -f context.out
   fi
 
   rm -f key*.ctx out.yaml
 
-  ina "$@" "no-shut-down"
-  if [ $? -ne 0 ]; then
+  if [ $(ina "$@" "no-shut-down") -ne 0 ]; then
     shut_down
   fi
 }

--- a/test/integration/tests/create.sh
+++ b/test/integration/tests/create.sh
@@ -42,7 +42,7 @@ echo "$policy_orig" | xxd -r -p > policy.bin
 tpm2_create -C context.out -g sha256 -G 0x1 -L policy.bin -u key.pub -r key.priv \
   -b 'sign|fixedtpm|fixedparent|sensitivedataorigin' > out.pub
 
-policy_new=$(yaml_get_kv out.pub \"authorization\ policy\")
+policy_new=$(yaml_get_kv out.pub "authorization policy")
 
 test "$policy_orig" == "$policy_new"
 
@@ -52,16 +52,16 @@ test "$policy_orig" == "$policy_new"
 tpm2_create -Q -C context.out -g sha256 -G aes256cbc -u key.pub -r key.priv
 tpm2_load -Q -C context.out -u key.pub -r key.priv -o key1.ctx
 tpm2_readpublic -c key1.ctx > out.yaml
-keybits=$(yaml_get_kv out.yaml \"sym-keybits\")
-mode=$(yaml_get_kv out.yaml \"sym-mode\" \"value\")
+keybits=$(yaml_get_kv out.yaml "sym-keybits")
+mode=$(yaml_get_kv out.yaml "sym-mode" "value")
 test "$keybits" -eq "256"
 test "$mode" == "cbc"
 
 tpm2_create -Q -C context.out -g sha256 -G aes128ofb -u key.pub -r key.priv
 tpm2_load -Q -C context.out -u key.pub -r key.priv -o key2.ctx
 tpm2_readpublic -c key2.ctx > out.yaml
-keybits=$(yaml_get_kv out.yaml \"sym-keybits\")
-mode=$(yaml_get_kv out.yaml \"sym-mode\" \"value\")
+keybits=$(yaml_get_kv out.yaml "sym-keybits")
+mode=$(yaml_get_kv out.yaml "sym-mode" "value")
 test "$keybits" -eq "128"
 test "$mode" == "ofb"
 

--- a/test/integration/tests/createak.sh
+++ b/test/integration/tests/createak.sh
@@ -31,7 +31,7 @@ tpm2_createak -Q -C 0x8101000b -c ak.ctx -G rsa -D sha256 -s rsassa -p ak.pub -n
 # Find a vacant persistent handle
 tpm2_createak -C 0x8101000b -c ak.ctx -G rsa -D sha256 -s rsassa -p ak.pub -n ak.name
 tpm2_evictcontrol -c ak.ctx > ak.log
-phandle=`yaml_get_kv ak.log \"persistent\-handle\"`
+phandle=`yaml_get_kv ak.log "persistent-handle"`
 tpm2_evictcontrol -Q -a o -c $phandle
 
 # Test tpm2_createak with endorsement password

--- a/test/integration/tests/createek.sh
+++ b/test/integration/tests/createek.sh
@@ -25,7 +25,7 @@ tpm2_createek -c 0x81010005 -G rsa -p ek.pub
 cleanup "no-shut-down"
 
 tpm2_createek -c - -G rsa -p ek.pub > ek.log
-phandle=`yaml_get_kv ek.log \"persistent\-handle\"`
+phandle=`yaml_get_kv ek.log "persistent-handle"`
 tpm2_evictcontrol -Q -a o -c $phandle
 
 cleanup "no-shut-down"

--- a/test/integration/tests/createprimary.sh
+++ b/test/integration/tests/createprimary.sh
@@ -9,13 +9,11 @@ cleanup() {
 
   rm -f policy.bin obj.pub pub.out primary.ctx
 
-  ina "$@" "keep-context"
-  if [ $? -ne 0 ]; then
+  if [ $(ina "$@" "keep-context") -ne 0 ]; then
     rm -f context.out
   fi
 
-  ina "$@" "no-shut-down"
-  if [ $? -ne 0 ]; then
+  if [ $(ina "$@" "no-shut-down") -ne 0 ]; then
     shut_down
   fi
 }

--- a/test/integration/tests/createprimary.sh
+++ b/test/integration/tests/createprimary.sh
@@ -45,7 +45,7 @@ tpm2_createprimary -Q -a o -G rsa -g sha256 -o context.out -L policy.bin \
 
 tpm2_readpublic -c context.out > pub.out
 
-policy_new=$(yaml_get_kv pub.out \"authorization\ policy\")
+policy_new=$(yaml_get_kv pub.out "authorization policy")
 
 test "$policy_orig" == "$policy_new"
 

--- a/test/integration/tests/dictionarylockout.sh
+++ b/test/integration/tests/dictionarylockout.sh
@@ -20,19 +20,19 @@ tpm2_dictionarylockout -Q -V -c &>/dev/null
 tpm2_dictionarylockout -s -n 5 -t 6 -l 7
 
 tpm2_getcap -c properties-variable > $out
-v=$(yaml_get_kv "$out" \"TPM2_PT_MAX_AUTH_FAIL\")
+v=$(yaml_get_kv "$out" "TPM2_PT_MAX_AUTH_FAIL")
 if [ $v -ne 5 ];then
   echo "Failure: setting up the number of allowed tries in the lockout parameters"
   exit 1
 fi
 
-v=$(yaml_get_kv "$out" \"TPM2_PT_LOCKOUT_INTERVAL\")
+v=$(yaml_get_kv "$out" "TPM2_PT_LOCKOUT_INTERVAL")
 if [ $v -ne 6 ];then
   echo "Failure: setting up the lockout period in the lockout parameters"
   exit 1
 fi
 
-v=$(yaml_get_kv "$out" \"TPM2_PT_LOCKOUT_RECOVERY\")
+v=$(yaml_get_kv "$out" "TPM2_PT_LOCKOUT_RECOVERY")
 if [ $v -ne 7 ];then
   echo "Failure: setting up the lockout recovery period in the lockout parameters"
   exit 1

--- a/test/integration/tests/evictcontrol.sh
+++ b/test/integration/tests/evictcontrol.sh
@@ -37,7 +37,7 @@ tpm2_evictcontrol -Q -a o -c 0x81010003
 
 # Load the context into an available handle, delete it
 tpm2_evictcontrol -a o -c key.dat > evict.log
-phandle=$(yaml_get_kv evict.log \"persistent-handle\")
+phandle=$(yaml_get_kv evict.log "persistent-handle")
 tpm2_evictcontrol -Q -a o -c $phandle
 
 yaml_verify evict.log

--- a/test/integration/tests/getmanufec.sh
+++ b/test/integration/tests/getmanufec.sh
@@ -55,7 +55,7 @@ fi
 # Test with automatic persistent handle
 tpm2_getmanufec -H - -U -E ECcert2.bin -o test_ek.pub -w $opass -e $epass \
                 https://ekop.intel.com/ekcertservice/ > man.log
-phandle=`yaml_get_kv man.log \"persistent\-handle\"`
+phandle=`yaml_get_kv man.log "persistent-handle"`
 
 tpm2_evictcontrol -Q -c $phandle -a o -P $opass
 

--- a/test/integration/tests/gettestresult.sh
+++ b/test/integration/tests/gettestresult.sh
@@ -18,6 +18,6 @@ tempfile=$(mktemp)
 
 # Verify that tests have succeeded
 tpm2_gettestresult > "${tempfile}"
-yaml_get_kv "${tempfile}" \"status\" | grep "success"
+yaml_get_kv "${tempfile}" "status" | grep "success"
 
 exit 0

--- a/test/integration/tests/hmac.sh
+++ b/test/integration/tests/hmac.sh
@@ -23,16 +23,14 @@ cleanup() {
   rm -f $file_primary_key_ctx $file_hmac_key_pub $file_hmac_key_priv \
         $file_hmac_key_name $file_hmac_output
 
-  ina "$@" "keep-context"
-  if [ $? -ne 0 ]; then
+  if [ $(ina "$@" "keep-context") -ne 0 ]; then
     rm -f $file_hmac_key_ctx $file_input_data
     # attempt to evict the hmac persistent key handle, but don't cause failures if this fails
     # as it may not be loaded.
     tpm2_evictcontrol -c $file_hmac_key_handle 2>/dev/null || true
   fi
 
-  ina "$@" "no-shut-down"
-  if [ $? -ne 0 ]; then
+  if [ $(ina "$@" "no-shut-down") -ne 0 ]; then
     shut_down
   fi
 }

--- a/test/integration/tests/incrementalselftest.sh
+++ b/test/integration/tests/incrementalselftest.sh
@@ -19,7 +19,7 @@ cleanup "no-shut-down"
 temp=$(mktemp)
 tpm2_incrementalselftest > "${temp}"
 cat ${temp}
-alglist="$(yaml_get_kv "${temp}" \"remaining\" || true)"
+alglist="$(yaml_get_kv "${temp}" "remaining" || true)"
 rm -f "${temp}"
 
 # If the list of remaining algs is not empty, we can test
@@ -35,7 +35,7 @@ if [ -n "${alglist}" ]; then
     done
     localtmp=$(mktemp)
     tpm2_incrementalselftest > "${localtmp}"
-    alglist="$(yaml_get_kv "${localtmp}" \"remaining\" || true)"
+    alglist="$(yaml_get_kv "${localtmp}" "remaining" || true)"
     rm -f "${localtmp}"
 
     if [ -n "${alglist}" ]; then

--- a/test/integration/tests/load.sh
+++ b/test/integration/tests/load.sh
@@ -28,13 +28,11 @@ cleanup() {
 
   tpm2_evictcontrol -Q -ao -c $Handle_parent 2>/dev/null || true
 
-  ina "$@" "keep_ctx"
-  if [ $? -ne 0 ]; then
+  if [ $(ina "$@" "keep_ctx") -ne 0 ]; then
     rm -f $file_primary_key_ctx
   fi
 
-  ina "$@" "no-shut-down"
-  if [ $? -ne 0 ]; then
+  if [ $(ina "$@" "no-shut-down") -ne 0 ]; then
           shut_down
   fi
 }

--- a/test/integration/tests/loadexternal.sh
+++ b/test/integration/tests/loadexternal.sh
@@ -56,14 +56,14 @@ run_tss_test() {
 
     tpm2_create -Q -C $Handle_parent   -g $alg_create_obj  -G $alg_create_key -u $file_loadexternal_key_pub  -r  $file_loadexternal_key_priv
 
-    tpm2_loadexternal -Q -a n   -u $file_loadexternal_key_pub
+    tpm2_loadexternal -Q -a n   -u $file_loadexternal_key_pub -o $file_loadexternal_key_ctx
 
     # Test with default hierarchy (and handle)
     cleanup "keep_handle" "no-shut-down"
 
     tpm2_create -Q -C $Handle_parent -g $alg_create_obj -G $alg_create_key -u $file_loadexternal_key_pub -r  $file_loadexternal_key_priv
 
-    tpm2_loadexternal -Q -u $file_loadexternal_key_pub
+    tpm2_loadexternal -Q -u $file_loadexternal_key_pub -o $file_loadexternal_key_ctx
 
     cleanup "no-shut-down"
 }

--- a/test/integration/tests/loadexternal.sh
+++ b/test/integration/tests/loadexternal.sh
@@ -108,8 +108,8 @@ run_aes_test() {
 
     tpm2_loadexternal -G aes -r sym.key -n name.bin -o key.ctx > stdout.yaml
 
-    local name1=`yaml_get_kv "stdout.yaml" "name"`
-    local name2=`xxd -c 256 -p name.bin`
+    local name1=$(yaml_get_kv "stdout.yaml" "name")
+    local name2="0x$(xxd -c 256 -p name.bin)"
 
     test "$name1" == "$name2"
 

--- a/test/integration/tests/loadexternal.sh
+++ b/test/integration/tests/loadexternal.sh
@@ -25,13 +25,11 @@ cleanup() {
          data.in.digest data.out.signed ticket.out name.bin stdout.yaml \
          passfile private.pem
 
-  ina "$@" "keep_handle"
-  if [ $? -ne 0 ]; then
+  if [ $(ina "$@" "keep_handle") -ne 0 ]; then
     tpm2_evictcontrol -Q -ao -c $Handle_parent 2>/dev/null || true
   fi
 
-  ina "$@" "no-shut-down"
-  if [ $? -ne 0 ]; then
+  if [ $(ina "$@" "no-shut-down") -ne 0 ]; then
     shut_down
   fi
 }

--- a/test/integration/tests/loadexternal.sh
+++ b/test/integration/tests/loadexternal.sh
@@ -117,8 +117,8 @@ run_aes_test() {
 
     tpm2_encryptdecrypt -c key.ctx -i plain.txt -o plain.enc
 
-    openssl enc -in plain.enc -out plain.dec.ssl -d -K `xxd -p sym.key` -iv 0 \
-        -aes-$1-cfb
+    openssl enc -in plain.enc -out plain.dec.ssl -d -K `xxd -c 256 -p sym.key` \
+	-iv 0 -aes-$1-cfb
 
     diff plain.txt plain.dec.ssl
 

--- a/test/integration/tests/loadexternal.sh
+++ b/test/integration/tests/loadexternal.sh
@@ -158,6 +158,8 @@ run_ecc_test() {
 
 run_rsa_passin_test() {
 
+    openssl genrsa -aes128 -passout "pass:mypassword" -out "private.pem" 1024
+
     if [ "$2" != "stdin" ]; then
         cmd="tpm2_loadexternal -Q -G rsa -r $1 -o key.ctx --passin $2"
     else
@@ -182,8 +184,6 @@ run_ecc_test prime256v1
 #
 # Test loadexternal passin option
 #
-openssl genrsa -aes128 -passout "pass:mypassword" -out "private.pem" 1024
-
 run_rsa_passin_test "private.pem" "pass:mypassword"
 
 export envvar="mypassword"
@@ -192,9 +192,11 @@ run_rsa_passin_test "private.pem" "env:envvar"
 echo -n "mypassword" > "passfile"
 run_rsa_passin_test "private.pem" "file:passfile"
 
+echo -n "mypassword" > "passfile"
 exec 42<> passfile
 run_rsa_passin_test "private.pem" "fd:42"
 
+echo -n "mypassword" > "passfile"
 run_rsa_passin_test "private.pem" "stdin" "passfile"
 
 

--- a/test/integration/tests/nv.sh
+++ b/test/integration/tests/nv.sh
@@ -47,7 +47,7 @@ tpm2_nvwrite -Q -x $nv_test_index -a o nv.test_w
 tpm2_nvread -Q -x $nv_test_index -a o -s 32 -o 0
 
 tpm2_nvlist > nv.out
-yaml_get_kv nv.out $nv_test_index > /dev/null
+yaml_get_kv nv.out "$nv_test_index" > /dev/null
 
 
 # Test writing to and reading from an offset by:
@@ -110,7 +110,7 @@ tpm2_nvrelease -Q -x 0x1500016 -a 0x40000001
 #
 
 tpm2_getcap -c properties-fixed > cap.out
-large_file_size=`yaml_get_kv cap.out \"TPM2_PT_NV_INDEX_MAX\" \"raw\"`
+large_file_size=`yaml_get_kv cap.out "TPM2_PT_NV_INDEX_MAX" "raw"`
 nv_test_index=0x1000000
 
 # Create an nv space with attributes 1010 = TPMA_NV_PPWRITE and TPMA_NV_AUTHWRITE
@@ -126,7 +126,7 @@ tpm2_nvread -x $nv_test_index -a o > $large_file_read_name
 cmp -s $large_file_read_name $large_file_name
 
 tpm2_nvlist > nv.out
-yaml_get_kv nv.out $nv_test_index > /dev/null
+yaml_get_kv nv.out "$nv_test_index" > /dev/null
 
 tpm2_nvrelease -Q -x $nv_test_index -a o
 

--- a/test/integration/tests/nvinc.sh
+++ b/test/integration/tests/nvinc.sh
@@ -38,7 +38,7 @@ tpm2_nvincrement -Q -x $nv_test_index -a o
 tpm2_nvread -Q -x $nv_test_index -a o -s 8
 
 tpm2_nvlist > nv.out
-yaml_get_kv nv.out $nv_test_index > /dev/null
+yaml_get_kv nv.out "$nv_test_index" > /dev/null
 
 # Test writing to and reading from an offset by:
 # 1. incrementing the nv counter

--- a/test/integration/tests/pcrevent.sh
+++ b/test/integration/tests/pcrevent.sh
@@ -47,14 +47,14 @@ while IFS='' read -r l || [[ -n "$l" ]]; do
 done < $hash_out_file
 
 tpm2_pcrlist -L sha1:9 > $yaml_out_file
-old_pcr_value=`yaml_get_kv $yaml_out_file \"sha1\" 9`
+old_pcr_value=`yaml_get_kv $yaml_out_file "sha1" "9"`
 
 # Verify that extend works, and test large files
 dd if=/dev/urandom of=$hash_in_file count=1 bs=2093 2> /dev/null
 tpm2_pcrevent -Q -x 9 $hash_in_file
 
 tpm2_pcrlist -L sha1:9 > $yaml_out_file
-new_pcr_value=`yaml_get_kv $yaml_out_file \"sha1\" 9`
+new_pcr_value=`yaml_get_kv $yaml_out_file "sha1" "9"`
 
 if [ "$new_pcr_value" == "$old_pcr_value" ]; then
   echo "Expected PCR value to change after pcrevent with index 9."

--- a/test/integration/tests/quote.sh
+++ b/test/integration/tests/quote.sh
@@ -43,7 +43,7 @@ trap cleanup EXIT
 start_up
 
 tpm2_getcap -c properties-fixed | tr -dc '[[:print:]]\r\n' > $out
-maxdigest=$(yaml_get_kv $out \"TPM2_PT_MAX_DIGEST\" \"raw\")
+maxdigest=$(yaml_get_kv $out "TPM2_PT_MAX_DIGEST" "raw")
 if ! [[ "$maxdigest" =~ ^(0x)*[0-9]+$ ]] ; then
  echo "error: not a number, got: \"$maxdigest\"" >&2
  exit 1

--- a/test/integration/tests/sign.sh
+++ b/test/integration/tests/sign.sh
@@ -272,7 +272,7 @@ trap - ERR
 
 tpm2_sign -Q -p "badpassword" -c $file_signing_key_ctx -g $alg_hash -m $file_input_data -o $file_output_data
 if [ $? != 3]; then
-	echo "Expected RC 3, got: $?" 1>&2
+    echo "Expected RC 3, got: $?" 1>&2
 fi
 trap onerror ERR
 


### PR DESCRIPTION
As discussed in #1535, the bash ERR trap is not inherited to bash functions. As a consequence, commands in bash functions will not lead to a failed test even if they return a non-zero error code.

To inherit the trap, the option `-E` has to be passed:

    If set, any trap on ERR is inherited by shell functions, command substitutions,
    and commands executed in a subshell environment. The ERR trap is normally not
    inherited in such cases.

Due to this issue, quite some problems have been missed. This PR also fixes those. Additionally, a man typo is fixed.

Fixes #1535.