### PR TITLE
tpm2_errata: Fix zeroed attribute returned by errata handler

### DIFF
--- a/lib/tpm2_errata.c
+++ b/lib/tpm2_errata.c
@@ -225,7 +225,7 @@ static void fixup_sign_decrypt_attribute_encoding(va_list *ap) {
 
     TPMA_OBJECT *attrs = va_arg(*ap, TPMA_OBJECT *);
 
-    *attrs = 0;
+    *attrs &= ~TPMA_OBJECT_SIGN_ENCRYPT;
 }
 
 static bool errata_match(struct tpm2_errata_desc *errata) {


### PR DESCRIPTION
The commit ac9a5d78 wrongly clears up all attributes, resulting in
a zeroed attribute returned when applying errata.

Signed-off-by: Jia Zhang <zhang.jia@linux.alibaba.com>