### PR TITLE
tpm2_alg_util: fix extended specifier errors

### DIFF
--- a/man/common/alg.md
+++ b/man/common/alg.md
@@ -16,6 +16,7 @@ list of known "Simple Specifiers Below".
 
 ### Symmetric
   * aes
+  * camellia
 
 ### Hashing Algorithms
   * sha1

--- a/man/common/alg.md
+++ b/man/common/alg.md
@@ -16,7 +16,6 @@ list of known "Simple Specifiers Below".
 
 ### Symmetric
   * aes
-  * camellia
 
 ### Hashing Algorithms
   * sha1
@@ -90,7 +89,7 @@ algorithm is missing, it defaults to *sha256*. Some take no arguments, and some 
 arguments.
 
 #### Hash Optional Scheme Specifiers
-These scheme specifiers are followed immediately by a valid hash algorithm, For example: `oaepsha256`.
+These scheme specifiers are followed by a dash and a valid hash algorithm, For example: `oaep-sha256`.
 
   * oaep
   * ecdh
@@ -100,8 +99,9 @@ These scheme specifiers are followed immediately by a valid hash algorithm, For 
   * ecschnorr
 
 #### Multiple Option Scheme Specifiers
-This scheme specifier is followed by a count (max size UINT16) a dash(-) and a valid hash algorithm.
+This scheme specifier is followed by a count (max size UINT16) then folloed by a dash(-) and a valid hash algorithm.
   * ecdaa
+For example, ecdaa4-sha256. If no count is specified, it defaults to 4.
 
 #### No Option Scheme Specifiers
 This scheme specifier takes NO arguments.
@@ -119,8 +119,3 @@ specified, an asymmetric objects symmetric details defaults to *aes128cfb*.
 
 ### Create an ecc256 key with an ecdaa signing scheme with a count of 4 and sha384 hash
 `/tpm2_create -C parent.ctx -G ecc256:ecdaa4-sha384 -u key.pub -r key.priv`
-
-
-**DEPRECATED**
-The old numerical arguments are deprecated, and use is discouraged and will not be officially supported
-going forward.

--- a/test/integration/tests/abrmd_policycommandcode.sh
+++ b/test/integration/tests/abrmd_policycommandcode.sh
@@ -44,6 +44,9 @@ tpm2_flushcontext -S $file_session_data
 
 rm $file_session_data
 
+echo "tpm2_create -C $file_primary_key_ctx -u $file_unseal_key_pub \
+  -r $file_unseal_key_priv -L $file_policy -i- <<< $secret"
+
 tpm2_create -C $file_primary_key_ctx -u $file_unseal_key_pub \
   -r $file_unseal_key_priv -L $file_policy -i- <<< $secret
 

--- a/test/integration/tests/create.sh
+++ b/test/integration/tests/create.sh
@@ -27,7 +27,7 @@ tpm2_createprimary -Q -a o -g sha1 -G rsa -o context.out
 # Keep the algorithm specifiers mixed to test friendly and raw
 # values.
 for gAlg in `populate_hash_algs`; do
-    for GAlg in rsa 0x08 ecc 0x25; do
+    for GAlg in rsa keyedhash ecc aes; do
         echo "tpm2_create -Q -C context.out -g $gAlg -G $GAlg -u key.pub -r key.priv"
         tpm2_create -Q -C context.out -g $gAlg -G $GAlg -u key.pub -r key.priv
         cleanup "keep-context" "no-shut-down"
@@ -39,7 +39,7 @@ cleanup "keep-context" "no-shut-down"
 policy_orig="f28230c080bbe417141199e36d18978228d8948fc10a6a24921b9eba6bb1d988"
 echo "$policy_orig" | xxd -r -p > policy.bin
 
-tpm2_create -C context.out -g sha256 -G 0x1 -L policy.bin -u key.pub -r key.priv \
+tpm2_create -C context.out -g sha256 -G rsa -L policy.bin -u key.pub -r key.priv \
   -b 'sign|fixedtpm|fixedparent|sensitivedataorigin' > out.pub
 
 policy_new=$(yaml_get_kv out.pub "authorization policy")

--- a/test/integration/tests/readpublic.sh
+++ b/test/integration/tests/readpublic.sh
@@ -3,9 +3,9 @@
 
 source helpers.sh
 
-alg_primary_obj=0x000B
-alg_primary_key=0x0001
-alg_create_obj=0x000B
+alg_primary_obj=sha256
+alg_primary_key=rsa
+alg_create_obj=sha256
 alg_create_key=hmac
 
 file_primary_key_ctx=context.p_"$alg_primary_obj"_"$alg_primary_key"

--- a/test/integration/tests/rsadecrypt.sh
+++ b/test/integration/tests/rsadecrypt.sh
@@ -14,9 +14,9 @@ file_rsa_en_output_data=rsa_en.out
 file_rsa_de_output_data=rsa_de.out
 file_input_data=secret.data
 
