### PR TITLE
tpm2_changeauth: reconfigure options

### DIFF
--- a/lib/tpm2.c
+++ b/lib/tpm2.c
@@ -940,3 +940,79 @@ tool_rc tpm2_create_loaded(
 
     return tool_rc_success;
 }
+
+tool_rc tpm2_object_change_auth(
+        ESYS_CONTEXT *esysContext,
+        tpm2_loaded_object *parent_object,
+        tpm2_loaded_object *object,
+        const TPM2B_AUTH *newAuth,
+        TPM2B_PRIVATE **outPrivate) {
+
+    ESYS_TR shandle1 = ESYS_TR_NONE;
+    tool_rc rc = tpm2_auth_util_get_shandle(esysContext,
+                            object->tr_handle,
+                            object->session, &shandle1);
+    if (rc != tool_rc_success) {
+        return rc;
+    }
+
+    TSS2_RC rval = Esys_ObjectChangeAuth(esysContext,
+                        object->tr_handle,
+                        parent_object->tr_handle,
+                        shandle1, ESYS_TR_NONE, ESYS_TR_NONE,
+                        newAuth, outPrivate);
+    if (rval != TPM2_RC_SUCCESS) {
+        LOG_PERR(Esys_ObjectChangeAuth, rval);
+        return tool_rc_from_tpm(rval);
+    }
+
+    return tool_rc_success;
+}
+
+tool_rc tpm2_nv_change_auth(
+        ESYS_CONTEXT *esysContext,
+        tpm2_loaded_object *nv,
+        const TPM2B_AUTH *newAuth) {
+
+    ESYS_TR shandle1 = ESYS_TR_NONE;
+    tool_rc rc = tpm2_auth_util_get_shandle(esysContext,
+                            nv->tr_handle,
+                            nv->session, &shandle1);
+    if (rc != tool_rc_success) {
+        return rc;
+    }
+
+    TSS2_RC rval = Esys_NV_ChangeAuth(esysContext,
+                nv->tr_handle,
+                shandle1, ESYS_TR_NONE, ESYS_TR_NONE, newAuth);
+    if (rval != TPM2_RC_SUCCESS) {
+        LOG_PERR(Esys_NV_ChangeAuth, rval);
+        return tool_rc_from_tpm(rval);
+    }
+
+    return tool_rc_success;
+}
+
+tool_rc tpm2_hierarchy_change_auth(
+        ESYS_CONTEXT *esysContext,
+        tpm2_loaded_object *hierarchy,
+        const TPM2B_AUTH *newAuth) {
+
+    ESYS_TR shandle1 = ESYS_TR_NONE;
+    tool_rc rc = tpm2_auth_util_get_shandle(esysContext,
+                            hierarchy->tr_handle,
+                            hierarchy->session, &shandle1);
+    if (rc != tool_rc_success) {
+        return rc;
+    }
+
+    TSS2_RC rval = Esys_HierarchyChangeAuth(esysContext,
+                hierarchy->tr_handle,
+                shandle1, ESYS_TR_NONE, ESYS_TR_NONE, newAuth);
+    if (rval != TPM2_RC_SUCCESS) {
+        LOG_PERR(Esys_HierarchyChangeAuth, rval);
+        return tool_rc_from_tpm(rval);
+    }
+
+    return tool_rc_success;
+}

--- a/lib/tpm2.h
+++ b/lib/tpm2.h
@@ -330,4 +330,22 @@ tool_rc tpm2_create_loaded(
     TPM2B_PRIVATE **outPrivate,
     TPM2B_PUBLIC **outPublic);
 
+
+tool_rc tpm2_object_change_auth(
+        ESYS_CONTEXT *esysContext,
+        tpm2_loaded_object *parent_object,
+        tpm2_loaded_object *object,
+        const TPM2B_AUTH *newAuth,
+        TPM2B_PRIVATE **outPrivate);
+
+tool_rc tpm2_nv_change_auth(
+        ESYS_CONTEXT *esysContext,
+        tpm2_loaded_object *nv,
+        const TPM2B_AUTH *newAuth);
+
+tool_rc tpm2_hierarchy_change_auth(
+        ESYS_CONTEXT *esysContext,
+        tpm2_loaded_object *hierarchy,
+        const TPM2B_AUTH *newAuth);
+
 #endif /* LIB_TPM2_H_ */

