### PR TITLE
Rename options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 ## Changelog
 ### next
+  * tpm2_quote: short and long options changed
+    auth-ak is now ak-auth
+    id-list is now pcr-index
+    sel-list is now pcr-list
+    qualify-data is now qualification-data
+    pcrs is now pcr
+    halg is now hash-signature
+    -l is now -i
+    -L is now -l
+    -p is now -f
+    -f is now -F
   * tpm2_policysecret: short and long options changed
     context is now object-context
     out-policy-file is now policy

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Changelog
 ### next
+  * tpm2_pcrevent: long options changed
+    auth-pcr is now auth
   * tpm2_pcrallocate: long option changed
     auth-platform is now auth
   * tpm2_nvwrite: short and long options changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 ## Changelog
 ### next
+  * tpm2_createek: short and long options changed
+    auth-endorse is now eh-auth
+    auth-owner is now owner-auth
+    auth-ek is now ek-auth
+    file is now public
+    context is now ek-context
+    algorithm is now key-algorithm
+    -e is now -P
+    -P is now -p
+    -p is now -u
   * tpm2_createak:
     auth-endorse is now eh-auth
     auth-ak is now ak-auth

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 ## Changelog
 ### next
+  * tpm2_pcrlist: short and long options changed
+    halg is now hash-algorithm
+    out-file is now output
+    algs is now pcr-algorithms
+    sel-list is now pcr-list
+    -L is now -l
   * tpm2_pcrevent: long options changed
     auth-pcr is now auth
   * tpm2_pcrallocate: long option changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 ## Changelog
 ### next
+  * tpm2_createpolicy: long options changed
+    out-policy-file is now policy
+    policy-digest-alg is now policy-algorithm
+    pcr-input-file is now pcr
+    -o is now -L
+    -L is now -l
+    -F is now -f
   * tpm2_createek: short and long options changed
     auth-endorse is now eh-auth
     auth-owner is now owner-auth

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 ## Changelog
 ### next
+  * tpm2_policypcr: short and long options changed
+    out-policy-file is now policy
+    pcr-input-file is now pcr
+    set-list is now pcr-list
+    -o is now -L
+    -F is now -f
+    -L is now -l
   * tpm2_policypassword: short and long options changed
     out-policy-file is now policy
     -o is now -L

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## Changelog
 ### next
+  * tpm2_policyor: short and long options changed
+    out-policy-file is now policy
+    -o is now -L
+    -L is now -l
   * tpm2_policylocality: short and long options changed
     out-policy-file is now policy
     -o is now -L

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Changelog
 ### next
+  * tpm2_pcrallocate: long option changed
+    auth-platform is now auth
   * tpm2_nvwrite: short and long options changed
     auth-hierarchy is now auth
     -a is now -C

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 ## Changelog
 ### next
+  * tpm2_loadexternal: long options changed
+    key-alg is now key-algorithm
+    pubfile is now public
+    privfile is now private
+    auth-key is now auth
+    policy-file is now policy
+    halg is now hash-algorithm
+    out-context is now key-context
   * tpm2_load: long options changed
     context-parent is now parent-context
     auth-parent is now auth

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## Changelog
 ### next
+  * tpm2_evictcontrol: long options changed
+    auth-hierarchy is now auth
+    context is now key-context
   * tpm2_encryptdecrypt: long options changed
     auth-key is now auth
     in-file is now input

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 ## Changelog
 ### next
+  * tpm2_import: long options changed
+    auth-parent is now parent-auth
+    auth-key is now key-auth
+    algorithm is now key-algorithm
+    in-file is now input
+    parent-key is now parent-context
+    privfile is now private
+    pubfile is now public
+    halg is now hash-algorithm
+    policy-file is now policy
+    sym-alg-file is now encryption-key
   * tpm2_hmac: short and long options changed
     out-file is now output
     auth-key is now auth

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## Changelog
 ### next
+  * tpm2_policysecret: short and long options changed
+    context is now object-context
+    out-policy-file is now policy
+    -o is now -L
   * tpm2_policypcr: short and long options changed
     out-policy-file is now policy
     pcr-input-file is now pcr

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 ## Changelog
 ### next
+  * tpm2_hmac: short and long options changed
+    out-file is now output
+    auth-key is now auth
+    -C is now -c
+    -P is now -p
   * tpm2_hash: short and long options changed
     halg is now hash-algorithm
     out-file is now output

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## Changelog
 ### next
+  * tpm2_readpublic: long options changed
+    out-file is now output
+    context is now object-context
   * tpm2_quote: short and long options changed
     auth-ak is now ak-auth
     id-list is now pcr-index

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Changelog
 ### next
+  * tpm2_nvincrement: long option changed
+    auth-hierarchy is now auth
   * tpm2_nvdefine: long options changed
     auth-hierarchy is now hierarchy-auth
     auth-index is now index-auth

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Changelog
 ### next
+  * tpm2_send: long option changed
+    out-file is now output
   * tpm2_rsaencrypt: long option changed
     out-file is now output
   * tpm2_rsadecrypt: long options changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## Changelog
 ### next
+  * tpm2_encryptdecrypt: long options changed
+    auth-key is now auth
+    in-file is now input
+    out-file is now output
   * tpm2_duplicate: long options changed
     auth-key is now auth
     inner-wrapper-alg is now wrapper-algorithm

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## Changelog
 ### next
+  * tpm2_startauthsession: short and long options changed
+    halg is now hash-algorithm
+    key is now key-context
+    -k is now -c
   * tpm2_sign: short and long options changed
     auth-key is now auth
     halg is now hash-algorithm

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## Changelog
 ### next
+  * tpm2_nvdefine: long options changed
+    auth-hierarchy is now hierarchy-auth
+    auth-index is now index-auth
+    policy-file is now policy
   * tpm2_makecredential: long options changed
     enckey is now encryption-key
     out-file is now output

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## Changelog
 ### next
+  * tpm2_nvreadlock: short and long options changed
+    auth-hierarchy is now auth
+    -a is now -C
   * tpm2_nvread: short and long options changed
     out-file is now output
     auth-hierarchy is now auth

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## Changelog
 ### next
+  * tpm2_changeauth: --privfile becomes private
   * tpm2_evictcontrol: -p becomes an argument.
   * tpm2_getcap: -c becomes an argument.
   * tpm2_evictcontrol: -a becomes -C.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 ## Changelog
 ### next
+  * tpm2_sign: short and long options changed
+    auth-key is now auth
+    halg is now hash-algorithm
+    sig-scheme is now scheme
+    out-sig is now signature
+    -D is now -d
   * tpm2_send: long option changed
     out-file is now output
   * tpm2_rsaencrypt: long option changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 ## Changelog
 ### next
+  * tpm2_policyauthorize: short and long options changed
+    out-policy-file is now policy-output
+    in-policy-file is now policy
+    qualify-data is now qualification-data
+    -i is now -L
   * tpm2_pcrlist: short and long options changed
     halg is now hash-algorithm
     out-file is now output

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## Changelog
 ### next
+  * tpm2_policylocality: short and long options changed
+    out-policy-file is now policy
+    -o is now -L
   * tpm2_policyduplicationselect: short and long options changed
     new-parent-name is now parent-name
     out-policy-file is now policy

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## Changelog
 ### next
+  * tpm2_nvwrite: short and long options changed
+    auth-hierarchy is now auth
+    -a is now -C
   * tpm2_nvrelease: short and long options changed
     auth-hierarchy is now auth
     -a is now -C

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Changelog
 ### next
+  * tpm2_rsaencrypt: long option changed
+    out-file is now output
   * tpm2_rsadecrypt: long options changed
     auth-key is now auth
     in-file is now input

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 ## Changelog
 ### next
+  * tpm2_load: long options changed
+    context-parent is now parent-context
+    auth-parent is now auth
+    pubfile is now public
+    privfile is now private
+    out-context is now key-context
   * tpm2_import: long options changed
     auth-parent is now parent-auth
     auth-key is now key-auth

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## Changelog
 ### next
+  * tpm2_policypassword: short and long options changed
+    out-policy-file is now policy
+    -o is now -L
   * tpm2_policyor: short and long options changed
     out-policy-file is now policy
     -o is now -L

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## Changelog
 ### next
+  * tpm2_hash: short and long options changed
+    halg is now hash-algorithm
+    out-file is now output
+    -a is now -C
   * tpm2_getrandom: long option changed
     out-file is now output
   * tpm2_getmanufec: short and long options changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Changelog
 ### next
+  * tpm2_dictionarylockout: long option changed
+    auth-lockout is now auth
   * tpm2_createprimary: long options changed
     auth-hierarchy is now hierarchy-auth
     auth-object is now key-auth

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## Changelog
 ### next
+  * tpm2_nvrelease: short and long options changed
+    auth-hierarchy is now auth
+    -a is now -C
   * tpm2_nvreadlock: short and long options changed
     auth-hierarchy is now auth
     -a is now -C

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## Changelog
 ### next
+  * tpm2_policycommandcode: short and long options changed
+    out-policy-file is now policy
+    -o is now -L
   * tpm2_policyauthorize: short and long options changed
     out-policy-file is now policy-output
     in-policy-file is now policy

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Changelog
 ### next
+  * tpm2_getrandom: long option changed
+    out-file is now output
   * tpm2_getmanufec: short and long options changed
     auth-endorse is now eh-auth
     auth-owner is now owner-auth

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Changelog
 ### next
+  * tpm2_certify: long option changed
+    halg is now hash-algorithm
   * tpm2_createpolicy: long options changed
     out-policy-file is now policy
     policy-digest-alg is now policy-algorithm

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 ## Changelog
 ### next
+  * tpm2_createprimary: long options changed
+    auth-hierarchy is now hierarchy-auth
+    auth-object is now key-auth
+    halg is now hash-algorithm
+    kalg is now key-algorithm
+    context-object is now key-context
+    policy-file is now policy
   * tpm2_certify: long option changed
     halg is now hash-algorithm
   * tpm2_createpolicy: long options changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 ## Changelog
 ### next
+  * tpm2_create:
+    auth-parent is now parent-auth
+    auth-key is now key-auth
+    in-file is now sealing-input
+    policy-file is now policy
+    pubfile is now public
+    privfile is now private
+    out-context is now key-context
+    halg is now hash-algorithm
+    kalg is now key-algorithm
   * tpm2_changeauth: --privfile becomes private
   * tpm2_evictcontrol: -p becomes an argument.
   * tpm2_getcap: -c becomes an argument.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 ## Changelog
 ### next
+  * tpm2_createak:
+    auth-endorse is now eh-auth
+    auth-ak is now ak-auth
+    halg is now hash-algorithm
+    kalg is now key-algorithm
   * tpm2_clearcontrol: Short and long options changed
     auth-handle is now hierarchy
     -c is now -C

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 ## Changelog
 ### next
+  * tpm2_duplicate: long options changed
+    auth-key is now auth
+    inner-wrapper-alg is now wrapper-algorithm
+    input-key-file is now encryptionkey-in
+    output-key-file is now encryptionkey-out
+    parent-key is now parent-context
+    context is now key-context
   * tpm2_dictionarylockout: long option changed
     auth-lockout is now auth
   * tpm2_createprimary: long options changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## Changelog
 ### next
+  * tpm2_makecredential: long options changed
+    enckey is now encryption-key
+    out-file is now output
   * tpm2_loadexternal: long options changed
     key-alg is now key-algorithm
     pubfile is now public

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## Changelog
 ### next
+  * tpm2_verifysignature: short and long options changed
+    halg is now hash-algorithm
+    sig is now signature
+    -D is now -d
   * tpm2_unseal: long options changed
     auth-key is now auth
     out-file is now output

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## Changelog
 ### next
+  * tpm2_rsadecrypt: long options changed
+    auth-key is now auth
+    in-file is now input
+    out-file is now output
   * tpm2_readpublic: long options changed
     out-file is now output
     context is now object-context

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## Changelog
 ### next
+  * tpm2_unseal: long options changed
+    auth-key is now auth
+    out-file is now output
+    context-object is now object-context
   * tpm2_startauthsession: short and long options changed
     halg is now hash-algorithm
     key is now key-context

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## Changelog
 ### next
+  * tpm2_policyduplicationselect: short and long options changed
+    new-parent-name is now parent-name
+    out-policy-file is now policy
+    -o is now -L
   * tpm2_policycommandcode: short and long options changed
     out-policy-file is now policy
     -o is now -L

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 ## Changelog
 ### next
+  * tpm2_getmanufec: short and long options changed
+    auth-endorse is now eh-auth
+    auth-owner is now owner-auth
+    auth-ek is now ek-auth
+    handle is now persistent-handle
+    algorithm is now ek-algorithm
+    -e is now -P
+    -P is now -p
   * tpm2_evictcontrol: long options changed
     auth-hierarchy is now auth
     context is now key-context

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## Changelog
 ### next
+  * tpm2_clearcontrol: Short and long options changed
+    auth-handle is now hierarchy
+    -c is now -C
   * tpm2_create:
     auth-parent is now parent-auth
     auth-key is now key-auth

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## Changelog
 ### next
+  * tpm2_nvread: short and long options changed
+    out-file is now output
+    auth-hierarchy is now auth
+    -a is now -C
   * tpm2_nvincrement: long option changed
     auth-hierarchy is now auth
   * tpm2_nvdefine: long options changed

--- a/man/tpm2_certify.1.md
+++ b/man/tpm2_certify.1.md
@@ -39,7 +39,7 @@ These options control the certification:
     Authorization values should follow the "authorization formatting standards",
     see section "Authorization Formatting".
 
-  * **-g**, **\--halg**=_HASH\_ALGORITHM_:
+  * **-g**, **\--hash-algorithm**=_HASH\_ALGORITHM_:
 
     The hash algorithm to use.
     Algorithms should follow the "formatting standards", see section

--- a/man/tpm2_changeauth.1.md
+++ b/man/tpm2_changeauth.1.md
@@ -38,7 +38,7 @@ see section "Authorization Formatting".
     transient or persistent object.
     See section "Context Object Format" for details.
 
-  * **-r**, **\--privfile**=_OUTPUT\_PRIVATE\_FILE_:
+  * **-r**, **\--private**=_OUTPUT\_PRIVATE\_FILE_:
     The output file which contains the new sensitive portion of the object whose auth was being changed.
 
 [common options](common/options.md)

--- a/man/tpm2_changeauth.1.md
+++ b/man/tpm2_changeauth.1.md
@@ -88,15 +88,14 @@ Requires Extended Session Support.
 ```
 tpm2_startauthsession -S session.ctx
 
-TPM2_NV_ChangeAuth=0x13B
-tpm2_policycommandcode -S session.ctx -c $TPM2_NV_ChangeAuth -o policy.nvchange
+tpm2_policycommandcode -S session.ctx -L policy.nvchange nvchangeauth
 tpm2_flushcontext -S session.ctx
 
 NVIndex=0x1500015
 tpm2_nvdefine -x $NVIndex -a o -s 32 -t "authread|authwrite" -L policy.nvchange
 tpm2_startauthsession \--policy-session -S session.ctx
 
-tpm2_policycommandcode -S session.ctx -c $TPM2_NV_ChangeAuth -o policy.nvchange
+tpm2_policycommandcode -S session.ctx -L policy.nvchange nvchangeauth
 
 tpm2_changeauth -p session:session.ctx -c $NVIndex newindexauth
 ```

--- a/man/tpm2_checkquote.1.md
+++ b/man/tpm2_checkquote.1.md
@@ -80,7 +80,7 @@ tpm2_createek -c 0x81010009 -G rsa -u ekpub.pem -f pem
 
 tpm2_createak -C 0x81010009 -k 0x8101000a -G rsa -s rsassa -D sha256 -p akpub.pem -f pem -n ak.name
 
-tpm2_quote -C 0x8101000a -L sha256:15,16,22 -q abc123 -m quote.out -s sig.out -p pcrs.out -G sha256
+tpm2_quote -C 0x8101000a -l sha256:15,16,22 -q abc123 -m quote.out -s sig.out -f pcrs.out -g sha256
 
 tpm2_checkquote -c akpub.pem -m quote.out -s sig.out -p pcrs.out -G sha256 -q abc123
 ```

--- a/man/tpm2_checkquote.1.md
+++ b/man/tpm2_checkquote.1.md
@@ -76,7 +76,7 @@ provided, verify that the qualifying data and PCR values match those in the quot
 
 ## Generate a quote with a TPM, then verify it
 ```
-tpm2_createek -c 0x81010009 -G rsa -p ekpub.pem -f pem
+tpm2_createek -c 0x81010009 -G rsa -u ekpub.pem -f pem
 
 tpm2_createak -C 0x81010009 -k 0x8101000a -G rsa -s rsassa -D sha256 -p akpub.pem -f pem -n ak.name
 

--- a/man/tpm2_clearcontrol.1.md
+++ b/man/tpm2_clearcontrol.1.md
@@ -22,7 +22,7 @@ tpm2_clear command.
 
 # OPTIONS
 
-  * **-c**, **\--auth-handle**=_TPM\_HANDLE:
+  * **-C**, **\--hierarchy**=_TPM\_HANDLE:
 
     Specifies what auth handle, either platform hierarchy or lockout the tool
     should operate on. By default it operates on the platform hierarchy handle.
@@ -30,7 +30,7 @@ tpm2_clear command.
 
     **NOTE : Operating on platform hierarchy require platform authentication.**
 
-  * **-p**, **\--auth**=_HANDLE\_PASSWORD:
+  * **-P**, **\--auth**=_HANDLE\_PASSWORD:
 
     The handle's authorization value.
 
@@ -48,12 +48,12 @@ tpm2_clear command.
 
 ## Set the disableClear to block the lockout authorization's access to TPM clear
 ```
-tpm2_clearcontrol -c l s
+tpm2_clearcontrol -C l s
 ```
 
 ## Clear the disableClear to unblock lockout authorization for TPM clear operation
 ```
-tpm2_clearcontrol -c p c
+tpm2_clearcontrol -C p c
 ```
 
 [returns](common/returns.md)

--- a/man/tpm2_create.1.md
+++ b/man/tpm2_create.1.md
@@ -19,24 +19,24 @@ maximum size of 256 bytes. Additionally it will load the created object if the
 
 These options for creating the TPM entity:
 
-  * **-C**, **\--context-parent**=_PARENT\_CONTEXT\_OBJECT_:
+  * **-C**, **\--parent-context**=_PARENT\_CONTEXT\_OBJECT_:
 
     Context object for the created object's parent. Either a file or a handle
     number. See section "Context Object Format".
 
-  * **-P**, **\--auth-parent**=_PARENT\_KEY\_AUTH_:
+  * **-P**, **\--parent-auth**=_PARENT\_KEY\_AUTH_:
 
     The authorization value for using the parent key, optional.
     Authorization values should follow the "authorization formatting standards",
     see section "Authorization Formatting".
 
-  * **-p**, **\--auth-key**=_KEY\_AUTH_:
+  * **-p**, **\--key-auth**=_KEY\_AUTH_:
 
     The authorization value for the key, optional.
     Follows the authorization formatting of the
     "password for parent key" option: **-P**.
 
-  * **-g**, **\--halg**=_ALGORITHM_:
+  * **-g**, **\--hash-algorithm**=_ALGORITHM_:
 
     The hash algorithm for generating the objects name. This is optional
     and defaults to sha256 when not specified. Algorithms should follow the
@@ -44,7 +44,7 @@ These options for creating the TPM entity:
     Also, see section "Supported Hash Algorithms" for a list of supported
     hash algorithms.
 
-  * **-G**, **\--kalg**=_KEY\_ALGORITHM_:
+  * **-G**, **\--key-algorithm**=_KEY\_ALGORITHM_:
 
     The key algorithm associated with this object. It defaults to "rsa" if not
     specified.
@@ -65,25 +65,25 @@ These options for creating the TPM entity:
     I.e. one cannot use an object for sealing and cryptography
     operations.
 
-  * **-i**, **\--in-file**=_FILE_:
+  * **-i**, **\--sealing-input**=_FILE_:
 
     The data file to be sealed, optional. If file is -, read from stdin.
     When sealing data only the _TPM\_ALG\_KEYEDHASH_ algorithm with a NULL scheme is allowed.
     Thus, **-G** cannot be specified.
 
-  * **-L**, **\--policy-file**=_POLICY\_FILE_:
+  * **-L**, **\--policy**=_POLICY\_FILE_:
 
     The input policy file, optional.
 
-  * **-u**, **\--pubfile**=_OUTPUT\_PUBLIC\_FILE_:
+  * **-u**, **\--public**=_OUTPUT\_PUBLIC\_FILE_:
 
     The output file which contains the public portion of the created object, optional.
 
-  * **-r**, **\--privfile**=_OUTPUT\_PRIVATE\_FILE_:
+  * **-r**, **\--private**=_OUTPUT\_PRIVATE\_FILE_:
 
     The output file which contains the sensitive portion of the object, optional.
 
-  * **-o**, **\--out-context**=_OUTPUT\_CONTEXT\_FILE_:
+  * **-o**, **\--key-context**=_OUTPUT\_CONTEXT\_FILE_:
 
     The output file which contains the key context, optional. The key context is analogous to the context
     file produced by **tpm2_load**(1), however is generated via a **tpm2_createloaded**(1) command. This option

--- a/man/tpm2_createak.1.md
+++ b/man/tpm2_createak.1.md
@@ -23,13 +23,13 @@ loaded-key:
 
 # OPTIONS
 
-  * **-P**, **\--auth-endorse**=_ENDORSE\_AUTH_:
+  * **-P**, **\--eh-auth**=_ENDORSE\_AUTH_:
 
     Specifies current endorsement hierarchy authorization.
     Authorizations should follow the "authorization formatting standards", see section
     "Authorization Formatting".
 
-  * **-p**, **\--auth-ak**=_AK\_AUTH_
+  * **-p**, **\--ak-auth**=_AK\_AUTH_
 
     Specifies the attestation key authorization when created.
     Same formatting as the endorse authorization value or **-e** option.
@@ -43,14 +43,14 @@ loaded-key:
 
     Specifies a file path to save the context of the attestation key.
 
-  * **-G**, **\--kalg**=_ALGORITHM_:
+  * **-G**, **\--key-algorithm**=_ALGORITHM_:
 
     Specifies the algorithm type of AK. Supports:
     * ecc - An P256 key.
     * rsa - An RSA2048 key.
     * keyedhash - hmac key.
 
-  * **-g**, **\--halg**=_HASH\_ALGORITHM_:
+  * **-g**, **\--hash-algorithm**=_HASH\_ALGORITHM_:
 
     Like **-G**, but specifies the digest algorithm used for signing.
     Algorithms should follow the "formatting standards", see section

--- a/man/tpm2_createak.1.md
+++ b/man/tpm2_createak.1.md
@@ -106,7 +106,7 @@ loaded-key:
 ### Create an Attestation Key and make it persistent
 
 ```
-tpm2_createek -c ek.handle -G rsa -p ek.pub
+tpm2_createek -c ek.handle -G rsa -u ek.pub
 tpm2_createak -C ek.handle -c ak.ctx -u ak.pub -n ak.name
 tpm2_evictcontrol -c 0x81010002 -o ak.ctx
 ```

--- a/man/tpm2_createek.1.md
+++ b/man/tpm2_createek.1.md
@@ -20,23 +20,23 @@ Refer to:
 
 # OPTIONS
 
-  * **-e**, **\--auth-endorse**=_ENDORSE\_AUTH_:
+  * **-P**, **\--eh-auth**=_ENDORSE\_AUTH_:
 
     Specifies current endorsement hierarchy authorization.
     authorizations should follow the "authorization formatting standards", see section
     "Authorization Formatting".
 
-  * **-P**, **\--auth-ek**=_EK\_AUTH_
+  * **-p**, **\--ek-auth**=_EK\_AUTH_
 
     Specifies the endorsement key authorization when created.
     Same formatting as the endorse authorization value or **-e** option.
 
-  * **-w**, **\--auth-owner**=_OWNER\_AUTH_
+  * **-w**, **\--owner-auth**=_OWNER\_AUTH_
 
     Specifies the current owner authorization.
     Same formatting as the endorse password value or **-e** option.
 
-  * **-c**, **\--context**=_PERSISTENT\_HANDLE_:
+  * **-c**, **\--ek-context**=_PERSISTENT\_HANDLE_:
 
     Specifies the name of a context object used to store the EK, either a path
     to save the context of the EK or a handle used to persist EK in the TPM.
@@ -47,14 +47,14 @@ Refer to:
     If one saves the context file via this option and the public key via the
     **-p** option, the EK can be restored via a call to **tpm2_loadexternal**(1).
 
-  * **-G**, **\--algorithm**=_ALGORITHM_:
+  * **-G**, **\--key-algorithm**=_ALGORITHM_:
 
     Specifies the algorithm type of EK. Supports:
     * **ecc** - An P256 key.
     * **rsa** - An RSA2048 key.
     * **keyedhash** - hmac key.
 
-  * **-p**, **\--file**=_FILE_:
+  * **-u**, **\--public**=_FILE_:
 
     Optional: specifies the file used to save the public portion of EK. This defaults
     to a binary data structure corresponding to the **TPM2B_PUBLIC** structure in the
@@ -85,12 +85,12 @@ Refer to:
 
 ### Create an Endorsement Key and make it persistent
 ```
-tpm2_createek -e abc123 -w abc123 -P passwd -c 0x81010001 -G rsa -p ek.pub
+tpm2_createek -P abc123 -w abc123 -p passwd -c 0x81010001 -G rsa -u ek.pub
 ```
 
 ### Create a transient Endorsement Key, flush it, and reload it.
 ```
-tpm2_createek -G rsa -p ek.pub
+tpm2_createek -G rsa -u ek.pub
 
 # Check that it is loaded in transient memory
 tpm2_getcap handles-transient

--- a/man/tpm2_createpolicy.1.md
+++ b/man/tpm2_createpolicy.1.md
@@ -19,7 +19,7 @@ object creation and or tools using the object.
 
 These options control creating the policy authorization session:
 
-  * **-o**, **\--out-policy-file**=_POLICY\_FILE_:
+  * **-L**, **\--policy**=_POLICY\_FILE_:
 
     File to save the policy digest.
 
@@ -27,18 +27,18 @@ These options control creating the policy authorization session:
 
     Identifies the PCR policy type for policy creation.
 
-  * **-g**, **\--policy-digest-alg**=_HASH\_ALGORITHM_:
+  * **-g**, **\--policy-algorithm**=_HASH\_ALGORITHM_:
 
     The hash algorithm used in computation of the policy digest. Algorithms
     should follow the "formatting standards", see section "Algorithm Specifiers".
     Also, see section "Supported Hash Algorithms" for a list of supported hash
     algorithms.
 
-  * **-L**, **\--set-list**=_PCR\_LIST_:
+  * **-l**, **\--pcr-list**=_PCR\_LIST_:
 
     The list of PCR banks and selected PCRs' ids for each bank.
 
-  * **-F**, **\--pcr-input-file**=_PCR\_FILE_:
+  * **-f**, **\--pcr**=_PCR\_FILE_:
 
     Optional Path or Name of the file containing expected PCR values for the
     specified index. Default is to read the current PCRs per the set list.
@@ -62,7 +62,7 @@ These options control creating the policy authorization session:
 
 ## Create a authorization policy tied to a specific PCR index
 ```
