### PR TITLE
Interactive password

### DIFF
--- a/lib/tpm2_auth_util.c
+++ b/lib/tpm2_auth_util.c
@@ -249,6 +249,17 @@ out:
     return rc;
 }
 
+static tool_rc handle_stdin_password(ESYS_CONTEXT *ectx, tpm2_session **session) {
+
+    tool_rc rc = handle_file(ectx, "file:-", session);
+    if (rc != tool_rc_success) {
+        LOG_ERR("stdin password error.");
+        return rc;
+    }
+
+    return tool_rc_success;
+}
+
 tool_rc tpm2_auth_util_from_optarg(ESYS_CONTEXT *ectx, const char *password,
     tpm2_session **session, bool is_restricted) {
 
@@ -270,6 +281,12 @@ tool_rc tpm2_auth_util_from_optarg(ESYS_CONTEXT *ectx, const char *password,
     bool is_file = !strncmp(password, FILE_PREFIX, FILE_PREFIX_LEN);
     if (is_file) {
         return handle_file(ectx, password, session);
+    }
+
+    /* Is stdin"-" */
+    bool is_stdin = ( (!strncmp(password, "-", 1)) && (strlen(password) == 1) );
+    if (is_stdin)  {
+        return handle_stdin_password(ectx, session);
     }
 
     /* starts with pcr: */

--- a/man/common/authorizations.md
+++ b/man/common/authorizations.md
@@ -9,21 +9,38 @@ Authorization for use of an object in TPM2.0 can come in 3 different forms:
 
 ## Passwords
 
-Passwords are interpreted in three forms; string, hex-string or a file. A string password is not
-interpreted, and is directly used for authorization. A hex-string password is converted from
-a hexidecimal form into a byte array form, thus allowing passwords with non-printable
-and/or terminal un-friendly characters.
-A file form should be the path of a file containing a password in string or hex-string format to be read by the tool.
-Storing passwords in files prevents information leakage, passwords passed as options can be read from the process list.
+Passwords are interpreted in four forms:
+1. String
+2. Hex-string
+3. File
+4. Stdin
 
-By default passwords are assumed to be in the string form. Password form is specified
-with special prefix values, they are:
+A string password is not interpreted, and is directly used for authorization. A
+hex-string password is converted from a hexidecimal form into a byte array form,
+thus allowing passwords with non-printable and/or terminal un-friendly
+characters. A file form should be the path of a file containing a password in
+string or hex-string format to be read by the tool. Storing passwords in files
+prevents information leakage, passwords passed as options can be read from the
+process list. Stdin password input, just like string, is not interpreted. When
+specifying stdin passwords, there are two ways: Prompt and Process substitution.
+When using the prompt method, specifying the password should be followed with
+a return and ctrl+d so it becomes equivalent to a string password. As an example,
+tpm2_tool -p str:password is equivalent to tpm2_tool -p -, followed by
+prompt:password<return><ctrl+d>
 
-  * str: - Used to indicate it is a raw string. Useful for escaping a password that starts
-         with the "hex:" prefix.
-  * hex: - Used when specifying a password in hex string format.
-  * file: - Used when specifying a password stored in a file. Useful to prevent leaking the
-         password to UNIX utilities (such as ps).
+By default passwords are assumed to be in the string form. Password form is
+specified with special prefix values, they are:
+
+  * str:<password> Used to indicate it is a raw string. Useful for escaping a
+                   password that starts with the "hex:" prefix.
+  * hex:<password> Used when specifying a password in hex string format.
+  * file:<file>    Used when specifying a password stored in a file. Useful to
+                   prevent leaking the password to UNIX utilities (such as ps).
+  * "-"            Used when specifying a password from stdin. There are 2 ways
+                   to specify the password. A prompt and by the process
+                   substitution method. Note that this is is similar to using
+                   file:-, however this option additionally hides password
+                   characters being echoed back to screen when using prompt.
 
 ## Sessions
 
@@ -80,4 +97,14 @@ session:session.ctx+mypassword
 To use a session context file called *session.ctx* **AND** send the *HEX* authvalue 0x11223344.
 ```
 session:session.ctx+hex:11223344
+```
+
+To use stdin method of specifying the password.
+```
+echo $password | tpm2_tool -p -
+```
+
+To use stdin method of specifying the password with process substitution.
+```
+tpm2_tool -p - <<< $password
 ```


### PR DESCRIPTION
Fixes #1194 
1. Adds method to specify password from stdin either on a prompt or through process substitution.
2. Adds method to hide password characters when reading from stdin prompt.
3. Update authorization manual to add information on stdin password input mechanism.