### PR TITLE
test: undo change of platform auth in clear.sh after test is done

### DIFF
--- a/test/integration/tests/clear.sh
+++ b/test/integration/tests/clear.sh
@@ -28,4 +28,7 @@ tpm2_clear -c l $lockPasswd
 tpm2_changeauth -c p $platPasswd
 tpm2_clear -c p $platPasswd
 
+#Undo change of platform auth
+tpm2_changeauth -c p -p $platPasswd
+
 exit 0


### PR DESCRIPTION
The new test `clear.sh` introduced in 8821cff6 changes the platform auth but does not change it back after it is done. If possible, tests should always clean up after themselves.

After 8821cff6, when running `tpm2_clearcontrol` after the test is done, an authorization failure (`0x9A2`) occurs. Hence, `tpm2_changeauth` has to be called in the end of the test to reverse the change.