-tpm2_createpolicy \--policy-pcr -L 0x4:0 -o policy.file -F pcr0.bin
+tpm2_createpolicy \--policy-pcr -l 0x4:0 -L policy.file -f pcr0.bin
 ```
 
 [returns](common/returns.md)

--- a/man/tpm2_createprimary.1.md
+++ b/man/tpm2_createprimary.1.md
@@ -30,20 +30,20 @@ with the created primary.
       * **n** for **TPM_RH_NULL**
       * **`<num>`** where a raw number can be used.
 
-  * **-P**, **\--auth-hierarchy**=_HIERARCHY\_\_AUTH\_VALUE_:
+  * **-P**, **\--hierarchy-auth**=_HIERARCHY\_\_AUTH\_VALUE_:
 
     Optional authorization value when authorization is required to create object
     under the specified hierarchy given via the **-a** option. Authorization
     values should follow the "authorization formatting standards", see section
     "Authorization Formatting".
 
-  * **-p**, **\--auth-object**=_OBJECT\_AUTH_:
+  * **-p**, **\--key-auth**=_OBJECT\_AUTH_:
 
     Optional authorization password for the newly created object. Password
     values should follow the "authorization formatting standards", see section
     "Authorization Formatting".
 
-  * **-g**, **\--halg**=_ALGORITHM_:
+  * **-g**, **\--hash-algorithm**=_ALGORITHM_:
 
     The hash algorithm to use for generating the objects name.
     If not specified, the default name algorithm is SHA256.
@@ -51,17 +51,17 @@ with the created primary.
     "Algorithm Specifiers". Also, see section
     "Supported Hash Algorithms" for a list of supported hash algorithms.
 
-  * **-G**, **\--kalg**=_KEY\_ALGORITHM_:
+  * **-G**, **\--key-algorithm**=_KEY\_ALGORITHM_:
 
     Algorithm type for generated key. If not specified, the default key
     algorithm is rsa2048:null:aes128cfb. See section "Supported Public Object Algorithms"
     for a list of supported object algorithms.
 
-  * **-o**, **\--context-object**=_CONTEXT\_FILE\_NAME_:
+  * **-o**, **\--key-context**=_CONTEXT\_FILE\_NAME_:
 
     File name to use for the returned object context, required.
 
-  * **-L**, **\--policy-file**=_POLICY\_FILE_:
+  * **-L**, **\--policy**=_POLICY\_FILE_:
 
     An optional file input that contains the policy digest for policy based authorization of the object.
 

--- a/man/tpm2_dictionarylockout.1.md
+++ b/man/tpm2_dictionarylockout.1.md
@@ -40,7 +40,7 @@ dictionary-attack-lockout state.
     Specifies the maximum number of allowed authentication attempts on
     DA-protected-object; after which DA is activated.
 
-  * **-p**, **\--auth-lockout**=_LOCKOUT\_AUTH_:
+  * **-p**, **\--auth**=_LOCKOUT\_AUTH_:
 
     The lockout authorization value.
 

--- a/man/tpm2_duplicate.1.md
+++ b/man/tpm2_duplicate.1.md
@@ -67,7 +67,7 @@ These options control the key importation process:
 To duplicate a key, one needs the key to duplicate, created with a policy that allows duplication and a new parent:
 ```
 tpm2_startauthsession -S session.dat
-tpm2_policycommandcode -S session.dat -o policy.dat 0x14B
+tpm2_policycommandcode -S session.dat -L policy.dat duplicate
 tpm2_flushcontext -S session.dat
 
 tpm2_createprimary -C o -g sha256 -G rsa -o primary.ctxt
@@ -76,7 +76,7 @@ tpm2_create -C primary.ctxt -g sha256 -G rsa -r key.prv -u key.pub -L policy.dat
 tpm2_loadexternal -C o -u new_parent.pub -o new_parent.ctxt
 
 tpm2_startauthsession \--policy-session -S session.dat
-tpm2_policycommandcode -S session.dat -o policy.dat 0x14B
+tpm2_policycommandcode -S session.dat -L policy.dat duplicate
 tpm2_duplicate -C new_parent.ctxt -c key.ctxt -G null -p "session:session.dat" -r duprv.bin -s seed.dat
 tpm2_flushcontext -S session.dat
 ```

--- a/man/tpm2_duplicate.1.md
+++ b/man/tpm2_duplicate.1.md
@@ -16,21 +16,21 @@ tpm2_duplicate(1) -  Duplicates a loaded object so that it may be used in a diff
 
 These options control the key importation process:
 
-  * **-G**, **\--inner-wrapper-alg**=_ALGORITHM_:
+  * **-G**, **\--wrapper-algorithm**=_ALGORITHM_:
 
     The symmetric algorithm to be used for the inner wrapper. Supports:
     * aes - AES 128 in CFB mode.
     * null - none
 
-  * **-i**, **\--input-key-file**=_FILE_:
+  * **-i**, **\--encryptionkey-in**=_FILE_:
 
     Specifies the filename of the symmetric key (128 bit data) to be used for the inner wrapper. Valid only when specified symmetric algorithm is not null
 
-  * **-o**, **\--output-key-file**=_FILE_:
+  * **-o**, **\--encryptionkey-out**=_FILE_:
 
     Specifies the filename to store the symmetric key (128 bit data) that was used for the inner wrapper. Valid only when specified symmetric algorithm is not null and \--input-key-file is not specified. The TPM generates the key in this case.
 
-  * **-C**, **\--parent-key**=_PARENT\_CONTEXT_:
+  * **-C**, **\--parent-context**=_PARENT\_CONTEXT_:
 
     Specifies the context object for the parent key. Either a file, a handle number or null to select TPM2_RH_NULL.
 
@@ -43,13 +43,13 @@ These options control the key importation process:
     Specifies the file path required to save the encrypted seed of the duplicated
     object.
 
-  * **-p**, **\--auth-key**=_KEY\_AUTH_:
+  * **-p**, **\--auth**=_KEY\_AUTH_:
 
     The authorization value for the key, optional.
     Follows the authorization formatting of the
     "password for parent key" option: **-P**.
 
-  * **-c**, **\--context**=_CONTEXT\_OBJECT_:
+  * **-c**, **\--key-context**=_CONTEXT\_OBJECT_:
 
     The handle or session file of the object to be duplicated.
     See section "Context Object Format".

--- a/man/tpm2_encryptdecrypt.1.md
+++ b/man/tpm2_encryptdecrypt.1.md
@@ -20,7 +20,7 @@ specified symmetric key.
     Name of the key context object to be used for the  operation. Either a file
     or a handle number. See section "Context Object Format".
 
-  * **-p**, **\--auth-key**=_KEY\_AUTH_:
+  * **-p**, **\--auth**=_KEY\_AUTH_:
 
     Optional authorization value to use the key specified by **-c**.
     Authorization values should follow the "authorization formatting standards",
@@ -36,12 +36,12 @@ specified symmetric key.
     Applicable only to encryption and for input data with last block shorter
     than encryption block length.
 
-  * **-i**, **\--in-file**=_INPUT\_FILE_:
+  * **-i**, **\--input**=_INPUT\_FILE_:
 
     Optional. Specifies the input file path for either the encrypted or decrypted
     data, depending on option **-D**. If not specified, defaults to **stdin**.
 
-  * **-o**, **\--out-file**=_OUT\_FILE_:
+  * **-o**, **\--output**=_OUT\_FILE_:
 
     Optional. Specifies the output file path for either the encrypted or decrypted
     data, depending on option **-D**. If not specified, defaults to **stdout**.

--- a/man/tpm2_evictcontrol.1.md
+++ b/man/tpm2_evictcontrol.1.md
@@ -23,7 +23,7 @@ be evicted.
       * **p** for **TPM_RH_PLATFORM**
       * **`<num>`** where a raw number can be used.
 
-  * **-c**, **\--context**=_OBJECT_CONTEXT_:
+  * **-c**, **\--key-context**=_OBJECT_CONTEXT_:
 
     A context object specifier of a transient or persistent object.
     Either a file path of a context blob or a handle id. See section "Context Object Format".
@@ -35,7 +35,7 @@ be evicted.
     If the handle is for a persistent object, then the object will be evicted from
     non-volatile memory.
 
-  * **-P**, **\--auth-hierarchy**=_AUTH\_HIERARCHY_\VALUE_:
+  * **-P**, **\--auth**=_AUTH\_HIERARCHY_\VALUE_:
 
     Optional authorization value. Authorization values should follow the
     "authorization formatting standards", see section "Authorization Formatting".

--- a/man/tpm2_getmanufec.1.md
+++ b/man/tpm2_getmanufec.1.md
@@ -18,36 +18,36 @@ server.
 
 # OPTIONS
 
-  * **-e**, **\--auth-endorse**=_ENDORSE\_AUTH_:
+  * **-P**, **\--eh-auth**=_ENDORSE\_AUTH_:
 
     Specifies current endorsement authorization.
     Authorizations should follow the "authorization formatting standards", see
     section "Authorization Formatting".
 
-  * **-P**, **\--auth-ek**=_EK\_AUTH_
+  * **-p**, **\--ek-auth**=_EK\_AUTH_
 
     Specifies the EK authorization when created.
     Same formatting as the endorse authorization value or **-e** option.
 
-  * **-w**, **\--auth-owner**=_OWNER\_AUTH_
+  * **-w**, **\--owner-auth**=_OWNER\_AUTH_
 
     Specifies the current owner authorization.
     Same formatting as the endorse authorization value or **-e** option.
 
-  * **-H**, **\--handle**=_HANDLE_:
+  * **-H**, **\--persistent-handle**=_HANDLE_:
 
     Specifies the handle used to make EK  persistent.
     If a value of **-** is passed the tool will find a vacant persistent handle
     to use and print out the automatically selected handle.
 
-  * **-G**, **\--algorithm**=_ALGORITHM_:
+  * **-G**, **\--key-algorithm**=_ALGORITHM_:
 
     Specifies the algorithm type of EK.
     See section "Supported Public Object Algorithms" for a list of supported
     object algorithms. See section "Algorithm Specifiers" on how to specify
     an algorithm argument.
 
-  * **-o**, **\--out-file**=_FILE_:
+  * **-o**, **\--output**=_FILE_:
 
     Specifies the file used to save the public portion of EK.
 
@@ -92,9 +92,9 @@ provided by setting the curl mode verbose, see
 # EXAMPLES
 
 ```
-tpm2_getmanufec -e abc123 -w abc123 -P passwd -H 0x81010001 -G rsa -O -N -U -E ECcert.bin -o ek.bin https://tpm.manufacturer.com/ekcertserver/
+tpm2_getmanufec -P abc123 -w abc123 -p passwd -H 0x81010001 -G rsa -O -N -U -E ECcert.bin -o ek.bin https://tpm.manufacturer.com/ekcertserver/
 
-tpm2_getmanufec -e 1a1b1c -w 1a1b1c -P 123abc -H 0x81010001 -G rsa -O -N -U -E ECcert.bin -o ek.bin https://tpm.manufacturer.com/ekcertserver/
+tpm2_getmanufec -P 1a1b1c -w 1a1b1c -p 123abc -H 0x81010001 -G rsa -O -N -U -E ECcert.bin -o ek.bin https://tpm.manufacturer.com/ekcertserver/
 ```
 
 [returns](common/returns.md)

--- a/man/tpm2_getrandom.1.md
+++ b/man/tpm2_getrandom.1.md
@@ -21,7 +21,7 @@ Most TPMs do this, and thus the tool verifies that input size is bounded by prop
 
 # OPTIONS
 
-  * **-o**, **\--out-file**=_FILE_
+  * **-o**, **\--output**=_FILE_
 
     Specifies the filename to output the raw bytes to. Defaults to stdout as a hex
     string.

--- a/man/tpm2_hash.1.md
+++ b/man/tpm2_hash.1.md
@@ -18,7 +18,7 @@ sign.
 
 # OPTIONS
 
-  * **-a**, **\--hierarchy**=_HIERARCHY_:
+  * **-C**, **\--hierarchy**=_HIERARCHY_:
 
     Hierarchy to use for the ticket. Defaults to **o**, **TPM_RH_OWNER**, when
     no value has been specified.
@@ -28,7 +28,7 @@ sign.
       * **e** for **TPM_RH_ENDORSEMENT**
       * **n** for **TPM_RH_NULL**
 
-  * **-g**, **\--halg**=_HASH\_ALGORITHM_:
+  * **-g**, **\--hash-algorithm**=_HASH\_ALGORITHM_:
 
     The hash algorithm to use.
     Algorithms should follow the "formatting standards", see section
@@ -36,7 +36,7 @@ sign.
     Also, see section "Supported Hash Algorithms" for a list of supported hash
     algorithms.
 
-  * **-o**, **\--out-file**=_OUT\_FILE_
+  * **-o**, **\--output**=_OUT\_FILE_
 
     Optional file record of the hash result. Defaults to stdout in hex form.
 
@@ -56,7 +56,7 @@ sign.
 
 ## Hash a file with sha1 hash algorithm and save the hash and ticket to a file
 ```
-tpm2_hash -H e -g sha1 -o hash.bin -t ticket.bin data.txt
+tpm2_hash -C e -g sha1 -o hash.bin -t ticket.bin data.txt
 ```
 
 [returns](common/returns.md)

--- a/man/tpm2_hmac.1.md
+++ b/man/tpm2_hmac.1.md
@@ -15,18 +15,18 @@ _FILE_ is not specified, then data is read from stdin.
 
 # OPTIONS
 
-  * **-C**, **\--key-context**=_KEY\_CONTEXT\_OBJECT_:
+  * **-c**, **\--key-context**=_KEY\_CONTEXT\_OBJECT_:
 
     The context object of the symmetric signing key providing the HMAC key.
     Either a file or a handle number. See section "Context Object Format".
 
-  * **-P**, **\--auth-key**=_KEY\_AUTH_:
+  * **-p**, **\--auth**=_KEY\_AUTH_:
 
     Optional authorization value to use the key specified by **-C**.
     Authorization values should follow the "authorization formatting standards",
     see section "Authorization Formatting".
 
-  * **-o**, **\--out-file**=_OUT\_FILE_
+  * **-o**, **\--output**=_OUT\_FILE_
 
     Optional file record of the HMAC result. Defaults to stdout.
 
@@ -46,17 +46,17 @@ _FILE_ is not specified, then data is read from stdin.
 
 ## Perform an HMAC on data.in and send output and possibly ticket to stdout
 ```
-tpm2_hmac -C 0x81010002 -P abc123 data.in
+tpm2_hmac -c 0x81010002 -p abc123 data.in
 ```
 
 ## Perform an HMAC on data.in read as a file to stdin and send output to a file
 ```
-tpm2_hmac -C key.context -P abc123 -o hash.out << data.in
+tpm2_hmac -c key.context -p abc123 -o hash.out << data.in
 ```
 
 ## Perform an HMAC on _stdin_ and send result and possibly ticket to stdout
 ```
-cat data.in | tpm2_hmac -C 0x81010002 -o hash.out
+cat data.in | tpm2_hmac -c 0x81010002 -o hash.out
 ```
 
 [returns](common/returns.md)

--- a/man/tpm2_import.1.md
+++ b/man/tpm2_import.1.md
@@ -18,14 +18,14 @@ key object created by the tpm2_duplicate tool.
 
 These options control the key importation process:
 
-  * **-G**, **\--algorithm**=_ALGORITHM_:
+  * **-G**, **\--key-algorithm**=_ALGORITHM_:
 
     The algorithm used by the key to be imported. Supports:
     * **aes** - AES 128, 192 or 256 key.
     * **rsa** - RSA 1024 or 2048 key.
     * **ecc** - ECC NIST P192, P224, P256, P384 or P521 public and private key.
 
-  * **-g**, **\--halg**=_ALGORITHM_:
+  * **-g**, **\--hash-algorithm**=_ALGORITHM_:
 
     The hash algorithm for generating the objects name. This is optional
     and defaults to **sha256** when not specified. Algorithms should follow the
@@ -33,31 +33,31 @@ These options control the key importation process:
     Also, see section "Supported Hash Algorithms" for a list of supported
     hash algorithms.
 
-  * **-i**, **\--in-file**=_FILE_:
+  * **-i**, **\--input**=_FILE_:
 
     Specifies the filename of the key to be imported. For AES keys,
     this file is the raw key bytes. For assymetric keys in PEM or DER
     format. A typical file is generated with `openssl genrsa`.
 
-  * **-C**, **\--parent-key**=_PARENT\_CONTEXT_:
+  * **-C**, **\--parent-context**=_PARENT\_CONTEXT_:
 
     Specifies the context object for the parent key. Either a file or a handle number.
     See section "Context Object Format". The parent key **MUST** be an *RSA* key with an
     symmetric cipher of *aes128cfb*.
 
-  * **-K**, **\--parent-pubkey**=_FILE_:
+  * **-K**, **\--parent-public**=_FILE_:
 
     Optional. Specifies the parent key public data file input. This can be read with
     **tpm2_readpublic**(1) tool. If not specified, the tool invokes a tpm2_readpublic on the parent
     object.
 
-  * **-k**, **\--sym-alg-file**=_FILE_:
+  * **-k**, **\--encryption-key**=_FILE_:
 
     Optional. Specifies the file containing the symmetric algorithm key that was used for the
     inner wrapper. If the file is specified the tool assumes the algorithm is AES 128 in CFB mode
     otherwise none.
 
-  * **-r**, **\--privfile**=_FILE_:
+  * **-r**, **\--private**=_FILE_:
 
     Specifies the file path required to save the encrypted private portion of
     the object imported as key.
@@ -65,7 +65,7 @@ These options control the key importation process:
     When importing a duplicated object this option specifies the file containing the
     private portion of the object to be imported.
 
-  * **-u**, **\--pubfile**=_FILE_:
+  * **-u**, **\--public**=_FILE_:
 
     Specifies the file path required to save the public portion of the object imported as key
 
@@ -76,19 +76,19 @@ These options control the key importation process:
 
     The object attributes, optional.
 
-  * **-P**, **\--auth-parent**=_PARENT\_KEY\_AUTH_:
+  * **-P**, **\--parent-auth**=_PARENT\_KEY\_AUTH_:
 
     The authorization value for using the parent key, optional.
     Authorization values should follow the "authorization formatting standards",
     see section "Authorization Formatting".
 
-  * **-p**, **\--auth-key**=_KEY\_AUTH_:
+  * **-p**, **\--key-auth**=_KEY\_AUTH_:
 
     The authorization value for the key, optional.
     Follows the authorization formatting of the
     "password for parent key" option: **-P**.
 
-  * **-L**, **\--policy-file**=_POLICY\_FILE_:
+  * **-L**, **\--policy**=_POLICY\_FILE_:
 
     The policy file.
 

--- a/man/tpm2_load.1.md
+++ b/man/tpm2_load.1.md
@@ -19,22 +19,22 @@ context file for future interactions with the object.
 
 # OPTIONS
 
-  * **-C**, **\--context-parent**=_PARENT\_CONTEXT\_OBJECT_:
+  * **-C**, **\--parent-context**=_PARENT\_CONTEXT\_OBJECT_:
 
     Context object loaded object's parent. Either a file or a handle number.
     See section "Context Object Format".
 
-  * **-P**, **\--auth-parent**=_KEY\_AUTH_:
+  * **-P**, **\--auth**=_KEY\_AUTH_:
 
     Optional authorization value to use the parent object specified by **-C**.
     Authorization values should follow the "authorization formatting standards",
     see section "Authorization Formatting".
 
-  * **-u**, **\--pubfile**=_PUBLIC\_OBJECT\_DATA\_FILE_:
+  * **-u**, **\--public**=_PUBLIC\_OBJECT\_DATA\_FILE_:
 
     A file containing the public portion of the object.
 
-  * **-r**, **\--privfile**=_PRIVATE\_OBJECT\_DATA\_FILE_:
+  * **-r**, **\--private**=_PRIVATE\_OBJECT\_DATA\_FILE_:
 
     A file containing the sensitive portion of the object.
 
@@ -42,7 +42,7 @@ context file for future interactions with the object.
 
     An optional file to save the name structure of the object.
 
-  * **-o**, **\--out-context**=_CONTEXT\_FILE\_NAME_:
+  * **-o**, **\--key-context**=_CONTEXT\_FILE\_NAME_:
 
     The file name of the saved object context, required.
 

--- a/man/tpm2_loadexternal.1.md
+++ b/man/tpm2_loadexternal.1.md
@@ -28,14 +28,14 @@ and a sensitive area.
       * **e** for the **endorsement** hierarchy.
       * **n** for the **null** hierarchy.
 
-  * **-G**, **\--key-alg**=_ALGORITHM_:
+  * **-G**, **\--key-algorithm**=_ALGORITHM_:
 
     The algorithm used by the key to be imported. Supports:
     * **aes** - AES 128,192 or 256 key.
     * **rsa** - RSA 1024 or 2048 key.
     * **ecc** - ECC NIST P192, P224, P256, P384 or P521 public and private key.
 
-  * **-u**, **\--pubfile**=_PUBLIC\_FILE_:
+  * **-u**, **\--public**=_PUBLIC\_FILE_:
 
     The public portion of the object, this can be one of the following file formats:
       * TSS - The TSS/TPM format. For example from option `-u` of command **tpm2_create**(1).
@@ -44,7 +44,7 @@ and a sensitive area.
       * ECC - OSSL PEM formats. For example `public.pem` from the command
         `openssl ec -in private.ecc.pem -out public.ecc.pem -pubout`
 
-  * **-r**, **\--privfile**=_PRIVATE\_FILE_:
+  * **-r**, **\--private**=_PRIVATE\_FILE_:
 
     The sensitive portion of the object, optional. If one wishes to use the private portion
     of a key, this must be specified. Like option **-u**, this command takes files in the
@@ -56,18 +56,18 @@ and a sensitive area.
 
     *Note*: The private portion does not respect TSS formats as it's impossible to get a **TPM2B_SENSITIVE** output from a previous command.
 
-  * **-p**, **\--auth-key**=_KEY\_AUTH_:
+  * **-p**, **\--auth**=_KEY\_AUTH_:
 
     The authorization value for the key, optional.
     Follows the authorization formatting of the
     "password for parent key" option: **-P**.
 
-  * **-L**, **\--policy-file**=_POLICY\_FILE_:
+  * **-L**, **\--policy**=_POLICY\_FILE_:
 
     The input policy file, optional. A file containing the hash of a policy derived from
     `tpm2_createpolicy`.
 
-  * **-g**, **\--halg**=_NAME\_ALGORITHM_:
+  * **-g**, **\--hash-algorithm**=_NAME\_ALGORITHM_:
 
     The hash algorithm for generating the objects name. This is optional
     and defaults to sha256 when not specified. However, load external supports
@@ -88,7 +88,7 @@ and a sensitive area.
     *Note*: If specifying attributes, the TPM will reject certain attributes like
     **TPMA_OBJECT_FIXEDTPM**, as those guarantees cannot be made.
 
-  * **-o**, **\--out-context**=_CONTEXT\_FILE_
+  * **-o**, **\--key-context**=_CONTEXT\_FILE_
 
     The file name of the saved object context, required.
 

--- a/man/tpm2_makecredential.1.md
+++ b/man/tpm2_makecredential.1.md
@@ -17,7 +17,7 @@ the **none** TCTI option.
 
 # OPTIONS
 
-  * **-e**, **\--enckey**=_PUBLIC\_FILE_:
+  * **-e**, **\--encryption-key**=_PUBLIC\_FILE_:
 
     A TPM public key which was used to wrap the seed.
 
@@ -29,7 +29,7 @@ the **none** TCTI option.
 
     The name of the key for which certificate is to be created.
 
-  * **-o**, **\--out-file**=_OUT\_FILE_:
+  * **-o**, **\--output**=_OUT\_FILE_:
 
     The output file path, recording the two structures output by
     tpm2_makecredential function.

--- a/man/tpm2_nvdefine.1.md
+++ b/man/tpm2_nvdefine.1.md
@@ -38,19 +38,19 @@
     entity. Either the raw bitfield mask or "nice-names" may be used. See
     section "NV Attributes" for more details.
 
-  * **-P**, **\--auth-hierarchy**=_AUTH\_HIERARCHY\_VALUE_:
+  * **-P**, **\--hierarchy-auth**=_AUTH\_HIERARCHY\_VALUE_:
 
     Specifies the authorization value for the hierarchy. Authorization values
     should follow the "authorization formatting standards", see section
     "Authorization Formatting".
 
-  * **-p**, **\--auth-index**=_INDEX\_PASSWORD_:
+  * **-p**, **\--index-auth**=_INDEX\_PASSWORD_:
 
     Specifies the password of NV Index when created.
     HMAC and Password authorization values should follow the "authorization
     formatting standards", see section "Authorization Formatting".
 
-  * **-L**, **\--policy-file**=_POLICY\_FILE_:
+  * **-L**, **\--policy**=_POLICY\_FILE_:
 
     Specifies the policy digest file for policy based authorizations.
 

--- a/man/tpm2_nvincrement.1.md
+++ b/man/tpm2_nvincrement.1.md
@@ -31,7 +31,7 @@
     authorize against the index. The index auth value is set via the
     **-p** option to **tpm2_nvdefine**(1).
 
-  * **-P**, **\--auth-hierarchy**=_HIERARCHY\_AUTH_:
+  * **-P**, **\--auth**=_HIERARCHY\_AUTH_:
 
     Specifies the authorization value for the hierarchy. Authorization values
     should follow the "authorization formatting standards", see section

--- a/man/tpm2_nvread.1.md
+++ b/man/tpm2_nvread.1.md
@@ -18,7 +18,7 @@
 
     Specifies the index to define the space at.
 
-  * **-a**, **\--hierarchy**=_AUTH_:
+  * **-C**, **\--hierarchy**=_AUTH_:
 
     Specifies the hierarchy used to authorize. Defaults to **o**, **TPM_RH_OWNER**,
     when no value has been specified.
@@ -31,11 +31,11 @@
     authorize against the index. The index auth value is set via the
     **-p** option to **tpm2_nvdefine**(1).
 
-  * **-o**, **\--out-file**=_FILE_:
+  * **-o**, **\--output**=_FILE_:
 
     File to write data
 
-  * **-P**, **\--auth-hierarchy**=_AUTH\_HIERARCHY\_VALUE__:
+  * **-P**, **\--auth**=_AUTH\_HIERARCHY\_VALUE__:
 
     Specifies the authorization value for the hierarchy. Authorization values
     should follow the "authorization formatting standards", see section

--- a/man/tpm2_nvreadlock.1.md
+++ b/man/tpm2_nvreadlock.1.md
@@ -19,7 +19,7 @@ index is unlocked when the TPM is restarted and the NV index becomes readable ag
 
     Specifies the index to define the space at.
 
-  * **-a**, **\--hierarchy**=_AUTH_:
+  * **-C**, **\--hierarchy**=_AUTH\_HANDLE_:
 
     Specifies the hierarchy used to authorize:
     * **o** for **TPM_RH_OWNER**
@@ -28,7 +28,7 @@ index is unlocked when the TPM is restarted and the NV index becomes readable ag
     specified.
     * **`<num>`** where a hierarchy handle may be used.
 
-  * **-P**, **\--auth-hierarchy**=_AUTH\_HIERARCHY\_VALUE_:
+  * **-P**, **\--auth**=_AUTH\_VALUE_:
 
     Specifies the authorization value for the hierarchy. Authorization values
     should follow the "authorization formatting standards", see section
@@ -44,7 +44,7 @@ index is unlocked when the TPM is restarted and the NV index becomes readable ag
 
 ## Lock an index protected by a password
 ```
