### PR TITLE
 test/integration: check if port is bound to the simulator

### DIFF
--- a/test/unit/test_tpm2_policy.c
+++ b/test/unit/test_tpm2_policy.c
@@ -206,7 +206,7 @@ static test_file *test_file_new(void) {
         return NULL;
     }
 
-    tf->path = strdup("xxx_test_files_xxx.test");
+    tf->path = strdup("xxx_test_tpm2_policy_xxx.test");
     if (!tf->path) {
         free(tf);
         return NULL;


### PR DESCRIPTION
Currently the CI seems to have some problems (cf. the failed builds [#3004](https://travis-ci.org/tpm2-software/tpm2-tools/builds/546173212) and [#3005](https://travis-ci.org/tpm2-software/tpm2-tools/builds/546342459)) due to PR #1553 starting all integration tests in parallel. Unfortunately I can't reproduce this problem locally on my system or with the Dockerfile, but from the CI logs, this seems like this is a [TOCTOU](https://en.wikipedia.org/wiki/Time-of-check_to_time-of-use) problem between checking whether the simulator ports are free and actually starting the simulator on the specified ports. Fix this by trying to start the simulator first, then check whether it is listening on the port and retry if necessary.

While testing this, I once came across a different race condition in the unit tests `test_files` and `test_tpm2_policy` which both create a file `xxx_test_files_xxx.test`. Fix this by renaming one of the files to a different unique name.