### PR TITLE
tpm2_policycommandcode: add nice name resolution

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -181,7 +181,8 @@ check_PROGRAMS = \
     test/unit/test_tpm2_policy \
     test/unit/test_tpm2_hierarchy \
     test/unit/test_tpm2_error \
-    test/unit/test_options
+    test/unit/test_options \
+    test/unit/test_cc_util
 
 TESTS += $(ALL_SYSTEM_TESTS)
 
@@ -248,6 +249,9 @@ test_unit_test_options_LDFLAGS  = -Wl,--wrap=tpm2_util_dlopen \
                                -Wl,--wrap=tpm2_util_dlsym \
                                -Wl,--wrap=tpm2_util_getenv
 test_unit_test_options_LDADD    = $(CMOCKA_LIBS) $(LDADD)
+
+test_unit_test_cc_util_CFLAGS   = $(AM_CFLAGS) $(CMOCKA_CFLAGS)
+test_unit_test_cc_util_LDADD    = $(CMOCKA_LIBS) $(LDADD)
 
 AM_TESTS_ENVIRONMENT =	\
 	TPM2_ABRMD=tpm2-abrmd; export TPM2_ABRMD; \

--- a/lib/tpm2_cc_util.c
+++ b/lib/tpm2_cc_util.c
@@ -1,0 +1,171 @@
+/* SPDX-License-Identifier: BSD-3-Clause */
+#include <string.h>
+
+#include "log.h"
+#include "tpm2_cc_util.h"
+
+typedef struct cc_map cc_map;
+struct cc_map {
+    TPM2_CC cc;
+    const char *str;
+};
+
+#define ADDCC(s, c) { .str = s, .cc = c }
+
+bool tpm2_cc_util_from_str(const char *str, TPM2_CC *cc) {
+
+    /*
+     * build a map of str to CC value. This can't be as simple as they array index
+     * because they don't start at 0, and a fixed offset doesn't work becuase there
+     *  are gaps, for example: TPM2_CC_Sign to TPM2_CC_Unseal
+     *
+     * This map can be mostly generate by:
+     * for c in `grep TPM2_CC_ ./include/tss2/tss2_tpm2_types.h | cut -d' ' -f 2-2`; do \
+     *     p=`echo $c | cut -d'_' -f3- | sed s/_//g | tr '[:upper:]' '[:lower:]'`; \
+     *     echo "ADDCC(\"$p\", $c),"; \
+     * done;
+     *
+     * You have to remove TPM2_CC_FIRST and TPM2_CC_LAST
+     */
+    static const cc_map map[] = {
+        ADDCC("nvundefinespacespecial", TPM2_CC_NV_UndefineSpaceSpecial),
+        ADDCC("evictcontrol", TPM2_CC_EvictControl),
+        ADDCC("hierarchycontrol", TPM2_CC_HierarchyControl),
+        ADDCC("nvundefinespace", TPM2_CC_NV_UndefineSpace),
+        ADDCC("changeeps", TPM2_CC_ChangeEPS),
+        ADDCC("changepps", TPM2_CC_ChangePPS),
+        ADDCC("clear", TPM2_CC_Clear),
+        ADDCC("clearcontrol", TPM2_CC_ClearControl),
+        ADDCC("clockset", TPM2_CC_ClockSet),
+        ADDCC("hierarchychangeauth", TPM2_CC_HierarchyChangeAuth),
+        ADDCC("nvdefinespace", TPM2_CC_NV_DefineSpace),
+        ADDCC("pcrallocate", TPM2_CC_PCR_Allocate),
+        ADDCC("pcrsetauthpolicy", TPM2_CC_PCR_SetAuthPolicy),
+        ADDCC("ppcommands", TPM2_CC_PP_Commands),
+        ADDCC("setprimarypolicy", TPM2_CC_SetPrimaryPolicy),
+        ADDCC("fieldupgradestart", TPM2_CC_FieldUpgradeStart),
+        ADDCC("clockrateadjust", TPM2_CC_ClockRateAdjust),
+        ADDCC("createprimary", TPM2_CC_CreatePrimary),
+        ADDCC("nvglobalwritelock", TPM2_CC_NV_GlobalWriteLock),
+        ADDCC("getcommandauditdigest", TPM2_CC_GetCommandAuditDigest),
+        ADDCC("nvincrement", TPM2_CC_NV_Increment),
+        ADDCC("nvsetbits", TPM2_CC_NV_SetBits),
+        ADDCC("nvextend", TPM2_CC_NV_Extend),
+        ADDCC("nvwrite", TPM2_CC_NV_Write),
+        ADDCC("nvwritelock", TPM2_CC_NV_WriteLock),
+        ADDCC("dictionaryattacklockreset", TPM2_CC_DictionaryAttackLockReset),
+        ADDCC("dictionaryattackparameters", TPM2_CC_DictionaryAttackParameters),
+        ADDCC("nvchangeauth", TPM2_CC_NV_ChangeAuth),
+        ADDCC("pcrevent", TPM2_CC_PCR_Event),
+        ADDCC("pcrreset", TPM2_CC_PCR_Reset),
+        ADDCC("sequencecomplete", TPM2_CC_SequenceComplete),
+        ADDCC("setalgorithmset", TPM2_CC_SetAlgorithmSet),
+        ADDCC("setcommandcodeauditstatus", TPM2_CC_SetCommandCodeAuditStatus),
+        ADDCC("fieldupgradedata", TPM2_CC_FieldUpgradeData),
+        ADDCC("incrementalselftest", TPM2_CC_IncrementalSelfTest),
+        ADDCC("selftest", TPM2_CC_SelfTest),
+        ADDCC("startup", TPM2_CC_Startup),
+        ADDCC("shutdown", TPM2_CC_Shutdown),
+        ADDCC("stirrandom", TPM2_CC_StirRandom),
+        ADDCC("activatecredential", TPM2_CC_ActivateCredential),
+        ADDCC("certify", TPM2_CC_Certify),
+        ADDCC("policynv", TPM2_CC_PolicyNV),
+        ADDCC("certifycreation", TPM2_CC_CertifyCreation),
+        ADDCC("duplicate", TPM2_CC_Duplicate),
+        ADDCC("gettime", TPM2_CC_GetTime),
+        ADDCC("getsessionauditdigest", TPM2_CC_GetSessionAuditDigest),
+        ADDCC("nvread", TPM2_CC_NV_Read),
+        ADDCC("nvreadlock", TPM2_CC_NV_ReadLock),
+        ADDCC("objectchangeauth", TPM2_CC_ObjectChangeAuth),
+        ADDCC("policysecret", TPM2_CC_PolicySecret),
+        ADDCC("rewrap", TPM2_CC_Rewrap),
+        ADDCC("create", TPM2_CC_Create),
+        ADDCC("ecdhzgen", TPM2_CC_ECDH_ZGen),
+        ADDCC("hmac", TPM2_CC_HMAC),
+        ADDCC("import", TPM2_CC_Import),
+        ADDCC("load", TPM2_CC_Load),
+        ADDCC("quote", TPM2_CC_Quote),
+        ADDCC("rsadecrypt", TPM2_CC_RSA_Decrypt),
+        ADDCC("hmacstart", TPM2_CC_HMAC_Start),
+        ADDCC("sequenceupdate", TPM2_CC_SequenceUpdate),
+        ADDCC("sign", TPM2_CC_Sign),
+        ADDCC("unseal", TPM2_CC_Unseal),
+        ADDCC("policysigned", TPM2_CC_PolicySigned),
+        ADDCC("contextload", TPM2_CC_ContextLoad),
+        ADDCC("contextsave", TPM2_CC_ContextSave),
+        ADDCC("ecdhkeygen", TPM2_CC_ECDH_KeyGen),
+        ADDCC("encryptdecrypt", TPM2_CC_EncryptDecrypt),
+        ADDCC("flushcontext", TPM2_CC_FlushContext),
+        ADDCC("loadexternal", TPM2_CC_LoadExternal),
+        ADDCC("makecredential", TPM2_CC_MakeCredential),
+        ADDCC("nvreadpublic", TPM2_CC_NV_ReadPublic),
+        ADDCC("policyauthorize", TPM2_CC_PolicyAuthorize),
+        ADDCC("policyauthvalue", TPM2_CC_PolicyAuthValue),
+        ADDCC("policycommandcode", TPM2_CC_PolicyCommandCode),
+        ADDCC("policycountertimer", TPM2_CC_PolicyCounterTimer),
+        ADDCC("policycphash", TPM2_CC_PolicyCpHash),
+        ADDCC("policylocality", TPM2_CC_PolicyLocality),
+        ADDCC("policynamehash", TPM2_CC_PolicyNameHash),
+        ADDCC("policyor", TPM2_CC_PolicyOR),
+        ADDCC("policyticket", TPM2_CC_PolicyTicket),
+        ADDCC("readpublic", TPM2_CC_ReadPublic),
+        ADDCC("rsaencrypt", TPM2_CC_RSA_Encrypt),
+        ADDCC("startauthsession", TPM2_CC_StartAuthSession),
+        ADDCC("verifysignature", TPM2_CC_VerifySignature),
+        ADDCC("eccparameters", TPM2_CC_ECC_Parameters),
+        ADDCC("firmwareread", TPM2_CC_FirmwareRead),
+        ADDCC("getcapability", TPM2_CC_GetCapability),
+        ADDCC("getrandom", TPM2_CC_GetRandom),
+        ADDCC("gettestresult", TPM2_CC_GetTestResult),
+        ADDCC("hash", TPM2_CC_Hash),
+        ADDCC("pcrread", TPM2_CC_PCR_Read),
+        ADDCC("policypcr", TPM2_CC_PolicyPCR),
+        ADDCC("policyrestart", TPM2_CC_PolicyRestart),
+        ADDCC("readclock", TPM2_CC_ReadClock),
+        ADDCC("pcrextend", TPM2_CC_PCR_Extend),
+        ADDCC("pcrsetauthvalue", TPM2_CC_PCR_SetAuthValue),
+        ADDCC("nvcertify", TPM2_CC_NV_Certify),
+        ADDCC("eventsequencecomplete", TPM2_CC_EventSequenceComplete),
+        ADDCC("hashsequencestart", TPM2_CC_HashSequenceStart),
+        ADDCC("policyphysicalpresence", TPM2_CC_PolicyPhysicalPresence),
+        ADDCC("policyduplicationselect", TPM2_CC_PolicyDuplicationSelect),
+        ADDCC("policygetdigest", TPM2_CC_PolicyGetDigest),
+        ADDCC("testparms", TPM2_CC_TestParms),
+        ADDCC("commit", TPM2_CC_Commit),
+        ADDCC("policypassword", TPM2_CC_PolicyPassword),
+        ADDCC("zgen2phase", TPM2_CC_ZGen_2Phase),
+        ADDCC("ecephemeral", TPM2_CC_EC_Ephemeral),
+        ADDCC("policynvwritten", TPM2_CC_PolicyNvWritten),
+        ADDCC("policytemplate", TPM2_CC_PolicyTemplate),
+        ADDCC("createloaded", TPM2_CC_CreateLoaded),
+        ADDCC("policyauthorizenv", TPM2_CC_PolicyAuthorizeNV),
+        ADDCC("encryptdecrypt2", TPM2_CC_EncryptDecrypt2),
+        ADDCC("acgetcapability", TPM2_CC_AC_GetCapability),
+        ADDCC("acsend", TPM2_CC_AC_Send),
+        ADDCC("policyacsendselect", TPM2_CC_Policy_AC_SendSelect),
+        ADDCC("vendortcgtest", TPM2_CC_Vendor_TCG_Test),
+    };
+
+    if (!str || !cc) {
+        return false;
+    }
+
+    bool result = tpm2_util_string_to_uint32(str, cc);
+    if (result) {
+        return true;
+    }
+
+    size_t i;
+    for (i=0; i < ARRAY_LEN(map); i++) {
+        const cc_map *m = &map[i];
+        if (!strcmp(str, m->str)) {
+            *cc = m->cc;
+            return true;
+        }
+    }
+
+    LOG_ERR("Could not convert command-code to number, got: \"%s\"",
+            str);
+
+    return false;
+}

