### PR TITLE
tools: Add back the hierarchy filtering to tools

### DIFF
--- a/lib/object.c
+++ b/lib/object.c
@@ -9,7 +9,6 @@
 #include "log.h"
 #include "object.h"
 #include "tpm2_auth_util.h"
-#include "tpm2_hierarchy.h"
 
 #define NULL_OBJECT "null"
 #define NULL_OBJECT_LEN (sizeof(NULL_OBJECT) - 1)
@@ -31,7 +30,8 @@ static tool_rc tpm2_util_object_load2(
             const char *auth,
             bool do_auth,
             tpm2_loaded_object *outobject,
-            bool is_restricted_pswd_session) {
+            bool is_restricted_pswd_session,
+            tpm2_hierarchy_flags flags) {
 
     ESYS_CONTEXT *tmp_ctx = is_restricted_pswd_session ? NULL: ctx;
 
@@ -61,8 +61,7 @@ static tool_rc tpm2_util_object_load2(
 
     // 2. Try to convert a hierarchy or raw handle
     TPMI_RH_PROVISION handle;
-    bool result = tpm2_hierarchy_from_optarg(objectstr, &handle,
-            TPM2_HIERARCHY_FLAGS_ALL|TPM2_HIERARCHY_SUPPRESS);
+    bool result = tpm2_hierarchy_from_optarg(objectstr, &handle, flags);
     if (result){
         outobject->handle = handle;
         outobject->path = NULL;
@@ -75,9 +74,11 @@ static tool_rc tpm2_util_object_load2(
 }
 
 tool_rc tpm2_util_object_load(ESYS_CONTEXT *ctx,
-            const char *objectstr, tpm2_loaded_object *outobject) {
+            const char *objectstr, tpm2_loaded_object *outobject,
+            tpm2_hierarchy_flags flags) {
 
-    return tpm2_util_object_load2(ctx, objectstr, NULL, false, outobject, false);
+    return tpm2_util_object_load2(ctx, objectstr, NULL, false, outobject,
+        false, flags);
 }
 
 tool_rc tpm2_util_object_load_auth(
@@ -85,8 +86,9 @@ tool_rc tpm2_util_object_load_auth(
             const char *objectstr,
             const char *auth,
             tpm2_loaded_object *outobject,
-            bool is_restricted_pswd_session) {
+            bool is_restricted_pswd_session,
+            tpm2_hierarchy_flags flags) {
 
     return tpm2_util_object_load2(ctx, objectstr, auth, true, outobject,
-        is_restricted_pswd_session);
+        is_restricted_pswd_session, flags);
 }

--- a/lib/object.h
+++ b/lib/object.h
@@ -3,6 +3,8 @@
 
 #include "tpm2_error.h"
 #include "tpm2_session.h"
+#include "tpm2_hierarchy.h"
+
 
 typedef struct tpm2_loaded_object tpm2_loaded_object;
 struct tpm2_loaded_object {
@@ -27,12 +29,15 @@ struct tpm2_loaded_object {
  * @param outobject
  * A *tpm2_loaded_object* with a loaded handle. The path member will also be
  * set when the *objectstr* is a context file.
+ * @param flags
+ * A *tpm2_hierarchy_flags* value to specify expected valid hierarchy
  * @return
  *  tool_rc indicating status.
  *
  */
 tool_rc tpm2_util_object_load(ESYS_CONTEXT *ctx,
-                        const char *objectstr, tpm2_loaded_object *outobject);
+                        const char *objectstr, tpm2_loaded_object *outobject,
+                        tpm2_hierarchy_flags flags);
 
 /**
  * Same as tpm2_util_object_load but allows the auth string value to be populated
@@ -48,6 +53,8 @@ tool_rc tpm2_util_object_load(ESYS_CONTEXT *ctx,
  * @param outobject
  * A *tpm2_loaded_object* with a loaded handle. The path member will also be
  * set when the *objectstr* is a context file.
+ * @param flags
+ * A *tpm2_hierarchy_flags* value to specify expected valid hierarchy
  * @return
  *  tool_rc indicating status.
  * @return
@@ -58,6 +65,7 @@ tool_rc tpm2_util_object_load_auth(
             const char *objectstr,
             const char *auth,
             tpm2_loaded_object *outobject,
-            bool is_restricted_pswd_session);
+            bool is_restricted_pswd_session,
+            tpm2_hierarchy_flags flags);
 
 #endif /* LIB_OBJECT_H_ */

--- a/lib/tpm2_hierarchy.h
+++ b/lib/tpm2_hierarchy.h
@@ -20,7 +20,8 @@ enum tpm2_hierarchy_flags {
     TPM2_HIERARCHY_FLAGS_N    = 1 << 3,
     TPM2_HIERARCHY_FLAGS_L    = 1 << 4,
     TPM2_HIERARCHY_SUPPRESS   = 1 << 5,
-    TPM2_HIERARCHY_FLAGS_ALL  = 0x1F
+    TPM2_HIERARCHY_FLAGS_ALL  = 0x1F,
+    TPM2_HANDLES_ALL          = 0x3F
 };
 
 bool tpm2_hierarchy_from_optarg(const char *value,

--- a/tools/tpm2_activatecredential.c
+++ b/tools/tpm2_activatecredential.c
@@ -213,14 +213,15 @@ tool_rc tpm2_tool_onrun(ESYS_CONTEXT *ectx, tpm2_option_flags flags) {
     }
 
     tool_rc rc = tpm2_util_object_load_auth(ectx, ctx.credential_key.ctx_path,
-                ctx.credential_key.auth_str, &ctx.credential_key.object, false);
+                ctx.credential_key.auth_str, &ctx.credential_key.object, false,
+                TPM2_HANDLES_ALL);
     if (rc != tool_rc_success) {
         return rc;
     }
 
     rc = tpm2_util_object_load_auth(ectx, ctx.credentialed_key.ctx_path,
                 ctx.credentialed_key.auth_str, &ctx.credentialed_key.object,
-                false);
+                false, TPM2_HANDLES_ALL);
     if (rc != tool_rc_success) {
         return rc;
     }

--- a/tools/tpm2_certify.c
+++ b/tools/tpm2_certify.c
@@ -227,13 +227,15 @@ tool_rc tpm2_tool_onrun(ESYS_CONTEXT *ectx, tpm2_option_flags flags) {
 
     /* Load input files */
     tool_rc rc = tpm2_util_object_load_auth(ectx, ctx.certified_key.ctx_path,
-        ctx.certified_key.auth_str, &ctx.certified_key.object, false);
+        ctx.certified_key.auth_str, &ctx.certified_key.object, false,
+        TPM2_HANDLES_ALL);
     if (rc != tool_rc_success) {
         return rc;
     }
 
     rc = tpm2_util_object_load_auth(ectx, ctx.signing_key.ctx_path,
-        ctx.signing_key.auth_str, &ctx.signing_key.object, false);
+        ctx.signing_key.auth_str, &ctx.signing_key.object, false,
+        TPM2_HANDLES_ALL);
     if (rc != tool_rc_success) {
         return rc;
     }

--- a/tools/tpm2_changeauth.c
+++ b/tools/tpm2_changeauth.c
@@ -136,7 +136,7 @@ tool_rc tpm2_tool_onrun(ESYS_CONTEXT *ectx, tpm2_option_flags flags) {
     }
 
     tool_rc rc = tpm2_util_object_load_auth(ectx, ctx.object.ctx, ctx.object.auth_current,
-            &ctx.object.obj, false);
+            &ctx.object.obj, false, TPM2_HANDLES_ALL);
     if (rc != tool_rc_success) {
         return rc;
     }
@@ -155,7 +155,8 @@ tool_rc tpm2_tool_onrun(ESYS_CONTEXT *ectx, tpm2_option_flags flags) {
             return tool_rc_option_error;
         }
 
-        rc = tpm2_util_object_load(ectx, ctx.parent.ctx, &ctx.parent.obj);
+        rc = tpm2_util_object_load(ectx, ctx.parent.ctx, &ctx.parent.obj,
+            TPM2_HANDLES_ALL);
         if (rc != tool_rc_success) {
             return rc;
         }

--- a/tools/tpm2_clear.c
+++ b/tools/tpm2_clear.c
@@ -68,7 +68,8 @@ tool_rc tpm2_tool_onrun(ESYS_CONTEXT *ectx, tpm2_option_flags flags) {
     ctx.auth_hierarchy.ctx_path = ctx.platform ? platform : lockout;
 
     tool_rc rc = tpm2_util_object_load_auth(ectx, ctx.auth_hierarchy.ctx_path,
-        ctx.auth_hierarchy.auth_str, &ctx.auth_hierarchy.object, true);
+        ctx.auth_hierarchy.auth_str, &ctx.auth_hierarchy.object, true,
+        TPM2_HIERARCHY_FLAGS_L|TPM2_HIERARCHY_FLAGS_P);
     if (rc != tool_rc_success) {
         LOG_ERR("Invalid lockout authorization");
         return rc;

--- a/tools/tpm2_clearcontrol.c
+++ b/tools/tpm2_clearcontrol.c
@@ -109,7 +109,8 @@ tool_rc tpm2_tool_onrun(ESYS_CONTEXT *ectx, tpm2_option_flags flags) {
     UNUSED(flags);
 
     tool_rc rc = tpm2_util_object_load_auth(ectx, ctx.auth_hierarchy.ctx_path,
-        ctx.auth_hierarchy.auth_str, &ctx.auth_hierarchy.object, true);
+        ctx.auth_hierarchy.auth_str, &ctx.auth_hierarchy.object, true,
+        TPM2_HIERARCHY_FLAGS_P|TPM2_HIERARCHY_FLAGS_L);
     if (rc != tool_rc_success) {
         LOG_ERR("Invalid authorization");
         return rc;

--- a/tools/tpm2_create.c
+++ b/tools/tpm2_create.c
@@ -284,7 +284,7 @@ tool_rc tpm2_tool_onrun(ESYS_CONTEXT *ectx, tpm2_option_flags flags) {
     }
 
     rc = tpm2_util_object_load_auth(ectx, ctx.parent.ctx_path,
-            ctx.parent.auth_str, &ctx.parent.object, false);
+            ctx.parent.auth_str, &ctx.parent.object, false, TPM2_HANDLES_ALL);
     if (rc != tool_rc_success) {
         return rc;
     }

--- a/tools/tpm2_createak.c
+++ b/tools/tpm2_createak.c
@@ -458,7 +458,7 @@ tool_rc tpm2_tool_onrun(ESYS_CONTEXT *ectx, tpm2_option_flags flags) {
     }
 
     tool_rc rc = tpm2_util_object_load(ectx, ctx.ek.ctx_arg,
-                                &ctx.ek.ek_ctx);
+                                &ctx.ek.ek_ctx, TPM2_HANDLES_ALL);
     if (rc != tool_rc_success) {
         return rc;
     }

--- a/tools/tpm2_dictionarylockout.c
+++ b/tools/tpm2_dictionarylockout.c
@@ -109,7 +109,8 @@ tool_rc tpm2_tool_onrun(ESYS_CONTEXT *ectx, tpm2_option_flags flags) {
     }
 
     tool_rc rc = tpm2_util_object_load_auth(ectx, ctx.auth_hierarchy.ctx_path,
-        ctx.auth_hierarchy.auth_str, &ctx.auth_hierarchy.object, false);
+        ctx.auth_hierarchy.auth_str, &ctx.auth_hierarchy.object, false,
+        TPM2_HIERARCHY_FLAGS_L);
     if (rc != tool_rc_success) {
         LOG_ERR("Invalid authorization");
         return rc;

--- a/tools/tpm2_duplicate.c
+++ b/tools/tpm2_duplicate.c
@@ -227,13 +227,14 @@ tool_rc tpm2_tool_onrun(ESYS_CONTEXT *ectx, tpm2_option_flags flags) {
     }
 
     rc = tpm2_util_object_load(ectx, ctx.new_parent_key.ctx_path,
-            &ctx.new_parent_key.object);
+            &ctx.new_parent_key.object, TPM2_HANDLES_ALL);
     if (rc != tool_rc_success) {
         return rc;
     }
 
     rc = tpm2_util_object_load_auth(ectx, ctx.duplicable_key.ctx_path,
-		    ctx.duplicable_key.auth_str, &ctx.duplicable_key.object, false);
+		    ctx.duplicable_key.auth_str, &ctx.duplicable_key.object, false,
+            TPM2_HANDLES_ALL);
     if (rc != tool_rc_success) {
         LOG_ERR("Invalid authorization");
         return rc;

--- a/tools/tpm2_encryptdecrypt.c
+++ b/tools/tpm2_encryptdecrypt.c
@@ -324,7 +324,8 @@ tool_rc tpm2_tool_onrun(ESYS_CONTEXT *ectx, tpm2_option_flags flags) {
     }
 
     tool_rc rc = tpm2_util_object_load_auth(ectx, ctx.encryption_key.ctx_path,
-        ctx.encryption_key.auth_str, &ctx.encryption_key.object, false);
+        ctx.encryption_key.auth_str, &ctx.encryption_key.object, false,
+        TPM2_HANDLES_ALL);
     if (rc != tool_rc_success) {
         LOG_ERR("Invalid object key authorization");
         return rc;

--- a/tools/tpm2_evictcontrol.c
+++ b/tools/tpm2_evictcontrol.c
@@ -108,7 +108,7 @@ tool_rc tpm2_tool_onrun(ESYS_CONTEXT *ectx, tpm2_option_flags flags) {
     bool evicted = false;
 
     tool_rc tmp_rc = tpm2_util_object_load(ectx, ctx.to_persist_key.ctx_path,
-                &ctx.to_persist_key.object);
+                &ctx.to_persist_key.object, TPM2_HANDLES_ALL);
     if (tmp_rc != tool_rc_success) {
         rc = tmp_rc;
         goto out;
@@ -135,7 +135,8 @@ tool_rc tpm2_tool_onrun(ESYS_CONTEXT *ectx, tpm2_option_flags flags) {
     }
 
     rc = tpm2_util_object_load_auth(ectx, ctx.auth_hierarchy.ctx_path,
-        ctx.auth_hierarchy.auth_str, &ctx.auth_hierarchy.object, false);
+        ctx.auth_hierarchy.auth_str, &ctx.auth_hierarchy.object, false,
+        TPM2_HIERARCHY_FLAGS_O|TPM2_HIERARCHY_FLAGS_P);
     if (ctx.flags.o && !ctx.flags.p) {
         LOG_ERR("Cannot specify -o without using a persistent handle");
         goto out;

--- a/tools/tpm2_flushcontext.c
+++ b/tools/tpm2_flushcontext.c
@@ -154,7 +154,7 @@ tool_rc tpm2_tool_onrun(ESYS_CONTEXT *ectx, tpm2_option_flags flags) {
     }
 
     tool_rc rc = tpm2_util_object_load(ectx, ctx.context_arg,
-                &ctx.context_object);
+                &ctx.context_object, TPM2_HANDLES_ALL);
     if (rc != tool_rc_success) {
         return rc;
     }

--- a/tools/tpm2_hmac.c
+++ b/tools/tpm2_hmac.c
@@ -227,7 +227,7 @@ tool_rc tpm2_tool_onrun(ESYS_CONTEXT *ectx, tpm2_option_flags flags) {
     }
 
     tool_rc rc = tpm2_util_object_load_auth(ectx, ctx.hmac_key.ctx_path,
-        ctx.hmac_key.auth_str, &ctx.hmac_key.object, false);
+        ctx.hmac_key.auth_str, &ctx.hmac_key.object, false, TPM2_HANDLES_ALL);
     if (rc != tool_rc_success) {
         LOG_ERR("Invalid key handle authorization");
         return rc;

--- a/tools/tpm2_import.c
+++ b/tools/tpm2_import.c
@@ -632,7 +632,7 @@ tool_rc tpm2_tool_onrun(ESYS_CONTEXT *ectx, tpm2_option_flags flags) {
     }
 
     rc = tpm2_util_object_load_auth(ectx, ctx.parent.ctx_path,
-        ctx.parent.auth_str, &ctx.parent.object, false);
+        ctx.parent.auth_str, &ctx.parent.object, false, TPM2_HANDLES_ALL);
     if (rc != tool_rc_success) {
         LOG_ERR("Invalid parent key authorization");
         return rc;

--- a/tools/tpm2_load.c
+++ b/tools/tpm2_load.c
@@ -149,7 +149,7 @@ tool_rc tpm2_tool_onrun(ESYS_CONTEXT *ectx, tpm2_option_flags flags) {
     }
 
     tool_rc rc = tpm2_util_object_load_auth(ectx, ctx.parent.ctx_path,
-        ctx.parent.auth_str, &ctx.parent.object, false);
+        ctx.parent.auth_str, &ctx.parent.object, false, TPM2_HANDLES_ALL);
     if (rc != tool_rc_success) {
         return rc;
     }

