### PR TITLE
Tools options changes

### DIFF
--- a/man/tpm2_activatecredential.1.md
+++ b/man/tpm2_activatecredential.1.md
@@ -32,17 +32,17 @@ These options control the object verification:
     random seed. Either a file or a handle number. See section "Context Object
     Format".
 
-  * **-P**, **\--credentialedkey-auth**=_AUTH\_VALUE_:
+  * **-p**, **\--credentialedkey-auth**=_AUTH\_VALUE_:
 
     _AUTH\_VALUE_ for providing an authorization value for the
     _CREDENTIALED\_KEY\_OBJ\_CTX\_OR\_HANDLE_.
 
-  * **-E**, **\--credentialkey-auth**=_AUTH\_VALUE_:
+  * **-P**, **\--credentialkey-auth**=_AUTH\_VALUE_:
 
     _AUTH\_VALUE_ for providing an authorization value for the
     _CREDENTIAL\_KEY\_OBJ\_CTX\_OR\_HANDLE_.
 
-  * **-i**, **\--credential-secret**=_INPUT\_FILE_:
+  * **-i**, **\--credential-blob**=_INPUT\_FILE_:
 
     Input file path, containing the two structures - credential blob and secret,
     needed by **tpm2_activatecredential**(1) function. This is created from the

--- a/man/tpm2_certify.1.md
+++ b/man/tpm2_certify.1.md
@@ -22,17 +22,17 @@ its public area loaded cannot be certified.
 
 These options control the certification:
 
-  * **-C**, **\--certifiedkey-context**=_CERTIFIED\_KEY\_OBJECT\_CONTEXT_:
+  * **-c**, **\--certifiedkey-context**=_CERTIFIED\_KEY\_OBJECT\_CONTEXT_:
 
     Context object for the object to be certified. Either a file or a handle number.
     See section "Context Object Format".
 
-  * **-c**, **\--signingkey-context**=_SIGNING\_KEY\_OBJECT\_CONTEXT_:
+  * **-C**, **\--signingkey-context**=_SIGNING\_KEY\_OBJECT\_CONTEXT_:
 
     Context object for the key used to sign the attestation structure.
     See section "Context Object Format".
 
-  * **-P**, **\--certifiedkey-auth**=_CERTIFIED\_KEY\OBJECT\_AUTH_:
+  * **-p**, **\--certifiedkey-auth**=_CERTIFIED\_KEY\OBJECT\_AUTH_:
 
     Use _CERTIFIED\_KEY\OBJECT\_AUTH_ for providing an authorization value for the object specified
     in _CERTIFIED\_KEY\_OBJECT\_CONTEXT_.
@@ -47,18 +47,18 @@ These options control the certification:
     Also, see section "Supported Hash Algorithms" for a list of supported hash
     algorithms.
 
-  * **-p**, **\--signingkey-auth**=_SIGNING\_KEY_:
+  * **-P**, **\--signingkey-auth**=_SIGNING\_KEY_:
 
     Use _SIGNING\_KEY_ for providing an authorization value for the key specified
     in _SIGNING\_KEY\_OBJECT\_CONTEXT_.
     Follows the same formatting guidelines as the object handle authorization or
     **-P** option.
 
-  * **-o**, **\--out-attest-file**=_ATTEST\_FILE_:
+  * **-o**, **\--attestation**=_ATTEST\_FILE_:
 
     Output file name for the attestation data.
 
-  * **-s**, **\--sig-file**=_SIG\_FILE_:
+  * **-s**, **\--signature**=_SIGNATURE\_FILE_:
 
     Output file name for the signature data.
 

--- a/man/tpm2_clear.1.md
+++ b/man/tpm2_clear.1.md
@@ -19,9 +19,9 @@ lockout hierarchy
 
 # OPTIONS
 
-  * **-p**, **\--platform**:
+  * **-c**, **\--platform**:
 
-    Specifies the tool should operate on the platform hierarchy. By default
+    Specifies the hierarchy the tools should operate on. By default
     it operates on the lockout hierarchy.
 
     **NOTE : Operating on platform hierarchy require platform authentication.**
