### PR TITLE
configure: add -O2 and use AX_ADD_FORTIFY_SOURCE

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -165,8 +165,8 @@ AS_IF([test x"$enable_hardening" != x"no"], [
   add_hardened_c_flag([-Wstrict-overflow=5])
   add_hardened_c_flag([-Wbool-compare])
 
-  add_hardened_define_flag([-U_FORTIFY_SOURCE])
-  add_hardened_define_flag([-D_FORTIFY_SOURCE=2])
+  add_hardened_c_flag([-O2])
+  AX_ADD_FORTIFY_SOURCE
 
   add_hardened_c_flag([-fPIC])
   add_hardened_ld_flag([[-shared]])


### PR DESCRIPTION
Enabling optimisation is necessary for fortification, otherwise compilation fails with the error
```
/usr/include/features.h:382:4: error: #warning _FORTIFY_SOURCE requires compiling with optimization (-O) [-Werror=cpp]
  382 | #  warning _FORTIFY_SOURCE requires compiling with optimization (-O)
      |    ^~~~~~~
```
The optimisation level `-O2` chosen here is the default level also used by [`AC_PROG_CC`](https://www.gnu.org/software/autoconf/manual/autoconf-2.60/html_node/C-Compiler.html) (which isn't used here since [`AX_CHECK_ENABLE_DEBUG`](https://github.com/tpm2-software/tpm2-tools/blob/3535ed92281bf975c8b46ab07808480ef23ac96c/configure.ac#L6) explicitly sets `CFLAGS="$CFLAGS -g"`).

Also replace the manual definition of `_FORTIFY_SOURCE` by an Autoconf Archive macro as in https://github.com/tpm2-software/tpm2-tss/commit/b7925409ecdef98b389481aa95446c81d7ce8e79.