--- a/lib/tpm2_cc_util.h
+++ b/lib/tpm2_cc_util.h
@@ -1,0 +1,12 @@
+/* SPDX-License-Identifier: BSD-3-Clause */
+
+#ifndef LIB_TPM2_CC_UTIL_H_
+#define LIB_TPM2_CC_UTIL_H_
+
+#include <stdbool.h>
+
+#include <tss2/tss2_tpm2_types.h>
+
+bool tpm2_cc_util_from_str(const char *str, TPM2_CC *cc);
+
+#endif /* LIB_TPM2_CC_UTIL_H_ */

--- a/man/tpm2_policycommandcode.1.md
+++ b/man/tpm2_policycommandcode.1.md
@@ -16,7 +16,10 @@ TPM commands or operations.
 **tpm2_policycommandcode**(1) - Restricts TPM object authorization to specific
 TPM commands or operations. Useful when you want to allow only specific commands
 with the TPM object. As an argument it takes the _COMMAND\_CODE_ as an integer
-value. Requires support for extended sessions with resource manager.
+or friendly string value. Friendly string to COMMAND CODE mapping can be found
+in section *COMMAND CODE MAPPINGS*.
+
+Requires support for extended sessions with resource manager.
 
 # OPTIONS
 
@@ -31,6 +34,137 @@ value. Requires support for extended sessions with resource manager.
 [common options](common/options.md)
 
 [common tcti options](common/tcti.md)
