### PR TITLE
Refactor activate credential

### DIFF
--- a/lib/tpm2.c
+++ b/lib/tpm2.c
@@ -861,6 +861,53 @@ tool_rc tpm2_tr_set_auth(
     return tool_rc_success;
 }
 
+tool_rc tpm2_activatecredential(
+        ESYS_CONTEXT *esysContext,
+        tpm2_loaded_object *activatehandleobj,
+        tpm2_loaded_object *keyhandleobj,
+        const TPM2B_ID_OBJECT *credentialBlob,
+        const TPM2B_ENCRYPTED_SECRET *secret,
+        TPM2B_DIGEST **certInfo) {
+
+    ESYS_TR keyobj_session_handle = ESYS_TR_NONE;
+    tool_rc rc = tpm2_auth_util_get_shandle(
+                        esysContext,
+                        keyhandleobj->tr_handle,
+                        keyhandleobj->session,
+                        &keyobj_session_handle); //shandle1
+    if (rc != tool_rc_success) {
+        return rc;
+    }
+
+    ESYS_TR activateobj_session_handle = ESYS_TR_NONE;
+    rc = tpm2_auth_util_get_shandle(
+                esysContext,
+                activatehandleobj->tr_handle,
+                activatehandleobj->session,
+                &activateobj_session_handle); //shandle2
+    if (rc != tool_rc_success) {
+        return rc;
+    }
+
+    TSS2_RC rval = Esys_ActivateCredential(
+                    esysContext,
+                    activatehandleobj->tr_handle,
+                    keyhandleobj->tr_handle,
+                    activateobj_session_handle,
+                    keyobj_session_handle,
+                    ESYS_TR_NONE,
+                    credentialBlob,
+                    secret,
+                    certInfo);
+    if (rval != TPM2_RC_SUCCESS) {
+        LOG_PERR(Esys_ActivateCredential, rval);
+        rc = tool_rc_from_tpm(rval);
+        return rc;
+    }
+
+    return tool_rc_success;
+}
+
 tool_rc tpm2_create(
         ESYS_CONTEXT *esysContext,
         tpm2_loaded_object *parent_obj,

--- a/lib/tpm2.h
+++ b/lib/tpm2.h
@@ -308,6 +308,14 @@ tool_rc tpm2_tr_set_auth(
     ESYS_TR handle,
     TPM2B_AUTH const *authValue);
 
+tool_rc tpm2_activatecredential(
+        ESYS_CONTEXT *esysContext,
+        tpm2_loaded_object *activatehandle,
+        tpm2_loaded_object *keyhandle,
+        const TPM2B_ID_OBJECT *credentialBlob,
+        const TPM2B_ENCRYPTED_SECRET *secret,
+        TPM2B_DIGEST **certInfo);
+
 tool_rc tpm2_create(
     ESYS_CONTEXT *esysContext,
     tpm2_loaded_object *parent_obj,

--- a/man/tpm2_activatecredential.1.md
+++ b/man/tpm2_activatecredential.1.md
@@ -4,8 +4,8 @@
 
 # NAME
 
-**tpm2_activatecredential**(1) - Verify that an object is protected with a specific
-key.
+**tpm2_activatecredential**(1) - Enables access to the credential qualifier to
+recover the credential secret.
 
 # SYNOPSIS
 
@@ -13,47 +13,46 @@ key.
 
 # DESCRIPTION
 
-**tpm2_activatecredential**(1) -  Verify that the given content is protected
-with given key handle for given handle, and then decrypt and return the secret,
-if any password option is missing, assume NULL. Currently only support using
-TCG profile compliant EK as the key handle.
+**tpm2_activatecredential**(1) -  Enables the association of a credential with
+an object in a way that ensures that the TPM has validated the parameters of the
+credentialed object. In an attestation scheme , this guarantees the registrar that
+the attestation key belongs to the TPM with a qualified parent key in the TPM.
 
 # OPTIONS
 
 These options control the object verification:
 
-  * **-c**, **\--context**=_OBJ\_CTX\_OR\_HANDLE_:
+  * **-c**, **\--credentialedkey-context**=_CREDENTIALED\_KEY\_OBJ\_CTX\_OR\_HANDLE_:
 
     _CONTEXT\_OBJECT_ of the content object associated with the created
-    certificate by CA.
-    Either a file or a handle number. See section "Context Object Format".
+    certificate by CA. Either a file or a handle number. See section "Context
+    Object Format".
 
-  * **-C**, **\--key-context**=_KEY\_CONTEXT\_OBJECT_:
+  * **-C**, **\--credentialkey-context**=_CREDENTIAL\_KEY\_OBJ\_CTX\_OR\_HANDLE_:
 
-    The _KEY\_CONTEXT\_OBJECT_ of the loaded key used to decrypt the random seed.
-    Either a file or a handle number. See section "Context Object Format".
+    The _CREDENTIAL\_KEY\_OBJ\_CTX\_OR\_HANDLE_ of the loaded key used to decrypt the
+    random seed. Either a file or a handle number. See section "Context Object
+    Format".
 
-  * **-P**, **\--auth-key**=_AUTH\_VALUE_:
+  * **-P**, **\--credentialedkey-auth**=_AUTH\_VALUE_:
 
-    Use _AUTH\_VALUE_ for providing an authorization value for the
-    _KEY\_CONTEXT\_OBJECT_.
-    Passwords should follow the "authorization formatting standards", see
-    section "Authorization Formatting".
+    _AUTH\_VALUE_ for providing an authorization value for the
+    _CREDENTIALED\_KEY\_OBJ\_CTX\_OR\_HANDLE_.
 
-  * **-E**, **\--auth-endorse**=_ENDORSE\_PASSWORD_:
+  * **-E**, **\--credentialkey-auth**=_AUTH\_VALUE_:
 
-    The endorsement authorization value, optional. Follows the same formatting
-    guidelines as the key authorization option **-P**.
+    _AUTH\_VALUE_ for providing an authorization value for the
+    _CREDENTIAL\_KEY\_OBJ\_CTX\_OR\_HANDLE_.
 
-  * **-i**, **\--in-file**=_INPUT\_FILE_:
+  * **-i**, **\--credential-secret**=_INPUT\_FILE_:
 
-    Input file path, containing the two structures needed by
-    **tpm2_activatecredential**(1) function. This is created via the
-    **tpm2_makecredential**(1) command.
+    Input file path, containing the two structures - credential blob and secret,
+    needed by **tpm2_activatecredential**(1) function. This is created from the
+    **tpm2_makecredential**(1) tool.
 
-  * **-o**, **\--out-file**=_OUTPUT\_FILE_:
+  * **-o**, **\--certinfo-data**=_OUTPUT\_FILE_:
 
-    Output file path, record the secret to decrypt the certificate.
+    Output file path, record the decrypted credential secret information.
 
 [common options](common/options.md)
 

--- a/man/tpm2_activatecredential.1.md
+++ b/man/tpm2_activatecredential.1.md
@@ -65,11 +65,15 @@ These options control the object verification:
 # EXAMPLES
 
 ```
-tpm2_activatecredential -c 0x81010002 -C 0x81010001 -P abc123 -E abc123 -i <filePath> -o <filePath>
+TPM2_RH_ENDORSEMENT=0x4000000B
+tpm2_startauthsession --policy-session -S session.ctx
+tpm2_policysecret -S session.ctx -c $TPM2_RH_ENDORSEMENT
 
-tpm2_activatecredential -c ak.dat -C ek.dat -P abc123 -E abc123 -i <filePath> -o <filePath>
+tpm2_activatecredential -c 0x81010002 -C 0x81010001 -P abc123 -E session:session.ctx -i <filePath> -o <filePath>
 
-tpm2_activatecredential -c 0x81010002 -C 0x81010001 -P 123abc -E 1a1b1c  -i <filePath> -o <filePath>
+tpm2_activatecredential -c ak.dat -C ek.dat -P abc123 -E session:session.ctx -i <filePath> -o <filePath>
+
+tpm2_activatecredential -c 0x81010002 -C 0x81010001 -P 123abc -E session:session.ctx  -i <filePath> -o <filePath>
 ```
 
 [returns](common/returns.md)

--- a/test/integration/tests/activecredential.sh
+++ b/test/integration/tests/activecredential.sh
@@ -4,7 +4,8 @@
 source helpers.sh
 
 cleanup() {
-    rm -f secret.data ek.pub ak.pub ak.name mkcred.out actcred.out ak.out ak.ctx
+    rm -f secret.data ek.pub ak.pub ak.name mkcred.out actcred.out ak.out\
+     ak.ctx session.ctx
 
     # Evict persistent handles, we want them to always succeed and never trip
     # the onerror trap.
@@ -46,7 +47,11 @@ test "$loaded_key_name_yaml" == "$loaded_key_name"
 
 tpm2_makecredential -Q -e ek.pub  -s secret.data -n $loaded_key_name -o mkcred.out
 
+TPM2_RH_ENDORSEMENT=0x4000000B
+tpm2_startauthsession --policy-session -S session.ctx
+tpm2_policysecret -S session.ctx -c $TPM2_RH_ENDORSEMENT
 tpm2_activatecredential -Q -c ak.ctx -C 0x81010009 -i mkcred.out -o actcred.out\
-    -P akpass
+	-P akpass -E"session:session.ctx"
+tpm2_flushcontext -S session.ctx
 
 exit 0


### PR DESCRIPTION
1. Decouples activatecredential  hardcoded auth method of using policysecret to satisfy TPM2_RH_Endorsement auth.

2. Better variable names to align with the spec language.

3. Progresses: #1539