### PR TITLE
lib/tpm2_hierarchy: Add filtering for NV Indices

### DIFF
--- a/lib/tpm2_hierarchy.h
+++ b/lib/tpm2_hierarchy.h
@@ -19,8 +19,8 @@ enum tpm2_hierarchy_flags {
     TPM2_HIERARCHY_FLAGS_E    = 1 << 2,
     TPM2_HIERARCHY_FLAGS_N    = 1 << 3,
     TPM2_HIERARCHY_FLAGS_L    = 1 << 4,
-    TPM2_HIERARCHY_SUPPRESS   = 1 << 5,
     TPM2_HIERARCHY_FLAGS_ALL  = 0x1F,
+    TPM2_HANDLES_FLAGS_NV     = 1 << 5,
     TPM2_HANDLES_ALL          = 0x3F
 };
 

--- a/tools/tpm2_nvincrement.c
+++ b/tools/tpm2_nvincrement.c
@@ -86,7 +86,7 @@ tool_rc tpm2_tool_onrun(ESYS_CONTEXT *ectx, tpm2_option_flags flags) {
 
     tool_rc rc = tpm2_util_object_load_auth(ectx, ctx.auth_hierarchy.ctx_path,
         ctx.auth_hierarchy.auth_str, &ctx.auth_hierarchy.object, false,
-        TPM2_HANDLES_ALL);
+        TPM2_HANDLES_FLAGS_NV|TPM2_HIERARCHY_FLAGS_O|TPM2_HIERARCHY_FLAGS_P);
     if (rc != tool_rc_success) {
         LOG_ERR("Invalid handle authorization");
         return rc;

--- a/tools/tpm2_nvread.c
+++ b/tools/tpm2_nvread.c
@@ -147,7 +147,7 @@ tool_rc tpm2_tool_onrun(ESYS_CONTEXT *ectx, tpm2_option_flags flags) {
 
     tool_rc rc = tpm2_util_object_load_auth(ectx, ctx.auth_hierarchy.ctx_path,
         ctx.auth_hierarchy.auth_str, &ctx.auth_hierarchy.object, false,
-        TPM2_HANDLES_ALL);
+        TPM2_HANDLES_FLAGS_NV|TPM2_HIERARCHY_FLAGS_O|TPM2_HIERARCHY_FLAGS_P);
     if (rc != tool_rc_success) {
         LOG_ERR("Invalid handle authorization");
         return rc;

--- a/tools/tpm2_nvreadlock.c
+++ b/tools/tpm2_nvreadlock.c
@@ -82,7 +82,7 @@ tool_rc tpm2_tool_onrun(ESYS_CONTEXT *ectx, tpm2_option_flags flags) {
 
     tool_rc rc = tpm2_util_object_load_auth(ectx, ctx.auth_hierarchy.ctx_path,
         ctx.auth_hierarchy.auth_str, &ctx.auth_hierarchy.object, false,
-        TPM2_HANDLES_ALL);
+        TPM2_HANDLES_FLAGS_NV|TPM2_HIERARCHY_FLAGS_O|TPM2_HIERARCHY_FLAGS_P);
     if (rc != tool_rc_success) {
         LOG_ERR("Invalid handle authorization");
         return rc;

--- a/tools/tpm2_nvwrite.c
+++ b/tools/tpm2_nvwrite.c
@@ -186,7 +186,7 @@ tool_rc tpm2_tool_onrun(ESYS_CONTEXT *ectx, tpm2_option_flags flags) {
 
     tool_rc rc = tpm2_util_object_load_auth(ectx, ctx.auth_hierarchy.ctx_path,
         ctx.auth_hierarchy.auth_str, &ctx.auth_hierarchy.object, false,
-        TPM2_HANDLES_ALL);
+        TPM2_HANDLES_FLAGS_NV|TPM2_HIERARCHY_FLAGS_O|TPM2_HIERARCHY_FLAGS_P);
     if (rc != tool_rc_success) {
         LOG_ERR("Invalid handle authorization");
         return rc;


### PR DESCRIPTION
Progresses #1462
Progresses #880

1. Add filter for checking handle is in valid NV index range
2. Add option to specify NV indices simply as an offset. Eg. 1 for NV index @ 01000001
3. Add unit tests for the added functionality.

Signed-off-by: Imran Desai <imran.desai@intel.com>