-tpm2_nvreadlock -x 0x1500016 -a 0x40000001 -P passwd
+tpm2_nvreadlock -x 0x1500016 -C 0x40000001 -P passwd
 ```
 
 [returns](common/returns.md)

--- a/man/tpm2_nvrelease.1.md
+++ b/man/tpm2_nvrelease.1.md
@@ -19,7 +19,7 @@ defined with **tpm2_nvdefine**(1).
 
     Specifies the index to release.
 
-  * **-a**, **\--hierarchy**=_AUTH_:
+  * **-C**, **\--hierarchy**=_AUTH\_HANDLE_:
 
     Specifies the hierarchy used to authorize.
     Supported options are:
@@ -27,7 +27,7 @@ defined with **tpm2_nvdefine**(1).
       * **p** for **TPM_RH_PLATFORM**
       * **`<num>`** where a hierarchy handle may be specified.
 
-  * **-P**, **\--auth-hierarchy**=_AUTH\_HIERARCHY\_VALUE_:
+  * **-P**, **\--auth**=_AUTH\_VALUE_:
 
     Specifies the authorization value for the hierarchy. Authorization values
     should follow the "authorization formatting standards", see section
@@ -42,7 +42,7 @@ defined with **tpm2_nvdefine**(1).
 # EXAMPLES
 
 ```
-tpm2_nvrelease -x 0x1500016 -a 0x40000001 -P passwd
+tpm2_nvrelease -x 0x1500016 -C 0x40000001 -P passwd
 ```
 
 [returns](common/returns.md)

--- a/man/tpm2_nvwrite.1.md
+++ b/man/tpm2_nvwrite.1.md
@@ -19,7 +19,7 @@ If _FILE_ is not specified, it defaults to stdin.
 
     Specifies the index to define the space at.
 
-  * **-a**, **\--hierarchy**=_AUTH_:
+  * **-C**, **\--hierarchy**=_AUTH\_HANDLE_:
 
     Specifies the handle used to authorize. Defaults to **o**, **TPM_RH_OWNER**,
     when no value has been specified.
@@ -32,7 +32,7 @@ If _FILE_ is not specified, it defaults to stdin.
     authorize against the index. The index auth value is set via the
     **-p** option to **tpm2_nvdefine**(1).
 
-  * **-P**, **\--auth-hierarchy**=_HIERARCHY\_AUTH_:
+  * **-P**, **\--auth**=_HIERARCHY\_AUTH_:
 
     Specifies the authorization value for the hierarchy. Authorization values
     should follow the "authorization formatting standards", see section

--- a/man/tpm2_pcrallocate.1.md
+++ b/man/tpm2_pcrallocate.1.md
@@ -26,7 +26,7 @@ The new allocations become effective after the next reboot.
 
 # OPTIONS
 
-  * **-P**, **\--auth-platform**=_AUTH\_PLATFORM_\VALUE_:
+  * **-P**, **\--auth**=_PLATFORM\_AUTH\_VALUE_:
 
     Optional authorization value. Authorization values should follow the
     "authorization formatting standards", see section "Authorization Formatting".

--- a/man/tpm2_pcrevent.1.md
+++ b/man/tpm2_pcrevent.1.md
@@ -34,7 +34,7 @@ These options control extending the pcr:
     Not only compute the hash digests on _FILE_, also extend the PCR given by
     _INDEX_ for all supported hash algorithms.
 
-  * **-P**, **\--auth-pcr**=_PCR\_AUTH_:
+  * **-P**, **\--auth**=_PCR\_AUTH_:
 
     Specifies the authorization value for PCR. Authorization values
     should follow the "authorization formatting standards", see section

--- a/man/tpm2_pcrlist.1.md
+++ b/man/tpm2_pcrlist.1.md
@@ -27,7 +27,7 @@ sha256 :
 
 # OPTIONS
 
-  * **-g**, **\--halg**=_HASH\_ALGORITHM_:
+  * **-g**, **\--hash-algorithm**=_HASH\_ALGORITHM_:
 
     Only output PCR banks with the given algorithm.
     Algorithms should follow the "formatting standards", see section
@@ -35,11 +35,11 @@ sha256 :
     Also, see section "Supported Hash Algorithms" for a list of supported hash
     algorithms.
 
-  * **-o**, **\--out-file**=_FILE_:
+  * **-o**, **\--output**=_FILE_:
 
     The output file to write the PCR values in binary format, optional.
 
-  * **-L**, **\--sel-list**=_PCR\_SELECTION\_LIST_:
+  * **-l**, **\--pcr-list**=_PCR\_SELECTION\_LIST_:
 
     The list of PCR banks and selected PCRs' ids for each bank to display.
     _PCR\_SELECTION\_LIST_ values should follow the
@@ -47,7 +47,7 @@ sha256 :
 
     Also read **NOTES** section below.
 
-  * **-s**, **\--algs**:
+  * **-s**, **\--pcr-algorithms**:
 
     Output the list of supported algorithms.
 
@@ -75,7 +75,7 @@ tpm2_pcrlist -g sha1
 
 ## Display the PCR values with specified banks and store in a file
 ```
-tpm2_pcrlist -L sha1:16,17,18+sha256:16,17,18 -o pcrs
+tpm2_pcrlist -l sha1:16,17,18+sha256:16,17,18 -o pcrs
 ```
 
 ## Display the supported PCR bank algorithms and exit

--- a/man/tpm2_policyauthorize.1.md
+++ b/man/tpm2_policyauthorize.1.md
@@ -26,7 +26,7 @@ in the policy digest.
 
 # OPTIONS
 
-  * **-o**, **\--out-policy-file**=_POLICY\_FILE_:
+  * **-o**, **\--policy-output**=_POLICY\_FILE_:
 
     File to save the policy digest.
 
@@ -35,11 +35,11 @@ in the policy digest.
     The policy session file generated via the **-S** option to
     **tpm2_startauthsession**(1).
 
-  * **-i**, **\--in-policy-file**=_POLICY\_FILE_:
+  * **-L**, **\--policy**=_POLICY\_FILE_:
 
     The policy digest that has to be authorized.
 
-  * **-q**, **\--qualify-data**=_DATA_FILE_:
+  * **-q**, **\--qualification-data**=_DATA_FILE_:
 
     The policy qualifier data signed in conjunction with the input policy digest.
     This is a unique data that the signer can choose to include in the signature.
@@ -102,7 +102,7 @@ openssl dgst -sha256 -sign signing_key_private.pem -out pcr.signature pcr.policy
 ```
 tpm2_startauthsession -S session.ctx
 
-tpm2_policyauthorize -S session.ctx -i authorized.policy -o pcr.policy -n signing_key.name
+tpm2_policyauthorize -S session.ctx -L authorized.policy -o pcr.policy -n signing_key.name
 
 tpm2_flushcontext -S session.ctx
 ```
@@ -122,7 +122,7 @@ tpm2_startauthsession \--policy-session -S session.ctx
 
 tpm2_policypcr -Q -S session.ctx -L sha256:0 -o pcr.policy
 
-tpm2_policyauthorize -S session.ctx -o authorized.policy -i pcr.policy -n signing_key.name -t verification.tkt
+tpm2_policyauthorize -S session.ctx -o authorized.policy -L pcr.policy -n signing_key.name -t verification.tkt
 
 tpm2_load -Q -C prim.ctx -u sealing_pubkey.pub -r sealing_prikey.pub -o sealing_key.ctx
 

--- a/man/tpm2_policyauthorize.1.md
+++ b/man/tpm2_policyauthorize.1.md
@@ -88,7 +88,7 @@ tpm2_pcrlist -l sha256:0 -o pcr0.sha256
 
 tpm2_startauthsession -S session.ctx
 
-tpm2_policypcr -S session.ctx -L sha256:0 -F pcr0.sha256 -o pcr.policy
+tpm2_policypcr -S session.ctx -l sha256:0 -f pcr0.sha256 -L pcr.policy
 
 tpm2_flushcontext -S session.ctx
 ```
@@ -120,7 +120,7 @@ tpm2_verifysignature -c signing_key.ctx -g sha256 -m pcr.policy -s pcr.signature
 
 tpm2_startauthsession \--policy-session -S session.ctx
 
-tpm2_policypcr -Q -S session.ctx -L sha256:0 -o pcr.policy
+tpm2_policypcr -Q -S session.ctx -l sha256:0 -L pcr.policy
 
 tpm2_policyauthorize -S session.ctx -o authorized.policy -L pcr.policy -n signing_key.name -t verification.tkt
 

--- a/man/tpm2_policyauthorize.1.md
+++ b/man/tpm2_policyauthorize.1.md
@@ -84,7 +84,7 @@ tpm2_loadexternal -G rsa -C o -u signing_key_public.pem -o signing_key.ctx -n si
 
 ## Create a policy to be authorized like a PCR policy
 ```
-tpm2_pcrlist -L sha256:0 -o pcr0.sha256
+tpm2_pcrlist -l sha256:0 -o pcr0.sha256
 
 tpm2_startauthsession -S session.ctx
 

--- a/man/tpm2_policycommandcode.1.md
+++ b/man/tpm2_policycommandcode.1.md
@@ -25,7 +25,7 @@ Requires support for extended sessions with resource manager.
 
     A session file from **tpm2_startauthsession**(1)'s **-S** option.
 
-  * **-o**, **\--out-policy-file**=_POLICY\_FILE_:
+  * **-L**, **\--policy**=_POLICY\_FILE_:
 
     File to save the policy digest.
 
@@ -175,7 +175,7 @@ TPM_CC_UNSEAL=0x15E
 
 tpm2_startauthsession -S session.dat
 
-tpm2_policycommandcode -S session.dat -o policy.dat $TPM_CC_UNSEAL
+tpm2_policycommandcode -S session.dat -L policy.dat $TPM_CC_UNSEAL
 
 tpm2_flushcontext -S session.dat
 ```
@@ -195,7 +195,7 @@ tpm2_load -C prim.ctx -u sealkey.pub -r sealkey.priv -n sealkey.name \
 
 tpm2_startauthsession \--policy-session -S session.dat
 
-tpm2_policycommandcode -S session.dat -o policy.dat $TPM_CC_UNSEAL
+tpm2_policycommandcode -S session.dat -L policy.dat $TPM_CC_UNSEAL
 
 tpm2_unseal -p session:session.dat -c sealkey.ctx
 

--- a/man/tpm2_policyduplicationselect.1.md
+++ b/man/tpm2_policyduplicationselect.1.md
@@ -23,11 +23,11 @@
 
     Input name file of the object to be duplicated.
 
-  * **-N**, **\--new-parent-name**=_NP\_NAME\_FILE_:
+  * **-N**, **\--parent-name**=_NP\_NAME\_FILE_:
 
     Input name file of the new parent.
 
-  * **-o**, **\--out-policy-file**=_POLICY\_FILE_:
+  * **-L**, **\--policy**=_POLICY\_FILE_:
 
     File to save the policy digest.
 

--- a/man/tpm2_policylocality.1.md
+++ b/man/tpm2_policylocality.1.md
@@ -22,7 +22,7 @@ value. Requires support for extended sessions with resource manager.
 
     A session file from **tpm2_startauthsession**(1)'s **-S** option.
 
-  * **-o**, **\--out-policy-file**=_POLICY\_FILE_:
+  * **-L**, **\--policy**=_POLICY\_FILE_:
 
     File to save the policy digest.
 
@@ -41,7 +41,7 @@ TPM_LOCALITY=0x3
 
 tpm2_startauthsession -S session.dat
 
-tpm2_policylocality -S session.dat -o policy.dat $TPM_LOCALITY
+tpm2_policylocality -S session.dat -L policy.dat $TPM_LOCALITY
 
 tpm2_flushcontext -S session.dat
 ```
@@ -61,7 +61,7 @@ tpm2_load -C prim.ctx -u sealkey.pub -r sealkey.priv -n sealkey.name \
 
 tpm2_startauthsession \--policy-session -S session.dat
 
-tpm2_policylocality -S session.dat -o policy.dat $TPM_LOCALITY
+tpm2_policylocality -S session.dat -L policy.dat $TPM_LOCALITY
 
 # Change to locality 3, Note: this operation varies on different platforms
 

--- a/man/tpm2_policyor.1.md
+++ b/man/tpm2_policyor.1.md
@@ -22,11 +22,11 @@ at least one of the policy events are true.
 
 # OPTIONS
 
-  * **-o**, **\--out-policy-file**=_POLICY\_FILE_:
+  * **-L**, **\--policy**=_POLICY\_FILE_:
 
     File to save the compounded policy digest.
 
-  * **-L**, **\--policy-list**=_POLICY\_FILE_\_LIST:
+  * **-l**, **\--policy-list**=_POLICY\_FILE_\_LIST:
 
     The list of files for the policy digests that has to be compounded resulting
     in individual policies being added to final policy digest that can
@@ -81,7 +81,7 @@ tpm2_flushcontext -S session.ctx
 ```
 tpm2_startauthsession -S session.ctx
 
-tpm2_policyor -S session.ctx -o policy.or -L sha256:set1_pcr0.policy,set2_pcr0.policy
+tpm2_policyor -S session.ctx -L policy.or -l sha256:set1_pcr0.policy,set2_pcr0.policy
 
 tpm2_flushcontext -S session.ctx
 ```
@@ -99,7 +99,7 @@ tpm2_startauthsession \--policy-session -S session.ctx
 
 tpm2_policypcr -Q -S session.ctx -L sha1:0 -o o_set1_pcr0.policy
 
-tpm2_policyor -S session.ctx -o policy.or -L sha256:set1_pcr0.policy,set2_pcr0.policy
+tpm2_policyor -S session.ctx -L policy.or -l sha256:set1_pcr0.policy,set2_pcr0.policy
 
 unsealed=`tpm2_unseal -p"session:session.ctx" -c sealing_key.ctx
 

--- a/man/tpm2_policyor.1.md
+++ b/man/tpm2_policyor.1.md
@@ -58,7 +58,7 @@ and seal a secret. Unsealing with either of the PCR sets should be successful.
 
 ## Create two PCR sets and policies
 ```
-tpm2_pcrlist -L sha1:0 -o set1_pcr0.sha1
+tpm2_pcrlist -l sha1:0 -o set1_pcr0.sha1
 
 tpm2_startauthsession -S session.ctx
 

--- a/man/tpm2_policyor.1.md
+++ b/man/tpm2_policyor.1.md
@@ -62,7 +62,7 @@ tpm2_pcrlist -l sha1:0 -o set1_pcr0.sha1
 
 tpm2_startauthsession -S session.ctx
 
-tpm2_policypcr -S session.ctx -L sha1:0 -F set1_pcr0.sha1 -o set1_pcr0.policy
+tpm2_policypcr -S session.ctx -l sha1:0 -f set1_pcr0.sha1 -L set1_pcr0.policy
 
 tpm2_flushcontext -S session.ctx
 
@@ -72,7 +72,7 @@ cat set1_pcr0.sha1 rand.bin | openssl dgst -sha1 set2_pcr0.sha1
 
 tpm2_startauthsession -S session.ctx
 
-tpm2_policypcr -S session.ctx -L sha1:0 -F set2_pcr0.sha1 -o set2_pcr0.policy
+tpm2_policypcr -S session.ctx -l sha1:0 -f set2_pcr0.sha1 -L set2_pcr0.policy
 
 tpm2_flushcontext -S session.ctx
 ```
@@ -97,7 +97,7 @@ tpm2_create -Q -g sha256 -u sealing_key.pub -r sealing_key.pub -i- -C prim.ctx -
 ```
 tpm2_startauthsession \--policy-session -S session.ctx
 
-tpm2_policypcr -Q -S session.ctx -L sha1:0 -o o_set1_pcr0.policy
+tpm2_policypcr -Q -S session.ctx -l sha1:0 -L o_set1_pcr0.policy
 
 tpm2_policyor -S session.ctx -L policy.or -l sha256:set1_pcr0.policy,set2_pcr0.policy
 

--- a/man/tpm2_policypassword.1.md
+++ b/man/tpm2_policypassword.1.md
@@ -21,7 +21,7 @@ If using a resource manager (RM), then one supporting extended sessions, like
 
 # OPTIONS
 
-  * **-o**, **\--out-policy-file**=_POLICY\_FILE_:
+  * **-L**, **\--policy**=_POLICY\_FILE_:
 
     File to save the compounded policy digest.
 
@@ -49,7 +49,7 @@ using the **tpm2_policypassword**(1) tool.
 ```
 tpm2_startauthsession -S session.dat
 
-tpm2_policypassword -S session.dat -o policy.dat
+tpm2_policypassword -S session.dat -L policy.dat
 
 tpm2_flushcontext -S session.dat
 ```
@@ -74,7 +74,7 @@ tpm2_encryptdecrypt -c key.ctx -o encrypt.out -i plain.txt -p text
 ```
 tpm2_startauthsession \--policy-session -S session.dat
 
-tpm2_policypassword -S session.dat -o policy.dat
+tpm2_policypassword -S session.dat -L policy.dat
 
 tpm2_encryptdecrypt -c key.ctx -o encrypt.out -i plain.txt \
   -p session:session.dat+testpswd

--- a/man/tpm2_policypcr.1.md
+++ b/man/tpm2_policypcr.1.md
@@ -16,16 +16,16 @@ established via **tpm2_startauthsession**(1).
 
 # OPTIONS
 
-  * **-o**, **\--out-policy-file**=_POLICY\_FILE_:
+  * **-L**, **\--policy**=_POLICY\_FILE_:
 
     File to save the policy digest.
 
-  * **-F**, **\--pcr-input-file**=_PCR\_FILE_:
+  * **-f**, **\--pcr**=_PCR\_FILE_:
 
     Optional Path or Name of the file containing expected PCR values for the
     specified index. Default is to read the current PCRs per the set list.
 
-  * **-L**, **\--set-list**=_PCR\_LIST_:
+  * **-l**, **\--pcr-list**=_PCR\_LIST_:
 
     The list of PCR banks and selected PCRs' ids for each bank.
 
@@ -55,7 +55,7 @@ Then, it uses a *policy* session to unseal some data stored in the object.
 
     handle=`tpm2_startauthsession -S session.dat | cut -d' ' -f 2-2`
 
-    tpm2_policypcr -Q -S session.dat -L "sha1:0,1,2,3" -F pcr.dat -o policy.dat
+    tpm2_policypcr -Q -S session.dat -l "sha1:0,1,2,3" -f pcr.dat -L policy.dat
 
     tpm2_flushcontext -H "$handle"
     ```
@@ -69,7 +69,7 @@ Then, it uses a *policy* session to unseal some data stored in the object.
     ```
     handle=`tpm2_startauthsession \--policy-session -S session.dat | cut -d' ' -f 2-2`
 
-    tpm2_policypcr -Q -S session.dat -L "sha1:0,1,2,3" -F pcr.dat -o policy.dat
+    tpm2_policypcr -Q -S session.dat -l "sha1:0,1,2,3" -f pcr.dat -L policy.dat
     ```
 4. Using the actual policy session from step 3 in tpm2_unseal to unseal the object.
     ```

--- a/man/tpm2_policypcr.1.md
+++ b/man/tpm2_policypcr.1.md
@@ -51,7 +51,7 @@ Then, it uses a *policy* session to unseal some data stored in the object.
     ```
     tpm2_createprimary -C e -g sha256 -G ecc -o primary.ctx
 
-    tpm2_pcrlist -Q -L "sha1:0,1,2,3 -o pcr.dat
+    tpm2_pcrlist -Q -l "sha1:0,1,2,3 -o pcr.dat
 
     handle=`tpm2_startauthsession -S session.dat | cut -d' ' -f 2-2`
 

--- a/man/tpm2_policyrestart.1.md
+++ b/man/tpm2_policyrestart.1.md
@@ -36,7 +36,7 @@ state would still need to satisfy the policy
 ```
 tpm2_startauthsession \--policy-session
 
-tpm2_policypcr -Q -S session.dat -L "sha1:0,1,2,3" -F pcr.dat -o policy.dat
+tpm2_policypcr -Q -S session.dat -l "sha1:0,1,2,3" -f pcr.dat -L policy.dat
 
 # PCR event occurs here causing unseal to fail
 tpm2_unseal -S session.dat -c unseal.key.ctx
@@ -45,7 +45,7 @@ tpm2_unseal -S session.dat -c unseal.key.ctx
 # Clear the policy digest by restarting the policy session, try again, PCR state must satisfy policy
 tpm2_policyrestart -S session.dat
 
-tpm2_policypcr -Q -S session.dat -L "sha1:0,1,2,3" -F pcr.dat -o policy.dat
+tpm2_policypcr -Q -S session.dat -l "sha1:0,1,2,3" -f pcr.dat -L policy.dat
 
 tpm2_unseal -S session.dat -c unseal.key.ctx
 ```

--- a/man/tpm2_policysecret.1.md
+++ b/man/tpm2_policysecret.1.md
@@ -17,7 +17,7 @@ a policy.
 
 # OPTIONS
 
-  * **-c**, **\--context**=_OBJECT_CONTEXT_:
+  * **-c**, **\--object-context**=_OBJECT_CONTEXT_:
 
     A context object specifier of a transient/permanent/persistent object. Either
     a file path of a object context blob or a loaded/persistent/permanent handle
@@ -31,7 +31,7 @@ a policy.
     The policy session file generated via the **-S** option to
     **tpm2_startauthsession**(1).
 
-  * **-o**, **\--out-policy-file**=_POLICY\_FILE_:
+  * **-L**, **\--policy**=_POLICY\_FILE_:
 
     File to save the policy digest.
 
@@ -57,7 +57,7 @@ TPM_RH_OWNER=0x40000001
 
 tpm2_startauthsession -S session.ctx
 
-tpm2_policysecret -S session.ctx -c $TPM_RH_OWNER -o secret.policy
+tpm2_policysecret -S session.ctx -c $TPM_RH_OWNER -L secret.policy
 
 tpm2_flushcontext -S session.ctx
 ```
@@ -75,7 +75,7 @@ tpm2_load -C prim.ctx -u sealing_key.pub -r sealing_key.priv -n sealing_key.name
 ```
 tpm2_startauthsession \--policy-session -S session.ctx
 
-tpm2_policysecret -S session.ctx -c $TPM_RH_OWNER -o secret.policy
+tpm2_policysecret -S session.ctx -c $TPM_RH_OWNER -L secret.policy
 
 unsealed=`tpm2_unseal -p "session:session.ctx" -c sealing_key.ctx`
 echo $unsealed

--- a/man/tpm2_quote.1.md
+++ b/man/tpm2_quote.1.md
@@ -19,17 +19,17 @@
     Context object for the existing AK's context. Either a file or a handle number.
     See section "Context Object Format".
 
-  * **-P**, **\--auth-ak**=_AK\_AUTH_:
+  * **-P**, **\--ak-auth**=_AK\_AUTH_:
 
     Specifies the authorization value for AK specified by option **-C**.
     Authorization values should follow the "authorization formatting standards",
     see section "Authorization Formatting".
 
-  * **-l**, **\--id-list**=_PCR\_ID\_LIST_
+  * **-i**, **\--pcr-index**=_PCR\_ID\_LIST_
 
     The comma separated list of selected PCRs' e.g. "4,5,6".
 
-  * **-L**, **\--sel-list**=_PCR\_SELECTION\_LIST_:
+  * **-l**, **\--pcr-list**=_PCR\_SELECTION\_LIST_:
 
     The list of PCR banks and selected PCRs' ids for each bank.
     _PCR\_SELECTION\_LIST_ values should follow the
@@ -47,23 +47,23 @@
     Signature output file, records the signature in the format specified via the **-f**
     option.
 
-  * **-f**, **\--format**
+  * **-F**, **\--format**
 
     Format selection for the signature output file. See section "Signature Format Specifiers".
 
-  * **-p**, **\--pcrs**:
+  * **-f**, **\--pcr**:
 
     PCR output file, optional, records the list of PCR values as defined
     by **-l** or **-L**.  Note that only the digest of these values is stored in the
     signed quote message \-- these values themselves are not signed or
     stored in the message.
 
-  * **-q**, **\--qualify-data**:
+  * **-q**, **\--qualification-data**:
 
     Data given as a Hex string to qualify the  quote, optional. This is typically
     used to add a nonce against replay attacks.
 
-  * **-g**, **\--halg**:
+  * **-g**, **\--hash-algorithm**:
 
     Hash algorithm for signature. Required if **-p** is given.
 
@@ -82,15 +82,15 @@
 # EXAMPLES
 
 ```
-tpm2_quote -C 0x81010002 -P abc123 -l 16,17,18
+tpm2_quote -C 0x81010002 -P abc123 -i 16,17,18
 
-tpm2_quote -C ak.context -P "str:abc123" -l 16,17,18
+tpm2_quote -C ak.context -P "str:abc123" -i 16,17,18
 
