### PR TITLE
General man page changes

### DIFF
--- a/man/tpm2_activatecredential.1.md
+++ b/man/tpm2_activatecredential.1.md
@@ -1,6 +1,4 @@
 % tpm2_activatecredential(1) tpm2-tools | General Commands Manual
-%
-% AUGUST 2017
 
 # NAME
 

--- a/man/tpm2_certify.1.md
+++ b/man/tpm2_certify.1.md
@@ -1,6 +1,4 @@
 % tpm2_certify(1) tpm2-tools | General Commands Manual
-%
-% SEPTEMBER 2017
 
 # NAME
 

--- a/man/tpm2_changeauth.1.md
+++ b/man/tpm2_changeauth.1.md
@@ -1,6 +1,4 @@
 % tpm2_changeauth(1) tpm2-tools | General Commands Manual
-%
-% JUNE 2019
 
 # NAME
 

--- a/man/tpm2_checkquote.1.md
+++ b/man/tpm2_checkquote.1.md
@@ -1,6 +1,4 @@
 % tpm2_checkquote(1) tpm2-tools | General Commands Manual
-%
-% JANUARY 2019
 
 # NAME
 

--- a/man/tpm2_clear.1.md
+++ b/man/tpm2_clear.1.md
@@ -1,6 +1,4 @@
 % tpm2_clear(1) tpm2-tools | General Commands Manual
-%
-% DECEMBER 2017
 
 # NAME
 

--- a/man/tpm2_clear.1.md
+++ b/man/tpm2_clear.1.md
@@ -11,8 +11,8 @@ values.
 
 # DESCRIPTION
 
-**tpm2_clear**(1) - Send a clear command to the TPM to clear the 3 hierarchy authorization
-values. If the lockout password option is missing, assume NULL.
+**tpm2_clear**(1) - Send a clear command to the TPM to clear the 3 hierarchy
+authorization values.
 
 **NOTE**: All objects created under the respective hierarchies are lost.
 

--- a/man/tpm2_clearcontrol.1.md
+++ b/man/tpm2_clearcontrol.1.md
@@ -18,7 +18,7 @@ knowledge of the platform hierarchy can clear the disableClear. ** As an argumen
 the tool takes the _OPERATION_ as an integer 0|1 or string c|s to clear or set
 the disableClear attribute. By default it attempts a CLEAR operation**
 Note: Platform hierarchy auth handle can always be used to clear the TPM with
-tpm2_clear command. If password option is missing, assume NULL.
+tpm2_clear command.
 
 # OPTIONS
 

--- a/man/tpm2_clearcontrol.1.md
+++ b/man/tpm2_clearcontrol.1.md
@@ -1,6 +1,4 @@
 % tpm2_clearcontrol(1) tpm2-tools | General Commands Manual
-%
-% DECEMBER 2017
 
 # NAME
 

--- a/man/tpm2_create.1.md
+++ b/man/tpm2_create.1.md
@@ -1,6 +1,4 @@
 % tpm2_create(1) tpm2-tools | General Commands Manual
-%
-% AUGUST 2017
 
 # NAME
 

--- a/man/tpm2_createak.1.md
+++ b/man/tpm2_createak.1.md
@@ -1,6 +1,4 @@
 % tpm2_createak(1) tpm2-tools | General Commands Manual
-%
-% SEPTEMBER 2017
 
 # NAME
 

--- a/man/tpm2_createak.1.md
+++ b/man/tpm2_createak.1.md
@@ -15,8 +15,6 @@ endorsement hierarchy.
 under the endorsement hierarchy. The context of the attestation key is specified
 via **-c**.
 
