### PR TITLE
 test/integration: specify search directories for toggle_options.sh

### DIFF
--- a/man/tpm2_clear.1.md
+++ b/man/tpm2_clear.1.md
@@ -19,7 +19,7 @@ lockout hierarchy
 
 # OPTIONS
 
-  * **-c**, **\--platform**:
+  * **-c**, **\--auth-hierarchy**:
 
     Specifies the hierarchy the tools should operate on. By default
     it operates on the lockout hierarchy.

--- a/test/integration/tests/toggle_options.sh
+++ b/test/integration/tests/toggle_options.sh
@@ -26,7 +26,7 @@ function check_toggle() {
         exit 254
     fi
 
-    for i in $(grep -R "'${toggle}'[[:space:]]*}" --include=*.c | sed "s%[[:space:]]*%%g"); do
+    for i in $(grep "'${toggle}'[[:space:]]*}" "${toolsdir}"/*.c | sed "s%[[:space:]]*%%g"); do
         # An example:
         # i:           tools/tpm2_nvdefine.c:{"hierarchy",required_argument,NULL,'a'},
         # filename:    tools/tpm2_nvdefine.c
@@ -95,7 +95,7 @@ for i in $(grep -rn "case '.'" "${toolsdir}"/*.c | cut -d"'" -f2-2 | sort | uniq
 done
 
 # For each documented option toggle in the man pages, look if it is present in the code
-for j in $(grep -roe "\*\*-.\*\*, \*\*\\\--.*\*\*" --include=*.1.md | sed -r 's/\s//g' ); do
+for j in $(grep -oe "\*\*-.\*\*, \*\*\\\--.*\*\*" "${mandir}"/*.1.md | sed -r 's/\s//g' ); do
     filename=${j%%:*};
     option="$(grep -oP '(?<=\*\*-).(?=\*\*)' <<< "$j")"
     option_long="$(grep -oP '(?<=\*\*\\\--).*(?=\*\*)' <<< "$j")"


### PR DESCRIPTION
618e7e21c2f79ee3f49e4bbffa318e7ce0792b9a changed the long option name `--platform` of `tpm2_clear` to `--auth-hierarchy` without updating the man page to the new name.

Problems like this are supposed to be detected by the integration test [`toggle_options.sh`](https://github.com/tpm2-software/tpm2-tools/blob/master/test/integration/tests/toggle_options.sh), but this doesn't always work properly: the test uses [`grep -R` without specifying a directory](https://github.com/tpm2-software/tpm2-tools/blob/4ccd3cd6e9bd1e58f264f2d8d111bfdd42f3133f/test/integration/tests/toggle_options.sh#L29), therefore the current directory is searched, which is the build directory in this case. This works as expected when using the source directory as the build directory. However the CI builds in a separate subdirectory `./build`, which doesn't contain any source files, therefore the test doesn't work as expected. Fix this by explicitly specifying the source directories to be searched using the already existing variables `$toolsdir` and `$mandir`.

BTW, I don't think `toggle_options.sh` should be an integration test: its functionality is certainly very useful, but it doesn't test the dynamic behaviour of the program, but is some kind of static code analysis. Downstream users running the integration test suite shouldn't see it failing because this isn't the result of a build problem, but clearly an upstream error. I suggest moving the test to [`script/utils`](https://github.com/tpm2-software/tpm2-tools/tree/master/scripts/utils) and running it separately during CI, similar to the already existing option analyser [`analyze.py`](https://github.com/tpm2-software/tpm2-tools/blob/master/scripts/utils/analyze.py).