+
+<!-- Generated Via (requires minor hand tweaks still)
+IFS=$'\n'
+for c in `grep TPM2_CC_ ./include/tss2/tss2_tpm2_types.h`; do
+  n=`echo $c | awk {'print $4'} | sed s/\)// | sed s/0x00000/0x/`
+  p=`echo $c |awk {'print$2'} | cut -d'_' -f3- | sed s/_//g | tr '[:upper:]' '[:lower:]'`
+  echo "  -$p: $n"
+done;
+-->
+
+# COMM AND CODE MAPPINGS
+
+The friendly strings below can be used en lieu of the raw integer values.
+
+  - nvundefinespacespecial: 0x11f
+  - evictcontrol: 0x120
+  - hierarchycontrol: 0x121
+  - nvundefinespace: 0x122
+  - changeeps: 0x124
+  - changepps: 0x125
+  - clear: 0x126
+  - clearcontrol: 0x127
+  - clockset: 0x128
+  - hierarchychangeauth: 0x129
+  - nvdefinespace: 0x12a
+  - pcrallocate: 0x12b
+  - pcrsetauthpolicy: 0x12c
+  - ppcommands: 0x12d
+  - setprimarypolicy: 0x12e
+  - fieldupgradestart: 0x12f
+  - clockrateadjust: 0x130
+  - createprimary: 0x131
+  - nvglobalwritelock: 0x132
+  - getcommandauditdigest: 0x133
+  - nvincrement: 0x134
+  - nvsetbits: 0x135
+  - nvextend: 0x136
+  - nvwrite: 0x137
+  - nvwritelock: 0x138
+  - dictionaryattacklockreset: 0x139
+  - dictionaryattackparameters: 0x13a
+  - nvchangeauth: 0x13b
+  - pcrevent: 0x13c
+  - pcrreset: 0x13d
+  - sequencecomplete: 0x13e
+  - setalgorithmset: 0x13f
+  - setcommandcodeauditstatus: 0x140
+  - fieldupgradedata: 0x141
+  - incrementalselftest: 0x142
+  - selftest: 0x143
+  - startup: 0x144
+  - shutdown: 0x145
+  - stirrandom: 0x146
+  - activatecredential: 0x147
+  - certify: 0x148
+  - policynv: 0x149
+  - certifycreation: 0x14a
+  - duplicate: 0x14b
+  - gettime: 0x14c
+  - getsessionauditdigest: 0x14d
+  - nvread: 0x14e
+  - nvreadlock: 0x14f
+  - objectchangeauth: 0x150
+  - policysecret: 0x151
+  - rewrap: 0x152
+  - create: 0x153
+  - ecdhzgen: 0x154
+  - hmac: 0x155
+  - import: 0x156
+  - load: 0x157
+  - quote: 0x158
+  - rsadecrypt: 0x159
+  - hmacstart: 0x15b
+  - sequenceupdate: 0x15c
+  - sign: 0x15d
+  - unseal: 0x15e
+  - policysigned: 0x160
+  - contextload: 0x161
+  - contextsave: 0x162
+  - ecdhkeygen: 0x163
+  - encryptdecrypt: 0x164
+  - flushcontext: 0x165
+  - loadexternal: 0x167
+  - makecredential: 0x168
+  - nvreadpublic: 0x169
+  - policyauthorize: 0x16a
+  - policyauthvalue: 0x16b
+  - policycommandcode: 0x16c
+  - policycountertimer: 0x16d
+  - policycphash: 0x16e
+  - policylocality: 0x16f
+  - policynamehash: 0x170
+  - policyor: 0x171
+  - policyticket: 0x172
+  - readpublic: 0x173
+  - rsaencrypt: 0x174
+  - startauthsession: 0x176
+  - verifysignature: 0x177
+  - eccparameters: 0x178
+  - firmwareread: 0x179
+  - getcapability: 0x17a
+  - getrandom: 0x17b
+  - gettestresult: 0x17c
+  - hash: 0x17d
+  - pcrread: 0x17e
+  - policypcr: 0x17f
+  - policyrestart: 0x180
+  - readclock: 0x181
+  - pcrextend: 0x182
+  - pcrsetauthvalue: 0x183
+  - nvcertify: 0x184
+  - eventsequencecomplete: 0x185
+  - hashsequencestart: 0x186
+  - policyphysicalpresence: 0x187
+  - policyduplicationselect: 0x188
+  - policygetdigest: 0x189
+  - testparms: 0x18a
+  - commit: 0x18b
+  - policypassword: 0x18c
+  - zgen2phase: 0x18d
+  - ecephemeral: 0x18e
+  - policynvwritten: 0x18f
+  - policytemplate: 0x190
+  - createloaded: 0x191
+  - policyauthorizenv: 0x192
+  - encryptdecrypt2: 0x193
+  - acgetcapability: 0x194
+  - acsend: 0x195
+  - policyacsendselect: 0x196
+  - vendortcgtest: 0x20000000
+
 
 # EXAMPLES
 