@@ -42,7 +42,7 @@ tpm2_clear lockoutpasswd
 
 ## Clear the authorization values on the platform hierarchy
 ```
-tpm2_clear -p
+tpm2_clear -c p
 ```
 
 [returns](common/returns.md)

--- a/man/tpm2_clear.1.md
+++ b/man/tpm2_clear.1.md
@@ -7,12 +7,13 @@ values.
 
 # SYNOPSIS
 
-**tpm2_clear** [OPTIONS]
+**tpm2_clear** [OPTIONS] _AUTH\_VALUE_
 
 # DESCRIPTION
 
 **tpm2_clear**(1) - Send a clear command to the TPM to clear the 3 hierarchy
-authorization values.
+authorization values. As an argument takes the auth value for either platform or
+lockout hierarchy
 
 **NOTE**: All objects created under the respective hierarchies are lost.
 
@@ -25,13 +26,6 @@ authorization values.
 
     **NOTE : Operating on platform hierarchy require platform authentication.**
 
-  * **-L**, **\--auth-lockout**=_LOCKOUT\_AUTH_:
-
-    The lockout authorization value.
-
-    Authorization values should follow the "authorization formatting standards",
-    see section "Authorization Formatting".
-
 [common options](common/options.md)
 
 [common tcti options](common/tcti.md)
@@ -43,7 +37,7 @@ authorization values.
 ## Set owner, endorsement and lockout authorizations to an empty value
 
 ```
-tpm2_clear -L oldlockoutpasswd
+tpm2_clear lockoutpasswd
 ```
 
 ## Clear the authorization values on the platform hierarchy

--- a/man/tpm2_clearcontrol.1.md
+++ b/man/tpm2_clearcontrol.1.md
@@ -22,7 +22,7 @@ tpm2_clear command.
 
 # OPTIONS
 
-  * **-a**, **\--auth-handle**=_TPM\_HANDLE:
+  * **-c**, **\--auth-handle**=_TPM\_HANDLE:
 
     Specifies what auth handle, either platform hierarchy or lockout the tool
     should operate on. By default it operates on the platform hierarchy handle.
@@ -48,12 +48,12 @@ tpm2_clear command.
 
 ## Set the disableClear to block the lockout authorization's access to TPM clear
 ```
-tpm2_clearcontrol -a l s
+tpm2_clearcontrol -c l s
 ```
 
 ## Clear the disableClear to unblock lockout authorization for TPM clear operation
 ```
-tpm2_clearcontrol -a p c
+tpm2_clearcontrol -c p c
 ```
 
 [returns](common/returns.md)

--- a/test/integration/tests/activecredential.sh
+++ b/test/integration/tests/activecredential.sh
@@ -50,7 +50,7 @@ TPM2_RH_ENDORSEMENT=0x4000000B
 tpm2_startauthsession --policy-session -S session.ctx
 tpm2_policysecret -S session.ctx -c $TPM2_RH_ENDORSEMENT
 tpm2_activatecredential -Q -c ak.ctx -C 0x81010009 -i mkcred.out -o actcred.out\
-	-P akpass -E"session:session.ctx"
+	-p akpass -P"session:session.ctx"
 tpm2_flushcontext -S session.ctx
 
 exit 0

--- a/test/integration/tests/attestation.sh
+++ b/test/integration/tests/attestation.sh
@@ -80,7 +80,7 @@ tpm2_makecredential -Q -T none -e $output_ek_pub -s $file_input_data -n $loaded_
 TPM2_RH_ENDORSEMENT=0x4000000B
 tpm2_startauthsession --policy-session -S session.ctx
 tpm2_policysecret -S session.ctx -c $TPM2_RH_ENDORSEMENT $endorsepw
-tpm2_activatecredential -Q -c $context_ak -C $handle_ek -i $output_mkcredential -o $output_actcredential -P "$akpw" -E "session:session.ctx"
+tpm2_activatecredential -Q -c $context_ak -C $handle_ek -i $output_mkcredential -o $output_actcredential -p "$akpw" -P "session:session.ctx"
 tpm2_flushcontext -S session.ctx
 diff $file_input_data $output_actcredential
 

