### PR TITLE
test/integration: remove cmac from eccmethods and rsamethods

### DIFF
--- a/test/integration/tests/testparms.sh
+++ b/test/integration/tests/testparms.sh
@@ -19,8 +19,8 @@ hashalgs="$(populate_algs "details['hash'] and not details['method'] \
                                            and not details['signing'] \
                                            and not details['symmetric'] \
                                            and alg is not None")"
-eccmethods="$(populate_algs "details['signing'] and not details['hash'] and \"rsa\" not in alg")"
-rsamethods="$(populate_algs "details['signing'] and not details['hash'] and \"ec\" not in alg")"
+eccmethods="$(populate_algs "details['signing'] and not details['hash'] and \"ec\" in alg")"
+rsamethods="$(populate_algs "details['signing'] and not details['hash'] and \"rsa\" in alg")"
 
 # Test that common algorithms are supported
 for i in "rsa" "xor" "hmac" "ecc" "keyedhash"; do


### PR DESCRIPTION
When using the latest version 1332 of the TPM simulator, the integration test [`testparms.sh`](https://github.com/tpm2-software/tpm2-tools/blob/master/test/integration/tests/testparms.sh) fails with
```
[...]
tpm2_testparms rsa:rsapss
tpm2_testparms rsa:cmac
ERROR: Could not handle algorithm spec: "rsa:cmac"
ERROR: Invalid or unsupported by the tool : rsa:cmac
tpm2_testparms "rsa:${i}" on line 34 failed: 1
[...]
```
The cause for this is the same as in #1533, and the same solution as in  333cfcaabadea98c0d2a741ade23b71f87fdcaf5 applies.