### PR TITLE
ci: don't limit the amount of parallel jobs for make check

### DIFF
--- a/.ci/docker.run
+++ b/.ci/docker.run
@@ -75,7 +75,7 @@ fi
 
 ../configure --enable-unit $config_flags
 make -j$(nproc)
-make -j$(nproc) check
+make -j check
 
 popd
 


### PR DESCRIPTION
Similar to https://github.com/tpm2-software/tpm2-tss/pull/1446, most of the CI time is spent on running the integration test suite, which is not CPU bound, so allowing more parallel jobs allows for some speedup. This reduces the CI time from about [00:12 real-time/00:23 total](https://travis-ci.org/diabonas/tpm2-tools/builds/546159523) to about [00:08 real-time/00:12 total](https://travis-ci.org/diabonas/tpm2-tools/builds/546161799).