--- a/tools/tpm2_nvdefine.c
+++ b/tools/tpm2_nvdefine.c
@@ -157,7 +157,8 @@ tool_rc tpm2_tool_onrun(ESYS_CONTEXT *ectx, tpm2_option_flags flags) {
     UNUSED(flags);
 
     tool_rc rc = tpm2_util_object_load_auth(ectx, ctx.auth_hierarchy.ctx_path,
-            ctx.auth_hierarchy.auth_str, &ctx.auth_hierarchy.object, false);
+            ctx.auth_hierarchy.auth_str, &ctx.auth_hierarchy.object, false,
+            TPM2_HIERARCHY_FLAGS_O|TPM2_HIERARCHY_FLAGS_P);
     if (rc != tool_rc_success) {
         LOG_ERR("Invalid authorization");
         return rc;

--- a/tools/tpm2_nvincrement.c
+++ b/tools/tpm2_nvincrement.c
@@ -85,7 +85,8 @@ tool_rc tpm2_tool_onrun(ESYS_CONTEXT *ectx, tpm2_option_flags flags) {
     UNUSED(flags);
 
     tool_rc rc = tpm2_util_object_load_auth(ectx, ctx.auth_hierarchy.ctx_path,
-        ctx.auth_hierarchy.auth_str, &ctx.auth_hierarchy.object, false);
+        ctx.auth_hierarchy.auth_str, &ctx.auth_hierarchy.object, false,
+        TPM2_HANDLES_ALL);
     if (rc != tool_rc_success) {
         LOG_ERR("Invalid handle authorization");
         return rc;

--- a/tools/tpm2_nvread.c
+++ b/tools/tpm2_nvread.c
@@ -146,7 +146,8 @@ tool_rc tpm2_tool_onrun(ESYS_CONTEXT *ectx, tpm2_option_flags flags) {
     UNUSED(flags);
 
     tool_rc rc = tpm2_util_object_load_auth(ectx, ctx.auth_hierarchy.ctx_path,
-        ctx.auth_hierarchy.auth_str, &ctx.auth_hierarchy.object, false);
+        ctx.auth_hierarchy.auth_str, &ctx.auth_hierarchy.object, false,
+        TPM2_HANDLES_ALL);
     if (rc != tool_rc_success) {
         LOG_ERR("Invalid handle authorization");
         return rc;

--- a/tools/tpm2_nvreadlock.c
+++ b/tools/tpm2_nvreadlock.c
@@ -81,7 +81,8 @@ tool_rc tpm2_tool_onrun(ESYS_CONTEXT *ectx, tpm2_option_flags flags) {
     UNUSED(flags);
 
     tool_rc rc = tpm2_util_object_load_auth(ectx, ctx.auth_hierarchy.ctx_path,
-        ctx.auth_hierarchy.auth_str, &ctx.auth_hierarchy.object, false);
+        ctx.auth_hierarchy.auth_str, &ctx.auth_hierarchy.object, false,
+        TPM2_HANDLES_ALL);
     if (rc != tool_rc_success) {
         LOG_ERR("Invalid handle authorization");
         return rc;

--- a/tools/tpm2_nvrelease.c
+++ b/tools/tpm2_nvrelease.c
@@ -80,7 +80,8 @@ tool_rc tpm2_tool_onrun(ESYS_CONTEXT *ectx, tpm2_option_flags flags) {
     UNUSED(flags);
 
     tool_rc rc = tpm2_util_object_load_auth(ectx, ctx.auth_hierarchy.ctx_path,
-        ctx.auth_hierarchy.auth_str, &ctx.auth_hierarchy.object, false);
+        ctx.auth_hierarchy.auth_str, &ctx.auth_hierarchy.object, false,
+        TPM2_HIERARCHY_FLAGS_O|TPM2_HIERARCHY_FLAGS_P);
     if (rc != tool_rc_success) {
         LOG_ERR("Invalid handle authorization");
         return rc;

--- a/tools/tpm2_nvwrite.c
+++ b/tools/tpm2_nvwrite.c
@@ -185,7 +185,8 @@ tool_rc tpm2_tool_onrun(ESYS_CONTEXT *ectx, tpm2_option_flags flags) {
     UNUSED(flags);
 
     tool_rc rc = tpm2_util_object_load_auth(ectx, ctx.auth_hierarchy.ctx_path,
-        ctx.auth_hierarchy.auth_str, &ctx.auth_hierarchy.object, false);
+        ctx.auth_hierarchy.auth_str, &ctx.auth_hierarchy.object, false,
+        TPM2_HANDLES_ALL);
     if (rc != tool_rc_success) {
         LOG_ERR("Invalid handle authorization");
         return rc;

--- a/tools/tpm2_pcrallocate.c
+++ b/tools/tpm2_pcrallocate.c
@@ -82,7 +82,8 @@ tool_rc tpm2_tool_onrun(ESYS_CONTEXT *ectx, tpm2_option_flags flags) {
     UNUSED(flags);
 
     tool_rc rc = tpm2_util_object_load_auth(ectx, ctx.auth_hierarchy.ctx_path,
-        ctx.auth_hierarchy.auth_str, &ctx.auth_hierarchy.object, false);
+        ctx.auth_hierarchy.auth_str, &ctx.auth_hierarchy.object, false,
+        TPM2_HIERARCHY_FLAGS_P);
     if (rc != tool_rc_success) {
         LOG_ERR("Invalid platform authorization format.");
         return rc;

--- a/tools/tpm2_policysecret.c
+++ b/tools/tpm2_policysecret.c
@@ -117,7 +117,8 @@ tool_rc tpm2_tool_onrun(ESYS_CONTEXT *ectx, tpm2_option_flags flags) {
     }
 
     rc = tpm2_util_object_load_auth(ectx, ctx.auth_entity.ctx_path,
-            ctx.auth_entity.auth_str, &ctx.auth_entity.object, true);
+            ctx.auth_entity.auth_str, &ctx.auth_entity.object, true,
+            TPM2_HANDLES_ALL);
     if (rc != tool_rc_success) {
         return rc;
     }

--- a/tools/tpm2_quote.c
+++ b/tools/tpm2_quote.c
@@ -307,7 +307,7 @@ tool_rc tpm2_tool_onrun(ESYS_CONTEXT *ectx, tpm2_option_flags flags) {
     }
 
     tool_rc rc = tpm2_util_object_load_auth(ectx, ctx.ak.ctx_path,
-        ctx.ak.auth_str, &ctx.ak.object, false);
+        ctx.ak.auth_str, &ctx.ak.object, false, TPM2_HANDLES_ALL);
     if (rc != tool_rc_success) {
         LOG_ERR("Invalid AK authorization");
         return rc;

--- a/tools/tpm2_readpublic.c
+++ b/tools/tpm2_readpublic.c
@@ -139,8 +139,8 @@ bool tpm2_tool_onstart(tpm2_options **opts) {
 
 static tool_rc init(ESYS_CONTEXT *context) {
 
-    tool_rc rc = tpm2_util_object_load(context,
-                                ctx.context_arg, &ctx.context_object);
+    tool_rc rc = tpm2_util_object_load(context, ctx.context_arg,
+        &ctx.context_object, TPM2_HANDLES_ALL);
     if (rc != tool_rc_success) {
         return rc;
     }

--- a/tools/tpm2_rsadecrypt.c
+++ b/tools/tpm2_rsadecrypt.c
@@ -125,7 +125,7 @@ static tool_rc init(ESYS_CONTEXT *ectx) {
     }
 
     return tpm2_util_object_load_auth(ectx, ctx.key.ctx_path, ctx.key.auth_str,
-                                &ctx.key.object, false);
+                                &ctx.key.object, false, TPM2_HANDLES_ALL);
 }
 
 tool_rc tpm2_tool_onrun(ESYS_CONTEXT *ectx, tpm2_option_flags flags) {

--- a/tools/tpm2_rsaencrypt.c
+++ b/tools/tpm2_rsaencrypt.c
@@ -120,8 +120,8 @@ static tool_rc init(ESYS_CONTEXT *context) {
         return tool_rc_general_error;
     }
 
-    return tpm2_util_object_load(context,
-                     ctx.context_arg, &ctx.key_context);
+    return tpm2_util_object_load(context, ctx.context_arg, &ctx.key_context,
+        TPM2_HANDLES_ALL);
 }
 
 tool_rc tpm2_tool_onrun(ESYS_CONTEXT *context, tpm2_option_flags flags) {

--- a/tools/tpm2_sign.c
+++ b/tools/tpm2_sign.c
@@ -261,7 +261,8 @@ tool_rc tpm2_tool_onrun(ESYS_CONTEXT *ectx, tpm2_option_flags flags) {
     UNUSED(flags);
 
     tool_rc rc = tpm2_util_object_load_auth(ectx, ctx.signing_key.ctx_path,
-        ctx.signing_key.auth_str, &ctx.signing_key.object, false);
+        ctx.signing_key.auth_str, &ctx.signing_key.object, false,
+        TPM2_HANDLES_ALL);
     if (rc != tool_rc_success) {
         LOG_ERR("Invalid key authorization");
         return rc;

--- a/tools/tpm2_startauthsession.c
+++ b/tools/tpm2_startauthsession.c
@@ -98,8 +98,9 @@ tool_rc tpm2_tool_onrun(ESYS_CONTEXT *ectx, tpm2_option_flags flags) {
     }
 
     if (ctx.session.key_context_arg_str) {
-        tool_rc tmp_rc = tpm2_util_object_load(ectx, ctx.session.key_context_arg_str,
-                                    &ctx.session.key_context_object);
+        tool_rc tmp_rc = tpm2_util_object_load(ectx,
+            ctx.session.key_context_arg_str, &ctx.session.key_context_object,
+            TPM2_HANDLES_ALL);
         if (tmp_rc != tool_rc_success) {
             return tmp_rc;
         }

--- a/tools/tpm2_unseal.c
+++ b/tools/tpm2_unseal.c
@@ -73,7 +73,7 @@ static tool_rc init(ESYS_CONTEXT *ectx) {
     }
 
     tool_rc rc =  tpm2_util_object_load_auth(ectx, ctx.sealkey.ctx_path,
-            ctx.sealkey.auth_str, &ctx.sealkey.object, false);
+            ctx.sealkey.auth_str, &ctx.sealkey.object, false, TPM2_HANDLES_ALL);
     if (rc != tool_rc_success) {
         LOG_ERR("Invalid item handle authorization");
         return rc;

--- a/tools/tpm2_verifysignature.c
+++ b/tools/tpm2_verifysignature.c
@@ -129,7 +129,7 @@ static tool_rc init(ESYS_CONTEXT *context) {
     TPM2B *msg = NULL;
 
     tool_rc tmp_rc = tpm2_util_object_load(context, ctx.context_arg,
-                                &ctx.key_context_object);
+        &ctx.key_context_object, TPM2_HANDLES_ALL);
     if (tmp_rc != tool_rc_success) {
         return tmp_rc;
     }


### PR DESCRIPTION
Progresses #1462 

Tools that operate only with certain hierarchies could explicitly
specify it either with a string or a hex handle of the hierarchy.
This is required in tools like tpm2_clear tpm2_clearcontrol
tpm2_dictionarylockout tpm2_evictcontrol tpm2_nvdefine
tpm2_nvrelease tpm2_pcrallocate.

Signed-off-by: Imran Desai <imranodesai@gmail.com>