--- a/lib/tpm2_hierarchy.c
+++ b/lib/tpm2_hierarchy.c
@@ -32,11 +32,11 @@
 bool tpm2_hierarchy_from_optarg(const char *value,
         TPMI_RH_PROVISION *hierarchy, tpm2_hierarchy_flags flags) {
 
-    if (!value) {
+    if (!value || !value[0]) {
         return false;
     }
 
-    bool is_o = !strcmp(value, "o");
+    bool is_o = !strncmp(value, "owner", strlen(value));
     if (is_o) {
         if (!(flags & TPM2_HIERARCHY_FLAGS_O)) {
             LOG_ERR("Owner hierarchy not supported by this command.");
@@ -46,7 +46,7 @@ bool tpm2_hierarchy_from_optarg(const char *value,
         return true;
     }
 
-    bool is_p = !strcmp(value, "p");
+    bool is_p = !strncmp(value, "platform", strlen(value));
     if (is_p) {
         if (!(flags & TPM2_HIERARCHY_FLAGS_P)) {
             LOG_ERR("Platform hierarchy not supported by this command.");
@@ -56,7 +56,7 @@ bool tpm2_hierarchy_from_optarg(const char *value,
         return true;
     }
 
-    bool is_e = !strcmp(value, "e");
+    bool is_e = !strncmp(value, "endorsement", strlen(value));
     if (is_e) {
         if (!(flags & TPM2_HIERARCHY_FLAGS_E)) {
             LOG_ERR("Endorsement hierarchy not supported by this command.");
@@ -66,7 +66,7 @@ bool tpm2_hierarchy_from_optarg(const char *value,
         return true;
     }
 
-    bool is_n = !strcmp(value, "n");
+    bool is_n = !strncmp(value, "null", strlen(value));
     if (is_n) {
         if (!(flags & TPM2_HIERARCHY_FLAGS_N)) {
             LOG_ERR("NULL hierarchy not supported by this command.");
@@ -76,9 +76,19 @@ bool tpm2_hierarchy_from_optarg(const char *value,
         return true;
     }
 
+    bool is_l = !strncmp(value, "lockout", strlen(value));
+    if (is_l) {
+        if (!(flags & TPM2_HIERARCHY_FLAGS_L)) {
+            LOG_ERR("Permanent handle lockout not supported by this command.");
+            return false;
+        }
+        *hierarchy = TPM2_RH_LOCKOUT;
+        return true;
+    }
+
     bool result = tpm2_util_string_to_uint32(value, hierarchy);
     if (!result) {
-        LOG_ERR("Incorrect hierarchy value, got: \"%s\", expected [o|p|e|n]"
+        LOG_ERR("Incorrect hierarchy value, got: \"%s\", expected [o|p|e|n|l]"
                 "or a number",
             value);
     }

--- a/lib/tpm2_hierarchy.h
+++ b/lib/tpm2_hierarchy.h
@@ -18,7 +18,9 @@ enum tpm2_hierarchy_flags {
     TPM2_HIERARCHY_FLAGS_P    = 1 << 1,
     TPM2_HIERARCHY_FLAGS_E    = 1 << 2,
     TPM2_HIERARCHY_FLAGS_N    = 1 << 3,
-    TPM2_HIERARCHY_FLAGS_ALL  = 0x0F
+    TPM2_HIERARCHY_FLAGS_L    = 1 << 4,
+    TPM2_HIERARCHY_SUPPRESS   = 1 << 5,
+    TPM2_HIERARCHY_FLAGS_ALL  = 0x1F
 };
 
 bool tpm2_hierarchy_from_optarg(const char *value,

--- a/lib/tpm2_util.c
+++ b/lib/tpm2_util.c
@@ -629,16 +629,14 @@ ESYS_TR tpm2_tpmi_hierarchy_to_esys_tr(TPMI_RH_PROVISION inh) {
     switch (inh) {
     case TPM2_RH_OWNER:
         return ESYS_TR_RH_OWNER;
-        break;
     case TPM2_RH_PLATFORM:
         return ESYS_TR_RH_PLATFORM;
-        break;
     case TPM2_RH_ENDORSEMENT:
         return ESYS_TR_RH_ENDORSEMENT;
-        break;
     case TPM2_RH_NULL:
         return ESYS_TR_RH_NULL;
-        break;
+    case TPM2_RH_LOCKOUT:
+        return ESYS_TR_RH_LOCKOUT;
     }
     return ESYS_TR_NONE;
 }

--- a/man/common/ctxobj.md
+++ b/man/common/ctxobj.md
@@ -1,10 +1,15 @@
 # Context Object Format
 
 The type of a context object, whether it is a handle or file name, is
-determined according to the following logic:
+determined according to the following logic *in-order*:
 
-  * if the argument begins with the prefix "file:" it will be treated as a
-    context file, e.g. file:0x0001
-  * if the argument can be loaded as a number it will be treat as a handle,
-    e.g. 0x81010013
-  * otherwise the object is treated as a file
+  * If the argument is a file path, then the file is loaded as a restored TPM transient object.
+
+  * If the argument is a *prefix* match on one of:
+    * owner: the owner hierarchy
+    * platform: the platform hierarchy
+    * endorsement: the endorsement hierarchy
+    * lockout: the lockout control persistent object
+
+  * If the argument argument can be loaded as a number it will be treat as a handle,
+    e.g. 0x81010013 and used directly.

--- a/test/integration/tests/attestation.sh
+++ b/test/integration/tests/attestation.sh
@@ -43,8 +43,6 @@ cleanup() {
 
   tpm2_nvrelease -Q -x $handle_nv -a $handle_hier -P "$ownerpw" 2>/dev/null || true
 
-  tpm2_changeauth -Q -W "$ownerpw" -E "$endorsepw" 2>/dev/null || true
-
   if [ $(ina "$@" "no-shut-down") -ne 0 ]; then
     shut_down
   fi
@@ -63,8 +61,8 @@ getrandom() {
   loaded_randomness=`cat rand.out | xxd -p -c $file_size`
 }
 
-
-tpm2_changeauth -Q -w "$ownerpw" -e "$endorsepw"
+tpm2_changeauth -c o "$ownerpw"
+tpm2_changeauth -c e "$endorsepw"
 
 # Key generation
 tpm2_createek -Q -c $handle_ek -G $ek_alg -p $output_ek_pub_pem -f pem -P "$ekpw" -w "$ownerpw" -e "$endorsepw"

--- a/test/integration/tests/changeauth.sh
+++ b/test/integration/tests/changeauth.sh
@@ -21,13 +21,19 @@ new_lockPasswd=newpswd
 
 tpm2_clear
 
-tpm2_changeauth -w $ownerPasswd -e $endorsePasswd -l $lockPasswd
+tpm2_changeauth -c o $ownerPasswd
+tpm2_changeauth -c e $endorsePasswd
+tpm2_changeauth -c l $lockPasswd
 
-tpm2_changeauth -W $ownerPasswd -E $endorsePasswd -L $lockPasswd -w $new_ownerPasswd -e $new_endorsePasswd -l $new_lockPasswd
+tpm2_changeauth -c o -p $ownerPasswd $new_ownerPasswd
+tpm2_changeauth -c e -p $endorsePasswd $new_endorsePasswd
+tpm2_changeauth -c l -p $lockPasswd $new_lockPasswd
 
 tpm2_clear -L $new_lockPasswd
 
-tpm2_changeauth -w $ownerPasswd -e $endorsePasswd -l $lockPasswd
+tpm2_changeauth -c o $ownerPasswd
+tpm2_changeauth -c e $endorsePasswd
+tpm2_changeauth -c l $lockPasswd
 
 echo -n $lockPasswd > secret.txt
 tpm2_clear -L "file:secret.txt"
@@ -36,7 +42,6 @@ tpm2_clear -L "file:secret.txt"
 tpm2_createprimary -Q -a o -o primary.ctx
 tpm2_create -Q -C primary.ctx -p foo -u key.pub -r key.priv
 tpm2_load -Q -C primary.ctx -u key.pub -r key.priv -o key.ctx
-tpm2_changeauth -C primary.ctx -P foo -p bar -c key.ctx -r new.priv
-
+tpm2_changeauth -C primary.ctx -p foo -c key.ctx -r new.priv bar
 
 exit 0

--- a/test/integration/tests/checkquote.sh
+++ b/test/integration/tests/checkquote.sh
@@ -9,8 +9,6 @@ ek_alg=rsa
 ak_alg=rsa
 digestAlg=sha256
 signAlg=rsassa
-ownerpw=ownerpass
-endorsepw=endorsepass
 ekpw=ekpass
 akpw=akpass
 ak_ctx=ak.ctx
@@ -29,10 +27,8 @@ cleanup() {
         $ak_ctx
 
   tpm2_pcrreset 16
-  tpm2_evictcontrol -a o -c $handle_ek -P "$ownerpw" 2>/dev/null || true
-  tpm2_evictcontrol -a o -c $handle_ak -P "$ownerpw" 2>/dev/null || true
-
-  tpm2_changeauth -W "$ownerpw" -E "$endorsepw" 2>/dev/null || true
+  tpm2_evictcontrol -a o -c $handle_ek 2>/dev/null || true
+  tpm2_evictcontrol -a o -c $handle_ak 2>/dev/null || true
 
   if [ $(ina "$@" "no-shut-down") -ne 0 ]; then
     shut_down

--- a/test/integration/tests/createak.sh
+++ b/test/integration/tests/createak.sh
@@ -36,7 +36,7 @@ tpm2_evictcontrol -Q -a o -c $phandle
 
 # Test tpm2_createak with endorsement password
 cleanup "no-shut-down"
-tpm2_changeauth -e endauth
+tpm2_changeauth -c e endauth
 tpm2_createek -Q -e endauth -c 0x8101000b -G rsa -p ek.pub
 tpm2_createak -Q -e endauth -C 0x8101000b -c ak.ctx -G rsa -p ak.pub -n ak.name
 

--- a/test/integration/tests/getmanufec.sh
+++ b/test/integration/tests/getmanufec.sh
@@ -38,7 +38,8 @@ cmp ECcert.bin ECcert2.bin
 
 # Test providing endorsement password to create EK and owner password to persist.
 tpm2_clear
-tpm2_changeauth -w $opass -e $epass
+tpm2_changeauth -c o $opass
+tpm2_changeauth -c e $epass
 
 tpm2_getmanufec -H $handle -U -E ECcert2.bin -o test_ek.pub -w $opass -e $epass \
                 https://ekop.intel.com/ekcertservice/

--- a/test/integration/tests/nv.sh
+++ b/test/integration/tests/nv.sh
@@ -163,7 +163,7 @@ fi
 #
 trap onerror ERR
 
-tpm2_changeauth -w owner
+tpm2_changeauth -c o owner
 
 tpm2_nvdefine -x 0x1500015 -a 0x40000001 -s 32 \
   -b "policyread|policywrite|authread|authwrite|ownerwrite|ownerread" \

--- a/test/integration/tests/nvinc.sh
+++ b/test/integration/tests/nvinc.sh
@@ -111,7 +111,7 @@ fi
 #
 trap onerror ERR
 
-tpm2_changeauth -w owner
+tpm2_changeauth -c o owner
 
 tpm2_nvdefine -x 0x1500015 -a 0x40000001 -s 8 \
   -b "policyread|policywrite|authread|authwrite|ownerwrite|ownerread|nt=1" \

--- a/test/integration/tests/tcti/abrmd/policysecret.sh
+++ b/test/integration/tests/tcti/abrmd/policysecret.sh
@@ -32,7 +32,7 @@ cleanup "no-shutdown"
 
 tpm2_clear
 
-tpm2_changeauth -w ownerauth
+tpm2_changeauth -c o ownerauth
 
 # Create Policy
 tpm2_startauthsession -S $session_ctx
@@ -61,7 +61,7 @@ fi
 
 #Test the policy with auth reference object password not set
 unsealed=""
-tpm2_changeauth -W ownerauth
+tpm2_changeauth -c o -p ownerauth
 
 tpm2_startauthsession --policy-session -S $session_ctx
 tpm2_policysecret -S $session_ctx -c $TPM_RH_OWNER -o $o_policy_digest

--- a/tools/tpm2_startauthsession.c
+++ b/tools/tpm2_startauthsession.c
@@ -104,17 +104,13 @@ tool_rc tpm2_tool_onrun(ESYS_CONTEXT *ectx, tpm2_option_flags flags) {
             return tmp_rc;
         }
 
-        bool is_persistent = false;
         /* if the loaded object has a handle then it must be a persistent object */
         if (ctx.session.key_context_object.handle) {
 
-            is_persistent = (ctx.session.key_context_object.handle >> TPM2_HR_SHIFT) == TPM2_HT_PERSISTENT;
-            if (!is_persistent) {
-                LOG_ERR("Specified encryption key not a persistent object, got: %s", ctx.session.key_context_arg_str);
-                return rc;
+            bool is_transient = (ctx.session.key_context_object.handle >> TPM2_HR_SHIFT) == TPM2_HT_TRANSIENT;
+            if (!is_transient) {
+                LOG_WARN("check public key portion manually");
             }
-
-            LOG_WARN("check public key portion");
         }
 
         has_key = true;


### PR DESCRIPTION
tpm2_changeauth has the ability to change multiple TPM objects at once,
which made the interface complicated and difficult to use. Change the
interface to only be able to set one object at a time.

Fixes: #1289

Signed-off-by: William Roberts <william.c.roberts@intel.com>