### PR TITLE
tpm2_hierarchy.c: Fix hierarchy filtering bug

### DIFF
--- a/lib/tpm2_hierarchy.c
+++ b/lib/tpm2_hierarchy.c
@@ -36,62 +36,75 @@ bool tpm2_hierarchy_from_optarg(const char *value,
         return false;
     }
 
+    *hierarchy = 0;
+
     bool is_o = !strncmp(value, "owner", strlen(value));
     if (is_o) {
-        if (!(flags & TPM2_HIERARCHY_FLAGS_O)) {
-            LOG_ERR("Owner hierarchy not supported by this command.");
-            return false;
-        }
         *hierarchy = TPM2_RH_OWNER;
-        return true;
     }
 
     bool is_p = !strncmp(value, "platform", strlen(value));
     if (is_p) {
-        if (!(flags & TPM2_HIERARCHY_FLAGS_P)) {
-            LOG_ERR("Platform hierarchy not supported by this command.");
-            return false;
-        }
         *hierarchy = TPM2_RH_PLATFORM;
-        return true;
     }
 
     bool is_e = !strncmp(value, "endorsement", strlen(value));
     if (is_e) {
-        if (!(flags & TPM2_HIERARCHY_FLAGS_E)) {
-            LOG_ERR("Endorsement hierarchy not supported by this command.");
-            return false;
-        }
         *hierarchy = TPM2_RH_ENDORSEMENT;
-        return true;
     }
 
     bool is_n = !strncmp(value, "null", strlen(value));
     if (is_n) {
-        if (!(flags & TPM2_HIERARCHY_FLAGS_N)) {
-            LOG_ERR("NULL hierarchy not supported by this command.");
-            return false;
-        }
         *hierarchy = TPM2_RH_NULL;
-        return true;
     }
 
     bool is_l = !strncmp(value, "lockout", strlen(value));
     if (is_l) {
-        if (!(flags & TPM2_HIERARCHY_FLAGS_L)) {
+        *hierarchy = TPM2_RH_LOCKOUT;
+    }
+
+    bool result = true;
+    if (!*hierarchy) {
+        /*
+         * This branch is executed when hierarchy is specified as a hex handle.
+         * The raw hex returned may be a generic (non hierarchy) TPM2_HANDLE.
+         */
+        result = tpm2_util_string_to_uint32(value, hierarchy);
+    }
+    if (!result) {
+        LOG_ERR("Incorrect handle value, got: \"%s\", expected [o|p|e|n|l]"
+                "or a handle number", value);
+        return false;
+    }
+
+    /*
+     * If the caller specifies the expected valid hierarchies, either as string,
+     * or hex handles, they are additionally filtered here.
+     */
+    if (!(flags & TPM2_HIERARCHY_FLAGS_O) && *hierarchy == TPM2_RH_OWNER) {
+            LOG_ERR("Owner hierarchy not supported by this command.");
+            return false;
+        }
+
+    if (!(flags & TPM2_HIERARCHY_FLAGS_P) && *hierarchy == TPM2_RH_PLATFORM) {
+            LOG_ERR("Platform hierarchy not supported by this command.");
+            return false;
+        }
+
+    if (!(flags & TPM2_HIERARCHY_FLAGS_E) && *hierarchy == TPM2_RH_ENDORSEMENT) {
+            LOG_ERR("Endorsement hierarchy not supported by this command.");
+            return false;
+        }
+
+    if (!(flags & TPM2_HIERARCHY_FLAGS_N) && *hierarchy == TPM2_RH_NULL) {
+            LOG_ERR("NULL hierarchy not supported by this command.");
+            return false;
+        }
+
+    if (!(flags & TPM2_HIERARCHY_FLAGS_L) && *hierarchy == TPM2_RH_LOCKOUT) {
             LOG_ERR("Permanent handle lockout not supported by this command.");
             return false;
         }
-        *hierarchy = TPM2_RH_LOCKOUT;
-        return true;
-    }
-
-    bool result = tpm2_util_string_to_uint32(value, hierarchy);
-    if (!result) {
-        LOG_ERR("Incorrect hierarchy value, got: \"%s\", expected [o|p|e|n|l]"
-                "or a number",
-            value);
-    }
 
     return result;
 }


### PR DESCRIPTION
Fixes #1510
This commit fixes an issue wherein the filtering of the valid
hierarchies is skipped if value is specified as a hex number
as supposed to a string. Eg: 0x40000007 vs "null"

Signed-off-by: Imran Desai <imranodesai@gmail.com>