--- a/test/integration/tests/changeauth.sh
+++ b/test/integration/tests/changeauth.sh
@@ -3,7 +3,7 @@
 source helpers.sh
 
 cleanup() {
-    rm secret.txt key.ctx key.pub key.priv primary.ctx
+    rm key.ctx key.pub key.priv primary.ctx
 
     shut_down
 }
@@ -28,14 +28,13 @@ tpm2_changeauth -c o -p $ownerPasswd $new_ownerPasswd
 tpm2_changeauth -c e -p $endorsePasswd $new_endorsePasswd
 tpm2_changeauth -c l -p $lockPasswd $new_lockPasswd
 
-tpm2_clear -L $new_lockPasswd
+tpm2_clear $new_lockPasswd
 
 tpm2_changeauth -c o $ownerPasswd
 tpm2_changeauth -c e $endorsePasswd
 tpm2_changeauth -c l $lockPasswd
 
-echo -n $lockPasswd > secret.txt
-tpm2_clear -L "file:secret.txt"
+tpm2_clear $lockPasswd
 
 # Test changing an objects auth
 tpm2_createprimary -Q -C o -o primary.ctx

--- a/test/integration/tests/clear.sh
+++ b/test/integration/tests/clear.sh
@@ -1,0 +1,31 @@
+# SPDX-License-Identifier: BSD-3-Clause
+
+source helpers.sh
+
+cleanup() {
+
+    shut_down
+}
+trap cleanup EXIT
+
+start_up
+
+lockPasswd=lockoutpass
+platPasswd=platformpass
+
+#Test tpm2_clear works with blank lockout auth as default
+tpm2_clear
+
+#Test tpm2_clear works with non-empy lockout auth as default
+tpm2_changeauth -c l $lockPasswd
+tpm2_clear $lockPasswd
+
+#Test tpm2_clear works with non-empy lockout auth and specified auth hierarchy
+tpm2_changeauth -c l $lockPasswd
+tpm2_clear -c l $lockPasswd
+
+#Test tpm2_clear works with non-empy platform auth and specified auth hierarchy
+tpm2_changeauth -c p $platPasswd
+tpm2_clear -c p $platPasswd
+
+exit 0

--- a/test/integration/tests/clearcontrol.sh
+++ b/test/integration/tests/clearcontrol.sh
@@ -13,7 +13,7 @@ trap cleanup EXIT
 
 start_up
 
-tpm2_clearcontrol -a l s
+tpm2_clearcontrol -c l s
 trap - ERR
 tpm2_clear
 