-alg_hash=0x000B
-alg_primary_key=0x0001
-alg_rsaencrypt_key=0x0001
+alg_hash=sha256
+alg_primary_key=rsa
+alg_rsaencrypt_key=rsa
 
 cleanup() {
     rm -f $file_input_data $file_primary_key_ctx $file_rsaencrypt_key_pub \

--- a/test/integration/tests/rsaencrypt.sh
+++ b/test/integration/tests/rsaencrypt.sh
@@ -12,9 +12,9 @@ file_rsaencrypt_key_name=name.load.B1_B8
 file_rsa_en_output_data=rsa_en.out
 file_input_data=secret.data
 
-alg_hash=0x000B
-alg_primary_key=0x0001
-alg_rsaencrypt_key=0x0001
+alg_hash=sha256
+alg_primary_key=rsa
+alg_rsaencrypt_key=rsa
 
 cleanup() {
     rm -f $file_input_data $file_primary_key_ctx $file_rsaencrypt_key_pub \

--- a/test/integration/tests/sign.sh
+++ b/test/integration/tests/sign.sh
@@ -20,7 +20,7 @@ ecc_key_type=ecc256
 handle_signing_key=0x81010005
 
 alg_hash=sha256
-alg_primary_key=0x0001
+alg_primary_key=rsa
 
 cleanup() {
     rm -f $file_input_data $file_primary_key_ctx $file_signing_key_pub \

--- a/test/integration/tests/testparms.sh
+++ b/test/integration/tests/testparms.sh
@@ -30,6 +30,7 @@ done
 
 # Test that RSA signing schemes are supported
 for i in ${rsamethods}; do
+    echo "tpm2_testparms rsa:${i}"
     tpm2_testparms "rsa:${i}"
 done
 

--- a/test/integration/tests/verifysignature.sh
+++ b/test/integration/tests/verifysignature.sh
@@ -18,8 +18,8 @@ file_input_data_hash_tk=secret_hash_tk.data
 handle_signing_key=0x81010005
 
 alg_hash=sha256
-alg_primary_key=0x0001
-alg_signing_key=0x0001
+alg_primary_key=rsa
+alg_signing_key=rsa
 
 cleanup() {
     rm -f $file_primary_key_ctx $file_signing_key_pub $file_signing_key_priv \

--- a/test/unit/test_tpm2_alg_util.c
+++ b/test/unit/test_tpm2_alg_util.c
@@ -1070,6 +1070,55 @@ static void test_extended_alg_keyedhash(void **state) {
     assert_int_equal(k->scheme.scheme, TPM2_ALG_NULL);
 }
 
+static void test_extended_rsa_camellia(void **state) {
+    UNUSED(state);
+
+    TPM2B_PUBLIC pub = { 0 };
+
+    bool res = tpm2_alg_util_handle_ext_alg("rsa:camellia", &pub);
+    assert_true(res);
+
+    assert_int_equal(pub.publicArea.type, TPM2_ALG_RSA);
+
+    TPMT_SYM_DEF_OBJECT *s = &pub.publicArea.parameters.rsaDetail.symmetric;
+    assert_int_equal(s->keyBits.aes, 128);
+    assert_int_equal(s->mode.aes, TPM2_ALG_NULL);
+    assert_int_equal(s->algorithm, TPM2_ALG_CAMELLIA);
+}
+
+static void test_extended_rsa_camellia256cbc(void **state) {
+    UNUSED(state);
+
+    TPM2B_PUBLIC pub = { 0 };
+
+    bool res = tpm2_alg_util_handle_ext_alg("rsa:camellia256cbc", &pub);
+    assert_true(res);
+
+    assert_int_equal(pub.publicArea.type, TPM2_ALG_RSA);
+
+    TPMT_SYM_DEF_OBJECT *s = &pub.publicArea.parameters.rsaDetail.symmetric;
+    assert_int_equal(s->keyBits.aes, 256);
+    assert_int_equal(s->mode.aes, TPM2_ALG_CBC);
+    assert_int_equal(s->algorithm, TPM2_ALG_CAMELLIA);
+}
+
+static void test_extended_camellia192cbc(void **state) {
+    UNUSED(state);
+
+    TPM2B_PUBLIC pub = { 0 };
+
+    bool res = tpm2_alg_util_handle_ext_alg("camellia192cbc", &pub);
+    assert_true(res);
+
+    assert_int_equal(pub.publicArea.type, TPM2_ALG_SYMCIPHER);
+
+    TPMT_SYM_DEF_OBJECT *s = &pub.publicArea.parameters.symDetail.sym;
+    assert_int_equal(s->keyBits.aes, 192);
+    assert_int_equal(s->mode.aes, TPM2_ALG_CBC);
+    assert_int_equal(s->algorithm, TPM2_ALG_CAMELLIA);
+}
+
+
 static void test_extended_alg_bad(void **state) {
     UNUSED(state);
 
@@ -1215,6 +1264,9 @@ int main(int argc, char* argv[]) {
         cmocka_unit_test(test_extended_alg_aes256cbc_restricted),
         cmocka_unit_test(test_extended_alg_aes256cbc),
         cmocka_unit_test(test_extended_alg_keyedhash),
+        cmocka_unit_test(test_extended_rsa_camellia),
+        cmocka_unit_test(test_extended_rsa_camellia256cbc),
+        cmocka_unit_test(test_extended_camellia192cbc),
         cmocka_unit_test(test_extended_alg_bad),
     };
 

--- a/test/unit/test_tpm2_alg_util.c
+++ b/test/unit/test_tpm2_alg_util.c
@@ -391,6 +391,739 @@ static void test_tpm2_alg_util_flags_hash(void **state) {
     assert_null(name);
 }
 
+static void test_extended_alg_rsa2048_non_restricted(void **state) {
+    UNUSED(state);
+
+    TPM2B_PUBLIC pub = { 0 };
+
+    bool res = tpm2_alg_util_handle_ext_alg("rsa2048", &pub);
+    assert_true(res);
+
+    assert_int_equal(pub.publicArea.type, TPM2_ALG_RSA);
+
+    assert_int_equal(pub.publicArea.objectAttributes, 0);
+
+    TPMS_RSA_PARMS *r = &pub.publicArea.parameters.rsaDetail;
+    assert_int_equal(r->exponent, 0);
+    assert_int_equal(r->keyBits, 2048);
+    assert_int_equal(r->scheme.scheme, TPM2_ALG_NULL);
+}
+
+static void test_extended_alg_rsa2048_aes128cfb_non_restricted(void **state) {
+    UNUSED(state);
+
+    TPM2B_PUBLIC pub = { 0 };
+
+    bool res = tpm2_alg_util_handle_ext_alg("rsa2048:aes128cfb", &pub);
+    assert_true(res);
+
+    assert_int_equal(pub.publicArea.type, TPM2_ALG_RSA);
+
+    assert_int_equal(pub.publicArea.objectAttributes, 0);
+
+    TPMS_RSA_PARMS *r = &pub.publicArea.parameters.rsaDetail;
+    assert_int_equal(r->exponent, 0);
+    assert_int_equal(r->keyBits, 2048);
+    assert_int_equal(r->scheme.scheme, TPM2_ALG_NULL);
+
+    TPMT_SYM_DEF_OBJECT *s = &r->symmetric;
+    assert_int_equal(s->keyBits.aes, 128);
+    assert_int_equal(s->mode.sym, TPM2_ALG_CFB);
+    assert_int_equal(s->algorithm, TPM2_ALG_AES);
+}
+
+static void test_extended_alg_rsa2048_restricted(void **state) {
+    UNUSED(state);
+
+    TPM2B_PUBLIC pub = {
+        .publicArea = {
+            .objectAttributes = TPMA_OBJECT_RESTRICTED
+        }
+    };
+
+    bool res = tpm2_alg_util_handle_ext_alg("rsa2048", &pub);
+    assert_true(res);
+
+    assert_int_equal(pub.publicArea.type, TPM2_ALG_RSA);
+
+    assert_int_equal(pub.publicArea.objectAttributes, TPMA_OBJECT_RESTRICTED);
+
+    TPMS_RSA_PARMS *r = &pub.publicArea.parameters.rsaDetail;
+    assert_int_equal(r->exponent, 0);
+    assert_int_equal(r->keyBits, 2048);
+    assert_int_equal(r->scheme.scheme, TPM2_ALG_NULL);
+
+    TPMT_SYM_DEF_OBJECT *s = &r->symmetric;
+    assert_int_equal(s->keyBits.aes, 128);
+    assert_int_equal(s->mode.sym, TPM2_ALG_CFB);
+    assert_int_equal(s->algorithm, TPM2_ALG_AES);
+}
+
+static void test_extended_alg_rsa_non_restricted(void **state) {
+    UNUSED(state);
+
+    TPM2B_PUBLIC pub = { 0 };
+
+    bool res = tpm2_alg_util_handle_ext_alg("rsa", &pub);
+    assert_true(res);
+
+    assert_int_equal(pub.publicArea.type, TPM2_ALG_RSA);
+
+    assert_int_equal(pub.publicArea.objectAttributes, 0);
+
+    TPMS_RSA_PARMS *r = &pub.publicArea.parameters.rsaDetail;
+    assert_int_equal(r->exponent, 0);
+    assert_int_equal(r->keyBits, 2048);
+    assert_int_equal(r->scheme.scheme, TPM2_ALG_NULL);
+
+    TPMT_SYM_DEF_OBJECT *s = &r->symmetric;
+    assert_int_equal(s->algorithm, TPM2_ALG_NULL);
+}
+
+static void test_extended_alg_rsa1024_rsaes_restricted(void **state) {
+    UNUSED(state);
+
+    TPM2B_PUBLIC pub = {
+        .publicArea = {
+            .objectAttributes = TPMA_OBJECT_RESTRICTED
+        }
+    };
+
+    bool res = tpm2_alg_util_handle_ext_alg("rsa1024:rsaes", &pub);
+    assert_true(res);
+
+    assert_int_equal(pub.publicArea.type, TPM2_ALG_RSA);
+
+    assert_int_equal(pub.publicArea.objectAttributes, TPMA_OBJECT_RESTRICTED);
+
+    TPMS_RSA_PARMS *r = &pub.publicArea.parameters.rsaDetail;
+    assert_int_equal(r->exponent, 0);
+    assert_int_equal(r->keyBits, 1024);
+    assert_int_equal(r->scheme.scheme, TPM2_ALG_RSAES);
+
+    TPMT_SYM_DEF_OBJECT *s = &r->symmetric;
+    assert_int_equal(s->keyBits.aes, 128);
+    assert_int_equal(s->mode.sym, TPM2_ALG_CFB);
+    assert_int_equal(s->algorithm, TPM2_ALG_AES);
+}
+
+static void test_extended_alg_rsa1024_rsaes(void **state) {
+    UNUSED(state);
+
+    TPM2B_PUBLIC pub = { 0 };
+
+    bool res = tpm2_alg_util_handle_ext_alg("rsa1024:rsaes", &pub);
+    assert_true(res);
+
+    assert_int_equal(pub.publicArea.type, TPM2_ALG_RSA);
+
+    assert_int_equal(pub.publicArea.objectAttributes, 0);
+
+    TPMS_RSA_PARMS *r = &pub.publicArea.parameters.rsaDetail;
+    assert_int_equal(r->exponent, 0);
+    assert_int_equal(r->keyBits, 1024);
+    assert_int_equal(r->scheme.scheme, TPM2_ALG_RSAES);
+
+    TPMT_SYM_DEF_OBJECT *s = &r->symmetric;
+    assert_int_equal(s->algorithm, TPM2_ALG_NULL);
+}
+
+static void test_extended_alg_rsa_restricted(void **state) {
+    UNUSED(state);
+
+    TPM2B_PUBLIC pub = {
+        .publicArea = {
+            .objectAttributes = TPMA_OBJECT_RESTRICTED
+        }
+    };
+
+    bool res = tpm2_alg_util_handle_ext_alg("rsa", &pub);
+    assert_true(res);
+
+    assert_int_equal(pub.publicArea.type, TPM2_ALG_RSA);
+
+    TPMS_RSA_PARMS *r = &pub.publicArea.parameters.rsaDetail;
+    assert_int_equal(r->exponent, 0);
+    assert_int_equal(r->keyBits, 2048);
+    assert_int_equal(r->scheme.scheme, TPM2_ALG_NULL);
+
+    TPMT_SYM_DEF_OBJECT *s = &r->symmetric;
+    assert_int_equal(s->keyBits.aes, 128);
+    assert_int_equal(s->mode.aes, TPM2_ALG_CFB);
+    assert_int_equal(s->algorithm, TPM2_ALG_AES);
+}
+
+static void test_extended_alg_rsa_rsapss(void **state) {
+    UNUSED(state);
+
+    TPM2B_PUBLIC pub = { 0 };
+
+    bool res = tpm2_alg_util_handle_ext_alg("rsa:rsapss", &pub);
+    assert_true(res);
+
+    assert_int_equal(pub.publicArea.type, TPM2_ALG_RSA);
+
+    TPMS_RSA_PARMS *r = &pub.publicArea.parameters.rsaDetail;
+    assert_int_equal(r->exponent, 0);
+    assert_int_equal(r->keyBits, 2048);
+    assert_int_equal(r->scheme.scheme, TPM2_ALG_RSAPSS);
+
+    TPMT_SYM_DEF_OBJECT *s = &r->symmetric;
+    assert_int_equal(s->keyBits.aes, 128);
+    assert_int_equal(s->mode.aes, TPM2_ALG_CFB);
+    assert_int_equal(s->algorithm, TPM2_ALG_AES);
+}
+
+static void test_extended_alg_rsa_rsassa_non_restricted(void **state) {
+    UNUSED(state);
+
+    TPM2B_PUBLIC pub = { 0 };
+
+    bool res = tpm2_alg_util_handle_ext_alg("rsa:rsassa", &pub);
+    assert_true(res);
+
+    assert_int_equal(pub.publicArea.objectAttributes, 0);
+
+    assert_int_equal(pub.publicArea.type, TPM2_ALG_RSA);
+
+    TPMS_RSA_PARMS *r = &pub.publicArea.parameters.rsaDetail;
+    assert_int_equal(r->exponent, 0);
+    assert_int_equal(r->keyBits, 2048);
+    assert_int_equal(r->scheme.scheme, TPM2_ALG_RSASSA);
+
+    TPMS_SIG_SCHEME_RSASSA *s = &r->scheme.details.rsassa;
+    assert_int_equal(s->hashAlg, TPM2_ALG_SHA256);
+}
+
+static void test_extended_alg_ecc256_non_restricted(void **state) {
+    UNUSED(state);
+
+    TPM2B_PUBLIC pub = { 0 };
+
+    bool res = tpm2_alg_util_handle_ext_alg("ecc256", &pub);
+    assert_true(res);
+
+    assert_int_equal(pub.publicArea.type, TPM2_ALG_ECC);
+
+    assert_int_equal(pub.publicArea.objectAttributes, 0);
+
+    TPMS_ECC_PARMS *e = &pub.publicArea.parameters.eccDetail;
+    assert_int_equal(e->scheme.scheme, TPM2_ALG_NULL);
+    assert_int_equal(e->curveID, TPM2_ECC_NIST_P256);
+    assert_int_equal(e->kdf.scheme, TPM2_ALG_NULL);
+    assert_int_equal(e->kdf.details.mgf1.hashAlg, 0);
+}
+
+static void test_extended_alg_ecc256_aes128cbc_non_restricted(void **state) {
+    UNUSED(state);
+
+    TPM2B_PUBLIC pub = { 0 };
+
+    bool res = tpm2_alg_util_handle_ext_alg("ecc256:aes128cbc", &pub);
+    assert_true(res);
+
+    assert_int_equal(pub.publicArea.type, TPM2_ALG_ECC);
+
+    assert_int_equal(pub.publicArea.objectAttributes, 0);
+
+    TPMS_ECC_PARMS *e = &pub.publicArea.parameters.eccDetail;
+    assert_int_equal(e->scheme.scheme, TPM2_ALG_NULL);
+    assert_int_equal(e->curveID, TPM2_ECC_NIST_P256);
+    assert_int_equal(e->kdf.scheme, TPM2_ALG_NULL);
+    assert_int_equal(e->kdf.details.mgf1.hashAlg, 0);
+
+    TPMT_SYM_DEF_OBJECT *s = &e->symmetric;
+    assert_int_equal(s->keyBits.aes, 128);
+    assert_int_equal(s->mode.sym, TPM2_ALG_CBC);
+    assert_int_equal(s->algorithm, TPM2_ALG_AES);
+}
+
+static void test_extended_alg_ecc384_ecdaa4_sha256_non_restricted(void **state) {
+    UNUSED(state);
+
+    TPM2B_PUBLIC pub = { 0 };
+
+    bool res = tpm2_alg_util_handle_ext_alg("ecc384:ecdaa4-sha256", &pub);
+    assert_true(res);
+
+    assert_int_equal(pub.publicArea.type, TPM2_ALG_ECC);
+
+    assert_int_equal(pub.publicArea.objectAttributes, 0);
+
+    TPMS_ECC_PARMS *e = &pub.publicArea.parameters.eccDetail;
+    assert_int_equal(e->scheme.scheme, TPM2_ALG_ECDAA);
+
+    assert_int_equal(e->curveID, TPM2_ECC_NIST_P384);
+    assert_int_equal(e->kdf.scheme, TPM2_ALG_NULL);
+    assert_int_equal(e->kdf.details.mgf1.hashAlg, 0);
+
+    TPMS_SIG_SCHEME_ECDAA *a = &e->scheme.details.ecdaa;
+    assert_int_equal(a->count, 4);
+    assert_int_equal(a->hashAlg, TPM2_ALG_SHA256);
+}
+
+static void test_extended_alg_ecc384_ecdaa4_sha256(void **state) {
+    UNUSED(state);
+
+    TPM2B_PUBLIC pub = {
+        .publicArea = {
+            .objectAttributes = TPMA_OBJECT_RESTRICTED
+        }
+    };
+
+    bool res = tpm2_alg_util_handle_ext_alg("ecc384:ecdaa4-sha256", &pub);
+    assert_true(res);
+
+    assert_int_equal(pub.publicArea.type, TPM2_ALG_ECC);
+
+    TPMS_ECC_PARMS *e = &pub.publicArea.parameters.eccDetail;
+    assert_int_equal(e->scheme.scheme, TPM2_ALG_ECDAA);
+    assert_int_equal(e->curveID, TPM2_ECC_NIST_P384);
+    assert_int_equal(e->kdf.scheme, TPM2_ALG_NULL);
+    assert_int_equal(e->kdf.details.mgf1.hashAlg, 0);
+
+    TPMS_SIG_SCHEME_ECDAA *a = &e->scheme.details.ecdaa;
+    assert_int_equal(a->count, 4);
+    assert_int_equal(a->hashAlg, TPM2_ALG_SHA256);
+
+    TPMT_SYM_DEF_OBJECT *s = &e->symmetric;
+    assert_int_equal(s->keyBits.aes, 128);
+    assert_int_equal(s->mode.sym, TPM2_ALG_CFB);
+    assert_int_equal(s->algorithm, TPM2_ALG_AES);
+}
+
+static void test_extended_alg_ecc256_restricted(void **state) {
+    UNUSED(state);
+
+    TPM2B_PUBLIC pub = {
+        .publicArea = {
+            .objectAttributes = TPMA_OBJECT_RESTRICTED
+        }
+    };
+
+    bool res = tpm2_alg_util_handle_ext_alg("ecc256", &pub);
+    assert_true(res);
+
+    assert_int_equal(pub.publicArea.objectAttributes, TPMA_OBJECT_RESTRICTED);
+
+    assert_int_equal(pub.publicArea.type, TPM2_ALG_ECC);
+
+    TPMS_ECC_PARMS *e = &pub.publicArea.parameters.eccDetail;
+    assert_int_equal(e->scheme.scheme, TPM2_ALG_NULL);
+    assert_int_equal(e->curveID, TPM2_ECC_NIST_P256);
+    assert_int_equal(e->kdf.scheme, TPM2_ALG_NULL);
+    assert_int_equal(e->kdf.details.mgf1.hashAlg, 0);
+}
+
+static void test_extended_alg_ecc_non_restricted(void **state) {
+    UNUSED(state);
+
+    TPM2B_PUBLIC pub = { 0 };
+
+    bool res = tpm2_alg_util_handle_ext_alg("ecc", &pub);
+    assert_true(res);
+
+    assert_int_equal(pub.publicArea.objectAttributes, 0);
+
+    assert_int_equal(pub.publicArea.type, TPM2_ALG_ECC);
+
+    TPMS_ECC_PARMS *e = &pub.publicArea.parameters.eccDetail;
+    assert_int_equal(e->scheme.scheme, TPM2_ALG_NULL);
+    assert_int_equal(e->curveID, TPM2_ECC_NIST_P256);
+    assert_int_equal(e->kdf.scheme, TPM2_ALG_NULL);
+    assert_int_equal(e->kdf.details.mgf1.hashAlg, 0);
+}
+
+static void test_extended_alg_ecc_restricted(void **state) {
+    UNUSED(state);
+
+    TPM2B_PUBLIC pub = {
+        .publicArea = {
+            .objectAttributes = TPMA_OBJECT_RESTRICTED
+        }
+    };
+
+    bool res = tpm2_alg_util_handle_ext_alg("ecc", &pub);
+    assert_true(res);
+
+    assert_int_equal(pub.publicArea.objectAttributes, TPMA_OBJECT_RESTRICTED);
+
+    assert_int_equal(pub.publicArea.type, TPM2_ALG_ECC);
+
+    TPMS_ECC_PARMS *e = &pub.publicArea.parameters.eccDetail;
+    assert_int_equal(e->scheme.scheme, TPM2_ALG_NULL);
+    assert_int_equal(e->curveID, TPM2_ECC_NIST_P256);
+    assert_int_equal(e->kdf.scheme, TPM2_ALG_NULL);
+    assert_int_equal(e->kdf.details.mgf1.hashAlg, 0);
+}
+
+static void test_extended_alg_ecc_ecdsa_restricted(void **state) {
+    UNUSED(state);
+
+    TPM2B_PUBLIC pub = {
+        .publicArea = {
+            .objectAttributes = TPMA_OBJECT_RESTRICTED
+        }
+    };
+
+    bool res = tpm2_alg_util_handle_ext_alg("ecc:ecdaa", &pub);
+    assert_true(res);
+
+    assert_int_equal(pub.publicArea.objectAttributes, TPMA_OBJECT_RESTRICTED);
+
+    assert_int_equal(pub.publicArea.type, TPM2_ALG_ECC);
+
+    TPMS_ECC_PARMS *e = &pub.publicArea.parameters.eccDetail;
+    assert_int_equal(e->scheme.scheme, TPM2_ALG_ECDAA);
+    assert_int_equal(e->curveID, TPM2_ECC_NIST_P256);
+    assert_int_equal(e->kdf.scheme, TPM2_ALG_NULL);
+    assert_int_equal(e->kdf.details.mgf1.hashAlg, 0);
+
+    TPMS_SIG_SCHEME_ECDAA *a = &e->scheme.details.ecdaa;
+    assert_int_equal(a->count, 4);
+    assert_int_equal(a->hashAlg, TPM2_ALG_SHA256);
+}
+
+static void test_extended_alg_xor_restricted(void **state) {
+    UNUSED(state);
+
+    TPM2B_PUBLIC pub = {
+        .publicArea = {
+            .objectAttributes = TPMA_OBJECT_RESTRICTED
+        }
+    };
+
+    bool res = tpm2_alg_util_handle_ext_alg("xor", &pub);
+    assert_true(res);
+
+    assert_int_equal(pub.publicArea.objectAttributes, TPMA_OBJECT_RESTRICTED);
+
+    assert_int_equal(pub.publicArea.type, TPM2_ALG_KEYEDHASH);
+
+    TPMT_KEYEDHASH_SCHEME *s = &pub.publicArea.parameters.keyedHashDetail.scheme;
+    assert_int_equal(s->scheme, TPM2_ALG_XOR);
+    assert_int_equal(s->details.exclusiveOr.hashAlg, TPM2_ALG_SHA256);
+    assert_int_equal(s->details.exclusiveOr.kdf, TPM2_ALG_KDF1_SP800_108);
+}
+
+static void test_extended_alg_xorsha256_restricted(void **state) {
+    UNUSED(state);
+
+    TPM2B_PUBLIC pub = {
+        .publicArea = {
+            .objectAttributes = TPMA_OBJECT_RESTRICTED
+        }
+    };
+
+    bool res = tpm2_alg_util_handle_ext_alg("xor:sha256", &pub);
+    assert_true(res);
+
+    assert_int_equal(pub.publicArea.objectAttributes, TPMA_OBJECT_RESTRICTED);
+
+    assert_int_equal(pub.publicArea.type, TPM2_ALG_KEYEDHASH);
+
+    TPMT_KEYEDHASH_SCHEME *s = &pub.publicArea.parameters.keyedHashDetail.scheme;
+    assert_int_equal(s->scheme, TPM2_ALG_XOR);
+    assert_int_equal(s->details.exclusiveOr.hashAlg, TPM2_ALG_SHA256);
+    assert_int_equal(s->details.exclusiveOr.kdf, TPM2_ALG_KDF1_SP800_108);
+}
+
+static void test_extended_alg_xor(void **state) {
+    UNUSED(state);
+
+    TPM2B_PUBLIC pub = { 0 };
+
+    bool res = tpm2_alg_util_handle_ext_alg("xor", &pub);
+    assert_true(res);
+
+    assert_int_equal(pub.publicArea.objectAttributes, 0);
+
+    assert_int_equal(pub.publicArea.type, TPM2_ALG_KEYEDHASH);
+
+    TPMT_KEYEDHASH_SCHEME *s = &pub.publicArea.parameters.keyedHashDetail.scheme;
+    assert_int_equal(s->scheme, TPM2_ALG_XOR);
+    assert_int_equal(s->details.exclusiveOr.hashAlg, TPM2_ALG_SHA256);
+    assert_int_equal(s->details.exclusiveOr.kdf, TPM2_ALG_KDF1_SP800_108);
+}
+
+static void test_extended_alg_xorsha256(void **state) {
+    UNUSED(state);
+
+    TPM2B_PUBLIC pub = { 0 };
+
+    bool res = tpm2_alg_util_handle_ext_alg("xor:sha256", &pub);
+    assert_true(res);
+
+    assert_int_equal(pub.publicArea.objectAttributes, 0);
+
+    assert_int_equal(pub.publicArea.type, TPM2_ALG_KEYEDHASH);
+
+    TPMT_KEYEDHASH_SCHEME *s = &pub.publicArea.parameters.keyedHashDetail.scheme;
+    assert_int_equal(s->scheme, TPM2_ALG_XOR);
+    assert_int_equal(s->details.exclusiveOr.hashAlg, TPM2_ALG_SHA256);
+    assert_int_equal(s->details.exclusiveOr.kdf, TPM2_ALG_KDF1_SP800_108);
+}
+
+static void test_extended_alg_hmac_restricted(void **state) {
+    UNUSED(state);
+
+    TPM2B_PUBLIC pub = {
+        .publicArea = {
+            .objectAttributes = TPMA_OBJECT_RESTRICTED
+        }
+    };
+
+    bool res = tpm2_alg_util_handle_ext_alg("hmac", &pub);
+    assert_true(res);
+
+    assert_int_equal(pub.publicArea.objectAttributes, TPMA_OBJECT_RESTRICTED);
+
+    assert_int_equal(pub.publicArea.type, TPM2_ALG_KEYEDHASH);
+
+    TPMI_ALG_HASH alg = pub.publicArea.parameters.keyedHashDetail.scheme.details.hmac.hashAlg;
+    assert_int_equal(alg, TPM2_ALG_SHA256);
+}
+
+static void test_extended_alg_hmac(void **state) {
+    UNUSED(state);
+
+    TPM2B_PUBLIC pub = { 0 };
+
+    bool res = tpm2_alg_util_handle_ext_alg("hmac", &pub);
+    assert_true(res);
+
+    assert_int_equal(pub.publicArea.objectAttributes, 0);
+
+    assert_int_equal(pub.publicArea.type, TPM2_ALG_KEYEDHASH);
+
+    TPMI_ALG_HASH alg = pub.publicArea.parameters.keyedHashDetail.scheme.details.hmac.hashAlg;
+    assert_int_equal(alg, TPM2_ALG_SHA256);
+}
+
+static void test_extended_alg_hmacsha384_restricted(void **state) {
+    UNUSED(state);
+
+    TPM2B_PUBLIC pub = {
+        .publicArea = {
+            .objectAttributes = TPMA_OBJECT_RESTRICTED
+        }
+    };
+
+    bool res = tpm2_alg_util_handle_ext_alg("hmac:sha384", &pub);
+    assert_true(res);
+
+    assert_int_equal(pub.publicArea.objectAttributes, TPMA_OBJECT_RESTRICTED);
+
+    assert_int_equal(pub.publicArea.type, TPM2_ALG_KEYEDHASH);
+
+    TPMI_ALG_HASH alg = pub.publicArea.parameters.keyedHashDetail.scheme.details.hmac.hashAlg;
+    assert_int_equal(alg, TPM2_ALG_SHA384);
+}
+
+static void test_extended_alg_hmacsha384(void **state) {
+    UNUSED(state);
+
+    TPM2B_PUBLIC pub = { 0 };
+
+    bool res = tpm2_alg_util_handle_ext_alg("hmac:sha384", &pub);
+    assert_true(res);
+
+    assert_int_equal(pub.publicArea.objectAttributes, 0);
+
+    assert_int_equal(pub.publicArea.type, TPM2_ALG_KEYEDHASH);
+
+    TPMI_ALG_HASH alg = pub.publicArea.parameters.keyedHashDetail.scheme.details.hmac.hashAlg;
+    assert_int_equal(alg, TPM2_ALG_SHA384);
+}
+
+static void test_extended_alg_aes_restricted(void **state) {
+    UNUSED(state);
+
+    TPM2B_PUBLIC pub = {
+        .publicArea = {
+            .objectAttributes = TPMA_OBJECT_RESTRICTED
+        }
+    };
+
+    bool res = tpm2_alg_util_handle_ext_alg("aes", &pub);
+    assert_true(res);
+
+    assert_int_equal(pub.publicArea.type, TPM2_ALG_SYMCIPHER);
+
+    TPMT_SYM_DEF_OBJECT *s = &pub.publicArea.parameters.symDetail.sym;
+    assert_int_equal(s->keyBits.aes, 128);
+    assert_int_equal(s->mode.aes, TPM2_ALG_NULL);
+    assert_int_equal(s->algorithm, TPM2_ALG_AES);
+}
+
+static void test_extended_alg_aes(void **state) {
+    UNUSED(state);
+
+    TPM2B_PUBLIC pub = {
+        .publicArea = {
+            .objectAttributes = TPMA_OBJECT_RESTRICTED
+        }
+    };
+
+    bool res = tpm2_alg_util_handle_ext_alg("aes", &pub);
+    assert_true(res);
+
+    assert_int_equal(pub.publicArea.type, TPM2_ALG_SYMCIPHER);
+
+    TPMT_SYM_DEF_OBJECT *s = &pub.publicArea.parameters.symDetail.sym;
+    assert_int_equal(s->keyBits.aes, 128);
+    assert_int_equal(s->mode.aes, TPM2_ALG_NULL);
+    assert_int_equal(s->algorithm, TPM2_ALG_AES);
+}
+
+static void test_extended_alg_aes256_restricted(void **state) {
+    UNUSED(state);
+
+    TPM2B_PUBLIC pub = {
+        .publicArea = {
+            .objectAttributes = TPMA_OBJECT_RESTRICTED
+        }
+    };
+
+    bool res = tpm2_alg_util_handle_ext_alg("aes256", &pub);
+    assert_true(res);
+
+    assert_int_equal(pub.publicArea.type, TPM2_ALG_SYMCIPHER);
+
+    TPMT_SYM_DEF_OBJECT *s = &pub.publicArea.parameters.symDetail.sym;
+    assert_int_equal(s->keyBits.aes, 256);
+    assert_int_equal(s->mode.aes, TPM2_ALG_NULL);
+    assert_int_equal(s->algorithm, TPM2_ALG_AES);
+}
+
+static void test_extended_alg_aes256(void **state) {
+    UNUSED(state);
+
+    TPM2B_PUBLIC pub = {
+        .publicArea = {
+            .objectAttributes = TPMA_OBJECT_RESTRICTED
+        }
+    };
+
+    bool res = tpm2_alg_util_handle_ext_alg("aes256", &pub);
+    assert_true(res);
+
+    assert_int_equal(pub.publicArea.type, TPM2_ALG_SYMCIPHER);
+
+    TPMT_SYM_DEF_OBJECT *s = &pub.publicArea.parameters.symDetail.sym;
+    assert_int_equal(s->keyBits.aes, 256);
+    assert_int_equal(s->mode.aes, TPM2_ALG_NULL);
+    assert_int_equal(s->algorithm, TPM2_ALG_AES);
+}
+
+static void test_extended_alg_aes256cbc_restricted(void **state) {
+    UNUSED(state);
+
+    TPM2B_PUBLIC pub = {
+        .publicArea = {
+            .objectAttributes = TPMA_OBJECT_RESTRICTED
+        }
+    };
+
+    bool res = tpm2_alg_util_handle_ext_alg("aes256cbc", &pub);
+    assert_true(res);
+
+    assert_int_equal(pub.publicArea.type, TPM2_ALG_SYMCIPHER);
+
+    TPMT_SYM_DEF_OBJECT *s = &pub.publicArea.parameters.symDetail.sym;
+    assert_int_equal(s->keyBits.aes, 256);
+    assert_int_equal(s->mode.aes, TPM2_ALG_CBC);
+    assert_int_equal(s->algorithm, TPM2_ALG_AES);
+}
+
+static void test_extended_alg_aes256cbc(void **state) {
+    UNUSED(state);
+
+    TPM2B_PUBLIC pub = {
+        .publicArea = {
+            .objectAttributes = TPMA_OBJECT_RESTRICTED
+        }
+    };
+
+    bool res = tpm2_alg_util_handle_ext_alg("aes256cbc", &pub);
+    assert_true(res);
+
+    assert_int_equal(pub.publicArea.type, TPM2_ALG_SYMCIPHER);
+
+    TPMT_SYM_DEF_OBJECT *s = &pub.publicArea.parameters.symDetail.sym;
+    assert_int_equal(s->keyBits.aes, 256);
+    assert_int_equal(s->mode.aes, TPM2_ALG_CBC);
+    assert_int_equal(s->algorithm, TPM2_ALG_AES);
+}
+
+static void test_extended_alg_keyedhash(void **state) {
+    UNUSED(state);
+
+    TPM2B_PUBLIC pub = { 0 };
+
+    bool res = tpm2_alg_util_handle_ext_alg("keyedhash", &pub);
+    assert_true(res);
+
+    assert_int_equal(pub.publicArea.type, TPM2_ALG_KEYEDHASH);
+
+    TPMS_KEYEDHASH_PARMS *k = &pub.publicArea.parameters.keyedHashDetail;
+    assert_int_equal(k->scheme.scheme, TPM2_ALG_NULL);
+}
+
+static void test_extended_alg_bad(void **state) {
+    UNUSED(state);
+
+    TPM2B_PUBLIC pub = { 0 };
+
+    bool res = tpm2_alg_util_handle_ext_alg("ecc256funnytexthere", &pub);
+    assert_false(res);
+
+    res = tpm2_alg_util_handle_ext_alg("ecc256:funnytexthere", &pub);
+    assert_false(res);
+
+    res = tpm2_alg_util_handle_ext_alg("rsafunnytexthere", &pub);
+    assert_false(res);
+
+    res = tpm2_alg_util_handle_ext_alg("rsa:funnytexthere", &pub);
+    assert_false(res);
+
+    res = tpm2_alg_util_handle_ext_alg("rsa2048funnytexthere", &pub);
+    assert_false(res);
+
+    res = tpm2_alg_util_handle_ext_alg("rsa2048:funnytexthere", &pub);
+    assert_false(res);
+
+    res = tpm2_alg_util_handle_ext_alg("aesfunnytexthere", &pub);
+    assert_false(res);
+
+    res = tpm2_alg_util_handle_ext_alg("aes:funnytexthere", &pub);
+    assert_false(res);
+
+    res = tpm2_alg_util_handle_ext_alg("aes128funnytexthere", &pub);
+    assert_false(res);
+
+    res = tpm2_alg_util_handle_ext_alg("aes128:funnytexthere", &pub);
+    assert_false(res);
+
+    res = tpm2_alg_util_handle_ext_alg("xorfunnytexthere", &pub);
+    assert_false(res);
+
+    res = tpm2_alg_util_handle_ext_alg("xor:funnytexthere", &pub);
+    assert_false(res);
+
+    res = tpm2_alg_util_handle_ext_alg("hmacfunnytexthere", &pub);
+    assert_false(res);
+
+    res = tpm2_alg_util_handle_ext_alg("hmac:funnytexthere", &pub);
+    assert_false(res);
+
+    res = tpm2_alg_util_handle_ext_alg("keyedhashfunytexthere", &pub);
+    assert_false(res);
+
+    res = tpm2_alg_util_handle_ext_alg("keyedhash:funnytexthere", &pub);
+    assert_false(res);
+}
+
 /* link required symbol, but tpm2_tool.c declares it AND main, which
  * we have a main below for cmocka tests.
  */
@@ -449,7 +1182,40 @@ int main(int argc, char* argv[]) {
         cmocka_unit_test(test_tpm2_alg_util_get_hash_size),
         cmocka_unit_test(test_tpm2_alg_util_flags_sig),
         cmocka_unit_test(test_tpm2_alg_util_flags_enc_scheme),
-        cmocka_unit_test(test_tpm2_alg_util_flags_hash)
+        cmocka_unit_test(test_tpm2_alg_util_flags_hash),
+        cmocka_unit_test(test_extended_alg_rsa2048_non_restricted),
+        cmocka_unit_test(test_extended_alg_rsa2048_restricted),
+        cmocka_unit_test(test_extended_alg_rsa_non_restricted),
+        cmocka_unit_test(test_extended_alg_rsa_restricted),
+        cmocka_unit_test(test_extended_alg_rsa1024_rsaes_restricted),
+        cmocka_unit_test(test_extended_alg_rsa1024_rsaes),
+        cmocka_unit_test(test_extended_alg_rsa_rsapss),
+        cmocka_unit_test(test_extended_alg_rsa_rsassa_non_restricted),
+        cmocka_unit_test(test_extended_alg_rsa2048_aes128cfb_non_restricted),
+        cmocka_unit_test(test_extended_alg_ecc256_non_restricted),
+        cmocka_unit_test(test_extended_alg_ecc256_aes128cbc_non_restricted),
+        cmocka_unit_test(test_extended_alg_ecc384_ecdaa4_sha256_non_restricted),
+        cmocka_unit_test(test_extended_alg_ecc384_ecdaa4_sha256),
+        cmocka_unit_test(test_extended_alg_ecc256_restricted),
+        cmocka_unit_test(test_extended_alg_ecc_non_restricted),
+        cmocka_unit_test(test_extended_alg_ecc_restricted),
+        cmocka_unit_test(test_extended_alg_ecc_ecdsa_restricted),
+        cmocka_unit_test(test_extended_alg_xor_restricted),
+        cmocka_unit_test(test_extended_alg_xor),
+        cmocka_unit_test(test_extended_alg_xorsha256_restricted),
+        cmocka_unit_test(test_extended_alg_xorsha256),
+        cmocka_unit_test(test_extended_alg_hmac_restricted),
+        cmocka_unit_test(test_extended_alg_hmac),
+        cmocka_unit_test(test_extended_alg_hmacsha384_restricted),
+        cmocka_unit_test(test_extended_alg_hmacsha384),
+        cmocka_unit_test(test_extended_alg_aes_restricted),
+        cmocka_unit_test(test_extended_alg_aes),
+        cmocka_unit_test(test_extended_alg_aes256_restricted),
+        cmocka_unit_test(test_extended_alg_aes256),
+        cmocka_unit_test(test_extended_alg_aes256cbc_restricted),
+        cmocka_unit_test(test_extended_alg_aes256cbc),
+        cmocka_unit_test(test_extended_alg_keyedhash),
+        cmocka_unit_test(test_extended_alg_bad),
     };
 
     return cmocka_run_group_tests(tests, NULL, NULL);


### PR DESCRIPTION
If one attempts to specify such algorithm permutation:
  - ecc256<insert_something_here>
For example:
  -  ecc256funnytexthere

The tool will silently convert the algorithm specifier into ecc256:null:null.

The same behavior can be obtained by using RSA or any algorithm specification
that has data between identifier and the colon (or NULL) and where beginning
of the spec. is correct (all permutations of ecc/rsa with a valid curve/key size)
On top of that, algorithms defaults changes between restricted and non restricted modes.
ecc256:null:null in non restricted
ecc256:null:aes128cfb in restricted

Correct this by issuing errors when invalid text strings are presented.

Fixes: #1371

Signed-off-by: William Roberts <william.c.roberts@intel.com>