--- a/test/integration/tests/abrmd_policycommandcode.sh
+++ b/test/integration/tests/abrmd_policycommandcode.sh
@@ -3,7 +3,6 @@
 
 source helpers.sh
 
-TPM_CC_UNSEAL=0x15E
 file_primary_key_ctx=prim.ctx
 file_input_data=secret.data
 file_policy=policy.data
@@ -37,11 +36,9 @@ tpm2_clear
 
 tpm2_createprimary -Q -a o -o $file_primary_key_ctx
 
-TPM_CC_UNSEAL=0x15E
-
 tpm2_startauthsession -S $file_session_data
 
-tpm2_policycommandcode -S $file_session_data -o $file_policy $TPM_CC_UNSEAL
+tpm2_policycommandcode -S $file_session_data -o $file_policy unseal
 
 tpm2_flushcontext -S $file_session_data
 
@@ -57,7 +54,7 @@ tpm2_load -C $file_primary_key_ctx -u $file_unseal_key_pub \
 # Ensure unsealing passes with proper policy
 tpm2_startauthsession --policy-session -S $file_session_data
 
-tpm2_policycommandcode -S $file_session_data -o $file_policy $TPM_CC_UNSEAL
+tpm2_policycommandcode -S $file_session_data -o $file_policy unseal
 
 tpm2_unseal -p session:$file_session_data -c sealkey.ctx > $file_output_data
 