--- a/tools/tpm2_activatecredential.c
+++ b/tools/tpm2_activatecredential.c
@@ -155,13 +155,13 @@ static bool on_option(char key, char *value) {
     case 'c':
         ctx.credentialed_key.ctx_path = value;
         break;
-    case 'P':
+    case 'p':
         ctx.credentialed_key.auth_str = value;
         break;
     case 'C':
         ctx.credential_key.ctx_path = value;
         break;
-    case 'E':
+    case 'P':
         ctx.credential_key.auth_str = value;
         break;
     case 'i':
@@ -186,14 +186,14 @@ bool tpm2_tool_onstart(tpm2_options **opts) {
 
     static const struct option topts[] = {
          {"credentialedkey-context", required_argument, NULL, 'c'},
-         {"credentialkey-context",      required_argument, NULL, 'C'},
-         {"credentialedkey-auth",    required_argument, NULL, 'P'},
-         {"credentialkey-auth",         required_argument, NULL, 'E'},
-         {"credential-secret",      required_argument, NULL, 'i'},
-         {"certinfo-data",          required_argument, NULL, 'o'},
+         {"credentialkey-context",   required_argument, NULL, 'C'},
+         {"credentialedkey-auth",    required_argument, NULL, 'p'},
+         {"credentialkey-auth",      required_argument, NULL, 'P'},
+         {"credential-blob",         required_argument, NULL, 'i'},
+         {"certinfo-data",           required_argument, NULL, 'o'},
     };
 
-    *opts = tpm2_options_new("c:C:P:E:i:o:", ARRAY_LEN(topts), topts,
+    *opts = tpm2_options_new("c:C:p:P:i:o:", ARRAY_LEN(topts), topts,
                              on_option, NULL, 0);
 
     return *opts != NULL;

--- a/tools/tpm2_certify.c
+++ b/tools/tpm2_certify.c
@@ -199,13 +199,13 @@ static bool on_option(char key, char *value) {
 bool tpm2_tool_onstart(tpm2_options **opts) {
 
     const struct option topts[] = {
-      { "certifiedkey-auth",    required_argument, NULL, 'P' },
-      { "signingkey-auth",      required_argument, NULL, 'p' },
+      { "certifiedkey-context", required_argument, NULL, 'c' },
+      { "signingkey-context",   required_argument, NULL, 'C' },
+      { "certifiedkey-auth",    required_argument, NULL, 'p' },
+      { "signingkey-auth",      required_argument, NULL, 'P' },
       { "halg",                 required_argument, NULL, 'g' },
-      { "out-attest-file",      required_argument, NULL, 'o' },
-      { "sig-file",             required_argument, NULL, 's' },
-      { "certifiedkey-context", required_argument, NULL, 'C' },
-      { "signingkey-context",   required_argument, NULL, 'c' },
+      { "attestation",          required_argument, NULL, 'o' },
+      { "signature",            required_argument, NULL, 's' },
       { "format",               required_argument, NULL, 'f' },
     };
 

--- a/tools/tpm2_clear.c
+++ b/tools/tpm2_clear.c
@@ -38,22 +38,36 @@ static bool on_option(char key, char *value) {
     case 'p':
         ctx.platform = true;
         break;
-    case 'L':
-        ctx.auth_hierarchy.auth_str = value;
-        break;
     }
 
     return true;
 }
 
+bool on_arg (int argc, char **argv) {
+
+    if (argc > 1) {
+        LOG_ERR("Specify a single auth value");
+        return false;
+    }
+
+    if (!argc) {
+        //empty auth
+        return true;
+     }
+
+    ctx.auth_hierarchy.auth_str = argv[0];
+
+     return true;
+ }
+
+
 bool tpm2_tool_onstart(tpm2_options **opts) {
 
     const struct option topts[] = {
         { "platform",     no_argument,       NULL, 'p' },
-        { "auth-lockout", required_argument, NULL, 'L' },
     };
 
-    *opts = tpm2_options_new("pL:", ARRAY_LEN(topts), topts, on_option, NULL,
+    *opts = tpm2_options_new("p", ARRAY_LEN(topts), topts, on_option, on_arg,
                              0);
 
     return *opts != NULL;

--- a/tools/tpm2_clearcontrol.c
+++ b/tools/tpm2_clearcontrol.c
@@ -80,7 +80,7 @@ bool on_arg (int argc, char **argv) {
 static bool on_option(char key, char *value) {
 
     switch (key) {
-    case 'a':
+    case 'c':
         ctx.auth_hierarchy.ctx_path = value;
         break;
     case 'p':
@@ -94,11 +94,11 @@ static bool on_option(char key, char *value) {
 bool tpm2_tool_onstart(tpm2_options **opts) {
 
     const struct option topts[] = {
-        { "auth-handle",    required_argument, NULL, 'a' },
+        { "auth-handle",    required_argument, NULL, 'c' },
         { "auth",           required_argument, NULL, 'p' },
     };
 
-    *opts = tpm2_options_new("a:p:", ARRAY_LEN(topts), topts, on_option,
+    *opts = tpm2_options_new("c:p:", ARRAY_LEN(topts), topts, on_option,
         on_arg, 0);
 
     return *opts != NULL;


### PR DESCRIPTION
tpm2_clearcontrol: Change short option for -a to -c
 tpm2_clear: Add a test for evaluating tpm2_clear implementation
tpm2_clear: Change option to specify the hierarchy used to clear
tpm2_clear: Change input password option to argument
certify: Change tool options
activatecredential: Change tool options

Progresses #1042 