-tpm2_quote -C 0x81010002 -L sha1:16,17,18
+tpm2_quote -C 0x81010002 -l sha1:16,17,18
 
-tpm2_quote -C ak.dat -L sha1:16,17,18
+tpm2_quote -C ak.dat -l sha1:16,17,18
 
-tpm2_quote -C 0x81010002 -P "hex:123abc" -L sha1:16,17,18+sha256:16,17,18 -q 11aa22bb
+tpm2_quote -C 0x81010002 -P "hex:123abc" -l sha1:16,17,18+sha256:16,17,18 -q 11aa22bb
 ```
 
 # NOTES

--- a/man/tpm2_readpublic.1.md
+++ b/man/tpm2_readpublic.1.md
@@ -14,7 +14,7 @@
 
 # OPTIONS
 
-  * **-c**, **\--context**=_OBJECT\_CONTEXT_:
+  * **-c**, **\--object-context**=_OBJECT\_CONTEXT_:
 
     Context object for the object to read. Either a file, a serialized handle or a handle number.
     See section "Context Object Format".
@@ -23,7 +23,7 @@
 
     An optional file to save the name structure of the object.
 
-  * **-o**, **\--out-file**=_OUT\_FILE_:
+  * **-o**, **\--output**=_OUT\_FILE_:
 
     The output file path, recording the public portion of the object.
 

--- a/man/tpm2_rsadecrypt.1.md
+++ b/man/tpm2_rsadecrypt.1.md
@@ -26,17 +26,17 @@ The key referenced by key-context is **required** to be:
     decryption. Either a file or a handle number.
     See section "Context Object Format".
 
-  * **-p**, **\--auth-key**=_KEY\_AUTH_:
+  * **-p**, **\--auth**=_KEY\_AUTH_:
 
     Optional authorization value to use the key specified by **-k**.
     Authorization values should follow the "authorization formatting standards",
     see section "Authorization Formatting".
 
-  * **-i**, **\--in-file**=_INPUT\FILE_:
+  * **-i**, **\--input**=_INPUT\FILE_:
 
     Input file path, containing the data to be decrypted.
 
-  * **-o**, **\--out-file**=_OUTPUT\_FILE_:
+  * **-o**, **\--output**=_OUTPUT\_FILE_:
 
     Output file path, record the decrypted data.
 

--- a/man/tpm2_rsaencrypt.1.md
+++ b/man/tpm2_rsaencrypt.1.md
@@ -27,7 +27,7 @@ The key referenced by key-context is **required** to be:
     encryption. Either a file or a handle number.
     See section "Context Object Format".
 
-  * **-o**, **\--out-file**=_OUTPUT\_FILE_:
+  * **-o**, **\--output**=_OUTPUT\_FILE_:
 
     Output file path, record the decrypted data. The default is to print an
     xxd compatible hexdump to stdout. If a file is specified, raw binary

--- a/man/tpm2_send.1.md
+++ b/man/tpm2_send.1.md
@@ -20,7 +20,7 @@ program to decode and display the response in a human readable form.
 
 # OPTIONS
 
-  * **-o**, **\--out-file**=_OUTPUT\_FILE_:
+  * **-o**, **\--output**=_OUTPUT\_FILE_:
 
     Output file to send response buffer to. Defaults to stdout.
 

--- a/man/tpm2_sign.1.md
+++ b/man/tpm2_sign.1.md
@@ -23,13 +23,13 @@ data and validation shall indicate that hashed data did not start with
     Context object pointing to the the key used for signing. Either a file or a
     handle number. See section "Context Object Format".
 
-  * **-p**, **\--auth-key**=_KEY\_AUTH_:
+  * **-p**, **\--auth**=_KEY\_AUTH_:
 
     Optional authorization value to use the key specified by **-c**.
     Authorization values should follow the "authorization formatting standards",
     see section "Authorization Formatting".
 
-  * **-g**, **\--halg**=_HASH\_ALGORITHM_:
+  * **-g**, **\--hash-algorithm**=_HASH\_ALGORITHM_:
 
     The hash algorithm used to digest the message.
     Algorithms should follow the "formatting standards", see section
@@ -37,7 +37,7 @@ data and validation shall indicate that hashed data did not start with
     Also, see section "Supported Hash Algorithms" for a list of supported hash
     algorithms.
 
-  * **-s**, **\--sig-scheme**=_SIGNING\_SCHEME_:
+  * **-s**, **\--scheme**=_SIGNING\_SCHEME_:
 
     The signing scheme used to sign the message. Optional.
     Signing schemes should follow the "formatting standards", see section
@@ -52,7 +52,7 @@ data and validation shall indicate that hashed data did not start with
 
     The message file, containing the content to be  digested.
 
-  * **-D**, **\--digest**=_DIGEST\_FILE_:
+  * **-d**, **\--digest**=_DIGEST\_FILE_:
 
     The digest file that shall be computed using the correct hash
     algorithm. When this option is specified, a warning is generated and
@@ -65,7 +65,7 @@ data and validation shall indicate that hashed data did not start with
 
     The ticket file, containing the validation structure, optional.
 
-  * **-o**, **\--out-sig**=_SIGNATURE\_FILE_:
+  * **-o**, **\--signature**=_SIGNATURE\_FILE_:
 
     The signature file, records the signature structure.
 
@@ -121,7 +121,7 @@ sha256sum data.in.raw | awk '{ print "000000 " $1 }' | xxd -r -c 32 > data.in.di
 tpm2_loadexternal -Q -G ecc -r private.ecc.pem -o key.ctx
 
 # Sign in the TPM and verify with OSSL
-tpm2_sign -Q -c key.ctx -g sha256 -D data.in.digest -f plain -s data.out.signed
+tpm2_sign -Q -c key.ctx -g sha256 -d data.in.digest -f plain -s data.out.signed
 
 openssl dgst -verify public.ecc.pem -keyform pem -sha256 -signature data.out.signed data.in.raw
 ```

--- a/man/tpm2_startauthsession.1.md
+++ b/man/tpm2_startauthsession.1.md
@@ -29,14 +29,14 @@ This will work with direct TPM access, but note that internally this calls a *Co
     **NOTE**: A *trial* session is used when building a policy and a *policy*
     session is used when authenticating with a policy.
 
-  * **-g**, **\--halg**=_HASH\_ALGORITHM_:
+  * **-g**, **\--hash-algorithm**=_HASH\_ALGORITHM_:
 
     The hash algorithm used in computation of the policy digest. Algorithms
     should follow the "formatting standards", see section "Algorithm Specifiers".
     Also, see section "Supported Hash Algorithms" for a list of supported hash
     algorithms.
 
-  * **-k**, **\--key**=_SESSION\_ENCRYPTION\_KEY_:
+  * **-c**, **\--key-context**=_SESSION\_ENCRYPTION\_KEY_:
 
     Set the session encryption and bind key. When using this, sensitive data transmitted to
     the TPM will be encrypted with AES128CFB. **This prevents bus snooping attacks.**
@@ -72,7 +72,7 @@ tpm2_startauthsession \--policy-session -S mysession.ctx
 ## Start an encrypted and bound *policy* session and save the session data to a file
 ```
 tpm2_createprimary -o primary.ctx
-tpm2_startauthsession \--policy-session -k primary.ctx -S mysession.ctx
+tpm2_startauthsession \--policy-session -c primary.ctx -S mysession.ctx
 ```
 
 [returns](common/returns.md)

--- a/man/tpm2_unseal.1.md
+++ b/man/tpm2_unseal.1.md
@@ -14,18 +14,18 @@
 
 # OPTIONS
 
-  * **-c**, **\--context-object**=_CONTEXT\_OBJECT_:
+  * **-c**, **\--object-context**=_CONTEXT\_OBJECT_:
 
     Context object for the loaded object. Either a file or a handle number.
     See section "Context Object Format".
 
-  * **-p**, **\--auth-key**=_KEY\_AUTH_:
+  * **-p**, **\--auth**=_KEY\_AUTH_:
 
     Optional authorization value to use the key specified by **-c**.
     Authorization values should follow the "authorization formatting standards",
     see section "Authorization Formatting".
 
-  * **-o**, **\--out-file**=_OUT\_FILE_:
+  * **-o**, **\--output**=_OUT\_FILE_:
 
     Output file name, containing the unsealed data. Defaults to stdout if not specified.
 
@@ -48,7 +48,7 @@ tpm2_unseal -c item.context -p abc123 -o out.dat
 
 tpm2_unseal -c 0x81010001 -p "hex:123abc" -o out.dat
 