--- a/test/integration/tests/import_tpm.sh
+++ b/test/integration/tests/import_tpm.sh
@@ -1,7 +1,5 @@
 #!/bin/bash
 
-TPM_CC_DUPLICATE=0x14B
-
 source helpers.sh
 
 cleanup() {
@@ -53,7 +51,7 @@ load_new_parent() {
 
 create_load_duplicatee() {
     # Create the key we want to duplicate
-    create_policy dpolicy.dat $TPM_CC_DUPLICATE
+    create_policy dpolicy.dat duplicate
     tpm2_create -Q -C primary.ctx -g sha256 -G $1 -p foo -r key.prv -u key.pub -L dpolicy.dat -b "sensitivedataorigin|decrypt|userwithauth"
     # Load the key
     tpm2_load -Q -C primary.ctx -r key.prv -u key.pub -o key.ctx
@@ -62,7 +60,7 @@ create_load_duplicatee() {
 }
 
 do_duplication() {
-    start_session dpolicy.dat $TPM_CC_DUPLICATE
+    start_session dpolicy.dat duplicate
     if [ "$2" = "aes" ]
     then
         tpm2_duplicate -Q -C new_parent.ctx -c key.ctx -g aes -o sym.key -p "session:session.dat" -r dup.dup -s dup.seed

--- a/test/unit/test_cc_util.c
+++ b/test/unit/test_cc_util.c
@@ -1,0 +1,231 @@
+/* SPDX-License-Identifier: BSD-3-Clause */
+
+#include <errno.h>
+#include <setjmp.h>
+#include <stdarg.h>
+#include <stddef.h>
+#include <stdbool.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include <unistd.h>
+
+#include <cmocka.h>
+
+#include <tss2/tss2_tpm2_types.h>
+
+#include "tpm2_cc_util.h"
+#include "tpm2_util.h"
+
+static void test_tpm2_cc_util_from_str_null_str_ptr(void **state) {
+    UNUSED(state);
+
+    TPM2_CC cc;
+    bool result = tpm2_cc_util_from_str(NULL, &cc);
+    assert_false(result);
+}
+
+static void test_tpm2_cc_util_from_str_null_cc_ptr(void **state) {
+    UNUSED(state);
+
+    bool result = tpm2_cc_util_from_str("duplicate", NULL);
+    assert_false(result);
+}
+
+static void test_tpm2_cc_util_from_str_null_ptrs(void **state) {
+    UNUSED(state);
+
+    bool result = tpm2_cc_util_from_str(NULL, NULL);
+    assert_false(result);
+}
+
+static void test_tpm2_cc_util_from_str_invalid_str(void **state) {
+    UNUSED(state);
+
+    TPM2_CC cc = 0;
+    bool result = tpm2_cc_util_from_str("nofound", &cc);
+    assert_false(result);
+    assert_int_equal(cc, 0);
+}
+
+static void test_tpm2_cc_util_from_str_empty_str(void **state) {
+    UNUSED(state);
+
+    TPM2_CC cc = 0;
+    bool result = tpm2_cc_util_from_str("", &cc);
+    assert_false(result);
+    assert_int_equal(cc, 0);
+}
+
+static void test_tpm2_cc_util_from_str_valid_hex_str(void **state) {
+    UNUSED(state);
+
+    TPM2_CC cc = 0;
+    bool result = tpm2_cc_util_from_str("0x42", &cc);
+    assert_true(result);
+    assert_int_equal(cc, 0x42);
+}
+
+typedef struct cc_map cc_map;
+struct cc_map {
+    TPM2_CC cc;
+    const char *str;
+};
+
+#define ADDCC(s, c) { .str = s, .cc = c }
+
+static void test_tpm2_cc_util_from_str_validate_map(void **state) {
+    UNUSED(state);
+
+    static const cc_map map[] = {
+        ADDCC("nvundefinespacespecial", TPM2_CC_NV_UndefineSpaceSpecial),
+        ADDCC("evictcontrol", TPM2_CC_EvictControl),
+        ADDCC("hierarchycontrol", TPM2_CC_HierarchyControl),
+        ADDCC("nvundefinespace", TPM2_CC_NV_UndefineSpace),
+        ADDCC("changeeps", TPM2_CC_ChangeEPS),
+        ADDCC("changepps", TPM2_CC_ChangePPS),
+        ADDCC("clear", TPM2_CC_Clear),
+        ADDCC("clearcontrol", TPM2_CC_ClearControl),
+        ADDCC("clockset", TPM2_CC_ClockSet),
+        ADDCC("hierarchychangeauth", TPM2_CC_HierarchyChangeAuth),
+        ADDCC("nvdefinespace", TPM2_CC_NV_DefineSpace),
+        ADDCC("pcrallocate", TPM2_CC_PCR_Allocate),
+        ADDCC("pcrsetauthpolicy", TPM2_CC_PCR_SetAuthPolicy),
+        ADDCC("ppcommands", TPM2_CC_PP_Commands),
+        ADDCC("setprimarypolicy", TPM2_CC_SetPrimaryPolicy),
+        ADDCC("fieldupgradestart", TPM2_CC_FieldUpgradeStart),
+        ADDCC("clockrateadjust", TPM2_CC_ClockRateAdjust),
+        ADDCC("createprimary", TPM2_CC_CreatePrimary),
+        ADDCC("nvglobalwritelock", TPM2_CC_NV_GlobalWriteLock),
+        ADDCC("getcommandauditdigest", TPM2_CC_GetCommandAuditDigest),
+        ADDCC("nvincrement", TPM2_CC_NV_Increment),
+        ADDCC("nvsetbits", TPM2_CC_NV_SetBits),
+        ADDCC("nvextend", TPM2_CC_NV_Extend),
+        ADDCC("nvwrite", TPM2_CC_NV_Write),
+        ADDCC("nvwritelock", TPM2_CC_NV_WriteLock),
+        ADDCC("dictionaryattacklockreset", TPM2_CC_DictionaryAttackLockReset),
+        ADDCC("dictionaryattackparameters", TPM2_CC_DictionaryAttackParameters),
+        ADDCC("nvchangeauth", TPM2_CC_NV_ChangeAuth),
+        ADDCC("pcrevent", TPM2_CC_PCR_Event),
+        ADDCC("pcrreset", TPM2_CC_PCR_Reset),
+        ADDCC("sequencecomplete", TPM2_CC_SequenceComplete),
+        ADDCC("setalgorithmset", TPM2_CC_SetAlgorithmSet),
+        ADDCC("setcommandcodeauditstatus", TPM2_CC_SetCommandCodeAuditStatus),
+        ADDCC("fieldupgradedata", TPM2_CC_FieldUpgradeData),
+        ADDCC("incrementalselftest", TPM2_CC_IncrementalSelfTest),
+        ADDCC("selftest", TPM2_CC_SelfTest),
+        ADDCC("startup", TPM2_CC_Startup),
+        ADDCC("shutdown", TPM2_CC_Shutdown),
+        ADDCC("stirrandom", TPM2_CC_StirRandom),
+        ADDCC("activatecredential", TPM2_CC_ActivateCredential),
+        ADDCC("certify", TPM2_CC_Certify),
+        ADDCC("policynv", TPM2_CC_PolicyNV),
+        ADDCC("certifycreation", TPM2_CC_CertifyCreation),
+        ADDCC("duplicate", TPM2_CC_Duplicate),
+        ADDCC("gettime", TPM2_CC_GetTime),
+        ADDCC("getsessionauditdigest", TPM2_CC_GetSessionAuditDigest),
+        ADDCC("nvread", TPM2_CC_NV_Read),
+        ADDCC("nvreadlock", TPM2_CC_NV_ReadLock),
+        ADDCC("objectchangeauth", TPM2_CC_ObjectChangeAuth),
+        ADDCC("policysecret", TPM2_CC_PolicySecret),
+        ADDCC("rewrap", TPM2_CC_Rewrap),
+        ADDCC("create", TPM2_CC_Create),
+        ADDCC("ecdhzgen", TPM2_CC_ECDH_ZGen),
+        ADDCC("hmac", TPM2_CC_HMAC),
+        ADDCC("import", TPM2_CC_Import),
+        ADDCC("load", TPM2_CC_Load),
+        ADDCC("quote", TPM2_CC_Quote),
+        ADDCC("rsadecrypt", TPM2_CC_RSA_Decrypt),
+        ADDCC("hmacstart", TPM2_CC_HMAC_Start),
+        ADDCC("sequenceupdate", TPM2_CC_SequenceUpdate),
+        ADDCC("sign", TPM2_CC_Sign),
+        ADDCC("unseal", TPM2_CC_Unseal),
+        ADDCC("policysigned", TPM2_CC_PolicySigned),
+        ADDCC("contextload", TPM2_CC_ContextLoad),
+        ADDCC("contextsave", TPM2_CC_ContextSave),
+        ADDCC("ecdhkeygen", TPM2_CC_ECDH_KeyGen),
+        ADDCC("encryptdecrypt", TPM2_CC_EncryptDecrypt),
+        ADDCC("flushcontext", TPM2_CC_FlushContext),
+        ADDCC("loadexternal", TPM2_CC_LoadExternal),
+        ADDCC("makecredential", TPM2_CC_MakeCredential),
+        ADDCC("nvreadpublic", TPM2_CC_NV_ReadPublic),
+        ADDCC("policyauthorize", TPM2_CC_PolicyAuthorize),
+        ADDCC("policyauthvalue", TPM2_CC_PolicyAuthValue),
+        ADDCC("policycommandcode", TPM2_CC_PolicyCommandCode),
+        ADDCC("policycountertimer", TPM2_CC_PolicyCounterTimer),
+        ADDCC("policycphash", TPM2_CC_PolicyCpHash),
+        ADDCC("policylocality", TPM2_CC_PolicyLocality),
+        ADDCC("policynamehash", TPM2_CC_PolicyNameHash),
+        ADDCC("policyor", TPM2_CC_PolicyOR),
+        ADDCC("policyticket", TPM2_CC_PolicyTicket),
+        ADDCC("readpublic", TPM2_CC_ReadPublic),
+        ADDCC("rsaencrypt", TPM2_CC_RSA_Encrypt),
+        ADDCC("startauthsession", TPM2_CC_StartAuthSession),
+        ADDCC("verifysignature", TPM2_CC_VerifySignature),
+        ADDCC("eccparameters", TPM2_CC_ECC_Parameters),
+        ADDCC("firmwareread", TPM2_CC_FirmwareRead),
+        ADDCC("getcapability", TPM2_CC_GetCapability),
+        ADDCC("getrandom", TPM2_CC_GetRandom),
+        ADDCC("gettestresult", TPM2_CC_GetTestResult),
+        ADDCC("hash", TPM2_CC_Hash),
+        ADDCC("pcrread", TPM2_CC_PCR_Read),
+        ADDCC("policypcr", TPM2_CC_PolicyPCR),
+        ADDCC("policyrestart", TPM2_CC_PolicyRestart),
+        ADDCC("readclock", TPM2_CC_ReadClock),
+        ADDCC("pcrextend", TPM2_CC_PCR_Extend),
+        ADDCC("pcrsetauthvalue", TPM2_CC_PCR_SetAuthValue),
+        ADDCC("nvcertify", TPM2_CC_NV_Certify),
+        ADDCC("eventsequencecomplete", TPM2_CC_EventSequenceComplete),
+        ADDCC("hashsequencestart", TPM2_CC_HashSequenceStart),
+        ADDCC("policyphysicalpresence", TPM2_CC_PolicyPhysicalPresence),
+        ADDCC("policyduplicationselect", TPM2_CC_PolicyDuplicationSelect),
+        ADDCC("policygetdigest", TPM2_CC_PolicyGetDigest),
+        ADDCC("testparms", TPM2_CC_TestParms),
+        ADDCC("commit", TPM2_CC_Commit),
+        ADDCC("policypassword", TPM2_CC_PolicyPassword),
+        ADDCC("zgen2phase", TPM2_CC_ZGen_2Phase),
+        ADDCC("ecephemeral", TPM2_CC_EC_Ephemeral),
+        ADDCC("policynvwritten", TPM2_CC_PolicyNvWritten),
+        ADDCC("policytemplate", TPM2_CC_PolicyTemplate),
+        ADDCC("createloaded", TPM2_CC_CreateLoaded),
+        ADDCC("policyauthorizenv", TPM2_CC_PolicyAuthorizeNV),
+        ADDCC("encryptdecrypt2", TPM2_CC_EncryptDecrypt2),
+        ADDCC("acgetcapability", TPM2_CC_AC_GetCapability),
+        ADDCC("acsend", TPM2_CC_AC_Send),
+        ADDCC("policyacsendselect", TPM2_CC_Policy_AC_SendSelect),
+        ADDCC("vendortcgtest", TPM2_CC_Vendor_TCG_Test),
+    };
+
+    size_t i;
+    for (i=0; i < ARRAY_LEN(map); i++) {
+        const cc_map *m = &map[i];
+        TPM2_CC expected = m->cc;
+        TPM2_CC got = 0;
+        bool result = tpm2_cc_util_from_str(m->str, &got);
+        assert_true(result);
+        assert_int_equal(got, expected);
+    }
+}
+
+/* link required symbol, but tpm2_tool.c declares it AND main, which
+ * we have a main below for cmocka tests.
+ */
+bool output_enabled = true;
+
+int main(int argc, char *argv[]) {
+    UNUSED(argc);
+    UNUSED(argv);
+
+    const struct CMUnitTest tests[] = {
+        cmocka_unit_test(test_tpm2_cc_util_from_str_null_str_ptr),
+        cmocka_unit_test(test_tpm2_cc_util_from_str_null_cc_ptr),
+        cmocka_unit_test(test_tpm2_cc_util_from_str_null_ptrs),
+        cmocka_unit_test(test_tpm2_cc_util_from_str_invalid_str),
+        cmocka_unit_test(test_tpm2_cc_util_from_str_empty_str),
+        cmocka_unit_test(test_tpm2_cc_util_from_str_valid_hex_str),
+        cmocka_unit_test(test_tpm2_cc_util_from_str_validate_map),
+    };
+
+    return cmocka_run_group_tests(tests, NULL, NULL);
+}

--- a/tools/tpm2_policycommandcode.c
+++ b/tools/tpm2_policycommandcode.c
@@ -12,6 +12,7 @@
 #include "files.h"
 #include "log.h"
 #include "pcr.h"
+#include "tpm2_cc_util.h"
 #include "tpm2_options.h"
 #include "tpm2_policy.h"
 #include "tpm2_session.h"
@@ -64,10 +65,8 @@ bool on_arg (int argc, char **argv) {
         return false;
     }
 
-    bool result = tpm2_util_string_to_uint32(argv[0], &ctx.command_code);
+    bool result = tpm2_cc_util_from_str(argv[0], &ctx.command_code);
     if (!result) {
-        LOG_ERR("Could not convert command-code to number, got: \"%s\"",
-                argv[0]);
         return false;
     }
 


### PR DESCRIPTION
Ass support for passing nice names to the tool, like duplicate instead
of 0x14B. Keep raw numeric support in place and add tests.

Fixes: #1242

Signed-off-by: William Roberts <william.c.roberts@intel.com>