### PR TITLE
tpm2_encryptdecrypt: Update encryptdecrypt tool and man page

### DIFF
--- a/man/tpm2_encryptdecrypt.1.md
+++ b/man/tpm2_encryptdecrypt.1.md
@@ -32,7 +32,7 @@ specified symmetric key.
 
     Perform a decrypt operation. Default is encryption.
 
-  * **-e**, **\--enable-pkcs7-padding**:
+  * **-e**, **\--pad**:
 
     Enable pkcs7 padding for applicable AES encryption modes cfb/cbc/ecb.
     Applicable only to encryption and for input data with last block shorter

--- a/test/integration/tests/encryptdecrypt.sh
+++ b/test/integration/tests/encryptdecrypt.sh
@@ -95,11 +95,31 @@ tpm2_encryptdecrypt -Q -c decrypt.ctx -i encrypt.out -D -o decrypt.out
 cmp secret2.dat decrypt.out
 
 # Test that last block in input data shorter than block length has pkcs7 padding
-dd if=/dev/zero bs=1 count=1026 status=none of=secret2.dat
+dd if=/dev/zero bs=1 count=2050 status=none of=secret2.dat
 cat secret2.dat | tpm2_encryptdecrypt -Q -c decrypt.ctx -o encrypt.out -e
 tpm2_encryptdecrypt -Q -c decrypt.ctx -i encrypt.out -D -o decrypt.out
 ## Last block is short 14 or hex 0E trailing bytes
 echo "0e0e0e0e0e0e0e0e0e0e0e0e0e0e" | xxd -r -p >> secret2.dat
+cmp secret2.dat decrypt.out
+
+# Test that pkcs7 padding is added as last block for block length aligned inputs
+dd if=/dev/zero bs=1 count=2048 status=none of=secret2.dat
+cat secret2.dat | tpm2_encryptdecrypt -Q -c decrypt.ctx -o encrypt.out -e
+tpm2_encryptdecrypt -Q -c decrypt.ctx -i encrypt.out -D -o decrypt.out
+## Last block is short 14 or hex 0E trailing bytes
+echo "10101010101010101010101010101010" | xxd -r -p >> secret2.dat
+cmp secret2.dat decrypt.out
+
+# Test pkcs7 padding is stripped from input data is shorter than block length
+dd if=/dev/zero bs=1 count=2050 status=none of=secret2.dat
+cat secret2.dat | tpm2_encryptdecrypt -Q -c decrypt.ctx -o encrypt.out -e
+tpm2_encryptdecrypt -Q -c decrypt.ctx -i encrypt.out -D -o decrypt.out -e
+cmp secret2.dat decrypt.out
+
+# Test that pkcs7 pad is stripped off last block for block length aligned inputs
+dd if=/dev/zero bs=1 count=2048 status=none of=secret2.dat
+cat secret2.dat | tpm2_encryptdecrypt -Q -c decrypt.ctx -o encrypt.out -e
+tpm2_encryptdecrypt -Q -c decrypt.ctx -i encrypt.out -D -o decrypt.out -e
 cmp secret2.dat decrypt.out
 
 # Negative that bad mode fails


### PR DESCRIPTION
Progresses #1547
1. Rename cmdline option to pkcs7-pad
2. Separate out a function for pkcs7 padding
3. Use memset instead of for loops to allow compiler to optimize padding
4. Fix: Padding is necessary also for data that is aligned at block length
5. Add tests for checking padding on data that is aligned at block length 
6. Fix: Strip padding data when decrypting
7. Add tests for checking pad data is stripped on input data with aligned block length
8. Add tests for checking pad data is stripped on input data with unaligned block length

Signed-off-by: Imran Desai <imranodesai@gmail.com>