-tpm2_unseal -c item.context -L sha1:0,1,2 -F out.dat
+tpm2_unseal -c item.context -p pcr:sha256:0,1+pcr.value -o out.dat
 ```
 
 # NOTES

--- a/man/tpm2_verifysignature.1.md
+++ b/man/tpm2_verifysignature.1.md
@@ -108,7 +108,7 @@ sha256sum data.in.raw | awk '{ print "000000 " $1 }' | xxd -r -c 32 > data.in.di
 tpm2_loadexternal -Q -G ecc -r private.ecc.pem -o key.ctx
 
 # Sign in the TPM and verify with OSSL
-tpm2_sign -Q -c key.ctx -g sha256 -D data.in.digest -f plain -s data.out.signed
+tpm2_sign -Q -c key.ctx -g sha256 -d data.in.digest -f plain -s data.out.signed
 
 openssl dgst -verify public.ecc.pem -keyform pem -sha256 -signature data.out.signed data.in.raw
 

--- a/man/tpm2_verifysignature.1.md
+++ b/man/tpm2_verifysignature.1.md
@@ -24,7 +24,7 @@ symmetric key, both the public and private portions need to be loaded.
     Context object for the key context used for the operation. Either a file
     or a handle number. See section "Context Object Format".
 
-  * **-g**, **\--halg**=_HASH\_ALGORITHM_:
+  * **-g**, **\--hash-algorithm**=_HASH\_ALGORITHM_:
 
     The hash algorithm used to digest the message.
     Algorithms should follow the "formatting standards", see section
@@ -36,13 +36,13 @@ symmetric key, both the public and private portions need to be loaded.
 
     The message file, containing the content to be  digested.
 
-  * **-D**, **\--digest**=_DIGEST\_FILE_:
+  * **-d**, **\--digest**=_DIGEST\_FILE_:
 
     The input hash file, containing the hash of the message. If this option is
     selected, then the message (**-m**) and algorithm (**-g**) options do not need
     to be specified.
 
-  * **-s**, **\--sig**=_SIG\_FILE_:
+  * **-s**, **\--signature**=_SIG\_FILE_:
 
     The input signature file of the signature to be validated.
 

--- a/test/integration/tests/abrmd_extended-sessions.sh
+++ b/test/integration/tests/abrmd_extended-sessions.sh
@@ -66,7 +66,7 @@ tpm2_pcrlist -Q -l ${alg_pcr_policy}:${pcr_ids} -o $file_pcr_value
 
 tpm2_startauthsession -Q -S $file_session_file
 
-tpm2_policypcr -Q -S $file_session_file -L ${alg_pcr_policy}:${pcr_ids} -F $file_pcr_value -o $file_policy
+tpm2_policypcr -Q -S $file_session_file -l ${alg_pcr_policy}:${pcr_ids} -f $file_pcr_value -L $file_policy
 
 tpm2_flushcontext -S $file_session_file
 
@@ -80,7 +80,7 @@ rm $file_session_file
 # Start a REAL encrypted and bound policy session (-a option) and perform a pcr policy event
 tpm2_startauthsession --policy-session -k $file_primary_key_ctx -S $file_session_file
 
-tpm2_policypcr -Q -S $file_session_file -L ${alg_pcr_policy}:${pcr_ids} -F $file_pcr_value -o $file_policy
+tpm2_policypcr -Q -S $file_session_file -l ${alg_pcr_policy}:${pcr_ids} -f $file_pcr_value -L $file_policy
 
 unsealed=`tpm2_unseal -p"session:$file_session_file" -c $file_unseal_key_ctx`
 

--- a/test/integration/tests/abrmd_extended-sessions.sh
+++ b/test/integration/tests/abrmd_extended-sessions.sh
@@ -78,7 +78,7 @@ tpm2_load -Q -C $file_primary_key_ctx -u $file_unseal_key_pub -r $file_unseal_ke
 rm $file_session_file
 
 # Start a REAL encrypted and bound policy session (-a option) and perform a pcr policy event
-tpm2_startauthsession --policy-session -k $file_primary_key_ctx -S $file_session_file
+tpm2_startauthsession --policy-session -c $file_primary_key_ctx -S $file_session_file
 
 tpm2_policypcr -Q -S $file_session_file -l ${alg_pcr_policy}:${pcr_ids} -f $file_pcr_value -L $file_policy
 

--- a/test/integration/tests/abrmd_extended-sessions.sh
+++ b/test/integration/tests/abrmd_extended-sessions.sh
@@ -62,7 +62,7 @@ tpm2_clear
 
 tpm2_createprimary -Q -C e -g $alg_primary_obj -G $alg_primary_key -o $file_primary_key_ctx
 
-tpm2_pcrlist -Q -L ${alg_pcr_policy}:${pcr_ids} -o $file_pcr_value
+tpm2_pcrlist -Q -l ${alg_pcr_policy}:${pcr_ids} -o $file_pcr_value
 
 tpm2_startauthsession -Q -S $file_session_file
 

--- a/test/integration/tests/abrmd_policyauthorize.sh
+++ b/test/integration/tests/abrmd_policyauthorize.sh
@@ -50,7 +50,7 @@ dd if=/dev/urandom of=$file_policyref bs=1 count=32 2>/dev/null
 
 tpm2_pcrlist -Q -l ${alg_pcr_policy}:${pcr_ids} -o $file_pcr_value
 tpm2_startauthsession -Q -S $file_session_file
-tpm2_policypcr -Q -S $file_session_file -L ${alg_pcr_policy}:${pcr_ids} -F $file_pcr_value -o $file_policy
+tpm2_policypcr -Q -S $file_session_file -l ${alg_pcr_policy}:${pcr_ids} -f $file_pcr_value -L $file_policy
 tpm2_flushcontext -S $file_session_file
 rm $file_session_file
 
@@ -62,7 +62,7 @@ tpm2_pcrextend  \
 
 tpm2_pcrlist -Q -l ${alg_pcr_policy}:${pcr_ids} -o $file_pcr_value
 tpm2_startauthsession -Q -S $file_session_file
-tpm2_policypcr -Q -S $file_session_file -L ${alg_pcr_policy}:${pcr_ids} -F $file_pcr_value -o $file_policy
+tpm2_policypcr -Q -S $file_session_file -l ${alg_pcr_policy}:${pcr_ids} -f $file_pcr_value -L $file_policy
 tpm2_flushcontext -S $file_session_file
 rm $file_session_file
 

--- a/test/integration/tests/abrmd_policyauthorize.sh
+++ b/test/integration/tests/abrmd_policyauthorize.sh
@@ -48,7 +48,7 @@ tpm2_loadexternal -G rsa -C n -u $file_public_key -o $file_verifying_key_ctx \
 
 dd if=/dev/urandom of=$file_policyref bs=1 count=32 2>/dev/null
 
-tpm2_pcrlist -Q -L ${alg_pcr_policy}:${pcr_ids} -o $file_pcr_value
+tpm2_pcrlist -Q -l ${alg_pcr_policy}:${pcr_ids} -o $file_pcr_value
 tpm2_startauthsession -Q -S $file_session_file
 tpm2_policypcr -Q -S $file_session_file -L ${alg_pcr_policy}:${pcr_ids} -F $file_pcr_value -o $file_policy
 tpm2_flushcontext -S $file_session_file
@@ -60,7 +60,7 @@ generate_policy_authorize $file_policy $file_policyref $file_authorized_policy_1
 tpm2_pcrextend  \
   0:sha256=e7011b851ee967e2d24e035ae41b0ada2decb182e4f7ad8411f2bf564c56fd6f
 
-tpm2_pcrlist -Q -L ${alg_pcr_policy}:${pcr_ids} -o $file_pcr_value
+tpm2_pcrlist -Q -l ${alg_pcr_policy}:${pcr_ids} -o $file_pcr_value
 tpm2_startauthsession -Q -S $file_session_file
 tpm2_policypcr -Q -S $file_session_file -L ${alg_pcr_policy}:${pcr_ids} -F $file_pcr_value -o $file_policy
 tpm2_flushcontext -S $file_session_file

--- a/test/integration/tests/abrmd_policyauthorize.sh
+++ b/test/integration/tests/abrmd_policyauthorize.sh
@@ -36,7 +36,7 @@ cleanup "no-shutdown"
 
 generate_policy_authorize () {
     tpm2_startauthsession -Q -S $file_session_file
-    tpm2_policyauthorize -Q -S $file_session_file  -o $3 -i $1 -q $2 -n $4
+    tpm2_policyauthorize -Q -S $file_session_file  -o $3 -L $1 -q $2 -n $4
     tpm2_flushcontext -S $file_session_file
     rm $file_session_file
 }

--- a/test/integration/tests/abrmd_policycommandcode.sh
+++ b/test/integration/tests/abrmd_policycommandcode.sh
@@ -37,7 +37,7 @@ tpm2_createprimary -Q -C o -o $file_primary_key_ctx
 
 tpm2_startauthsession -S $file_session_data
 
-tpm2_policycommandcode -S $file_session_data -o $file_policy unseal
+tpm2_policycommandcode -S $file_session_data -L $file_policy unseal
 
 tpm2_flushcontext -S $file_session_data
 
@@ -56,7 +56,7 @@ tpm2_load -C $file_primary_key_ctx -u $file_unseal_key_pub \
 # Ensure unsealing passes with proper policy
 tpm2_startauthsession --policy-session -S $file_session_data
 
-tpm2_policycommandcode -S $file_session_data -o $file_policy unseal
+tpm2_policycommandcode -S $file_session_data -L $file_policy unseal
 
 tpm2_unseal -p session:$file_session_data -c sealkey.ctx > $file_output_data
 

--- a/test/integration/tests/abrmd_policyor.sh
+++ b/test/integration/tests/abrmd_policyor.sh
@@ -35,7 +35,7 @@ cat $policy_init $policyor_cc $policy_1 $policy_2 > $concatenated
 openssl dgst -binary -sha256 $concatenated > $test_vector
 
 tpm2_startauthsession -S $session_ctx
-tpm2_policyor -o $o_policy_digest -L sha256:$policy_1,$policy_2 -S $session_ctx
+tpm2_policyor -L $o_policy_digest -l sha256:$policy_1,$policy_2 -S $session_ctx
 tpm2_flushcontext -S $session_ctx
 
 diff $test_vector $o_policy_digest

--- a/test/integration/tests/abrmd_policypassword.sh
+++ b/test/integration/tests/abrmd_policypassword.sh
@@ -33,7 +33,7 @@ cleanup "no-shutdown"
 echo "plaintext" > $plain_txt
 
 tpm2_startauthsession -S $session_ctx
-tpm2_policypassword -S $session_ctx -o $policypassword
+tpm2_policypassword -S $session_ctx -L $policypassword
 tpm2_flushcontext -S $session_ctx
 rm $session_ctx
 
@@ -46,7 +46,7 @@ tpm2_load -C $primary_key_ctx -u $key_pub -r $key_priv -o $key_ctx
 tpm2_encryptdecrypt -c $key_ctx -o $encrypted_txt -i $plain_txt -p $testpswd
 
 tpm2_startauthsession --policy-session -S $session_ctx
-tpm2_policypassword -S $session_ctx -o $policypassword
+tpm2_policypassword -S $session_ctx -L $policypassword
 tpm2_encryptdecrypt -c $key_ctx -i $encrypted_txt -o $decrypted_txt -d \
   -p session:$session_ctx+$testpswd
 tpm2_flushcontext -S $session_ctx

--- a/test/integration/tests/abrmd_policysecret.sh
+++ b/test/integration/tests/abrmd_policysecret.sh
@@ -35,7 +35,7 @@ tpm2_changeauth -c o ownerauth
 
 # Create Policy
 tpm2_startauthsession -S $session_ctx
-tpm2_policysecret -S $session_ctx -c $TPM_RH_OWNER -o $o_policy_digest ownerauth
+tpm2_policysecret -S $session_ctx -c $TPM_RH_OWNER -L $o_policy_digest ownerauth
 tpm2_flushcontext -S $session_ctx
 rm $session_ctx
 
@@ -47,7 +47,7 @@ tpm2_load -C $primary_ctx -u $seal_key_pub -r $seal_key_priv -o $seal_key_ctx
 
 # Satisfy policy and unseal data
 tpm2_startauthsession --policy-session -S $session_ctx
-echo -n "ownerauth" | tpm2_policysecret -S $session_ctx -c $TPM_RH_OWNER -o $o_policy_digest file:-
+echo -n "ownerauth" | tpm2_policysecret -S $session_ctx -c $TPM_RH_OWNER -L $o_policy_digest file:-
 unsealed=`tpm2_unseal -p"session:$session_ctx" -c $seal_key_ctx`
 tpm2_flushcontext -S $session_ctx
 rm $session_ctx
@@ -63,7 +63,7 @@ unsealed=""
 tpm2_changeauth -c o -p ownerauth
 
 tpm2_startauthsession --policy-session -S $session_ctx
-tpm2_policysecret -S $session_ctx -c $TPM_RH_OWNER -o $o_policy_digest
+tpm2_policysecret -S $session_ctx -c $TPM_RH_OWNER -L $o_policy_digest
 unsealed=`tpm2_unseal -p"session:$session_ctx" -c $seal_key_ctx`
 tpm2_flushcontext -S $session_ctx
 rm $session_ctx

--- a/test/integration/tests/activecredential.sh
+++ b/test/integration/tests/activecredential.sh
@@ -22,7 +22,7 @@ cleanup "no-shut-down"
 
 echo "12345678" > secret.data
 
-tpm2_createek -Q -c 0x81010009 -G rsa -p ek.pub
+tpm2_createek -Q -c 0x81010009 -G rsa -u ek.pub
 
 tpm2_createak -C 0x81010009 -c ak.ctx -G rsa -g sha256 -s rsassa -u ak.pub\
     -n ak.name -p akpass> ak.out

--- a/test/integration/tests/attestation.sh
+++ b/test/integration/tests/attestation.sh
@@ -101,7 +101,7 @@ tpm2_checkquote -Q -u $output_ak_pub_pem -m $output_quote -s $output_quotesig -F
 
 # Save U key from verifier
 tpm2_nvdefine -Q -x $handle_nv -C $handle_hier -s 32 -a "ownerread|ownerwrite" -p "indexpass" -P "$ownerpw"
-tpm2_nvwrite -Q -x $handle_nv -a $handle_hier -P "$ownerpw" $file_input_key
+tpm2_nvwrite -Q -x $handle_nv -C $handle_hier -P "$ownerpw" $file_input_key
 tpm2_nvread -Q -x $handle_nv -C $handle_hier -s 32 -P "$ownerpw"
 
 exit 0

--- a/test/integration/tests/attestation.sh
+++ b/test/integration/tests/attestation.sh
@@ -102,6 +102,6 @@ tpm2_checkquote -Q -u $output_ak_pub_pem -m $output_quote -s $output_quotesig -F
 # Save U key from verifier
 tpm2_nvdefine -Q -x $handle_nv -C $handle_hier -s 32 -a "ownerread|ownerwrite" -p "indexpass" -P "$ownerpw"
 tpm2_nvwrite -Q -x $handle_nv -a $handle_hier -P "$ownerpw" $file_input_key
-tpm2_nvread -Q -x $handle_nv -a $handle_hier -s 32 -P "$ownerpw"
+tpm2_nvread -Q -x $handle_nv -C $handle_hier -s 32 -P "$ownerpw"
 
 exit 0

--- a/test/integration/tests/attestation.sh
+++ b/test/integration/tests/attestation.sh
@@ -92,7 +92,7 @@ tpm2_pcrreset -Q $debug_pcr
 tpm2_pcrextend -Q $debug_pcr:sha256=$rand_pcr_value
 tpm2_pcrlist -Q
 getrandom 20
-tpm2_quote -Q -C $context_ak -L $digestAlg:$debug_pcr_list -q $loaded_randomness -m $output_quote -s $output_quotesig -p $output_quotepcr -g $digestAlg -P "$akpw"
+tpm2_quote -Q -C $context_ak -l $digestAlg:$debug_pcr_list -q $loaded_randomness -m $output_quote -s $output_quotesig -f $output_quotepcr -g $digestAlg -P "$akpw"
 
 
 # Verify quote

--- a/test/integration/tests/attestation.sh
+++ b/test/integration/tests/attestation.sh
@@ -41,7 +41,7 @@ cleanup() {
   tpm2_evictcontrol -Q -C o -c $handle_ek -P "$ownerpw" 2>/dev/null || true
   tpm2_evictcontrol -Q -C o -c $context_ak -P "$ownerpw" 2>/dev/null || true
 
-  tpm2_nvrelease -Q -x $handle_nv -a $handle_hier -P "$ownerpw" 2>/dev/null || true
+  tpm2_nvrelease -Q -x $handle_nv -C $handle_hier -P "$ownerpw" 2>/dev/null || true
 
   if [ $(ina "$@" "no-shut-down") -ne 0 ]; then
     shut_down

--- a/test/integration/tests/attestation.sh
+++ b/test/integration/tests/attestation.sh
@@ -65,7 +65,7 @@ tpm2_changeauth -c o "$ownerpw"
 tpm2_changeauth -c e "$endorsepw"
 
 # Key generation
-tpm2_createek -Q -c $handle_ek -G $ek_alg -p $output_ek_pub_pem -f pem -P "$ekpw" -w "$ownerpw" -e "$endorsepw"
+tpm2_createek -Q -c $handle_ek -G $ek_alg -u $output_ek_pub_pem -f pem -p "$ekpw" -w "$ownerpw" -P "$endorsepw"
 tpm2_readpublic -Q -c $handle_ek -o $output_ek_pub
 
 tpm2_createak -Q -C $handle_ek -c $context_ak -G $ak_alg -g $digestAlg\

--- a/test/integration/tests/checkquote.sh
+++ b/test/integration/tests/checkquote.sh
@@ -47,7 +47,7 @@ getrandom() {
 }
 
 # Key generation
-tpm2_createek -c $handle_ek -G $ek_alg -p $output_ek_pub_pem -f pem -P "$ekpw"
+tpm2_createek -c $handle_ek -G $ek_alg -u $output_ek_pub_pem -f pem -p "$ekpw"
 
 tpm2_createak -C $handle_ek -c $ak_ctx -G $ak_alg -g $digestAlg -s $signAlg\
   -u $output_ak_pub_pem -f pem -n $output_ak_pub_name -p "$akpw"

--- a/test/integration/tests/checkquote.sh
+++ b/test/integration/tests/checkquote.sh
@@ -55,7 +55,7 @@ tpm2_evictcontrol -Q -c $ak_ctx $handle_ak
 
 # Quoting
 getrandom 20
-tpm2_quote -C $handle_ak -L sha256:15,16,22 -q $loaded_randomness -m $output_quote -s $output_quotesig -p $output_quotepcr -g $digestAlg -P "$akpw"
+tpm2_quote -C $handle_ak -l sha256:15,16,22 -q $loaded_randomness -m $output_quote -s $output_quotesig -f $output_quotepcr -g $digestAlg -P "$akpw"
 
 # Verify quote
 tpm2_checkquote -u $output_ak_pub_pem -m $output_quote -s $output_quotesig -F $output_quotepcr -g $digestAlg -q $loaded_randomness

--- a/test/integration/tests/clearcontrol.sh
+++ b/test/integration/tests/clearcontrol.sh
@@ -13,7 +13,7 @@ trap cleanup EXIT
 
 start_up
 
-tpm2_clearcontrol -c l s
+tpm2_clearcontrol -C l s
 trap - ERR
 tpm2_clear
 

--- a/test/integration/tests/createak.sh
+++ b/test/integration/tests/createak.sh
@@ -23,7 +23,7 @@ start_up
 
 cleanup "no-shut-down"
 
-tpm2_createek -Q -c 0x8101000b -G rsa -p ek.pub
+tpm2_createek -Q -c 0x8101000b -G rsa -u ek.pub
 
 tpm2_createak -Q -C 0x8101000b -c ak.ctx -G rsa -g sha256 -s rsassa -u ak.pub -n ak.name
 
@@ -36,7 +36,7 @@ tpm2_evictcontrol -Q -C o -c $phandle
 # Test tpm2_createak with endorsement password
 cleanup "no-shut-down"
 tpm2_changeauth -c e endauth
-tpm2_createek -Q -e endauth -c 0x8101000b -G rsa -p ek.pub
+tpm2_createek -Q -P endauth -c 0x8101000b -G rsa -u ek.pub
 tpm2_createak -Q -P endauth -C 0x8101000b -c ak.ctx -G rsa -u ak.pub -n ak.name
 
 exit 0

--- a/test/integration/tests/createek.sh
+++ b/test/integration/tests/createek.sh
@@ -19,17 +19,17 @@ start_up
 
 cleanup "no-shut-down"
 
-tpm2_createek -c 0x81010005 -G rsa -p ek.pub
+tpm2_createek -c 0x81010005 -G rsa -u ek.pub
 
 cleanup "no-shut-down"
 
-tpm2_createek -c - -G rsa -p ek.pub > ek.log
+tpm2_createek -c - -G rsa -u ek.pub > ek.log
 phandle=`yaml_get_kv ek.log "persistent-handle"`
 tpm2_evictcontrol -Q -C o -c $phandle
 
 cleanup "no-shut-down"
 
-tpm2_createek -G rsa -p ek.pub
+tpm2_createek -G rsa -u ek.pub
 
 cleanup "no-shut-down"
 
@@ -46,7 +46,7 @@ echo -n -e '\0' > ek.nonce
 tpm2_nvdefine -Q -x $ek_nonce_index -C o -s 1 -a "ownerread|policywrite|ownerwrite"
 tpm2_nvwrite -Q -x $ek_nonce_index -a o ek.nonce
 
-tpm2_createek -t -G rsa -p ek.pub
+tpm2_createek -t -G rsa -u ek.pub
 
 cleanup "no-shut-down"
 

--- a/test/integration/tests/createek.sh
+++ b/test/integration/tests/createek.sh
@@ -39,12 +39,12 @@ ek_template_index=0x01c00004
 # Define RSA EK template
 nbytes=$(wc -c $TPM2_TOOLS_TEST_FIXTURES/ek-template-default.bin | cut -f1 -d' ')
 tpm2_nvdefine -Q -x $ek_template_index -C o -s $nbytes -a "ownerread|policywrite|ownerwrite"
-tpm2_nvwrite -Q -x $ek_template_index -a o $TPM2_TOOLS_TEST_FIXTURES/ek-template-default.bin
+tpm2_nvwrite -Q -x $ek_template_index -C o $TPM2_TOOLS_TEST_FIXTURES/ek-template-default.bin
 
 # Define RSA EK nonce
 echo -n -e '\0' > ek.nonce
 tpm2_nvdefine -Q -x $ek_nonce_index -C o -s 1 -a "ownerread|policywrite|ownerwrite"
-tpm2_nvwrite -Q -x $ek_nonce_index -a o ek.nonce
+tpm2_nvwrite -Q -x $ek_nonce_index -C o ek.nonce
 
 tpm2_createek -t -G rsa -u ek.pub
 

--- a/test/integration/tests/createpolicy.sh
+++ b/test/integration/tests/createpolicy.sh
@@ -29,7 +29,7 @@ do
     head -c $((${digestlengths[$halg]} - 1)) /dev/zero > pcr.in
     echo -n -e '\x03' >> pcr.in
 
-    tpm2_createpolicy --policy-pcr -L $halg:0 -F pcr.in -o policy.out
+    tpm2_createpolicy --policy-pcr -l $halg:0 -f pcr.in -L policy.out
 
     # Test the policy creation hashes against expected
     if [ $(xxd -p policy.out | tr -d '\n' ) != "${expected_policy_digest[${halg}]}" ]; then

--- a/test/integration/tests/duplicate.sh
+++ b/test/integration/tests/duplicate.sh
@@ -2,8 +2,6 @@
 
 source helpers.sh
 
-TPM_CC_DUPLICATE=0x14B
-
 cleanup() {
     rm -f primary.ctx \
           new_parent.prv new_parent.pub new_parent.ctx \
@@ -23,14 +21,14 @@ start_up
 
 create_duplication_policy() {
     tpm2_startauthsession -Q -S session.dat
-    tpm2_policycommandcode -Q -S session.dat -o policy.dat $TPM_CC_DUPLICATE
+    tpm2_policycommandcode -Q -S session.dat -L policy.dat duplicate
     tpm2_flushcontext -Q -S session.dat
     rm session.dat
 }
 
 start_duplication_session() {
     tpm2_startauthsession -Q --policy-session -S session.dat
-    tpm2_policycommandcode -Q -S session.dat -o policy.dat $TPM_CC_DUPLICATE
+    tpm2_policycommandcode -Q -S session.dat -L policy.dat duplicate
 }
 
 end_duplication_session() {

--- a/test/integration/tests/flushcontext.sh
+++ b/test/integration/tests/flushcontext.sh
@@ -29,7 +29,7 @@ tpm2_createprimary -Q -C o -g sha256 -G rsa
 tpm2_flushcontext -Q -t
 
 # Test for flushing a loaded session
-tpm2_createpolicy -Q --policy-session --policy-pcr -L sha256:0
+tpm2_createpolicy -Q --policy-session --policy-pcr -l sha256:0
 tpm2_flushcontext -Q -l
 
 cleanup "no-shut-down"

--- a/test/integration/tests/getmanufec.sh
+++ b/test/integration/tests/getmanufec.sh
@@ -40,7 +40,7 @@ tpm2_clear
 tpm2_changeauth -c o $opass
 tpm2_changeauth -c e $epass
 
-tpm2_getmanufec -H $handle -U -E ECcert2.bin -o test_ek.pub -w $opass -e $epass \
+tpm2_getmanufec -H $handle -U -E ECcert2.bin -o test_ek.pub -w $opass -P $epass \
                 https://ekop.intel.com/ekcertservice/
 
 tpm2_listpersistent | grep -q $handle
@@ -53,7 +53,7 @@ if [ $(md5sum ECcert.bin| awk '{ print $1 }') != "56af9eb8a271bbf7ac41b780acd91f
 fi
 
 # Test with automatic persistent handle
-tpm2_getmanufec -H - -U -E ECcert2.bin -o test_ek.pub -w $opass -e $epass \
+tpm2_getmanufec -H - -U -E ECcert2.bin -o test_ek.pub -w $opass -P $epass \
                 https://ekop.intel.com/ekcertservice/ > man.log
 phandle=`yaml_get_kv man.log "persistent-handle"`
 

--- a/test/integration/tests/hash.sh
+++ b/test/integration/tests/hash.sh
@@ -26,7 +26,7 @@ echo "T0naX0u123abc" > $hash_in_file
 
 # Test with ticket and hash output files and verify that the output hash
 # is correct. Ticket is not stable and changes run to run, don't verify it.
-tpm2_hash -a e -g sha1 -o $hash_out_file -t $ticket_file $hash_in_file 1>/dev/null
+tpm2_hash -C e -g sha1 -o $hash_out_file -t $ticket_file $hash_in_file 1>/dev/null
 
 expected=`sha1sum $hash_in_file | awk '{print $1}'`
 actual=`cat $hash_out_file | xxd -p -c 20`
@@ -38,7 +38,7 @@ cleanup "no-shut-down"
 # Test platform hierarchy with multiple files and verify output against sha256sum
 # Test a file redirection as well.
 echo "T0naX0u123abc" > $hash_in_file
-tpm2_hash -a p -g sha256 -Q -o $hash_out_file -t $ticket_file < $hash_in_file
+tpm2_hash -C p -g sha256 -Q -o $hash_out_file -t $ticket_file < $hash_in_file
 
 expected=`sha256sum $hash_in_file | awk '{print $1}'`
 actual=`cat $hash_out_file | xxd -p -c 32`
@@ -49,7 +49,7 @@ cleanup "no-shut-down"
 
 # Test stdout output as well as no options.
 # Validate that hash outputs are as expected.
-tpm_hash_val=`echo 1234 | tpm2_hash -a n | tee $out | grep sha1 | cut -d\: -f 2-2 | tr -d '[:space:]'`
+tpm_hash_val=`echo 1234 | tpm2_hash -C n | tee $out | grep sha1 | cut -d\: -f 2-2 | tr -d '[:space:]'`
 sha1sum_val=`echo 1234 | sha1sum  | cut -d\  -f 1-2 | tr -d '[:space:]'`
 if [ "$tpm_hash_val" != "$sha1sum_val" ]; then
   echo "Expected tpm and sha1sum to produce same hashes."

--- a/test/integration/tests/hmac.sh
+++ b/test/integration/tests/hmac.sh
@@ -52,13 +52,13 @@ tpm2_load -Q -C $file_primary_key_ctx  -u $file_hmac_key_pub  -r $file_hmac_key_
 # verify that persistent object can be used via a serialized handle
 tpm2_evictcontrol -C o -c $file_hmac_key_ctx -o $file_hmac_key_handle
 
-cat $file_input_data | tpm2_hmac -Q -C $file_hmac_key_handle -o $file_hmac_output
+cat $file_input_data | tpm2_hmac -Q -c $file_hmac_key_handle -o $file_hmac_output
 
 cleanup "keep-context" "no-shut-down"
 
 # Test large file, ie sequence hmac'ing.
 dd if=/dev/urandom of=$file_input_data bs=2093 count=1 2>/dev/null
-tpm2_hmac -Q -C $file_hmac_key_ctx -o $file_hmac_output $file_input_data
+tpm2_hmac -Q -c $file_hmac_key_ctx -o $file_hmac_output $file_input_data
 
 ####handle test
 rm -f $file_hmac_output
@@ -76,13 +76,13 @@ tpm2_create -Q -G $alg_create_key -u $file_hmac_key_pub -r $file_hmac_key_priv  
 
 tpm2_load -Q -C $file_primary_key_ctx  -u $file_hmac_key_pub  -r $file_hmac_key_priv -n $file_hmac_key_name -o $file_hmac_key_ctx
 
-cat $file_input_data | tpm2_hmac -Q -C $file_hmac_key_ctx -o $file_hmac_output
+cat $file_input_data | tpm2_hmac -Q -c $file_hmac_key_ctx -o $file_hmac_output
 
 # test no output file
-cat $file_input_data | tpm2_hmac -C $file_hmac_key_ctx 1>/dev/null
+cat $file_input_data | tpm2_hmac -c $file_hmac_key_ctx 1>/dev/null
 
 # verify that silent is indeed silent
-stdout=`cat $file_input_data | tpm2_hmac -Q -C $file_hmac_key_ctx`
+stdout=`cat $file_input_data | tpm2_hmac -Q -c $file_hmac_key_ctx`
 if [ -n "$stdout" ]; then
     echo "Expected no output when run in quiet mode, got\"$stdout\""
     exit 1

--- a/test/integration/tests/import.sh
+++ b/test/integration/tests/import.sh
@@ -68,7 +68,7 @@ run_rsa_import_test() {
 
     sha256sum data.in.raw | awk '{ print "000000 " $1 }' | xxd -r -c 32 > data.in.digest
 
-    tpm2_sign -Q -c import_rsa_key.ctx -g sha256 -D data.in.digest -f plain -o data.out.signed
+    tpm2_sign -Q -c import_rsa_key.ctx -g sha256 -d data.in.digest -f plain -o data.out.signed
 
     openssl dgst -verify public.pem -keyform pem -sha256 -signature data.out.signed data.in.raw
 
@@ -102,7 +102,7 @@ run_ecc_import_test() {
     tpm2_load -Q -C $1 -u ecc.pub -r ecc.priv -n ecc.name -o ecc.ctx
 
     # Sign in the TPM and verify with OSSL
-    tpm2_sign -Q -c ecc.ctx -g sha256 -D data.in.digest -f plain -o data.out.signed
+    tpm2_sign -Q -c ecc.ctx -g sha256 -d data.in.digest -f plain -o data.out.signed
     openssl dgst -verify public.ecc.pem -keyform pem -sha256 -signature data.out.signed data.in.raw
 
     # Sign with openssl and verify with TPM.

--- a/test/integration/tests/import_tpm.sh
+++ b/test/integration/tests/import_tpm.sh
@@ -22,14 +22,14 @@ start_up
 
 create_policy() {
     tpm2_startauthsession -Q -S session.dat
-    tpm2_policycommandcode -Q -S session.dat -o $1 $2
+    tpm2_policycommandcode -Q -S session.dat -L $1 $2
     tpm2_flushcontext -Q -S session.dat
     rm session.dat
 }
 
 start_session() {
     tpm2_startauthsession -Q --policy-session -S session.dat
-    tpm2_policycommandcode -Q -S session.dat -o $1 $2
+    tpm2_policycommandcode -Q -S session.dat -L $1 $2
 }
 
 end_session() {

--- a/test/integration/tests/loadexternal.sh
+++ b/test/integration/tests/loadexternal.sh
@@ -144,7 +144,7 @@ run_ecc_test() {
     tpm2_loadexternal -Q -G ecc -r private.ecc.pem -o key.ctx
 
     # Sign in the TPM and verify with OSSL
-    tpm2_sign -Q -c key.ctx -g sha256 -D data.in.digest -f plain -o data.out.signed
+    tpm2_sign -Q -c key.ctx -g sha256 -d data.in.digest -f plain -o data.out.signed
     openssl dgst -verify public.ecc.pem -keyform pem -sha256 -signature data.out.signed data.in.raw
 
     # Sign with openssl and verify with TPM but only with the public portion of an object loaded

--- a/test/integration/tests/makecredential.sh
+++ b/test/integration/tests/makecredential.sh
@@ -33,7 +33,7 @@ cleanup "no-shut-down"
 
 echo "12345678" > $file_input_data
 
-tpm2_createek -Q -c $handle_ek -G $ek_alg -p $output_ek_pub
+tpm2_createek -Q -c $handle_ek -G $ek_alg -u $output_ek_pub
 
 tpm2_createak -Q -C $handle_ek -c $ak_ctx -G $ak_alg -g $digestAlg -s $signAlg -u $output_ak_pub -n $output_ak_pub_name
 

--- a/test/integration/tests/nv.sh
+++ b/test/integration/tests/nv.sh
@@ -84,7 +84,7 @@ cmp nv.test_w cmp.dat
 
 tpm2_nvrelease -x $nv_test_index -C o
 
-tpm2_pcrlist -Q -L ${alg_pcr_policy}:${pcr_ids} -o $file_pcr_value
+tpm2_pcrlist -Q -l ${alg_pcr_policy}:${pcr_ids} -o $file_pcr_value
 
 tpm2_createpolicy -Q --policy-pcr -l ${alg_pcr_policy}:${pcr_ids} -f $file_pcr_value -L $file_policy
 

--- a/test/integration/tests/nv.sh
+++ b/test/integration/tests/nv.sh
@@ -41,7 +41,7 @@ tpm2_nvdefine -Q -x $nv_test_index -C o -s 32 -a "ownerread|policywrite|ownerwri
 
 echo "please123abc" > nv.test_w
 
-tpm2_nvwrite -Q -x $nv_test_index -a o nv.test_w
+tpm2_nvwrite -Q -x $nv_test_index -C o nv.test_w
 
 tpm2_nvread -Q -x $nv_test_index -C o -s 32 -o 0
 
@@ -60,7 +60,7 @@ echo -n "foo" > foo.dat
 dd if=foo.dat of=nv.test_w bs=1 seek=4 conv=notrunc 2>/dev/null
 
 # Test a pipe input
-cat foo.dat | tpm2_nvwrite -Q -x $nv_test_index -a o --offset 4
+cat foo.dat | tpm2_nvwrite -Q -x $nv_test_index -C o --offset 4
 
 tpm2_nvread -x $nv_test_index -C o -s 13 > cmp.dat
 
@@ -71,7 +71,7 @@ cmp nv.test_w cmp.dat
 
 trap - ERR
 
-tpm2_nvwrite -Q -x $nv_test_index -a o -o 30 foo.dat 2>/dev/null
+tpm2_nvwrite -Q -x $nv_test_index -C o -o 30 foo.dat 2>/dev/null
 if [ $? -eq 0 ]; then
   echo "Writing past the public size shouldn't work!"
   exit 1
@@ -91,7 +91,7 @@ tpm2_createpolicy -Q --policy-pcr -l ${alg_pcr_policy}:${pcr_ids} -f $file_pcr_v
 tpm2_nvdefine -Q -x 0x1500016 -C 0x40000001 -s 32 -L $file_policy -a "policyread|policywrite"
 
 # Write with index authorization for now, since tpm2_nvwrite does not support pcr policy.
-echo -n "policy locked" | tpm2_nvwrite -Q -x 0x1500016 -a 0x1500016 -P pcr:${alg_pcr_policy}:${pcr_ids}+$file_pcr_value
+echo -n "policy locked" | tpm2_nvwrite -Q -x 0x1500016 -C 0x1500016 -P pcr:${alg_pcr_policy}:${pcr_ids}+$file_pcr_value
 
 str=`tpm2_nvread -x 0x1500016 -C 0x1500016 -P pcr:${alg_pcr_policy}:${pcr_ids}+$file_pcr_value -s 13`
 
@@ -118,7 +118,7 @@ tpm2_nvdefine -Q -x $nv_test_index -C o -s $large_file_size -a 0x2000A
 base64 /dev/urandom | head -c $(($large_file_size)) > $large_file_name
 
 # Test file input redirection
-tpm2_nvwrite -Q -x $nv_test_index -a o < $large_file_name
+tpm2_nvwrite -Q -x $nv_test_index -C o < $large_file_name
 
 tpm2_nvread -x $nv_test_index -C o > $large_file_read_name
 
@@ -136,7 +136,7 @@ tpm2_nvdefine -Q -x $nv_test_index -C o -s 32 -a "ownerread|policywrite|ownerwri
 
 echo "foobar" > nv.readlock
 
-tpm2_nvwrite -Q -x $nv_test_index -a o nv.readlock
+tpm2_nvwrite -Q -x $nv_test_index -C o nv.readlock
 
 tpm2_nvread -Q -x $nv_test_index -C o -s 6 -o 0
 
@@ -173,16 +173,16 @@ tpm2_nvwrite -Q -x 0x1500015 -P "index" nv.test_w
 tpm2_nvread -Q -x 0x1500015 -P "index"
 
 # Use index password write/read, explicit -a
-tpm2_nvwrite -Q -x 0x1500015 -a 0x1500015 -P "index" nv.test_w
+tpm2_nvwrite -Q -x 0x1500015 -C 0x1500015 -P "index" nv.test_w
 tpm2_nvread -Q -x 0x1500015 -C 0x1500015 -P "index"
 
 # use owner password
-tpm2_nvwrite -Q -x 0x1500015 -a 0x40000001 -P "owner" nv.test_w
+tpm2_nvwrite -Q -x 0x1500015 -C 0x40000001 -P "owner" nv.test_w
 tpm2_nvread -Q -x 0x1500015 -C 0x40000001 -P "owner"
 
 # Check a bad password fails
 trap - ERR
-tpm2_nvwrite -Q -x 0x1500015 -a 0x1500015 -P "wrong" nv.test_w 2>/dev/null
+tpm2_nvwrite -Q -x 0x1500015 -C 0x1500015 -P "wrong" nv.test_w 2>/dev/null
 if [ $? -eq 0 ];then
  echo "nvwrite with bad password should fail!"
  exit 1

--- a/test/integration/tests/nv.sh
+++ b/test/integration/tests/nv.sh
@@ -13,9 +13,9 @@ file_pcr_value=pcr.bin
 file_policy=policy.data
 
 cleanup() {
-  tpm2_nvrelease -Q -x $nv_test_index -a o 2>/dev/null || true
-  tpm2_nvrelease -Q -x 0x1500016 -a 0x40000001 2>/dev/null || true
-  tpm2_nvrelease -Q -x 0x1500015 -a 0x40000001 -P owner 2>/dev/null || true
+  tpm2_nvrelease -Q -x $nv_test_index -C o 2>/dev/null || true
+  tpm2_nvrelease -Q -x 0x1500016 -C 0x40000001 2>/dev/null || true
+  tpm2_nvrelease -Q -x 0x1500015 -C 0x40000001 -P owner 2>/dev/null || true
 
   rm -f policy.bin test.bin nv.test_w $large_file_name $large_file_read_name \
         nv.readlock foo.dat cmp.dat $file_pcr_value $file_policy nv.out cap.out
@@ -82,7 +82,7 @@ tpm2_nvread -x $nv_test_index -C o -s 13 > cmp.dat
 
 cmp nv.test_w cmp.dat
 
-tpm2_nvrelease -x $nv_test_index -a o
+tpm2_nvrelease -x $nv_test_index -C o
 
 tpm2_pcrlist -Q -L ${alg_pcr_policy}:${pcr_ids} -o $file_pcr_value
 
@@ -102,7 +102,7 @@ trap - ERR
 tpm2_nvread -x 0x1500016 -C 0x1500016 -P "index" 2>/dev/null
 trap onerror ERR
 
-tpm2_nvrelease -Q -x 0x1500016 -a 0x40000001
+tpm2_nvrelease -Q -x 0x1500016 -C 0x40000001
 
 #
 # Test large writes
@@ -127,7 +127,7 @@ cmp -s $large_file_read_name $large_file_name
 tpm2_nvlist > nv.out
 yaml_get_kv nv.out "$nv_test_index" > /dev/null
 
-tpm2_nvrelease -Q -x $nv_test_index -a o
+tpm2_nvrelease -Q -x $nv_test_index -C o
 
 #
 # Test NV access locked
@@ -191,6 +191,6 @@ fi
 # Check using authorisation with tpm2_nvrelease
 trap onerror ERR
 
-tpm2_nvrelease -x 0x1500015 -a 0x40000001 -P "owner"
+tpm2_nvrelease -x 0x1500015 -C 0x40000001 -P "owner"
 
 exit 0

--- a/test/integration/tests/nv.sh
+++ b/test/integration/tests/nv.sh
@@ -140,7 +140,7 @@ tpm2_nvwrite -Q -x $nv_test_index -a o nv.readlock
 
 tpm2_nvread -Q -x $nv_test_index -C o -s 6 -o 0
 
-tpm2_nvreadlock -Q -x $nv_test_index -a o
+tpm2_nvreadlock -Q -x $nv_test_index -C o
 
 # Reset ERR signal handler to test for expected nvread error
 trap - ERR

--- a/test/integration/tests/nv.sh
+++ b/test/integration/tests/nv.sh
@@ -86,7 +86,7 @@ tpm2_nvrelease -x $nv_test_index -a o
 
 tpm2_pcrlist -Q -L ${alg_pcr_policy}:${pcr_ids} -o $file_pcr_value
 
-tpm2_createpolicy -Q --policy-pcr -L ${alg_pcr_policy}:${pcr_ids} -F $file_pcr_value -o $file_policy
+tpm2_createpolicy -Q --policy-pcr -l ${alg_pcr_policy}:${pcr_ids} -f $file_pcr_value -L $file_policy
 
 tpm2_nvdefine -Q -x 0x1500016 -C 0x40000001 -s 32 -L $file_policy -a "policyread|policywrite"
 

--- a/test/integration/tests/nv.sh
+++ b/test/integration/tests/nv.sh
@@ -43,7 +43,7 @@ echo "please123abc" > nv.test_w
 
 tpm2_nvwrite -Q -x $nv_test_index -a o nv.test_w
 
-tpm2_nvread -Q -x $nv_test_index -a o -s 32 -o 0
+tpm2_nvread -Q -x $nv_test_index -C o -s 32 -o 0
 
 tpm2_nvlist > nv.out
 yaml_get_kv nv.out "$nv_test_index" > /dev/null
@@ -62,7 +62,7 @@ dd if=foo.dat of=nv.test_w bs=1 seek=4 conv=notrunc 2>/dev/null
 # Test a pipe input
 cat foo.dat | tpm2_nvwrite -Q -x $nv_test_index -a o --offset 4
 
-tpm2_nvread -x $nv_test_index -a o -s 13 > cmp.dat
+tpm2_nvread -x $nv_test_index -C o -s 13 > cmp.dat
 
 cmp nv.test_w cmp.dat
 
@@ -78,7 +78,7 @@ if [ $? -eq 0 ]; then
 fi
 trap onerror ERR
 
-tpm2_nvread -x $nv_test_index -a o -s 13 > cmp.dat
+tpm2_nvread -x $nv_test_index -C o -s 13 > cmp.dat
 
 cmp nv.test_w cmp.dat
 
@@ -93,13 +93,13 @@ tpm2_nvdefine -Q -x 0x1500016 -C 0x40000001 -s 32 -L $file_policy -a "policyread
 # Write with index authorization for now, since tpm2_nvwrite does not support pcr policy.
 echo -n "policy locked" | tpm2_nvwrite -Q -x 0x1500016 -a 0x1500016 -P pcr:${alg_pcr_policy}:${pcr_ids}+$file_pcr_value
 
-str=`tpm2_nvread -x 0x1500016 -a 0x1500016 -P pcr:${alg_pcr_policy}:${pcr_ids}+$file_pcr_value -s 13`
+str=`tpm2_nvread -x 0x1500016 -C 0x1500016 -P pcr:${alg_pcr_policy}:${pcr_ids}+$file_pcr_value -s 13`
 
 test "policy locked" == "$str"
 
 # this should fail because authread is not allowed
 trap - ERR
-tpm2_nvread -x 0x1500016 -a 0x1500016 -P "index" 2>/dev/null
+tpm2_nvread -x 0x1500016 -C 0x1500016 -P "index" 2>/dev/null
 trap onerror ERR
 
 tpm2_nvrelease -Q -x 0x1500016 -a 0x40000001
@@ -120,7 +120,7 @@ base64 /dev/urandom | head -c $(($large_file_size)) > $large_file_name
 # Test file input redirection
 tpm2_nvwrite -Q -x $nv_test_index -a o < $large_file_name
 
-tpm2_nvread -x $nv_test_index -a o > $large_file_read_name
+tpm2_nvread -x $nv_test_index -C o > $large_file_read_name
 
 cmp -s $large_file_read_name $large_file_name
 
@@ -138,14 +138,14 @@ echo "foobar" > nv.readlock
 
 tpm2_nvwrite -Q -x $nv_test_index -a o nv.readlock
 
-tpm2_nvread -Q -x $nv_test_index -a o -s 6 -o 0
+tpm2_nvread -Q -x $nv_test_index -C o -s 6 -o 0
 
 tpm2_nvreadlock -Q -x $nv_test_index -a o
 
 # Reset ERR signal handler to test for expected nvread error
 trap - ERR
 
-tpm2_nvread -Q -x $nv_test_index -a o -s 6 -o 0 2> /dev/null
+tpm2_nvread -Q -x $nv_test_index -C o -s 6 -o 0 2> /dev/null
 if [ $? != 1 ];then
  echo "nvread didn't fail!"
  exit 1
@@ -174,11 +174,11 @@ tpm2_nvread -Q -x 0x1500015 -P "index"
 
 # Use index password write/read, explicit -a
 tpm2_nvwrite -Q -x 0x1500015 -a 0x1500015 -P "index" nv.test_w
-tpm2_nvread -Q -x 0x1500015 -a 0x1500015 -P "index"
+tpm2_nvread -Q -x 0x1500015 -C 0x1500015 -P "index"
 
 # use owner password
 tpm2_nvwrite -Q -x 0x1500015 -a 0x40000001 -P "owner" nv.test_w
-tpm2_nvread -Q -x 0x1500015 -a 0x40000001 -P "owner"
+tpm2_nvread -Q -x 0x1500015 -C 0x40000001 -P "owner"
 
 # Check a bad password fails
 trap - ERR

--- a/test/integration/tests/nvinc.sh
+++ b/test/integration/tests/nvinc.sh
@@ -34,7 +34,7 @@ tpm2_nvdefine -Q -x $nv_test_index -C o -s 8 -a "ownerread|policywrite|ownerwrit
 
 tpm2_nvincrement -Q -x $nv_test_index -C o
 
-tpm2_nvread -Q -x $nv_test_index -a o -s 8
+tpm2_nvread -Q -x $nv_test_index -C o -s 8
 
 tpm2_nvlist > nv.out
 yaml_get_kv nv.out "$nv_test_index" > /dev/null
@@ -48,7 +48,7 @@ echo -n -e '\x00\x00\x00\x00\x00\x00\x00\x02' > nv.test_inc
 
 tpm2_nvincrement -Q -x $nv_test_index -C o
 
-tpm2_nvread -x $nv_test_index -a o -s 8 > cmp.dat
+tpm2_nvread -x $nv_test_index -C o -s 8 > cmp.dat
 
 cmp nv.test_inc cmp.dat
 
@@ -67,13 +67,13 @@ echo -n -e '\x00\x00\x00\x00\x00\x00\x00\x03' > nv.test_inc
 # Counter is initialised to highest value previously seen (in this case 2) then incremented
 tpm2_nvincrement -Q -x 0x1500016 -C 0x1500016 -P pcr:${alg_pcr_policy}:${pcr_ids}+$file_pcr_value
 
-tpm2_nvread -x 0x1500016 -a 0x1500016 -P pcr:${alg_pcr_policy}:${pcr_ids}+$file_pcr_value -s 8 > cmp.dat
+tpm2_nvread -x 0x1500016 -C 0x1500016 -P pcr:${alg_pcr_policy}:${pcr_ids}+$file_pcr_value -s 8 > cmp.dat
 
 cmp nv.test_inc cmp.dat
 
 # this should fail because authread is not allowed
 trap - ERR
-tpm2_nvread -x 0x1500016 -a 0x1500016 -P "index" 2>/dev/null
+tpm2_nvread -x 0x1500016 -C 0x1500016 -P "index" 2>/dev/null
 trap onerror ERR
 
 tpm2_nvrelease -Q -x 0x1500016 -a 0x40000001
@@ -86,14 +86,14 @@ tpm2_nvdefine -Q -x $nv_test_index -C o -s 8 -a "ownerread|policywrite|ownerwrit
 
 tpm2_nvincrement -Q -x $nv_test_index -C o
 
-tpm2_nvread -Q -x $nv_test_index -a o -s 8
+tpm2_nvread -Q -x $nv_test_index -C o -s 8
 
 tpm2_nvreadlock -Q -x $nv_test_index -a o
 
 # Reset ERR signal handler to test for expected nvread error
 trap - ERR
 
-tpm2_nvread -Q -x $nv_test_index -a o -s 8 2> /dev/null
+tpm2_nvread -Q -x $nv_test_index -C o -s 8 2> /dev/null
 if [ $? != 1 ];then
  echo "nvread didn't fail!"
  exit 1
@@ -122,11 +122,11 @@ tpm2_nvread -Q -x 0x1500015 -P "index"
 
 # Use index password write/read, explicit -C
 tpm2_nvincrement -Q -x 0x1500015 -C 0x1500015 -P "index"
-tpm2_nvread -Q -x 0x1500015 -a 0x1500015 -P "index"
+tpm2_nvread -Q -x 0x1500015 -C 0x1500015 -P "index"
 
 # use owner password
 tpm2_nvincrement -Q -x 0x1500015 -C 0x40000001 -P "owner"
-tpm2_nvread -Q -x 0x1500015 -a 0x40000001 -P "owner"
+tpm2_nvread -Q -x 0x1500015 -C 0x40000001 -P "owner"
 
 # Check a bad password fails
 trap - ERR

--- a/test/integration/tests/nvinc.sh
+++ b/test/integration/tests/nvinc.sh
@@ -88,7 +88,7 @@ tpm2_nvincrement -Q -x $nv_test_index -C o
 
 tpm2_nvread -Q -x $nv_test_index -C o -s 8
 
-tpm2_nvreadlock -Q -x $nv_test_index -a o
+tpm2_nvreadlock -Q -x $nv_test_index -C o
 
 # Reset ERR signal handler to test for expected nvread error
 trap - ERR

--- a/test/integration/tests/nvinc.sh
+++ b/test/integration/tests/nvinc.sh
@@ -57,7 +57,7 @@ tpm2_nvrelease -x $nv_test_index -a o
 
 tpm2_pcrlist -Q -L ${alg_pcr_policy}:${pcr_ids} -o $file_pcr_value
 
-tpm2_createpolicy -Q --policy-pcr -L ${alg_pcr_policy}:${pcr_ids} -F $file_pcr_value -o $file_policy
+tpm2_createpolicy -Q --policy-pcr -l ${alg_pcr_policy}:${pcr_ids} -f $file_pcr_value -L $file_policy
 
 tpm2_nvdefine -Q -x 0x1500016 -C 0x40000001 -s 8 -L $file_policy -a "policyread|policywrite|nt=1"
 

--- a/test/integration/tests/nvinc.sh
+++ b/test/integration/tests/nvinc.sh
@@ -11,9 +11,9 @@ file_pcr_value=pcr.bin
 file_policy=policy.data
 
 cleanup() {
-  tpm2_nvrelease -Q -x $nv_test_index -a o 2>/dev/null || true
-  tpm2_nvrelease -Q -x 0x1500016 -a 0x40000001 2>/dev/null || true
-  tpm2_nvrelease -Q -x 0x1500015 -a 0x40000001 -P owner 2>/dev/null || true
+  tpm2_nvrelease -Q -x $nv_test_index -C o 2>/dev/null || true
+  tpm2_nvrelease -Q -x 0x1500016 -C 0x40000001 2>/dev/null || true
+  tpm2_nvrelease -Q -x 0x1500015 -C 0x40000001 -P owner 2>/dev/null || true
 
   rm -f policy.bin test.bin nv.test_inc nv.readlock foo.dat cmp.dat \
         $file_pcr_value $file_policy nv.out cap.out
@@ -52,7 +52,7 @@ tpm2_nvread -x $nv_test_index -C o -s 8 > cmp.dat
 
 cmp nv.test_inc cmp.dat
 
-tpm2_nvrelease -x $nv_test_index -a o
+tpm2_nvrelease -x $nv_test_index -C o
 
 
 tpm2_pcrlist -Q -L ${alg_pcr_policy}:${pcr_ids} -o $file_pcr_value
@@ -76,7 +76,7 @@ trap - ERR
 tpm2_nvread -x 0x1500016 -C 0x1500016 -P "index" 2>/dev/null
 trap onerror ERR
 
-tpm2_nvrelease -Q -x 0x1500016 -a 0x40000001
+tpm2_nvrelease -Q -x 0x1500016 -C 0x40000001
 
 
 #
@@ -139,6 +139,6 @@ fi
 # Check using authorisation with tpm2_nvrelease
 trap onerror ERR
 
-tpm2_nvrelease -x 0x1500015 -a 0x40000001 -P "owner"
+tpm2_nvrelease -x 0x1500015 -C 0x40000001 -P "owner"
 
 exit 0

--- a/test/integration/tests/nvinc.sh
+++ b/test/integration/tests/nvinc.sh
@@ -55,7 +55,7 @@ cmp nv.test_inc cmp.dat
 tpm2_nvrelease -x $nv_test_index -C o
 
 
-tpm2_pcrlist -Q -L ${alg_pcr_policy}:${pcr_ids} -o $file_pcr_value
+tpm2_pcrlist -Q -l ${alg_pcr_policy}:${pcr_ids} -o $file_pcr_value
 
 tpm2_createpolicy -Q --policy-pcr -l ${alg_pcr_policy}:${pcr_ids} -f $file_pcr_value -L $file_policy
 

--- a/test/integration/tests/output_formats.sh
+++ b/test/integration/tests/output_formats.sh
@@ -88,7 +88,7 @@ done
 
 for fmt in tss plain; do
     this_sig="${file_quote_sig_base}.${fmt}"
-    tpm2_quote -Q -C $handle_ak -l 0 -L "$alg_hash":0 -f $fmt -m "$file_quote_msg" -s "$this_sig"
+    tpm2_quote -Q -C $handle_ak -i 0 -l "$alg_hash":0 -F $fmt -m "$file_quote_msg" -s "$this_sig"
 
     if [ "$fmt" = plain ]; then
         openssl dgst -verify "$file_pubak_pem" -keyform pem -${alg_hash} -signature "$this_sig" "$file_quote_msg" > /dev/null

--- a/test/integration/tests/output_formats.sh
+++ b/test/integration/tests/output_formats.sh
@@ -53,7 +53,7 @@ start_up
 
 head -c 4096 /dev/urandom > $file_hash_input
 
-tpm2_createek -Q -G $alg_ek -p "$file_pubek_orig" -c $handle_ek
+tpm2_createek -Q -G $alg_ek -u "$file_pubek_orig" -c $handle_ek
 
 for fmt in tss pem der; do
 

--- a/test/integration/tests/output_formats.sh
+++ b/test/integration/tests/output_formats.sh
@@ -75,7 +75,7 @@ tpm2_evictcontrol -Q -c $ak_ctx -o $handle_ak_file $handle_ak
 
 tpm2_readpublic -Q -c $handle_ak_file -f "pem" -o "$file_pubak_pem"
 
-tpm2_hash -Q -a e -g $alg_hash -t "$file_hash_ticket" -o "$file_hash_result" "$file_hash_input"
+tpm2_hash -Q -C e -g $alg_hash -t "$file_hash_ticket" -o "$file_hash_result" "$file_hash_input"
 
 for fmt in tss plain; do
     this_sig="${file_sig_base}.${fmt}"

--- a/test/integration/tests/pcrevent.sh
+++ b/test/integration/tests/pcrevent.sh
@@ -45,14 +45,14 @@ while IFS='' read -r l || [[ -n "$l" ]]; do
   fi
 done < $hash_out_file
 
-tpm2_pcrlist -L sha1:9 > $yaml_out_file
+tpm2_pcrlist -l sha1:9 > $yaml_out_file
 old_pcr_value=`yaml_get_kv $yaml_out_file "sha1" "9"`
 
 # Verify that extend works, and test large files
 dd if=/dev/urandom of=$hash_in_file count=1 bs=2093 2> /dev/null
 tpm2_pcrevent -Q -x 9 $hash_in_file
 
-tpm2_pcrlist -L sha1:9 > $yaml_out_file
+tpm2_pcrlist -l sha1:9 > $yaml_out_file
 new_pcr_value=`yaml_get_kv $yaml_out_file "sha1" "9"`
 
 if [ "$new_pcr_value" == "$old_pcr_value" ]; then

--- a/test/integration/tests/pcrlist.sh
+++ b/test/integration/tests/pcrlist.sh
@@ -20,7 +20,7 @@ yaml_verify pcrs.out
 
 tpm2_pcrlist -Q -g 0x04
 
-tpm2_pcrlist -Q -L 0x04:17,18,19+sha256:0,17,18,19 -o pcrs.out
+tpm2_pcrlist -Q -l 0x04:17,18,19+sha256:0,17,18,19 -o pcrs.out
 
 test -e pcrs.out
 

--- a/test/integration/tests/print.sh
+++ b/test/integration/tests/print.sh
@@ -34,7 +34,7 @@ tpm2_createak -Q -G rsa -g sha256 -s rsassa -C $ek_handle -c $ak_ctx\
   -u $ak_pubkey_file -n $ak_name_file
 
 # Take PCR quote
-tpm2_quote -Q -C $ak_ctx -L "sha256:0,2,4,9,10,11,12,17" -q "0f8beb45ac" -m $quote_file
+tpm2_quote -Q -C $ak_ctx -l "sha256:0,2,4,9,10,11,12,17" -q "0f8beb45ac" -m $quote_file
 
 # Print TPM's quote file
 tpm2_print -t TPMS_ATTEST -i $quote_file > $print_file

--- a/test/integration/tests/quote.sh
+++ b/test/integration/tests/quote.sh
@@ -61,18 +61,18 @@ tpm2_create -Q -g $alg_create_obj -G $alg_create_key -u $file_quote_key_pub -r $
 
 tpm2_load -Q -C $file_primary_key_ctx  -u $file_quote_key_pub  -r $file_quote_key_priv -n $file_quote_key_name -o $file_quote_key_ctx
 
-tpm2_quote -C $file_quote_key_ctx  -L $alg_quote:16,17,18 -q $nonce -m $toss_out -s $toss_out -p $toss_out -g $alg_primary_obj > $out
+tpm2_quote -C $file_quote_key_ctx  -l $alg_quote:16,17,18 -q $nonce -m $toss_out -s $toss_out -f $toss_out -g $alg_primary_obj > $out
 
 yaml_verify $out
 
-tpm2_quote -Q -C $file_quote_key_ctx  -L $alg_quote:16,17,18+$alg_quote1:16,17,18 -q $nonce -m $toss_out -s $toss_out -p $toss_out -g $alg_primary_obj
+tpm2_quote -Q -C $file_quote_key_ctx  -l $alg_quote:16,17,18+$alg_quote1:16,17,18 -q $nonce -m $toss_out -s $toss_out -f $toss_out -g $alg_primary_obj
 
 #####handle testing
 tpm2_evictcontrol -Q -C o -c $file_quote_key_ctx $Handle_ak_quote
 
-tpm2_quote -Q -C $Handle_ak_quote -L $alg_quote:16,17,18 -q $nonce -m $toss_out -s $toss_out -p $toss_out -g $alg_primary_obj
+tpm2_quote -Q -C $Handle_ak_quote -l $alg_quote:16,17,18 -q $nonce -m $toss_out -s $toss_out -f $toss_out -g $alg_primary_obj
 
-tpm2_quote -Q -C $Handle_ak_quote  -L $alg_quote:16,17,18+$alg_quote1:16,17,18 -q $nonce -m $toss_out -s $toss_out -p $toss_out -g $alg_primary_obj
+tpm2_quote -Q -C $Handle_ak_quote  -l $alg_quote:16,17,18+$alg_quote1:16,17,18 -q $nonce -m $toss_out -s $toss_out -f $toss_out -g $alg_primary_obj
 
 #####AK
 tpm2_createek -Q -c $Handle_ek_quote -G 0x01 -p ek.pub2
@@ -80,6 +80,6 @@ tpm2_createek -Q -c $Handle_ek_quote -G 0x01 -p ek.pub2
 tpm2_createak -Q -C $Handle_ek_quote -c $ak2_ctx -u ak.pub2 -n ak.name_2
 tpm2_evictcontrol -Q -C o -c $ak2_ctx $Handle_ak_quote2
 
-tpm2_quote -Q -C $Handle_ak_quote -L $alg_quote:16,17,18 -l 16,17,18 -q $nonce -m $toss_out -s $toss_out -p $toss_out -g $alg_primary_obj
+tpm2_quote -Q -C $Handle_ak_quote -l $alg_quote:16,17,18 -i 16,17,18 -q $nonce -m $toss_out -s $toss_out -f $toss_out -g $alg_primary_obj
 
 exit 0

--- a/test/integration/tests/sign.sh
+++ b/test/integration/tests/sign.sh
@@ -60,7 +60,7 @@ test_symmetric() {
 
     # generate hash and test validation
 
-    tpm2_hash -Q -a e -g $alg_hash -o $file_output_hash -t $file_output_ticket $file_input_data
+    tpm2_hash -Q -C e -g $alg_hash -o $file_output_hash -t $file_output_ticket $file_input_data
 
     tpm2_sign -Q -c $handle_signing_key -g $alg_hash -o $file_output_data -m $file_input_data -t $file_output_ticket
 

--- a/test/integration/tests/sign.sh
+++ b/test/integration/tests/sign.sh
@@ -70,13 +70,13 @@ test_symmetric() {
 
     sha256sum $file_input_data | awk '{ print "000000 " $1 }' | xxd -r -c 32 > $file_input_digest
 
-    tpm2_sign -Q -c $handle_signing_key -g $alg_hash -D $file_input_digest -o $file_output_data
+    tpm2_sign -Q -c $handle_signing_key -g $alg_hash -d $file_input_digest -o $file_output_data
 
     rm -f $file_output_data
 
     # test with digest + message/validation (warning generated)
 
-    tpm2_sign -Q -c $handle_signing_key -g $alg_hash -D $file_input_digest -o $file_output_data -m $file_input_data -t $file_output_ticket |& grep -q ^WARN
+    tpm2_sign -Q -c $handle_signing_key -g $alg_hash -d $file_input_digest -o $file_output_data -m $file_input_data -t $file_output_ticket |& grep -q ^WARN
 }
 
 create_signature() {

--- a/test/integration/tests/unseal.sh
+++ b/test/integration/tests/unseal.sh
@@ -68,7 +68,7 @@ rm $file_unseal_key_pub $file_unseal_key_priv $file_unseal_key_name $file_unseal
 
 tpm2_pcrlist -Q -L ${alg_pcr_policy}:${pcr_ids} -o $file_pcr_value
 
-tpm2_createpolicy -Q --policy-pcr -L ${alg_pcr_policy}:${pcr_ids} -F $file_pcr_value -o $file_policy
+tpm2_createpolicy -Q --policy-pcr -l ${alg_pcr_policy}:${pcr_ids} -f $file_pcr_value -L $file_policy
 
 tpm2_create -Q -g $alg_create_obj -u $file_unseal_key_pub -r $file_unseal_key_priv -i- -C $file_primary_key_ctx -L $file_policy \
   -a 'fixedtpm|fixedparent' <<< $secret
@@ -109,7 +109,7 @@ rm $file_unseal_key_pub $file_unseal_key_priv $file_unseal_key_name $file_unseal
 
 tpm2_pcrlist -Q -L ${alg_pcr_policy}:${pcr_ids} -o $file_pcr_value
 
-tpm2_createpolicy -Q --policy-pcr -L ${alg_pcr_policy}:${pcr_ids} -F $file_pcr_value -o $file_policy
+tpm2_createpolicy -Q --policy-pcr -l ${alg_pcr_policy}:${pcr_ids} -f $file_pcr_value -L $file_policy
 
 tpm2_create -Q -g $alg_create_obj -u $file_unseal_key_pub -r $file_unseal_key_priv -i- -C $file_primary_key_ctx -L $file_policy -p secretpass <<< $secret
 

--- a/test/integration/tests/unseal.sh
+++ b/test/integration/tests/unseal.sh
@@ -66,7 +66,7 @@ cmp -s $file_unseal_output_data $file_input_data
 
 rm $file_unseal_key_pub $file_unseal_key_priv $file_unseal_key_name $file_unseal_key_ctx
 
-tpm2_pcrlist -Q -L ${alg_pcr_policy}:${pcr_ids} -o $file_pcr_value
+tpm2_pcrlist -Q -l ${alg_pcr_policy}:${pcr_ids} -o $file_pcr_value
 
 tpm2_createpolicy -Q --policy-pcr -l ${alg_pcr_policy}:${pcr_ids} -f $file_pcr_value -L $file_policy
 
@@ -107,7 +107,7 @@ trap onerror ERR
 
 rm $file_unseal_key_pub $file_unseal_key_priv $file_unseal_key_name $file_unseal_key_ctx
 
-tpm2_pcrlist -Q -L ${alg_pcr_policy}:${pcr_ids} -o $file_pcr_value
+tpm2_pcrlist -Q -l ${alg_pcr_policy}:${pcr_ids} -o $file_pcr_value
 
 tpm2_createpolicy -Q --policy-pcr -l ${alg_pcr_policy}:${pcr_ids} -f $file_pcr_value -L $file_policy
 

--- a/test/integration/tests/unseal.sh
+++ b/test/integration/tests/unseal.sh
@@ -75,7 +75,7 @@ tpm2_create -Q -g $alg_create_obj -u $file_unseal_key_pub -r $file_unseal_key_pr
 
 tpm2_load -Q -C $file_primary_key_ctx  -u $file_unseal_key_pub  -r $file_unseal_key_priv -n $file_unseal_key_name -o $file_unseal_key_ctx
 
-unsealed=`tpm2_unseal -V --context-object $file_unseal_key_ctx -p pcr:${alg_pcr_policy}:${pcr_ids}+$file_pcr_value`
+unsealed=`tpm2_unseal -V --object-context $file_unseal_key_ctx -p pcr:${alg_pcr_policy}:${pcr_ids}+$file_pcr_value`
 
 test "$unsealed" == "$secret"
 

--- a/test/integration/tests/verifysignature.sh
+++ b/test/integration/tests/verifysignature.sh
@@ -50,7 +50,7 @@ tpm2_sign -Q -c $file_signing_key_ctx -g $alg_hash -m $file_input_data -o $file_
 
 tpm2_verifysignature -Q -c $file_signing_key_ctx -g $alg_hash -m $file_input_data -s $file_output_data -t $file_verify_tk_data
 
-tpm2_hash -Q -a n -g $alg_hash -o $file_input_data_hash -t $file_input_data_hash_tk $file_input_data
+tpm2_hash -Q -C n -g $alg_hash -o $file_input_data_hash -t $file_input_data_hash_tk $file_input_data
 
 rm -f $file_verify_tk_data
 tpm2_verifysignature -Q -c $file_signing_key_ctx -D $file_input_data_hash -s $file_output_data -t $file_verify_tk_data

--- a/test/integration/tests/verifysignature.sh
+++ b/test/integration/tests/verifysignature.sh
@@ -53,7 +53,7 @@ tpm2_verifysignature -Q -c $file_signing_key_ctx -g $alg_hash -m $file_input_dat
 tpm2_hash -Q -C n -g $alg_hash -o $file_input_data_hash -t $file_input_data_hash_tk $file_input_data
 
 rm -f $file_verify_tk_data
-tpm2_verifysignature -Q -c $file_signing_key_ctx -D $file_input_data_hash -s $file_output_data -t $file_verify_tk_data
+tpm2_verifysignature -Q -c $file_signing_key_ctx -d $file_input_data_hash -s $file_output_data -t $file_verify_tk_data
 
 rm -f $file_verify_tk_data $file_signing_key_ctx -rf
 tpm2_loadexternal -Q -C n -u $file_signing_key_pub -o $file_signing_key_ctx

--- a/tools/tpm2_certify.c
+++ b/tools/tpm2_certify.c
@@ -203,7 +203,7 @@ bool tpm2_tool_onstart(tpm2_options **opts) {
       { "signingkey-context",   required_argument, NULL, 'C' },
       { "certifiedkey-auth",    required_argument, NULL, 'p' },
       { "signingkey-auth",      required_argument, NULL, 'P' },
-      { "halg",                 required_argument, NULL, 'g' },
+      { "hash-algorithm",       required_argument, NULL, 'g' },
       { "attestation",          required_argument, NULL, 'o' },
       { "signature",            required_argument, NULL, 's' },
       { "format",               required_argument, NULL, 'f' },

--- a/tools/tpm2_changeauth.c
+++ b/tools/tpm2_changeauth.c
@@ -111,7 +111,7 @@ bool tpm2_tool_onstart(tpm2_options **opts) {
         { "object-auth",                required_argument, NULL, 'p' },
         { "object-context",             required_argument, NULL, 'c' },
         { "parent-context",             required_argument, NULL, 'C' },
-        { "privfile",                   required_argument, NULL, 'r' },
+        { "private",                    required_argument, NULL, 'r' },
     };
     *opts = tpm2_options_new("p:c:C:r:", ARRAY_LEN(topts), topts,
                              on_option, on_arg, 0);

--- a/tools/tpm2_clearcontrol.c
+++ b/tools/tpm2_clearcontrol.c
@@ -80,10 +80,10 @@ bool on_arg (int argc, char **argv) {
 static bool on_option(char key, char *value) {
 
     switch (key) {
-    case 'c':
+    case 'C':
         ctx.auth_hierarchy.ctx_path = value;
         break;
-    case 'p':
+    case 'P':
         ctx.auth_hierarchy.auth_str = value;
         break;
     }
@@ -94,11 +94,11 @@ static bool on_option(char key, char *value) {
 bool tpm2_tool_onstart(tpm2_options **opts) {
 
     const struct option topts[] = {
-        { "auth-handle",    required_argument, NULL, 'c' },
-        { "auth",           required_argument, NULL, 'p' },
+        { "hierarchy",      required_argument, NULL, 'C' },
+        { "auth",           required_argument, NULL, 'P' },
     };
 
-    *opts = tpm2_options_new("c:p:", ARRAY_LEN(topts), topts, on_option,
+    *opts = tpm2_options_new("C:P:", ARRAY_LEN(topts), topts, on_option,
         on_arg, 0);
 
     return *opts != NULL;

--- a/tools/tpm2_create.c
+++ b/tools/tpm2_create.c
@@ -197,17 +197,17 @@ static bool on_option(char key, char *value) {
 bool tpm2_tool_onstart(tpm2_options **opts) {
 
     static struct option topts[] = {
-      { "auth-parent",          required_argument, NULL, 'P' },
-      { "auth-key",             required_argument, NULL, 'p' },
-      { "halg",                 required_argument, NULL, 'g' },
-      { "kalg",                 required_argument, NULL, 'G' },
+      { "parent-auth",          required_argument, NULL, 'P' },
+      { "key-auth",             required_argument, NULL, 'p' },
+      { "hash-algorithm",       required_argument, NULL, 'g' },
+      { "key-algorithm",        required_argument, NULL, 'G' },
       { "object-attributes",    required_argument, NULL, 'a' },
-      { "in-file",              required_argument, NULL, 'i' },
-      { "policy-file",          required_argument, NULL, 'L' },
-      { "pubfile",              required_argument, NULL, 'u' },
-      { "privfile",             required_argument, NULL, 'r' },
-      { "context-parent",       required_argument, NULL, 'C' },
-      { "out-context",          required_argument, NULL, 'o' },
+      { "sealing-input",        required_argument, NULL, 'i' },
+      { "policy",               required_argument, NULL, 'L' },
+      { "public",               required_argument, NULL, 'u' },
+      { "private",              required_argument, NULL, 'r' },
+      { "parent-context",       required_argument, NULL, 'C' },
+      { "key-context",          required_argument, NULL, 'o' },
     };
 
     *opts = tpm2_options_new("P:p:g:G:a:i:L:u:r:C:o:", ARRAY_LEN(topts), topts,

--- a/tools/tpm2_createak.c
+++ b/tools/tpm2_createak.c
@@ -424,13 +424,13 @@ static bool on_option(char key, char *value) {
 bool tpm2_tool_onstart(tpm2_options **opts) {
 
     const struct option topts[] = {
-        { "auth-endorse",     required_argument, NULL, 'P' },
-        { "auth-ak",          required_argument, NULL, 'p' },
+        { "eh-auth",          required_argument, NULL, 'P' },
+        { "ak-auth",          required_argument, NULL, 'p' },
         { "ek-context",       required_argument, NULL, 'C' },
         { "ak-context",       required_argument, NULL, 'c' },
         { "ak-name",          required_argument, NULL, 'n' },
-        { "kalg",             required_argument, NULL, 'G' },
-        { "halg",             required_argument, NULL, 'g' },
+        { "key-algorithm",    required_argument, NULL, 'G' },
+        { "hash-algorithm",   required_argument, NULL, 'g' },
         { "signing-algorithm",required_argument, NULL, 's' },
         { "format",           required_argument, NULL, 'f' },
         { "public",           required_argument, NULL, 'u' },

--- a/tools/tpm2_createek.c
+++ b/tools/tpm2_createek.c
@@ -262,13 +262,13 @@ static tool_rc create_ek_handle(ESYS_CONTEXT *ectx) {
 static bool on_option(char key, char *value) {
 
     switch (key) {
-    case 'e':
+    case 'P':
         ctx.auth.endorse.auth_str = value;
         break;
     case 'w':
         ctx.auth.owner.auth_str = value;
         break;
-    case 'P':
+    case 'p':
         ctx.auth.ek.auth_str = value;
         break;
     case 'G': {
@@ -279,7 +279,7 @@ static bool on_option(char key, char *value) {
         }
         ctx.objdata.in.public.publicArea.type = type;
     }   break;
-    case 'p':
+    case 'u':
         if (!value) {
             LOG_ERR("Please specify an output file to save the pub ek to.");
             return false;
@@ -307,17 +307,17 @@ static bool on_option(char key, char *value) {
 bool tpm2_tool_onstart(tpm2_options **opts) {
 
     const struct option topts[] = {
-        { "auth-endorse",         required_argument, NULL, 'e' },
-        { "auth-owner",           required_argument, NULL, 'w' },
-        { "auth-ek",              required_argument, NULL, 'P' },
-        { "algorithm",            required_argument, NULL, 'G' },
-        { "file",                 required_argument, NULL, 'p' },
+        { "eh-auth",              required_argument, NULL, 'P' },
+        { "owner-auth",           required_argument, NULL, 'w' },
+        { "ek-auth",              required_argument, NULL, 'p' },
+        { "key-algorithm",        required_argument, NULL, 'G' },
+        { "public",               required_argument, NULL, 'u' },
         { "format",               required_argument, NULL, 'f' },
-        { "context",              required_argument, NULL, 'c' },
+        { "ek-context",           required_argument, NULL, 'c' },
         { "template",             required_argument, NULL, 't' },
     };
 
-    *opts = tpm2_options_new("e:w:P:G:p:f:c:t", ARRAY_LEN(topts), topts,
+    *opts = tpm2_options_new("P:w:p:G:u:f:c:t", ARRAY_LEN(topts), topts,
                              on_option, NULL, 0);
 
     return *opts != NULL;

--- a/tools/tpm2_createpolicy.c
+++ b/tools/tpm2_createpolicy.c
@@ -128,11 +128,11 @@ static tool_rc parse_policy_type_specific_command(ESYS_CONTEXT *ectx) {
 static bool on_option(char key, char *value) {
 
     switch (key) {
-    case 'o':
+    case 'L':
         pctx.common_policy_options.policy_file_flag = true;
         pctx.common_policy_options.policy_file = value;
         break;
-    case 'F':
+    case 'f':
         pctx.pcr_policy_options.raw_pcrs_file = value;
         break;
     case 'g':
@@ -143,7 +143,7 @@ static bool on_option(char key, char *value) {
             return false;
         }
         break;
-    case 'L':
+    case 'l':
         if (!pcr_parse_selections(value, &pctx.pcr_policy_options.pcr_selections)) {
             return false;
         }
@@ -162,15 +162,15 @@ static bool on_option(char key, char *value) {
 bool tpm2_tool_onstart(tpm2_options **opts) {
 
     const struct option topts[] = {
-        { "out-policy-file",     required_argument, NULL, 'o' },
-        { "policy-digest-alg",   required_argument, NULL, 'g' },
-        { "set-list",            required_argument, NULL, 'L' },
-        { "pcr-input-file",      required_argument, NULL, 'F' },
+        { "policy",              required_argument, NULL, 'L' },
+        { "policy-algorithm",    required_argument, NULL, 'g' },
+        { "pcr-list",            required_argument, NULL, 'l' },
+        { "pcr",                 required_argument, NULL, 'f' },
         { "policy-pcr",          no_argument,       NULL,  0  },
         { "policy-session",      no_argument,       NULL,  1  },
     };
 
-    *opts = tpm2_options_new("o:g:L:F:a", ARRAY_LEN(topts), topts, on_option,
+    *opts = tpm2_options_new("L:g:l:f:", ARRAY_LEN(topts), topts, on_option,
                              NULL, 0);
 
     return *opts != NULL;

--- a/tools/tpm2_createprimary.c
+++ b/tools/tpm2_createprimary.c
@@ -107,12 +107,12 @@ bool tpm2_tool_onstart(tpm2_options **opts) {
 
     const struct option topts[] = {
         { "hierarchy",            required_argument, NULL, 'C' },
-        { "auth-hierarchy",       required_argument, NULL, 'P' },
-        { "auth-object",          required_argument, NULL, 'p' },
-        { "halg",                 required_argument, NULL, 'g' },
-        { "kalg",                 required_argument, NULL, 'G' },
-        { "context-object",       required_argument, NULL, 'o' },
-        { "policy-file",          required_argument, NULL, 'L' },
+        { "hierarchy-auth",       required_argument, NULL, 'P' },
+        { "key-auth",             required_argument, NULL, 'p' },
+        { "hash-algorithm",       required_argument, NULL, 'g' },
+        { "key-algorithm",        required_argument, NULL, 'G' },
+        { "key-context",          required_argument, NULL, 'o' },
+        { "policy",               required_argument, NULL, 'L' },
         { "object-attributes",    required_argument, NULL, 'a' },
         { "unique-data",          required_argument, NULL, 'u' },
     };

--- a/tools/tpm2_dictionarylockout.c
+++ b/tools/tpm2_dictionarylockout.c
@@ -88,7 +88,7 @@ bool tpm2_tool_onstart(tpm2_options **opts) {
         { "max-tries",             required_argument, NULL, 'n' },
         { "recovery-time",         required_argument, NULL, 't' },
         { "lockout-recovery-time", required_argument, NULL, 'l' },
-        { "auth-lockout",          required_argument, NULL, 'p' },
+        { "auth",                  required_argument, NULL, 'p' },
         { "clear-lockout",         no_argument,       NULL, 'c' },
         { "setup-parameters",      no_argument,       NULL, 's' },
     };

--- a/tools/tpm2_duplicate.c
+++ b/tools/tpm2_duplicate.c
@@ -114,14 +114,14 @@ static bool on_option(char key, char *value) {
 bool tpm2_tool_onstart(tpm2_options **opts) {
 
     const struct option topts[] = {
-      { "auth-key",              required_argument, NULL, 'p'},
-      { "inner-wrapper-alg",     required_argument, NULL, 'G'},
-      { "private",               required_argument, NULL, 'r'},
-      { "input-key-file",        required_argument, NULL, 'i'},
-      { "output-key-file",       required_argument, NULL, 'o'},
-      { "encrypted-seed",        required_argument, NULL, 's'},
-      { "parent-key",            required_argument, NULL, 'C'},
-      { "context",               required_argument, NULL, 'c'},
+      { "auth",              required_argument, NULL, 'p'},
+      { "wrapper-algorithm", required_argument, NULL, 'G'},
+      { "private",           required_argument, NULL, 'r'},
+      { "encryptionkey-in",  required_argument, NULL, 'i'},
+      { "encryptionkey-out", required_argument, NULL, 'o'},
+      { "encrypted-seed",    required_argument, NULL, 's'},
+      { "parent-context",    required_argument, NULL, 'C'},
+      { "key-context",       required_argument, NULL, 'c'},
     };
 
     *opts = tpm2_options_new("p:G:i:C:o:s:r:c:", ARRAY_LEN(topts), topts, on_option,

--- a/tools/tpm2_encryptdecrypt.c
+++ b/tools/tpm2_encryptdecrypt.c
@@ -351,12 +351,12 @@ static bool on_option(char key, char *value) {
 bool tpm2_tool_onstart(tpm2_options **opts) {
 
     const struct option topts[] = {
-        { "auth-key",             required_argument, NULL, 'p' },
+        { "auth",                 required_argument, NULL, 'p' },
         { "decrypt",              no_argument,       NULL, 'd' },
-        { "in-file",              required_argument, NULL, 'i' },
+        { "input",                required_argument, NULL, 'i' },
         { "iv",                   required_argument, NULL, 't' },
         { "mode",                 required_argument, NULL, 'G' },
-        { "out-file",             required_argument, NULL, 'o' },
+        { "output",               required_argument, NULL, 'o' },
         { "key-context",          required_argument, NULL, 'c' },
         { "pad",                  no_argument,       NULL, 'e' },
     };

--- a/tools/tpm2_evictcontrol.c
+++ b/tools/tpm2_evictcontrol.c
@@ -98,8 +98,8 @@ bool tpm2_tool_onstart(tpm2_options **opts) {
 
     const struct option topts[] = {
       { "hierarchy",      required_argument, NULL, 'C' },
-      { "auth-hierarchy", required_argument, NULL, 'P' },
-      { "context",        required_argument, NULL, 'c' },
+      { "auth",           required_argument, NULL, 'P' },
+      { "key-context",    required_argument, NULL, 'c' },
       { "output",         required_argument, NULL, 'o' },
     };
 

--- a/tools/tpm2_getmanufec.c
+++ b/tools/tpm2_getmanufec.c
@@ -429,13 +429,13 @@ static bool on_option(char key, char *value) {
             return false;
         }
         break;
-    case 'e':
+    case 'P':
         ctx.auth.endorse.auth_str = value;
         break;
     case 'w':
         ctx.auth.owner.auth_str = value;
         break;
-    case 'P': {
+    case 'p': {
         ctx.ek_auth_str = value;
     }   break;
     case 'G':
@@ -485,19 +485,19 @@ bool tpm2_tool_onstart(tpm2_options **opts) {
 
     const struct option topts[] =
     {
-        { "auth-endorse",         required_argument, NULL, 'e' },
-        { "auth-owner",           required_argument, NULL, 'w' },
-        { "auth-ek",              required_argument, NULL, 'P' },
-        { "handle",               required_argument, NULL, 'H' },
-        { "algorithm",            required_argument, NULL, 'G' },
-        { "out-file",             required_argument, NULL, 'o' },
+        { "eh-auth",              required_argument, NULL, 'P' },
+        { "owner-auth",           required_argument, NULL, 'w' },
+        { "ek-auth",              required_argument, NULL, 'p' },
+        { "persistent-handle",    required_argument, NULL, 'H' },
+        { "key-algorithm",        required_argument, NULL, 'G' },
+        { "output",               required_argument, NULL, 'o' },
         { "non-persistent",       no_argument,       NULL, 'N' },
         { "offline",              required_argument, NULL, 'O' },
         { "ec-cert",              required_argument, NULL, 'E' },
         { "untrusted",            no_argument,       NULL, 'U' },
     };
 
-    *opts = tpm2_options_new("e:w:H:P:G:o:NO:E:i:U", ARRAY_LEN(topts), topts,
+    *opts = tpm2_options_new("P:w:H:p:G:o:NO:E:i:U", ARRAY_LEN(topts), topts,
                              on_option, on_args, 0);
 
     return *opts != NULL;

--- a/tools/tpm2_getrandom.c
+++ b/tools/tpm2_getrandom.c
@@ -134,7 +134,7 @@ static bool on_args(int argc, char **argv) {
 bool tpm2_tool_onstart(tpm2_options **opts) {
 
     const struct option topts[] = {
-        { "out-file",   required_argument, NULL, 'o' },
+        { "output",     required_argument, NULL, 'o' },
         { "force",      required_argument, NULL, 'f' },
     };
 

--- a/tools/tpm2_hash.c
+++ b/tools/tpm2_hash.c
@@ -105,7 +105,7 @@ static bool on_option(char key, char *value) {
 
     bool res;
     switch (key) {
-    case 'a':
+    case 'C':
         res = tpm2_hierarchy_from_optarg(value, &ctx.hierarchyValue,
                 TPM2_HIERARCHY_FLAGS_ALL);
         if (!res) {
@@ -132,16 +132,16 @@ static bool on_option(char key, char *value) {
 bool tpm2_tool_onstart(tpm2_options **opts) {
 
     static struct option topts[] = {
-        {"hierarchy", required_argument, NULL, 'a'},
-        {"halg",      required_argument, NULL, 'g'},
-        {"out-file",  required_argument, NULL, 'o'},
-        {"ticket",    required_argument, NULL, 't'},
+        {"hierarchy",          required_argument, NULL, 'C'},
+        {"hash-algorithm",     required_argument, NULL, 'g'},
+        {"output",             required_argument, NULL, 'o'},
+        {"ticket",             required_argument, NULL, 't'},
     };
 
     /* set up non-static defaults here */
     ctx.input_file = stdin;
 
-    *opts = tpm2_options_new("a:g:o:t:", ARRAY_LEN(topts), topts, on_option,
+    *opts = tpm2_options_new("C:g:o:t:", ARRAY_LEN(topts), topts, on_option,
                              on_args, 0);
 
     return *opts != NULL;

--- a/tools/tpm2_hmac.c
+++ b/tools/tpm2_hmac.c
@@ -167,10 +167,10 @@ out:
 static bool on_option(char key, char *value) {
 
     switch (key) {
-    case 'C':
+    case 'c':
         ctx.hmac_key.ctx_path = value;
         break;
-    case 'P':
+    case 'p':
         ctx.hmac_key.auth_str = value;
         break;
     case 'o':
@@ -201,14 +201,14 @@ static bool on_args(int argc, char **argv) {
 bool tpm2_tool_onstart(tpm2_options **opts) {
 
     const struct option topts[] = {
-        { "key-context",          required_argument, NULL, 'C' },
-        { "auth-key",             required_argument, NULL, 'P' },
-        { "out-file",             required_argument, NULL, 'o' },
+        { "key-context",          required_argument, NULL, 'c' },
+        { "auth",                 required_argument, NULL, 'p' },
+        { "output",               required_argument, NULL, 'o' },
     };
 
     ctx.input = stdin;
 
-    *opts = tpm2_options_new("C:P:o:", ARRAY_LEN(topts), topts, on_option,
+    *opts = tpm2_options_new("c:p:o:", ARRAY_LEN(topts), topts, on_option,
                              on_args, 0);
 
     return *opts != NULL;

--- a/tools/tpm2_import.c
+++ b/tools/tpm2_import.c
@@ -286,19 +286,19 @@ static bool on_option(char key, char *value) {
 bool tpm2_tool_onstart(tpm2_options **opts) {
 
     const struct option topts[] = {
-      { "auth-parent",        required_argument, NULL, 'P'},
-      { "auth-key",           required_argument, NULL, 'p'},
-      { "algorithm",          required_argument, NULL, 'G'},
-      { "in-file",            required_argument, NULL, 'i'},
-      { "parent-key",         required_argument, NULL, 'C'},
-      { "parent-pubkey",      required_argument, NULL, 'K'},
-      { "privfile",           required_argument, NULL, 'r'},
-      { "pubfile",            required_argument, NULL, 'u'},
+      { "parent-auth",        required_argument, NULL, 'P'},
+      { "key-auth",           required_argument, NULL, 'p'},
+      { "key-algorithm",      required_argument, NULL, 'G'},
+      { "input",              required_argument, NULL, 'i'},
+      { "parent-context",     required_argument, NULL, 'C'},
+      { "parent-public",      required_argument, NULL, 'K'},
+      { "private",            required_argument, NULL, 'r'},
+      { "public",             required_argument, NULL, 'u'},
       { "object-attributes",  required_argument, NULL, 'a'},
-      { "halg",               required_argument, NULL, 'g'},
+      { "hash-algorithm",     required_argument, NULL, 'g'},
       { "seed",               required_argument, NULL, 's'},
-      { "policy-file",        required_argument, NULL, 'L'},
-      { "sym-alg-file",       required_argument, NULL, 'k'},
+      { "policy",             required_argument, NULL, 'L'},
+      { "encryption-key",     required_argument, NULL, 'k'},
       { "passin",             required_argument, NULL,  0 },
     };
 

--- a/tools/tpm2_load.c
+++ b/tools/tpm2_load.c
@@ -120,12 +120,12 @@ static bool on_option(char key, char *value) {
 bool tpm2_tool_onstart(tpm2_options **opts) {
 
     const struct option topts[] = {
-      { "auth-parent",          required_argument, NULL, 'P' },
-      { "pubfile",              required_argument, NULL, 'u' },
-      { "privfile",             required_argument, NULL, 'r' },
+      { "auth",                 required_argument, NULL, 'P' },
+      { "public",               required_argument, NULL, 'u' },
+      { "private",              required_argument, NULL, 'r' },
       { "name",                 required_argument, NULL, 'n' },
-      { "out-context",          required_argument, NULL, 'o' },
-      { "context-parent",       required_argument, NULL, 'C' },
+      { "key-context",          required_argument, NULL, 'o' },
+      { "parent-context",       required_argument, NULL, 'C' },
     };
 
     *opts = tpm2_options_new("P:u:r:n:C:o:", ARRAY_LEN(topts), topts,

--- a/tools/tpm2_loadexternal.c
+++ b/tools/tpm2_loadexternal.c
@@ -124,14 +124,14 @@ bool tpm2_tool_onstart(tpm2_options **opts) {
 
     const struct option topts[] = {
       { "hierarchy",          required_argument, NULL, 'C'},
-      { "pubfile",            required_argument, NULL, 'u'},
-      { "privfile",           required_argument, NULL, 'r'},
-      { "out-context",        required_argument, NULL, 'o'},
+      { "public",             required_argument, NULL, 'u'},
+      { "private",            required_argument, NULL, 'r'},
+      { "key-context",        required_argument, NULL, 'o'},
       { "object-attributes",  required_argument, NULL, 'a'},
-      { "policy-file",        required_argument, NULL, 'L'},
-      { "auth-key",           required_argument, NULL, 'p'},
-      { "halg",               required_argument, NULL, 'g'},
-      { "key-alg",            required_argument, NULL, 'G'},
+      { "policy",             required_argument, NULL, 'L'},
+      { "auth",               required_argument, NULL, 'p'},
+      { "hash-algorithm",     required_argument, NULL, 'g'},
+      { "key-algorithm",      required_argument, NULL, 'G'},
       { "name",               required_argument, NULL, 'n'},
       { "passin",             required_argument, NULL,  0 },
     };

--- a/tools/tpm2_makecredential.c
+++ b/tools/tpm2_makecredential.c
@@ -251,10 +251,10 @@ static bool on_option(char key, char *value) {
 bool tpm2_tool_onstart(tpm2_options **opts) {
 
     const struct option topts[] = {
-      {"enckey"  ,required_argument, NULL, 'e'},
-      {"secret"   ,required_argument, NULL, 's'},
-      {"name"     ,required_argument, NULL, 'n'},
-      {"out-file" ,required_argument, NULL, 'o'},
+      {"encryption-key", required_argument, NULL, 'e'},
+      {"secret",         required_argument, NULL, 's'},
+      {"name",           required_argument, NULL, 'n'},
+      {"output",         required_argument, NULL, 'o'},
     };
 
     *opts = tpm2_options_new("e:s:n:o:", ARRAY_LEN(topts), topts, on_option,

--- a/tools/tpm2_nvdefine.c
+++ b/tools/tpm2_nvdefine.c
@@ -141,9 +141,9 @@ bool tpm2_tool_onstart(tpm2_options **opts) {
         { "hierarchy",              required_argument,  NULL,   'C' },
         { "size",                   required_argument,  NULL,   's' },
         { "attributes",             required_argument,  NULL,   'a' },
-        { "auth-hierarchy",         required_argument,  NULL,   'P' },
-        { "auth-index",             required_argument,  NULL,   'p' },
-        { "policy-file",            required_argument,  NULL,   'L' },
+        { "hierarchy-auth",         required_argument,  NULL,   'P' },
+        { "index-auth",             required_argument,  NULL,   'p' },
+        { "policy",                 required_argument,  NULL,   'L' },
     };
 
     *opts = tpm2_options_new("x:C:s:a:P:p:L:", ARRAY_LEN(topts), topts,

--- a/tools/tpm2_nvincrement.c
+++ b/tools/tpm2_nvincrement.c
@@ -71,7 +71,7 @@ bool tpm2_tool_onstart(tpm2_options **opts) {
     const struct option topts[] = {
         { "index",                required_argument, NULL, 'x' },
         { "hierarchy",            required_argument, NULL, 'C' },
-        { "auth-hierarchy",       required_argument, NULL, 'P' },
+        { "auth",                 required_argument, NULL, 'P' },
     };
 
     *opts = tpm2_options_new("x:C:P:", ARRAY_LEN(topts), topts,

--- a/tools/tpm2_nvread.c
+++ b/tools/tpm2_nvread.c
@@ -94,7 +94,7 @@ static bool on_option(char key, char *value) {
          */
         ctx.auth_hierarchy.ctx_path = value;
         break;
-    case 'a':
+    case 'C':
         ctx.auth_hierarchy.ctx_path = value;
         break;
     case 'o':
@@ -128,14 +128,14 @@ bool tpm2_tool_onstart(tpm2_options **opts) {
 
     const struct option topts[] = {
         { "index",                required_argument, NULL, 'x' },
-        { "hierarchy",            required_argument, NULL, 'a' },
-        { "out-file",             required_argument, NULL, 'o' },
+        { "hierarchy",            required_argument, NULL, 'C' },
+        { "output",               required_argument, NULL, 'o' },
         { "size",                 required_argument, NULL, 's' },
         { "offset",               required_argument, NULL,  0  },
-        { "auth-hierarchy",       required_argument, NULL, 'P' },
+        { "auth",                 required_argument, NULL, 'P' },
     };
 
-    *opts = tpm2_options_new("x:a:s:o:P:", ARRAY_LEN(topts),
+    *opts = tpm2_options_new("x:C:s:o:P:", ARRAY_LEN(topts),
                              topts, on_option, NULL, 0);
 
     return *opts != NULL;

--- a/tools/tpm2_nvreadlock.c
+++ b/tools/tpm2_nvreadlock.c
@@ -51,7 +51,7 @@ static bool on_option(char key, char *value) {
             return false;
         }
         break;
-    case 'a':
+    case 'C':
         ctx.auth_hierarchy.ctx_path = value;
         break;
     case 'P':
@@ -66,11 +66,11 @@ bool tpm2_tool_onstart(tpm2_options **opts) {
 
     const struct option topts[] = {
         { "index",                required_argument, NULL, 'x' },
-        { "hierarchy",            required_argument, NULL, 'a' },
-        { "auth-hierarchy",       required_argument, NULL, 'P' },
+        { "hierarchy",            required_argument, NULL, 'C' },
+        { "auth",                 required_argument, NULL, 'P' },
     };
 
-    *opts = tpm2_options_new("x:a:P:", ARRAY_LEN(topts), topts,
+    *opts = tpm2_options_new("x:C:P:", ARRAY_LEN(topts), topts,
                              on_option, NULL, 0);
 
     return *opts != NULL;

--- a/tools/tpm2_nvrelease.c
+++ b/tools/tpm2_nvrelease.c
@@ -50,7 +50,7 @@ static bool on_option(char key, char *value) {
             return false;
         }
         break;
-    case 'a':
+    case 'C':
         ctx.auth_hierarchy.ctx_path = value;
         break;
     case 'P':
@@ -65,11 +65,11 @@ bool tpm2_tool_onstart(tpm2_options **opts) {
 
     const struct option topts[] = {
         { "index",          required_argument, NULL, 'x' },
-        { "hierarchy",      required_argument, NULL, 'a' },
-        { "auth-hierarchy", required_argument, NULL, 'P' },
+        { "hierarchy",      required_argument, NULL, 'C' },
+        { "auth",           required_argument, NULL, 'P' },
     };
 
-    *opts = tpm2_options_new("x:a:P:", ARRAY_LEN(topts), topts, on_option,
+    *opts = tpm2_options_new("x:C:P:", ARRAY_LEN(topts), topts, on_option,
                              NULL, 0);
 
     return *opts != NULL;

--- a/tools/tpm2_nvwrite.c
+++ b/tools/tpm2_nvwrite.c
@@ -128,7 +128,7 @@ static bool on_option(char key, char *value) {
          */
         ctx.auth_hierarchy.ctx_path = value;
         break;
-    case 'a':
+    case 'C':
         ctx.auth_hierarchy.ctx_path = value;
         break;
     case 'P':
@@ -167,12 +167,12 @@ bool tpm2_tool_onstart(tpm2_options **opts) {
 
     const struct option topts[] = {
         { "index",                required_argument, NULL, 'x' },
-        { "hierarchy",            required_argument, NULL, 'a' },
-        { "auth-hierarchy",       required_argument, NULL, 'P' },
+        { "hierarchy",            required_argument, NULL, 'C' },
+        { "auth",                 required_argument, NULL, 'P' },
         { "offset",               required_argument, NULL,  0  },
     };
 
-    *opts = tpm2_options_new("x:a:P:", ARRAY_LEN(topts), topts,
+    *opts = tpm2_options_new("x:C:P:", ARRAY_LEN(topts), topts,
                              on_option, on_args, 0);
 
     ctx.input_file = stdin;

--- a/tools/tpm2_pcrallocate.c
+++ b/tools/tpm2_pcrallocate.c
@@ -69,7 +69,7 @@ static bool on_option(char key, char *value) {
 
 bool tpm2_tool_onstart(tpm2_options **opts) {
     const struct option topts[] = {
-        { "auth-platform",     required_argument, NULL, 'P' },
+        { "auth",     required_argument, NULL, 'P' },
     };
 
     *opts = tpm2_options_new("P:", ARRAY_LEN(topts), topts, on_option, on_arg,

--- a/tools/tpm2_pcrevent.c
+++ b/tools/tpm2_pcrevent.c
@@ -269,7 +269,7 @@ bool tpm2_tool_onstart(tpm2_options **opts) {
 
     static const struct option topts[] = {
         { "pcr-index", required_argument, NULL, 'x' },
-        { "auth-pcr",  required_argument, NULL, 'P' },
+        { "auth",      required_argument, NULL, 'P' },
     };
 
     *opts = tpm2_options_new("x:P:", ARRAY_LEN(topts), topts,

--- a/tools/tpm2_pcrlist.c
+++ b/tools/tpm2_pcrlist.c
@@ -158,7 +158,7 @@ static bool on_option(char key, char *value) {
         ctx.output_file_path = value;
         ctx.flags.o = 1;
         break;
-    case 'L':
+    case 'l':
         if (!pcr_parse_selections(value, &ctx.pcr_selections)) {
             LOG_ERR("Could not parse pcr list, got: \"%s\"", value);
             return false;
@@ -177,13 +177,13 @@ static bool on_option(char key, char *value) {
 bool tpm2_tool_onstart(tpm2_options **opts) {
 
     static struct option topts[] = {
-         { "halg",      required_argument, NULL, 'g' },
-         { "out-file",  required_argument, NULL, 'o' },
-         { "algs",      no_argument,       NULL, 's' },
-         { "sel-list",  required_argument, NULL, 'L' },
+         { "hash-algorithm", required_argument, NULL, 'g' },
+         { "output",         required_argument, NULL, 'o' },
+         { "pcr-algorithms", no_argument,       NULL, 's' },
+         { "pcr-list",       required_argument, NULL, 'l' },
      };
 
-    *opts = tpm2_options_new("g:o:L:s", ARRAY_LEN(topts), topts,
+    *opts = tpm2_options_new("g:o:l:s", ARRAY_LEN(topts), topts,
                              on_option, NULL, 0);
 
     return *opts != NULL;

--- a/tools/tpm2_policyauthorize.c
+++ b/tools/tpm2_policyauthorize.c
@@ -42,7 +42,7 @@ static bool on_option(char key, char *value) {
     case 'S':
         ctx.session_path = value;
         break;
-    case 'i':
+    case 'L':
         ctx.policy_digest_path = value;
         break;
     case 'q':
@@ -61,15 +61,15 @@ static bool on_option(char key, char *value) {
 bool tpm2_tool_onstart(tpm2_options **opts) {
 
     static struct option topts[] = {
-        { "out-policy-file",    required_argument, NULL, 'o' },
+        { "policy-output",      required_argument, NULL, 'o' },
         { "session",            required_argument, NULL, 'S' },
-        { "in-policy-file",     required_argument, NULL, 'i' },
-        { "qualify-data",       required_argument, NULL, 'q' },
+        { "policy",             required_argument, NULL, 'L' },
+        { "qualification-data", required_argument, NULL, 'q' },
         { "name",               required_argument, NULL, 'n' },
         { "ticket",             required_argument, NULL, 't' },
     };
 
-    *opts = tpm2_options_new("o:S:i:q:n:t:", ARRAY_LEN(topts), topts, on_option,
+    *opts = tpm2_options_new("o:S:L:q:n:t:", ARRAY_LEN(topts), topts, on_option,
                              NULL, 0);
 
     return *opts != NULL;

--- a/tools/tpm2_policycommandcode.c
+++ b/tools/tpm2_policycommandcode.c
@@ -36,7 +36,7 @@ static bool on_option(char key, char *value) {
     case 'S':
         ctx.session_path = value;
         break;
-    case 'o':
+    case 'L':
         ctx.out_policy_dgst_path = value;
         break;
     }
@@ -76,11 +76,11 @@ bool on_arg (int argc, char **argv) {
 bool tpm2_tool_onstart(tpm2_options **opts) {
 
     static struct option topts[] = {
-        { "session",        required_argument,  NULL,   'S' },
-        { "out-policy-file",    required_argument,  NULL,   'o' },
+        { "session", required_argument,  NULL,   'S' },
+        { "policy",  required_argument,  NULL,   'L' },
     };
 
-    *opts = tpm2_options_new("S:o:", ARRAY_LEN(topts), topts, on_option,
+    *opts = tpm2_options_new("S:L:", ARRAY_LEN(topts), topts, on_option,
                              on_arg, 0);
 
     return *opts != NULL;

--- a/tools/tpm2_policyduplicationselect.c
+++ b/tools/tpm2_policyduplicationselect.c
@@ -44,7 +44,7 @@ static bool on_option(char key, char *value) {
     case 'N':
         ctx.new_parent_name_path = value;
         break;
-    case 'o':
+    case 'L':
         ctx.out_policy_dgst_path = value;
         break;
     case 0:
@@ -77,12 +77,12 @@ bool tpm2_tool_onstart(tpm2_options **opts) {
     static struct option topts[] = {
         { "session",            required_argument,  NULL,   'S' },
         { "object-name",        required_argument,  NULL,   'n' },
-        { "new-parent-name",    required_argument,  NULL,   'N' },
-        { "out-policy-file",    required_argument,  NULL,   'o' },
+        { "parent-name",        required_argument,  NULL,   'N' },
+        { "policy",             required_argument,  NULL,   'L' },
         { "include-if-exists",  no_argument,        NULL,    0  },
     };
 
-    *opts = tpm2_options_new("S:n:N:o:", ARRAY_LEN(topts), topts, on_option,
+    *opts = tpm2_options_new("S:n:N:L:", ARRAY_LEN(topts), topts, on_option,
                              NULL, 0);
 
     return *opts != NULL;

--- a/tools/tpm2_policyduplicationselect.c
+++ b/tools/tpm2_policyduplicationselect.c
@@ -82,7 +82,7 @@ bool tpm2_tool_onstart(tpm2_options **opts) {
         { "include-if-exists",  no_argument,        NULL,    0  },
     };
 
-    *opts = tpm2_options_new("S:n:N:o:i", ARRAY_LEN(topts), topts, on_option,
+    *opts = tpm2_options_new("S:n:N:o:", ARRAY_LEN(topts), topts, on_option,
                              NULL, 0);
 
     return *opts != NULL;

--- a/tools/tpm2_policylocality.c
+++ b/tools/tpm2_policylocality.c
@@ -35,7 +35,7 @@ static bool on_option(char key, char *value) {
     case 'S':
         ctx.session_path = value;
         break;
-    case 'o':
+    case 'L':
         ctx.out_policy_dgst_path = value;
         break;
     }
@@ -78,10 +78,10 @@ bool tpm2_tool_onstart(tpm2_options **opts) {
 
     static struct option topts[] = {
         { "session",            required_argument,  NULL,   'S' },
-        { "out-policy-file",    required_argument,  NULL,   'o' },
+        { "policy",             required_argument,  NULL,   'L' },
     };
 
-    *opts = tpm2_options_new("S:o:", ARRAY_LEN(topts), topts, on_option,
+    *opts = tpm2_options_new("S:L:", ARRAY_LEN(topts), topts, on_option,
                              on_arg, 0);
 
     return *opts != NULL;

--- a/tools/tpm2_policyor.c
+++ b/tools/tpm2_policyor.c
@@ -33,13 +33,13 @@ static bool on_option(char key, char *value) {
     bool result = true;
 
     switch (key) {
-    case 'o':
+    case 'L':
         ctx.out_policy_dgst_path = value;
         break;
     case 'S':
         ctx.session_path = value;
         break;
-    case 'L':
+    case 'l':
         result = tpm2_policy_parse_policy_list(value, &ctx.policy_list);
         if (!result) {
             return false;
@@ -53,12 +53,12 @@ static bool on_option(char key, char *value) {
 bool tpm2_tool_onstart(tpm2_options **opts) {
 
     static struct option topts[] = {
-        { "out-policy-file",        required_argument, NULL, 'o' },
+        { "policy",                 required_argument, NULL, 'L' },
         { "session",                required_argument, NULL, 'S' },
-        { "policy-list",            required_argument, NULL, 'L' },
+        { "policy-list",            required_argument, NULL, 'l' },
     };
 
-    *opts = tpm2_options_new("o:S:L:", ARRAY_LEN(topts), topts, on_option,
+    *opts = tpm2_options_new("L:S:l:", ARRAY_LEN(topts), topts, on_option,
                              NULL, 0);
 
     return *opts != NULL;

--- a/tools/tpm2_policypassword.c
+++ b/tools/tpm2_policypassword.c
@@ -29,7 +29,7 @@ static tpm2_policypassword_ctx ctx;
 static bool on_option(char key, char *value) {
 
     switch (key) {
-    case 'o':
+    case 'L':
         ctx.out_policy_dgst_path = value;
         break;
     case 'S':
@@ -43,11 +43,11 @@ static bool on_option(char key, char *value) {
 bool tpm2_tool_onstart(tpm2_options **opts) {
 
     static struct option topts[] = {
-        { "out-policy-file",    required_argument, NULL, 'o' },
+        { "policy",             required_argument, NULL, 'L' },
         { "session",            required_argument, NULL, 'S' },
     };
 
-    *opts = tpm2_options_new("o:S:", ARRAY_LEN(topts), topts, on_option,
+    *opts = tpm2_options_new("S:L:", ARRAY_LEN(topts), topts, on_option,
                              NULL, 0);
 
     return *opts != NULL;

--- a/tools/tpm2_policypcr.c
+++ b/tools/tpm2_policypcr.c
@@ -33,13 +33,13 @@ static tpm2_policypcr_ctx ctx;
 static bool on_option(char key, char *value) {
 
     switch (key) {
-    case 'o':
+    case 'L':
         ctx.policy_out_path = value;
         break;
-    case 'F':
+    case 'f':
         ctx.raw_pcrs_file = value;
         break;
-    case 'L': {
+    case 'l': {
         bool result = pcr_parse_selections(value, &ctx.pcr_selection);
         if (!result) {
             LOG_ERR("Could not parse PCR selections");
@@ -56,13 +56,13 @@ static bool on_option(char key, char *value) {
 bool tpm2_tool_onstart(tpm2_options **opts) {
 
     static struct option topts[] = {
-        { "out-policy-file",    required_argument,  NULL,   'o' },
-        { "pcr-input-file",     required_argument,  NULL,   'F' },
-        { "set-list",           required_argument,  NULL,   'L' },
+        { "policy",             required_argument,  NULL,   'L' },
+        { "pcr",                required_argument,  NULL,   'f' },
+        { "pcr-list",           required_argument,  NULL,   'l' },
         { "session",            required_argument,  NULL,   'S' },
     };
 
-    *opts = tpm2_options_new("o:F:L:S:", ARRAY_LEN(topts), topts, on_option,
+    *opts = tpm2_options_new("L:f:l:S:", ARRAY_LEN(topts), topts, on_option,
                              NULL, 0);
 
     return *opts != NULL;

--- a/tools/tpm2_policysecret.c
+++ b/tools/tpm2_policysecret.c
@@ -41,7 +41,7 @@ static bool on_option(char key, char *value) {
     bool result = true;
 
     switch (key) {
-    case 'o':
+    case 'L':
         ctx.out_policy_dgst_path = value;
         break;
     case 'S':
@@ -76,12 +76,12 @@ bool on_arg (int argc, char **argv) {
 bool tpm2_tool_onstart(tpm2_options **opts) {
 
     static struct option topts[] = {
-        { "out-policy-file", required_argument, NULL, 'o' },
-        { "session",     required_argument, NULL, 'S' },
-        { "context",     required_argument, NULL, 'c' },
+        { "policy",         required_argument, NULL, 'L' },
+        { "session",        required_argument, NULL, 'S' },
+        { "object-context", required_argument, NULL, 'c' },
     };
 
-    *opts = tpm2_options_new("o:S:c:", ARRAY_LEN(topts), topts, on_option,
+    *opts = tpm2_options_new("L:S:c:", ARRAY_LEN(topts), topts, on_option,
                              on_arg, 0);
 
     return *opts != NULL;

--- a/tools/tpm2_quote.c
+++ b/tools/tpm2_quote.c
@@ -216,7 +216,7 @@ static bool on_option(char key, char *value) {
     case 'P':
         ctx.ak.auth_str = value;
         break;
-    case 'l':
+    case 'i':
         if(!pcr_parse_list(value, strlen(value), &ctx.pcrSelections.pcrSelections[0]))
         {
             LOG_ERR("Could not parse pcr list, got: \"%s\"", value);
@@ -224,7 +224,7 @@ static bool on_option(char key, char *value) {
         }
         ctx.flags.l = 1;
         break;
-    case 'L':
+    case 'l':
         if(!pcr_parse_selections(value, &ctx.pcrSelections))
         {
             LOG_ERR("Could not parse pcr selections, got: \"%s\"", value);
@@ -246,11 +246,11 @@ static bool on_option(char key, char *value) {
     case 'm':
          ctx.message_path = value;
          break;
-    case 'p':
+    case 'f':
          ctx.pcr_path = value;
          ctx.flags.p = 1;
          break;
-    case 'f':
+    case 'F':
          ctx.sig_format = tpm2_convert_sig_fmt_from_optarg(value);
 
          if (ctx.sig_format == signature_format_err) {
@@ -274,18 +274,18 @@ bool tpm2_tool_onstart(tpm2_options **opts) {
 
     static const struct option topts[] = {
         { "ak-context",           required_argument, NULL, 'C' },
-        { "auth-ak",              required_argument, NULL, 'P' },
-        { "id-list",              required_argument, NULL, 'l' },
-        { "sel-list",             required_argument, NULL, 'L' },
-        { "qualify-data",         required_argument, NULL, 'q' },
+        { "ak-auth",              required_argument, NULL, 'P' },
+        { "pcr-index",            required_argument, NULL, 'i' },
+        { "pcr-list",             required_argument, NULL, 'l' },
+        { "qualification-data",   required_argument, NULL, 'q' },
         { "signature",            required_argument, NULL, 's' },
         { "message",              required_argument, NULL, 'm' },
-        { "pcrs",                 required_argument, NULL, 'p' },
-        { "format",               required_argument, NULL, 'f' },
-        { "halg",                 required_argument, NULL, 'g' }
+        { "pcr",                  required_argument, NULL, 'f' },
+        { "format",               required_argument, NULL, 'F' },
+        { "hash-algorithm",       required_argument, NULL, 'g' }
     };
 
-    *opts = tpm2_options_new("C:P:l:L:q:s:m:p:f:g:", ARRAY_LEN(topts), topts,
+    *opts = tpm2_options_new("C:P:i:l:q:s:m:f:F:g:", ARRAY_LEN(topts), topts,
                              on_option, NULL, 0);
 
     return *opts != NULL;

--- a/tools/tpm2_quote.c
+++ b/tools/tpm2_quote.c
@@ -29,7 +29,6 @@ struct tpm_quote_ctx {
         tpm2_loaded_object object;
     } ak;
 
-    char *outFilePath;
     char *signature_path;
     char *message_path;
     char *pcr_path;
@@ -232,10 +231,6 @@ static bool on_option(char key, char *value) {
             return false;
         }
         ctx.flags.L = 1;
-        break;
-    case 'o':
-        ctx.outFilePath = value;
-        ctx.flags.o = 1;
         break;
     case 'q':
         ctx.qualifyingData.size = sizeof(ctx.qualifyingData) - 2;

--- a/tools/tpm2_readpublic.c
+++ b/tools/tpm2_readpublic.c
@@ -124,8 +124,8 @@ static bool on_option(char key, char *value) {
 bool tpm2_tool_onstart(tpm2_options **opts) {
 
     static const struct option topts[] = {
-        { "out-file",           required_argument, NULL, 'o' },
-        { "context",            required_argument, NULL, 'c' },
+        { "output",             required_argument, NULL, 'o' },
+        { "object-context",     required_argument, NULL, 'c' },
         { "format",             required_argument, NULL, 'f' },
         { "name",               required_argument, NULL, 'n' },
         { "serialized-handle",  required_argument, NULL, 't' }

--- a/tools/tpm2_rsadecrypt.c
+++ b/tools/tpm2_rsadecrypt.c
@@ -103,9 +103,9 @@ static bool on_option(char key, char *value) {
 bool tpm2_tool_onstart(tpm2_options **opts) {
 
     static struct option topts[] = {
-      { "auth-key",     required_argument, NULL, 'p' },
-      { "in-file",      required_argument, NULL, 'i' },
-      { "out-file",     required_argument, NULL, 'o' },
+      { "auth",         required_argument, NULL, 'p' },
+      { "input",        required_argument, NULL, 'i' },
+      { "output",       required_argument, NULL, 'o' },
       { "key-context",  required_argument, NULL, 'c' },
       { "scheme",       required_argument, NULL, 'g' },
     };

--- a/tools/tpm2_rsaencrypt.c
+++ b/tools/tpm2_rsaencrypt.c
@@ -95,7 +95,7 @@ static bool on_args(int argc, char **argv) {
 bool tpm2_tool_onstart(tpm2_options **opts) {
 
     static const struct option topts[] = {
-      {"out-file",    required_argument, NULL, 'o'},
+      {"output",      required_argument, NULL, 'o'},
       {"key-context", required_argument, NULL, 'c'},
       {"scheme",      required_argument, NULL, 'g'},
     };

--- a/tools/tpm2_send.c
+++ b/tools/tpm2_send.c
@@ -125,7 +125,7 @@ static bool on_args(int argc, char **argv) {
 bool tpm2_tool_onstart(tpm2_options **opts) {
 
     static const struct option topts[] = {
-        { "out-file", required_argument, NULL, 'o' },
+        { "output", required_argument, NULL, 'o' },
     };
 
     *opts = tpm2_options_new("o:", ARRAY_LEN(topts), topts,

--- a/tools/tpm2_sign.c
+++ b/tools/tpm2_sign.c
@@ -197,7 +197,7 @@ static bool on_option(char key, char *value) {
         }
     }
         break;
-    case 'D': {
+    case 'd': {
         ctx.digest = malloc(sizeof(TPM2B_DIGEST));
         ctx.digest->size = sizeof(TPM2B_DIGEST);
         if (!files_load_bytes_from_path(value, ctx.digest->buffer, &ctx.digest->size)) {
@@ -239,18 +239,18 @@ static bool on_option(char key, char *value) {
 bool tpm2_tool_onstart(tpm2_options **opts) {
 
     static const struct option topts[] = {
-      { "auth-key",             required_argument, NULL, 'p' },
-      { "halg",                 required_argument, NULL, 'g' },
-      { "sig-scheme",           required_argument, NULL, 's' },
+      { "auth",                 required_argument, NULL, 'p' },
+      { "hash-algorithm",       required_argument, NULL, 'g' },
+      { "scheme",               required_argument, NULL, 's' },
       { "message",              required_argument, NULL, 'm' },
-      { "digest",               required_argument, NULL, 'D' },
-      { "out-sig",              required_argument, NULL, 'o' },
+      { "digest",               required_argument, NULL, 'd' },
+      { "signature",            required_argument, NULL, 'o' },
       { "ticket",               required_argument, NULL, 't' },
       { "key-context",          required_argument, NULL, 'c' },
       { "format",               required_argument, NULL, 'f' }
     };
 
-    *opts = tpm2_options_new("p:g:m:D:t:o:c:f:s:", ARRAY_LEN(topts), topts,
+    *opts = tpm2_options_new("p:g:m:d:t:o:c:f:s:", ARRAY_LEN(topts), topts,
                              on_option, NULL, 0);
 
     return *opts != NULL;

--- a/tools/tpm2_startauthsession.c
+++ b/tools/tpm2_startauthsession.c
@@ -56,7 +56,7 @@ static bool on_option(char key, char *value) {
     case 'S':
         ctx.output.path = value;
         break;
-    case 'k':
+    case 'c':
         ctx.session.key_context_arg_str = value;
         break;
     }
@@ -68,12 +68,12 @@ bool tpm2_tool_onstart(tpm2_options **opts) {
 
     static struct option topts[] = {
         { "policy-session",      no_argument,       NULL,  0 },
-        { "key",                 required_argument, NULL, 'k'},
-        { "halg",                required_argument, NULL, 'g'},
+        { "key-context",         required_argument, NULL, 'c'},
+        { "hash-algorithm",      required_argument, NULL, 'g'},
         { "session",             required_argument, NULL, 'S'},
     };
 
-    *opts = tpm2_options_new("g:S:k:", ARRAY_LEN(topts), topts, on_option,
+    *opts = tpm2_options_new("g:S:c:", ARRAY_LEN(topts), topts, on_option,
                              NULL, 0);
 
     return *opts != NULL;

--- a/tools/tpm2_unseal.c
+++ b/tools/tpm2_unseal.c
@@ -104,9 +104,9 @@ static bool on_option(char key, char *value) {
 bool tpm2_tool_onstart(tpm2_options **opts) {
 
     static const struct option topts[] = {
-      { "auth-key",             required_argument, NULL, 'p' },
-      { "out-file",             required_argument, NULL, 'o' },
-      { "context-object",       required_argument, NULL, 'c' },
+      { "auth",             required_argument, NULL, 'p' },
+      { "output",           required_argument, NULL, 'o' },
+      { "object-context",   required_argument, NULL, 'c' },
     };
 
     *opts = tpm2_options_new("p:o:c:", ARRAY_LEN(topts), topts,

--- a/tools/tpm2_verifysignature.c
+++ b/tools/tpm2_verifysignature.c
@@ -198,7 +198,7 @@ static bool on_option(char key, char *value) {
 		ctx.flags.msg = 1;
 	}
 		break;
-	case 'D': {
+	case 'd': {
         ctx.msgHash = malloc(sizeof(TPM2B_DIGEST));
 	    ctx.msgHash->size = sizeof(ctx.msgHash->buffer);
 		if (!files_load_bytes_from_path(value, ctx.msgHash->buffer, &ctx.msgHash->size)) {
@@ -234,17 +234,17 @@ static bool on_option(char key, char *value) {
 bool tpm2_tool_onstart(tpm2_options **opts) {
 
     const struct option topts[] = {
-            { "digest",       required_argument, NULL, 'D' },
-            { "halg",         required_argument, NULL, 'g' },
-            { "message",      required_argument, NULL, 'm' },
-            { "format",       required_argument, NULL, 'f' },
-            { "sig",          required_argument, NULL, 's' },
-            { "ticket",       required_argument, NULL, 't' },
-            { "key-context",  required_argument, NULL, 'c' },
+            { "digest",         required_argument, NULL, 'd' },
+            { "hash-algorithm", required_argument, NULL, 'g' },
+            { "message",        required_argument, NULL, 'm' },
+            { "format",         required_argument, NULL, 'f' },
+            { "signature",      required_argument, NULL, 's' },
+            { "ticket",         required_argument, NULL, 't' },
+            { "key-context",    required_argument, NULL, 'c' },
     };
 
 
-    *opts = tpm2_options_new("g:m:D:f:s:t:c:", ARRAY_LEN(topts), topts,
+    *opts = tpm2_options_new("g:m:d:f:s:t:c:", ARRAY_LEN(topts), topts,
                              on_option, NULL, 0);
 
     return *opts != NULL;


### PR DESCRIPTION
Progresses #1039 and #1042
1. Tools requiring hierarchy specified should use option "hierarchy" --> auth-hierarchy goes away
2. Tools requiring single authentication should use option "auth" alone --> auth-hierarchy, hierarchy-auth, object-auth etc. goes away
3. Tools requiring multiple auths should follow "object-auth" to tell apart auths--> auth-hierarchy becomes hierarchy-auth, auth-key becomes key-auth, etc.
4. halg becomes hash-algorithm
5. kalg,algorithm becomes key-algorithm
6. sig becomes signature
7. All options drop the term file. Eg. in-file becomes input
8. All tools using hierarchy input should specify it  as C
9. Endorsement hierarchy will use known abbreviations and becomes eh
10. set-list, sel-list becomes pcr-list with short option becoming "l"
11. alg becomes algorithm in general
12. Tools with single option taking type hierarchy or NV or other tpm handle types should call it "object-context" and use short option "C"
13. qualify-data becomes qualification-data
14. pcr-input short option becomes "f" and long options becomes pcr