### PR TITLE
man/tools: rename option --sig to --signature for tpm2_checkquote

### DIFF
--- a/man/tpm2_checkquote.1.md
+++ b/man/tpm2_checkquote.1.md
@@ -35,7 +35,7 @@ provided, verify that the qualifying data and PCR values match those in the quot
 
     The quote message that makes up the data that is signed by the TPM.
 
-  * **-s**, **\--sig**=_SIG\_FILE_:
+  * **-s**, **\--signature**=_SIG\_FILE_:
 
     The input signature file of the signature to be validated.
 

--- a/tools/misc/tpm2_checkquote.c
+++ b/tools/misc/tpm2_checkquote.c
@@ -349,7 +349,7 @@ bool tpm2_tool_onstart(tpm2_options **opts) {
             { "halg",           required_argument, NULL, 'g' },
             { "message",        required_argument, NULL, 'm' },
             { "format",         required_argument, NULL, 'f' },
-            { "sig",            required_argument, NULL, 's' },
+            { "signature",      required_argument, NULL, 's' },
             { "pcr-input-file", required_argument, NULL, 'F' },
             { "pubfile",        required_argument, NULL, 'u' },
             { "qualify-data",   required_argument, NULL, 'q' },


### PR DESCRIPTION
Rename `--sig` to `--signature` for both the man page and the tool to align the options of `tpm2_checkquote` with `tpm2_quote`.

Fixes #1488.