-If any password option is missing, assume NULL.
-
 The tool outputs to stdout a YAML representation of the loaded key's name, for example:
 ```
 loaded-key:

--- a/man/tpm2_createek.1.md
+++ b/man/tpm2_createek.1.md
@@ -11,7 +11,7 @@
 # DESCRIPTION
 
 **tpm2_createek**(1) - Generate TCG profile compliant endorsement key (EK), which is the primary object
-of the endorsement hierarchy. If any password option is missing, assume NULL for the password.
+of the endorsement hierarchy.
 
 If a transient object is generated the tool outputs a context file specified via **-c**.
 

--- a/man/tpm2_createek.1.md
+++ b/man/tpm2_createek.1.md
@@ -1,6 +1,4 @@
 % tpm2_createek(1) tpm2-tools | General Commands Manual
-%
-% SEPTEMBER 2017
 
 # NAME
 

--- a/man/tpm2_createpolicy.1.md
+++ b/man/tpm2_createpolicy.1.md
@@ -1,6 +1,4 @@
 % tpm2_createpolicy(1) tpm2-tools | General Commands Manual
-%
-% AUGUST 2017
 
 # NAME
 

--- a/man/tpm2_createprimary.1.md
+++ b/man/tpm2_createprimary.1.md
@@ -1,6 +1,4 @@
 % tpm2_createprimary(1) tpm2-tools | General Commands Manual
-%
-% SEPTEMBER 2017
 
 # NAME
 

--- a/man/tpm2_dictionarylockout.1.md
+++ b/man/tpm2_dictionarylockout.1.md
@@ -1,6 +1,4 @@
 % tpm2_dictionarylockout(1) tpm2-tools | General Commands Manual
-%
-% SEPTEMBER 2017
 
 # NAME
 

--- a/man/tpm2_dictionarylockout.1.md
+++ b/man/tpm2_dictionarylockout.1.md
@@ -11,7 +11,7 @@
 # DESCRIPTION
 
 **tpm2_dictionarylockout**(1) - Setup dictionary-attack-lockout parameters or clear
-dictionary-attack-lockout state. If any password option is missing, assume NULL.
+dictionary-attack-lockout state.
 
 # OPTIONS
 

--- a/man/tpm2_duplicate.1.md
+++ b/man/tpm2_duplicate.1.md
@@ -1,6 +1,4 @@
 % tpm2_duplicate(1) tpm2-tools | General Commands Manual
-%
-% APRIL 2019
 
 # NAME
 

--- a/man/tpm2_encryptdecrypt.1.md
+++ b/man/tpm2_encryptdecrypt.1.md
@@ -1,6 +1,4 @@
 % tpm2_encryptdecrypt(1) tpm2-tools | General Commands Manual
-%
-% SEPTEMBER 2017
 
 # NAME
 

--- a/man/tpm2_evictcontrol.1.md
+++ b/man/tpm2_evictcontrol.1.md
@@ -1,6 +1,4 @@
 % tpm2_evictcontrol(1) tpm2-tools | General Commands Manual
-%
-% SEPTEMBER 2017
 
 # NAME
 

--- a/man/tpm2_flushcontext.1.md
+++ b/man/tpm2_flushcontext.1.md
@@ -1,6 +1,4 @@
 % tpm2_flushcontext(1) tpm2-tools | General Commands Manual
-%
-% NOVEMBER 2017
 
 # NAME
 

--- a/man/tpm2_getcap.1.md
+++ b/man/tpm2_getcap.1.md
@@ -1,6 +1,4 @@
 % tpm2_getcap(1) tpm2-tools | General Commands Manual
-%
-% SEPTEMBER 2017
 
 # NAME
 

--- a/man/tpm2_getmanufec.1.md
+++ b/man/tpm2_getmanufec.1.md
@@ -1,6 +1,4 @@
 % tpm2_getmanufec(1) tpm2-tools | General Commands Manual
-%
-% AUGUST 2017
 
 # NAME
 

--- a/man/tpm2_getrandom.1.md
+++ b/man/tpm2_getrandom.1.md
@@ -1,6 +1,4 @@
 % tpm2_getrandom(1) tpm2-tools | General Commands Manual
-%
-% SEPTEMBER 2017
 
 # NAME
 

--- a/man/tpm2_gettestresult.1.md
+++ b/man/tpm2_gettestresult.1.md
@@ -1,6 +1,4 @@
 % tpm2_gettestresult(1) tpm2-tools | General Commands Manual
-%
-% JANUARY 2019
 
 # NAME
 

--- a/man/tpm2_hash.1.md
+++ b/man/tpm2_hash.1.md
@@ -1,6 +1,4 @@
 % tpm2_hash(1) tpm2-tools | General Commands Manual
-%
-% SEPTEMBER 2017
 
 # NAME
 

--- a/man/tpm2_hmac.1.md
+++ b/man/tpm2_hmac.1.md
@@ -1,6 +1,4 @@
 % tpm2_hmac(1) tpm2-tools | General Commands Manual
-%
-% SEPTEMBER 2017
 
 # NAME
 

--- a/man/tpm2_import.1.md
+++ b/man/tpm2_import.1.md
@@ -1,6 +1,4 @@
 % tpm2_import(1) tpm2-tools | General Commands Manual
-%
-% SEPTEMBER 2017
 
 # NAME
 

--- a/man/tpm2_incrementalselftest.1.md
+++ b/man/tpm2_incrementalselftest.1.md
@@ -1,6 +1,4 @@
 % tpm2_incrementalselftest(1) tpm2-tools | General Commands Manual
-%
-% MARCH 2019
 
 # NAME
 

--- a/man/tpm2_listpersistent.1.md
+++ b/man/tpm2_listpersistent.1.md
@@ -1,6 +1,4 @@
 % tpm2_listpersistent(1) tpm2-tools | General Commands Manual
-%
-% SEPTEMBER 2017
 
 # NAME
 

--- a/man/tpm2_load.1.md
+++ b/man/tpm2_load.1.md
@@ -1,6 +1,4 @@
 % tpm2_load(1) tpm2-tools | General Commands Manual
-%
-% SEPTEMBER 2017
 
 # NAME
 

--- a/man/tpm2_loadexternal.1.md
+++ b/man/tpm2_loadexternal.1.md
@@ -1,6 +1,4 @@
 % tpm2_loadexternal(1) tpm2-tools | General Commands Manual
-%
-% SEPTEMBER 2017
 
 # NAME
 

--- a/man/tpm2_makecredential.1.md
+++ b/man/tpm2_makecredential.1.md
@@ -1,6 +1,4 @@
 % tpm2_makecredential(1) tpm2-tools | General Commands Manual
-%
-% SEPTEMBER 2017
 
 # NAME
 

--- a/man/tpm2_nvdefine.1.md
+++ b/man/tpm2_nvdefine.1.md
@@ -1,6 +1,4 @@
 % tpm2_nvdefine(1) tpm2-tools | General Commands Manual
-%
-% SEPTEMBER 2017
 
 # NAME
 

--- a/man/tpm2_nvincrement.1.md
+++ b/man/tpm2_nvincrement.1.md
@@ -1,6 +1,4 @@
 % tpm2_nvincrement(1) tpm2-tools | General Commands Manual
-%
-% MARCH 2019
 
 # NAME
 

--- a/man/tpm2_nvlist.1.md
+++ b/man/tpm2_nvlist.1.md
@@ -1,6 +1,4 @@
 % tpm2_nvlist(1) tpm2-tools | General Commands Manual
-%
-% SEPTEMBER 2017
 
 # NAME
 

--- a/man/tpm2_nvread.1.md
+++ b/man/tpm2_nvread.1.md
@@ -1,6 +1,4 @@
 % tpm2_nvread(1) tpm2-tools | General Commands Manual
-%
-% SEPTEMBER 2017
 
 # NAME
 

--- a/man/tpm2_nvreadlock.1.md
+++ b/man/tpm2_nvreadlock.1.md
@@ -1,6 +1,4 @@
 % tpm2_nvreadlock(1) tpm2-tools | General Commands Manual
-%
-% SEPTEMBER 2017
 
 # NAME
 

--- a/man/tpm2_nvrelease.1.md
+++ b/man/tpm2_nvrelease.1.md
@@ -1,6 +1,4 @@
 % tpm2_nvrelease(1) tpm2-tools | General Commands Manual
-%
-% SEPTEMBER 2017
 
 # NAME
 

--- a/man/tpm2_nvwrite.1.md
+++ b/man/tpm2_nvwrite.1.md
@@ -1,6 +1,4 @@
 % tpm2_nvwrite(1) tpm2-tools | General Commands Manual
-%
-% SEPTEMBER 2017
 
 # NAME
 

--- a/man/tpm2_pcrallocate.1.md
+++ b/man/tpm2_pcrallocate.1.md
@@ -1,6 +1,4 @@
 % tpm2_pcrallocate(1) tpm2-tools | General Commands Manual
-%
-% MARCH 2019
 
 # NAME
 

--- a/man/tpm2_pcrevent.1.md
+++ b/man/tpm2_pcrevent.1.md
@@ -1,6 +1,4 @@
 % tpm2_pcrevent(1) tpm2-tools | General Commands Manual
-%
-% SEPTEMBER 2017
 
 # NAME
 

--- a/man/tpm2_pcrextend.1.md
+++ b/man/tpm2_pcrextend.1.md
@@ -1,6 +1,4 @@
 % tpm2_pcrextend(1) tpm2-tools | General Commands Manual
-%
-% SEPTEMBER 2017
 
 # NAME
 

--- a/man/tpm2_pcrlist.1.md
+++ b/man/tpm2_pcrlist.1.md
@@ -1,6 +1,4 @@
 % tpm2_pcrlist(1) tpm2-tools | General Commands Manual
-%
-% AUGUST 2017
 
 # NAME
 

--- a/man/tpm2_pcrreset.1.md
+++ b/man/tpm2_pcrreset.1.md
@@ -1,6 +1,4 @@
 % tpm2_pcrreset(1) tpm2-tools | General Commands Manual
-%
-% JANUARY 2019
 
 # NAME
 

--- a/man/tpm2_policyauthorize.1.md
+++ b/man/tpm2_policyauthorize.1.md
@@ -1,6 +1,4 @@
 % tpm2_policyauthorize(1) tpm2-tools | General Commands Manual
-%
-% AUGUST 2018
 
 # NAME
 

--- a/man/tpm2_policycommandcode.1.md
+++ b/man/tpm2_policycommandcode.1.md
@@ -1,6 +1,4 @@
 % tpm2_policycommandcode(1) tpm2-tools | General Commands Manual
-%
-% JANUARY 2018
 
 # NAME
 

--- a/man/tpm2_policyduplicationselect.1.md
+++ b/man/tpm2_policyduplicationselect.1.md
@@ -1,6 +1,4 @@
 % tpm2_policyduplicationselect(1) tpm2-tools | General Commands Manual
-%
-% MARCH 2018
 
 # NAME
 

--- a/man/tpm2_policylocality.1.md
+++ b/man/tpm2_policylocality.1.md
@@ -1,6 +1,4 @@
 % tpm2_policylocality(1) tpm2-tools | General Commands Manual
-%
-% MARCH 2019
 
 # NAME
 

--- a/man/tpm2_policyor.1.md
+++ b/man/tpm2_policyor.1.md
@@ -1,6 +1,4 @@
 % tpm2_policyor(1) tpm2-tools | General Commands Manual
-%
-% AUGUST 2018
 
 # NAME
 

--- a/man/tpm2_policypassword.1.md
+++ b/man/tpm2_policypassword.1.md
@@ -1,6 +1,4 @@
 % tpm2_policypassword(1) tpm2-tools | General Commands Manual
-%
-% AUGUST 2018
 
 # NAME
 

--- a/man/tpm2_policypcr.1.md
+++ b/man/tpm2_policypcr.1.md
@@ -1,6 +1,4 @@
 % tpm2_policypcr(1) tpm2-tools | General Commands Manual
-%
-% JANUARY 2018
 
 # NAME
 

--- a/man/tpm2_policyrestart.1.md
+++ b/man/tpm2_policyrestart.1.md
@@ -1,6 +1,4 @@
 % tpm2_policyrestart(1) tpm2-tools | General Commands Manual
-%
-% JANUARY 2018
 
 # NAME
 

--- a/man/tpm2_policysecret.1.md
+++ b/man/tpm2_policysecret.1.md
@@ -1,6 +1,4 @@
 % tpm2_policysecret(1) tpm2-tools | General Commands Manual
-%
-% OCTOBER 2018
 
 # NAME
 

--- a/man/tpm2_print.1.md
+++ b/man/tpm2_print.1.md
@@ -1,6 +1,4 @@
 % tpm2_print(1) tpm2-tools | General Commands Manual
-%
-% DECEMBER 2017
 
 # NAME
 

--- a/man/tpm2_quote.1.md
+++ b/man/tpm2_quote.1.md
@@ -1,6 +1,4 @@
 % tpm2_quote(1) tpm2-tools | General Commands Manual
-%
-% SEPTEMBER 2017
 
 # NAME
 

--- a/man/tpm2_rc_decode.1.md
+++ b/man/tpm2_rc_decode.1.md
@@ -1,6 +1,4 @@
 % tpm2_rc_decode(1) tpm2-tools | General Commands Manual
-%
-% SEPTEMBER 2017
 
 # NAME
 

--- a/man/tpm2_readpublic.1.md
+++ b/man/tpm2_readpublic.1.md
@@ -1,6 +1,4 @@
 % tpm2_readpublic(1) tpm2-tools | General Commands Manual
-%
-% SEPTEMBER 2017
 
 # NAME
 

--- a/man/tpm2_rsadecrypt.1.md
+++ b/man/tpm2_rsadecrypt.1.md
@@ -1,6 +1,4 @@
 % tpm2_rsadecrypt(1) tpm2-tools | General Commands Manual
-%
-% SEPTEMBER 2017
 
 # NAME
 

--- a/man/tpm2_rsaencrypt.1.md
+++ b/man/tpm2_rsaencrypt.1.md
@@ -1,6 +1,4 @@
 % tpm2_rsaencrypt(1) tpm2-tools | General Commands Manual
-%
-% SEPTEMBER 2017
 
 # NAME
 

--- a/man/tpm2_selftest.1.md
+++ b/man/tpm2_selftest.1.md
@@ -1,6 +1,4 @@
 % tpm2_selftest(1) tpm2-tools | General Commands Manual
-%
-% JANUARY 2019
 
 # NAME
 

--- a/man/tpm2_send.1.md
+++ b/man/tpm2_send.1.md
@@ -1,6 +1,4 @@
 % tpm2_send(1) tpm2-tools | General Commands Manual
-%
-% SEPTEMBER 2017
 
 # NAME
 

--- a/man/tpm2_sign.1.md
+++ b/man/tpm2_sign.1.md
@@ -1,6 +1,4 @@
 % tpm2_sign(1) tpm2-tools | General Commands Manual
-%
-% SEPTEMBER 2017
 
 # NAME
 

--- a/man/tpm2_startauthsession.1.md
+++ b/man/tpm2_startauthsession.1.md
@@ -1,6 +1,4 @@
 % tpm2_startauthsession(1) tpm2-tools | General Commands Manual
-%
-% JANUARY 2018
 
 # NAME
 

--- a/man/tpm2_startup.1.md
+++ b/man/tpm2_startup.1.md
@@ -1,6 +1,4 @@
 % tpm2_startup(1) tpm2-tools | General Commands Manual
-%
-% SEPTEMBER 2017
 
 # NAME
 

--- a/man/tpm2_stirrandom.1.md
+++ b/man/tpm2_stirrandom.1.md
@@ -1,6 +1,4 @@
 % tpm2_stirrandom(1) tpm2-tools | General Commands Manual
-%
-% MARCH 2019
 
 # NAME
 

--- a/man/tpm2_testparms.1.md
+++ b/man/tpm2_testparms.1.md
@@ -1,6 +1,4 @@
 % tpm2_testparms(1) tpm2-tools | General Commands Manual
-%
-% MARCH 2019
 
 # NAME
 

--- a/man/tpm2_unseal.1.md
+++ b/man/tpm2_unseal.1.md
@@ -1,6 +1,4 @@
 % tpm2_unseal(1) tpm2-tools | General Commands Manual
-%
-% SEPTEMBER 2017
 
 # NAME
 

--- a/man/tpm2_verifysignature.1.md
+++ b/man/tpm2_verifysignature.1.md
@@ -1,6 +1,4 @@
 % tpm2_verifysignature(1) tpm2-tools | General Commands Manual
-%
-% SEPTEMBER 2017
 
 # NAME
 


### PR DESCRIPTION
Remove line: " If any password option is missing, assume NULL."
authorizations.md has the below information that generically applies.
"Authorizations default to the **EMPTY PASSWORD** when not specified"

Remove dates from the man pages
