### PR TITLE
Rename options v2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Changelog
 ### next
+  * tpm2_import: short option changed
+    object-attributes is now attributes
   * tpm2_load: short option changed
     -o is now -c
   * tpm2_loadexternal: short and long options changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## Changelog
 ### next
+  * tpm2_create: short and long options changed
+    object-attributes is now attributes
+    -o is now -c
   * tpm2_createprimary: short and long options changed
     object-attributes is now attributes
     -o is now -c

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 ## Changelog
 ### next
+  * tpm2_policyauthorize: short and long options changed.
+    policy-output is now policy.
+    input is now the option for specifying the policy to authorize.
+    qualification-data is now qualification.
+    -o is now -L.
+    -L is now -i.
   * tpm2_import: short option changed
     object-attributes is now attributes
   * tpm2_load: short option changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,17 @@
 ## Changelog
 ### next
+  * tpm2_checkquote: short and long options changed
+    halg is now hash-algorithm
+    pcr-input-file is now pcr
+    pubfile is now public
+    qualify-data is now qualification
+    -f is now -F
+    -F is now -f
   * tpm2_hash:
     - add --hex for specifying hex output.
     - default output of hash to stdout.
     - default output of hash to binary.
     - remove output of ticket to stdout.
-
   * tpm2_listpersistent: deleted as tpm2_getcap and tpm2_readpublic can be used instead.
   * tpm2_hmac:
       - add -g option for specifying hash algorithm.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## Changelog
 ### next
+  * tpm2_createprimary: short and long options changed
+    object-attributes is now attributes
+    -o is now -c
   * tpm2_print: long option changed
     in-file is now input
   * tpm2_checkquote: short and long options changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Changelog
 ### next
+  * tpm2_quote: long option changed
+    qualification-data is now qualification
   * tpm2_policyauthorize: short and long options changed.
     policy-output is now policy.
     input is now the option for specifying the policy to authorize.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Changelog
 ### next
+  * tpm2_load: short option changed
+    -o is now -c
   * tpm2_loadexternal: short and long options changed
     object-attributes is now attributes
     -o is now -c

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Changelog
 ### next
+  * tpm2_print: long option changed
+    in-file is now input
   * tpm2_checkquote: short and long options changed
     halg is now hash-algorithm
     pcr-input-file is now pcr

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## Changelog
 ### next
+  * tpm2_loadexternal: short and long options changed
+    object-attributes is now attributes
+    -o is now -c
   * tpm2_create: short and long options changed
     object-attributes is now attributes
     -o is now -c

--- a/man/tpm2_changeauth.1.md
+++ b/man/tpm2_changeauth.1.md
@@ -72,7 +72,7 @@ tpm2_changeauth -c o -p oldpass
 
 ## Modify authorization for a loadable transient object
 ```
-tpm2_createprimary -Q -C o -o prim.ctx
+tpm2_createprimary -Q -C o -c prim.ctx
 
 tpm2_create -Q -g sha256 -G aes -u key.pub -r key.priv -C prim.ctx
 

--- a/man/tpm2_changeauth.1.md
+++ b/man/tpm2_changeauth.1.md
@@ -76,7 +76,7 @@ tpm2_createprimary -Q -C o -c prim.ctx
 
 tpm2_create -Q -g sha256 -G aes -u key.pub -r key.priv -C prim.ctx
 
-tpm2_load -C prim.ctx -u key.pub -r key.priv -n key.name -o key.ctx
+tpm2_load -C prim.ctx -u key.pub -r key.priv -n key.name -c key.ctx
 
 tpm2_changeauth -c key.ctx -C prim.ctx -r key.priv newkeyauth
 ```

--- a/man/tpm2_checkquote.1.md
+++ b/man/tpm2_checkquote.1.md
@@ -16,12 +16,12 @@ provided, verify that the qualifying data and PCR values match those in the quot
 
 # OPTIONS
 
-  * **-u**, **\--pubfile**=_KEY\_CONTEXT\_OBJECT_:
+  * **-u**, **\--public**=_KEY\_CONTEXT\_OBJECT_:
 
     Context object for the key context used for the operation. Either a file
     or a handle number. See section "Context Object Format".
 
-  * **-g**, **\--halg**=_HASH\_ALGORITHM_:
+  * **-g**, **\--hash-algorithm**=_HASH\_ALGORITHM_:
 
     The hash algorithm used to digest the message.
     Algorithms should follow the "formatting standards", see section
@@ -37,7 +37,7 @@ provided, verify that the qualifying data and PCR values match those in the quot
 
     The input signature file of the signature to be validated.
 
-  * **-f**, **\--format**:
+  * **-F**, **\--format**:
 
     Set the input signature file to a specified format. The default is the TPM2.0 **TPMT_SIGNATURE**
     data format, however different schemes can be selected if the data came from an external
@@ -48,12 +48,12 @@ provided, verify that the qualifying data and PCR values match those in the quot
     Also, see section "Supported Signing Schemes" for a list of supported hash
     algorithms.
 
-  * **-F**, **\--pcr-input-file**:
+  * **-f**, **\--pcr**:
 
     PCR input file, optional, records the list of PCR values that were included
     in the quote.
 
-  * **-q**, **\--qualify-data**:
+  * **-q**, **\--qualification**:
 
     Data given as a hex string that was used to qualify the quote. This is typically
     used to add a nonce against replay attacks.
@@ -82,7 +82,7 @@ tpm2_createak -C 0x81010009 -k 0x8101000a -G rsa -s rsassa -D sha256 -p akpub.pe
 
 tpm2_quote -C 0x8101000a -l sha256:15,16,22 -q abc123 -m quote.out -s sig.out -f pcrs.out -g sha256
 
-tpm2_checkquote -c akpub.pem -m quote.out -s sig.out -p pcrs.out -G sha256 -q abc123
+tpm2_checkquote -u akpub.pem -m quote.out -s sig.out -f pcrs.out -g sha256 -q abc123
 ```
 
 [returns](common/returns.md)

--- a/man/tpm2_create.1.md
+++ b/man/tpm2_create.1.md
@@ -52,7 +52,7 @@ These options for creating the TPM entity:
     See section "Supported Public Object Algorithms" for a list
     of supported object algorithms. Mutually exclusive of **-i**.
 
-  * **-a**, **\--object-attributes**=_ATTRIBUTES_:
+  * **-a**, **\--attributes**=_ATTRIBUTES_:
 
     The object attributes, optional. Object attributes follow the specifications
     as outlined in "object attribute specifiers". The default for created objects is:
@@ -83,7 +83,7 @@ These options for creating the TPM entity:
 
     The output file which contains the sensitive portion of the object, optional.
 
-  * **-o**, **\--key-context**=_OUTPUT\_CONTEXT\_FILE_:
+  * **-c**, **\--key-context**=_OUTPUT\_CONTEXT\_FILE_:
 
     The output file which contains the key context, optional. The key context is analogous to the context
     file produced by **tpm2_load**(1), however is generated via a **tpm2_createloaded**(1) command. This option
@@ -121,7 +121,7 @@ tpm2_create -C parent.ctx  -K def456 -G keyedhash -i seal.dat -u obj.pub -r obj.
 
 ## Create an rsa2048 object and load it into the TPM
 ```
-tpm2_create -C primary.ctx -G rsa2048 -u obj.pub -r obj.priv -o obj.ctx
+tpm2_create -C primary.ctx -G rsa2048 -u obj.pub -r obj.priv -c obj.ctx
 ```
 
 [returns](common/returns.md)

--- a/man/tpm2_createek.1.md
+++ b/man/tpm2_createek.1.md
@@ -104,7 +104,7 @@ tpm2_getcap handles-transient
 <null output>
 
 # Reload it via loadexternal
-tpm2_loadexternal -C o -u ek.pub -o ek.ctx
+tpm2_loadexternal -C o -u ek.pub -c ek.ctx
 
 # Check that it is re-loaded in transient memory
 tpm2_getcap handles-transient

--- a/man/tpm2_createprimary.1.md
+++ b/man/tpm2_createprimary.1.md
@@ -57,7 +57,7 @@ with the created primary.
     algorithm is rsa2048:null:aes128cfb. See section "Supported Public Object Algorithms"
     for a list of supported object algorithms.
 
-  * **-o**, **\--key-context**=_CONTEXT\_FILE\_NAME_:
+  * **-c**, **\--key-context**=_CONTEXT\_FILE\_NAME_:
 
     File name to use for the returned object context, required.
 
@@ -65,7 +65,7 @@ with the created primary.
 
     An optional file input that contains the policy digest for policy based authorization of the object.
 
-  * **-a**, **\--object-attributes**=_ATTRIBUTES_:
+  * **-a**, **\--attributes**=_ATTRIBUTES_:
 
     The object attributes, optional. Object attributes follow the specifications
     as outlined in "object attribute specifiers". The default for created objects is:
@@ -94,7 +94,7 @@ with the created primary.
 
 ## Create an ECC primary object
 ```
-tpm2_createprimary -C o -g sha256 -G ecc -o context.out
+tpm2_createprimary -C o -g sha256 -G ecc -c context.out
 ```
 
 ## Create a primary object that follows the guidance of TCG Provisioning guide
@@ -104,7 +104,7 @@ See : https://trustedcomputinggroup.org/wp-content/uploads/TCG-TPM-v2.0-Provisio
 Where unique.dat contains the binary-formatted data: 0x00 0x01 (0x00 * 256)
 
 ```
-tpm2_createprimary -C o -G rsa2048:aes128cfb -g sha256 -o prim.ctx \
+tpm2_createprimary -C o -G rsa2048:aes128cfb -g sha256 -c prim.ctx \
   -a 'restricted|decrypt|fixedtpm|fixedparent|sensitivedataorigin|userwithauth|noda' \
   -u unique.dat
 ```

--- a/man/tpm2_duplicate.1.md
+++ b/man/tpm2_duplicate.1.md
@@ -73,7 +73,7 @@ tpm2_flushcontext -S session.dat
 tpm2_createprimary -C o -g sha256 -G rsa -c primary.ctxt
 tpm2_create -C primary.ctxt -g sha256 -G rsa -r key.prv -u key.pub -L policy.dat -a "sensitivedataorigin"
 
-tpm2_loadexternal -C o -u new_parent.pub -o new_parent.ctxt
+tpm2_loadexternal -C o -u new_parent.pub -c new_parent.ctxt
 
 tpm2_startauthsession \--policy-session -S session.dat
 tpm2_policycommandcode -S session.dat -L policy.dat duplicate

--- a/man/tpm2_duplicate.1.md
+++ b/man/tpm2_duplicate.1.md
@@ -70,7 +70,7 @@ tpm2_startauthsession -S session.dat
 tpm2_policycommandcode -S session.dat -L policy.dat duplicate
 tpm2_flushcontext -S session.dat
 
-tpm2_createprimary -C o -g sha256 -G rsa -o primary.ctxt
+tpm2_createprimary -C o -g sha256 -G rsa -c primary.ctxt
 tpm2_create -C primary.ctxt -g sha256 -G rsa -r key.prv -u key.pub -L policy.dat -a "sensitivedataorigin"
 
 tpm2_loadexternal -C o -u new_parent.pub -o new_parent.ctxt

--- a/man/tpm2_evictcontrol.1.md
+++ b/man/tpm2_evictcontrol.1.md
@@ -80,7 +80,7 @@ tpm2_evictcontrol -C o -c 0x81010002 -P abc123
 
 ## To make a transient handle persistent and output a serialized persistent handle.
 ```
-tpm2_createprimary -o primary.ctx
+tpm2_createprimary -c primary.ctx
 tpm2_evictcontrol -C o -c primary.ctx -o primary.handle
 ```
 

--- a/man/tpm2_import.1.md
+++ b/man/tpm2_import.1.md
@@ -114,7 +114,7 @@ These options control the key importation process:
 
 ## To import a key, one needs to have a parent key
 ```
-tpm2_createprimary -Grsa2048:aes128cfb -C o -o parent.ctx
+tpm2_createprimary -Grsa2048:aes128cfb -C o -c parent.ctx
 ```
 
 Create your key and and import it. If you already have a key, just use that

--- a/man/tpm2_import.1.md
+++ b/man/tpm2_import.1.md
@@ -72,7 +72,7 @@ These options control the key importation process:
     When importing a duplicated object this option specifies the file containing the
     public portion of the object to be imported.
 
-  * **-a**, **\--object-attributes**=_ATTRIBUTES_:
+  * **-a**, **\--attributes**=_ATTRIBUTES_:
 
     The object attributes, optional.
 

--- a/man/tpm2_load.1.md
+++ b/man/tpm2_load.1.md
@@ -42,7 +42,7 @@ context file for future interactions with the object.
 
     An optional file to save the name structure of the object.
 
-  * **-o**, **\--key-context**=_CONTEXT\_FILE\_NAME_:
+  * **-c**, **\--key-context**=_CONTEXT\_FILE\_NAME_:
 
     The file name of the saved object context, required.
 
@@ -58,7 +58,7 @@ context file for future interactions with the object.
 # EXAMPLES
 
 ```
-tpm2_load  -C parent.ctx -P abc123 -u <pubKeyFileName> -r <privKeyFileName> -n <outPutFileName> -o object.context
+tpm2_load  -C parent.ctx -P abc123 -u <pubKeyFileName> -r <privKeyFileName> -n <outPutFileName> -c object.context
 
 tpm2_load  -C parent.ctx -P "hex:123abc" -u <pubKeyFileName> -r <privKeyFileName> -n <outPutFileName>
 

--- a/man/tpm2_loadexternal.1.md
+++ b/man/tpm2_loadexternal.1.md
@@ -77,7 +77,7 @@ and a sensitive area.
     Also, see section "Supported Hash Algorithms" for a list of supported
     hash algorithms.
 
-  * **-a**, **\--object-attributes**=_ATTRIBUTES_:
+  * **-a**, **\--attributes**=_ATTRIBUTES_:
 
     The object attributes, optional. Object attributes follow the specifications
     as outlined in "object attribute specifiers". The default for created objects is:
@@ -88,7 +88,7 @@ and a sensitive area.
     *Note*: If specifying attributes, the TPM will reject certain attributes like
     **TPMA_OBJECT_FIXEDTPM**, as those guarantees cannot be made.
 
-  * **-o**, **\--key-context**=_CONTEXT\_FILE_
+  * **-c**, **\--key-context**=_CONTEXT\_FILE_
 
     The file name of the saved object context, required.
 

--- a/man/tpm2_policyauthorize.1.md
+++ b/man/tpm2_policyauthorize.1.md
@@ -109,7 +109,7 @@ tpm2_flushcontext -S session.ctx
 
 ## Create a TPM object like a sealing object with the authorized policy based authentication
 ```
-tpm2_createprimary -Q -C o -g sha256 -G rsa -o prim.ctx
+tpm2_createprimary -Q -C o -g sha256 -G rsa -c prim.ctx
 
 tpm2_create -Q -g sha256 -u sealing_pubkey.pub -r sealing_prikey.pub -i- -C prim.ctx -L authorized.policy <<< "secret to seal"
 ```

--- a/man/tpm2_policyauthorize.1.md
+++ b/man/tpm2_policyauthorize.1.md
@@ -26,7 +26,7 @@ in the policy digest.
 
 # OPTIONS
 
-  * **-o**, **\--policy-output**=_POLICY\_FILE_:
+  * **-L**, **\--policy**=_POLICY\_FILE_:
 
     File to save the policy digest.
 
@@ -35,11 +35,11 @@ in the policy digest.
     The policy session file generated via the **-S** option to
     **tpm2_startauthsession**(1).
 
-  * **-L**, **\--policy**=_POLICY\_FILE_:
+  * **-i**, **\--input**=_POLICY\_FILE_:
 
     The policy digest that has to be authorized.
 
-  * **-q**, **\--qualification-data**=_DATA_FILE_:
+  * **-q**, **\--qualification**=_DATA_FILE_:
 
     The policy qualifier data signed in conjunction with the input policy digest.
     This is a unique data that the signer can choose to include in the signature.
@@ -102,7 +102,7 @@ openssl dgst -sha256 -sign signing_key_private.pem -out pcr.signature pcr.policy
 ```
 tpm2_startauthsession -S session.ctx
 
-tpm2_policyauthorize -S session.ctx -L authorized.policy -o pcr.policy -n signing_key.name
+tpm2_policyauthorize -S session.ctx -L authorized.policy -i pcr.policy -n signing_key.name
 
 tpm2_flushcontext -S session.ctx
 ```
@@ -122,7 +122,7 @@ tpm2_startauthsession \--policy-session -S session.ctx
 
 tpm2_policypcr -Q -S session.ctx -l sha256:0 -L pcr.policy
 
-tpm2_policyauthorize -S session.ctx -o authorized.policy -L pcr.policy -n signing_key.name -t verification.tkt
+tpm2_policyauthorize -S session.ctx -L authorized.policy -i pcr.policy -n signing_key.name -t verification.tkt
 
 tpm2_load -Q -C prim.ctx -u sealing_pubkey.pub -r sealing_prikey.pub -c sealing_key.ctx
 

--- a/man/tpm2_policyauthorize.1.md
+++ b/man/tpm2_policyauthorize.1.md
@@ -124,7 +124,7 @@ tpm2_policypcr -Q -S session.ctx -l sha256:0 -L pcr.policy
 
 tpm2_policyauthorize -S session.ctx -o authorized.policy -L pcr.policy -n signing_key.name -t verification.tkt
 
-tpm2_load -Q -C prim.ctx -u sealing_pubkey.pub -r sealing_prikey.pub -o sealing_key.ctx
+tpm2_load -Q -C prim.ctx -u sealing_pubkey.pub -r sealing_prikey.pub -c sealing_key.ctx
 
 unsealed=$(tpm2_unseal -p"session:session.ctx" -c sealing_key.ctx)
 

--- a/man/tpm2_policyauthorize.1.md
+++ b/man/tpm2_policyauthorize.1.md
@@ -79,7 +79,7 @@ openssl genrsa -out signing_key_private.pem 2048
 
 openssl rsa -in signing_key_private.pem -out signing_key_public.pem -pubout
 
-tpm2_loadexternal -G rsa -C o -u signing_key_public.pem -o signing_key.ctx -n signing_key.name
+tpm2_loadexternal -G rsa -C o -u signing_key_public.pem -c signing_key.ctx -n signing_key.name
 ```
 
 ## Create a policy to be authorized like a PCR policy

--- a/man/tpm2_policycommandcode.1.md
+++ b/man/tpm2_policycommandcode.1.md
@@ -182,7 +182,7 @@ tpm2_flushcontext -S session.dat
 
 ## Create the object with unseal-only auth policy
 ```
-tpm2_createprimary -C o -o prim.ctx
+tpm2_createprimary -C o -c prim.ctx
 
 tpm2_create -C prim.ctx -u sealkey.pub -r sealkey.priv -L policy.dat \
   -i- <<< "SEALED-SECRET"

--- a/man/tpm2_policylocality.1.md
+++ b/man/tpm2_policylocality.1.md
@@ -48,7 +48,7 @@ tpm2_flushcontext -S session.dat
 
 ## Create the object with auth policy
 ```
-tpm2_createprimary -C o -o prim.ctx
+tpm2_createprimary -C o -c prim.ctx
 
 tpm2_create -C prim.ctx -u sealkey.pub -r sealkey.priv -L policy.dat \
   -I- <<< "SEALED-SECRET"

--- a/man/tpm2_policyor.1.md
+++ b/man/tpm2_policyor.1.md
@@ -88,7 +88,7 @@ tpm2_flushcontext -S session.ctx
 
 ## Create a TPM sealing object with the compounded auth policy
 ```
-tpm2_createprimary -Q -C o -g sha256 -G rsa -o prim.ctx
+tpm2_createprimary -Q -C o -g sha256 -G rsa -c prim.ctx
 
 tpm2_create -Q -g sha256 -u sealing_key.pub -r sealing_key.pub -i- -C prim.ctx -L policy.or <<< "secret to seal"
 ```

--- a/man/tpm2_policypassword.1.md
+++ b/man/tpm2_policypassword.1.md
@@ -57,7 +57,7 @@ tpm2_flushcontext -S session.dat
 ## Create the object with a passphrase and the password policy
 ```
 
-tpm2_createprimary -C o -o prim.ctx
+tpm2_createprimary -C o -c prim.ctx
 
 tpm2_create -g sha256 -G aes -u key.pub -r key.priv -C prim.ctx -L policy.pass \
   -p testpswd

--- a/man/tpm2_policypassword.1.md
+++ b/man/tpm2_policypassword.1.md
@@ -65,7 +65,7 @@ tpm2_create -g sha256 -G aes -u key.pub -r key.priv -C prim.ctx -L policy.pass \
 
 ## Authenticate with plaintext passphrase input
 ```
-tpm2_load -C prim.ctx -u key.pub -r key.priv -n key.name -o key.ctx
+tpm2_load -C prim.ctx -u key.pub -r key.priv -n key.name -c key.ctx
 
 tpm2_encryptdecrypt -c key.ctx -o encrypt.out -i plain.txt -p text
 ```

--- a/man/tpm2_policypcr.1.md
+++ b/man/tpm2_policypcr.1.md
@@ -63,7 +63,7 @@ Then, it uses a *policy* session to unseal some data stored in the object.
     ```
     tpm2_create -Q -g sha256 -G keyedhash -u key.pub -r key.priv -C primary.ctx -L policy.dat -a 'sign|fixedtpm|fixedparent|sensitivedataorigin' -i- <<< "12345678"
 
-    tpm2_load -Q -C primary.ctx -u key.pub -r key.priv -n unseal.key.name -o unseal.key.ctx
+    tpm2_load -Q -C primary.ctx -u key.pub -r key.priv -n unseal.key.name -c unseal.key.ctx
     ```
 3. Create an actual policy session and using a policyPCR event, update the session policy hash.
     ```

--- a/man/tpm2_policypcr.1.md
+++ b/man/tpm2_policypcr.1.md
@@ -49,7 +49,7 @@ Then, it uses a *policy* session to unseal some data stored in the object.
 
 1. Create a trial session and build a PCR policy via a **policyPCR** event to generate a policy hash.
     ```
-    tpm2_createprimary -C e -g sha256 -G ecc -o primary.ctx
+    tpm2_createprimary -C e -g sha256 -G ecc -c primary.ctx
 
     tpm2_pcrlist -Q -l "sha1:0,1,2,3 -o pcr.dat
 

--- a/man/tpm2_policysecret.1.md
+++ b/man/tpm2_policysecret.1.md
@@ -68,7 +68,7 @@ tpm2_createprimary -Q -C o -g sha256 -G rsa -c prim.ctx
 
 tpm2_create -Q -g sha256 -u sealing_key.pub -r sealing_key.priv -i- -C prim.ctx -L secret.policy <<< "SEALED-SECRET"
 
-tpm2_load -C prim.ctx -u sealing_key.pub -r sealing_key.priv -n sealing_key.name -o sealing_key.ctx
+tpm2_load -C prim.ctx -u sealing_key.pub -r sealing_key.priv -n sealing_key.name -c sealing_key.ctx
 ```
 
 ## Satisfy the policy and unseal the secret

--- a/man/tpm2_policysecret.1.md
+++ b/man/tpm2_policysecret.1.md
@@ -64,7 +64,7 @@ tpm2_flushcontext -S session.ctx
 
 ## Create a TPM object like a sealing object with the policy
 ```
-tpm2_createprimary -Q -C o -g sha256 -G rsa -o prim.ctx
+tpm2_createprimary -Q -C o -g sha256 -G rsa -c prim.ctx
 
 tpm2_create -Q -g sha256 -u sealing_key.pub -r sealing_key.priv -i- -C prim.ctx -L secret.policy <<< "SEALED-SECRET"
 

--- a/man/tpm2_print.1.md
+++ b/man/tpm2_print.1.md
@@ -20,7 +20,7 @@ elements to stdout as YAML.
     Required. Type of data structure. Only **TPMS_ATTEST** and **TPMS_CONTEXT** are
     presently supported.
 
-  * **-i**, **\--in-file**:
+  * **-i**, **\--input**:
 
     Optional. File containing TPM object. Reads from stdin if unspecified.
 
@@ -31,9 +31,9 @@ elements to stdout as YAML.
 # EXAMPLES
 
 ```
-tpm2_print -t TPMS_ATTEST -f /path/to/tpm/quote
+tpm2_print -t TPMS_ATTEST -i /path/to/tpm/quote
 
-tpm2_print \--type=TPMS_ATTEST \--file=/path/to/tpm/quote
+tpm2_print \--type=TPMS_ATTEST \--input=/path/to/tpm/quote
 
 cat /path/to/tpm/quote | tpm2_print \--type=TPMS_ATTEST
 ```

--- a/man/tpm2_quote.1.md
+++ b/man/tpm2_quote.1.md
@@ -58,7 +58,7 @@
     signed quote message \-- these values themselves are not signed or
     stored in the message.
 
-  * **-q**, **\--qualification-data**:
+  * **-q**, **\--qualification**:
 
     Data given as a Hex string to qualify the  quote, optional. This is typically
     used to add a nonce against replay attacks.

--- a/man/tpm2_readpublic.1.md
+++ b/man/tpm2_readpublic.1.md
@@ -45,7 +45,7 @@
 
 ## Create a primary object and read the public structure in an openssl compliant format
 ```
-tpm2_createprimary -o primary.ctx
+tpm2_createprimary -c primary.ctx
 tpm2_readpublic -c primary.ctx -o output.dat -f pem
 ```
 
@@ -60,7 +60,7 @@ We assume that an object has already been persisted, for example via:
 
 ```
 # We assume that an object has already been persisted, for example
-tpm2_createprimary -o primary.ctx
+tpm2_createprimary -c primary.ctx
 
 # context files have all the information for the TPM to verify the object
 tpm2_evictcontrol -c primary.ctx

--- a/man/tpm2_sign.1.md
+++ b/man/tpm2_sign.1.md
@@ -97,7 +97,7 @@ tpm2_createprimary -C e -c primary.ctx
 
 tpm2_create -G rsa -u rsa.pub -r rsa.priv -C primary.ctx
 
-tpm2_load -C primary.ctx -u rsa.pub -r rsa.priv -o rsa.ctx
+tpm2_load -C primary.ctx -u rsa.pub -r rsa.priv -c rsa.ctx
 
 echo "my message > message.dat
 

--- a/man/tpm2_sign.1.md
+++ b/man/tpm2_sign.1.md
@@ -118,7 +118,7 @@ echo "data to sign" > data.in.raw
 sha256sum data.in.raw | awk '{ print "000000 " $1 }' | xxd -r -c 32 > data.in.digest
 
 # Load the private key for signing
-tpm2_loadexternal -Q -G ecc -r private.ecc.pem -o key.ctx
+tpm2_loadexternal -Q -G ecc -r private.ecc.pem -c key.ctx
 
 # Sign in the TPM and verify with OSSL
 tpm2_sign -Q -c key.ctx -g sha256 -d data.in.digest -f plain -s data.out.signed

--- a/man/tpm2_sign.1.md
+++ b/man/tpm2_sign.1.md
@@ -93,7 +93,7 @@ data and validation shall indicate that hashed data did not start with
 
 ## Sign and verify with the TPM using the *endorsement* hierarchy
 ```
-tpm2_createprimary -C e -o primary.ctx
+tpm2_createprimary -C e -c primary.ctx
 
 tpm2_create -G rsa -u rsa.pub -r rsa.priv -C primary.ctx
 

--- a/man/tpm2_startauthsession.1.md
+++ b/man/tpm2_startauthsession.1.md
@@ -71,7 +71,7 @@ tpm2_startauthsession \--policy-session -S mysession.ctx
 
 ## Start an encrypted and bound *policy* session and save the session data to a file
 ```
-tpm2_createprimary -o primary.ctx
+tpm2_createprimary -c primary.ctx
 tpm2_startauthsession \--policy-session -c primary.ctx -S mysession.ctx
 ```
 

--- a/man/tpm2_verifysignature.1.md
+++ b/man/tpm2_verifysignature.1.md
@@ -83,7 +83,7 @@ tpm2_createprimary -C e -c primary.ctx
 
 tpm2_create -G rsa -u rsa.pub -r rsa.priv -C primary.ctx
 
-tpm2_load -C primary.ctx -u rsa.pub -r rsa.priv -o rsa.ctx
+tpm2_load -C primary.ctx -u rsa.pub -r rsa.priv -c rsa.ctx
 
 echo "my message > message.dat
 

--- a/man/tpm2_verifysignature.1.md
+++ b/man/tpm2_verifysignature.1.md
@@ -105,7 +105,7 @@ echo "data to sign" > data.in.raw
 sha256sum data.in.raw | awk '{ print "000000 " $1 }' | xxd -r -c 32 > data.in.digest
 
 # Load the private key for signing
-tpm2_loadexternal -Q -G ecc -r private.ecc.pem -o key.ctx
+tpm2_loadexternal -Q -G ecc -r private.ecc.pem -c key.ctx
 
 # Sign in the TPM and verify with OSSL
 tpm2_sign -Q -c key.ctx -g sha256 -d data.in.digest -f plain -s data.out.signed

--- a/man/tpm2_verifysignature.1.md
+++ b/man/tpm2_verifysignature.1.md
@@ -79,7 +79,7 @@ symmetric key, both the public and private portions need to be loaded.
 
 ## Sign and verify with the TPM using the *endorsement* hierarchy
 ```
-tpm2_createprimary -C e -o primary.ctx
+tpm2_createprimary -C e -c primary.ctx
 
 tpm2_create -G rsa -u rsa.pub -r rsa.priv -C primary.ctx
 

--- a/test/integration/tests/abrmd_extended-sessions.sh
+++ b/test/integration/tests/abrmd_extended-sessions.sh
@@ -60,7 +60,7 @@ tpm2_clear
 # Step 4: Using that actual policy session from step 3 in tpm2_unseal to unseal the object.
 #
 
-tpm2_createprimary -Q -C e -g $alg_primary_obj -G $alg_primary_key -o $file_primary_key_ctx
+tpm2_createprimary -Q -C e -g $alg_primary_obj -G $alg_primary_key -c $file_primary_key_ctx
 
 tpm2_pcrlist -Q -l ${alg_pcr_policy}:${pcr_ids} -o $file_pcr_value
 

--- a/test/integration/tests/abrmd_extended-sessions.sh
+++ b/test/integration/tests/abrmd_extended-sessions.sh
@@ -73,7 +73,7 @@ tpm2_flushcontext -S $file_session_file
 tpm2_create -Q -g $alg_create_obj -u $file_unseal_key_pub -r $file_unseal_key_priv -i- -C $file_primary_key_ctx -L $file_policy \
   -a 'fixedtpm|fixedparent' <<< $secret
 
-tpm2_load -Q -C $file_primary_key_ctx -u $file_unseal_key_pub -r $file_unseal_key_priv -n $file_unseal_key_name -o $file_unseal_key_ctx
+tpm2_load -Q -C $file_primary_key_ctx -u $file_unseal_key_pub -r $file_unseal_key_priv -n $file_unseal_key_name -c $file_unseal_key_ctx
 
 rm $file_session_file
 

--- a/test/integration/tests/abrmd_policyauthorize.sh
+++ b/test/integration/tests/abrmd_policyauthorize.sh
@@ -36,7 +36,7 @@ cleanup "no-shutdown"
 
 generate_policy_authorize () {
     tpm2_startauthsession -Q -S $file_session_file
-    tpm2_policyauthorize -Q -S $file_session_file  -o $3 -L $1 -q $2 -n $4
+    tpm2_policyauthorize -Q -S $file_session_file  -L $3 -i $1 -q $2 -n $4
     tpm2_flushcontext -S $file_session_file
     rm $file_session_file
 }

--- a/test/integration/tests/abrmd_policyauthorize.sh
+++ b/test/integration/tests/abrmd_policyauthorize.sh
@@ -43,7 +43,7 @@ generate_policy_authorize () {
 
 openssl genrsa -out $file_private_key 2048 2>/dev/null
 openssl rsa -in $file_private_key -out $file_public_key -pubout 2>/dev/null
-tpm2_loadexternal -G rsa -C n -u $file_public_key -o $file_verifying_key_ctx \
+tpm2_loadexternal -G rsa -C n -u $file_public_key -c $file_verifying_key_ctx \
   -n $file_verifying_key_name
 
 dd if=/dev/urandom of=$file_policyref bs=1 count=32 2>/dev/null

--- a/test/integration/tests/abrmd_policycommandcode.sh
+++ b/test/integration/tests/abrmd_policycommandcode.sh
@@ -33,7 +33,7 @@ echo $secret > $file_input_data
 
 tpm2_clear
 
-tpm2_createprimary -Q -C o -o $file_primary_key_ctx
+tpm2_createprimary -Q -C o -c $file_primary_key_ctx
 
 tpm2_startauthsession -S $file_session_data
 

--- a/test/integration/tests/abrmd_policycommandcode.sh
+++ b/test/integration/tests/abrmd_policycommandcode.sh
@@ -50,7 +50,7 @@ tpm2_create -C $file_primary_key_ctx -u $file_unseal_key_pub \
   -r $file_unseal_key_priv -L $file_policy -i- <<< $secret
 
 tpm2_load -C $file_primary_key_ctx -u $file_unseal_key_pub \
-  -r $file_unseal_key_priv -n $file_unseal_key_name -o $file_unseal_key_ctx
+  -r $file_unseal_key_priv -n $file_unseal_key_name -c $file_unseal_key_ctx
 
 
 # Ensure unsealing passes with proper policy

--- a/test/integration/tests/abrmd_policypassword.sh
+++ b/test/integration/tests/abrmd_policypassword.sh
@@ -42,7 +42,7 @@ tpm2_createprimary -C o -c $primary_key_ctx
 tpm2_create -g sha256 -G aes -u $key_pub -r $key_priv -C $primary_key_ctx \
   -L $policypassword -p $testpswd
 
-tpm2_load -C $primary_key_ctx -u $key_pub -r $key_priv -o $key_ctx
+tpm2_load -C $primary_key_ctx -u $key_pub -r $key_priv -c $key_ctx
 tpm2_encryptdecrypt -c $key_ctx -o $encrypted_txt -i $plain_txt -p $testpswd
 
 tpm2_startauthsession --policy-session -S $session_ctx

--- a/test/integration/tests/abrmd_policypassword.sh
+++ b/test/integration/tests/abrmd_policypassword.sh
@@ -37,7 +37,7 @@ tpm2_policypassword -S $session_ctx -L $policypassword
 tpm2_flushcontext -S $session_ctx
 rm $session_ctx
 
-tpm2_createprimary -C o -o $primary_key_ctx
+tpm2_createprimary -C o -c $primary_key_ctx
 
 tpm2_create -g sha256 -G aes -u $key_pub -r $key_priv -C $primary_key_ctx \
   -L $policypassword -p $testpswd

--- a/test/integration/tests/abrmd_policysecret.sh
+++ b/test/integration/tests/abrmd_policysecret.sh
@@ -40,7 +40,7 @@ tpm2_flushcontext -S $session_ctx
 rm $session_ctx
 
 # Create and Load Object
-tpm2_createprimary -Q -C o  -o $primary_ctx -P ownerauth
+tpm2_createprimary -Q -C o  -c $primary_ctx -P ownerauth
 tpm2_create -Q -g sha256 -u $seal_key_pub -r $seal_key_priv -C $primary_ctx\
   -L $o_policy_digest -i- <<< $SEALED_SECRET
 tpm2_load -C $primary_ctx -u $seal_key_pub -r $seal_key_priv -o $seal_key_ctx

--- a/test/integration/tests/abrmd_policysecret.sh
+++ b/test/integration/tests/abrmd_policysecret.sh
@@ -43,7 +43,7 @@ rm $session_ctx
 tpm2_createprimary -Q -C o  -c $primary_ctx -P ownerauth
 tpm2_create -Q -g sha256 -u $seal_key_pub -r $seal_key_priv -C $primary_ctx\
   -L $o_policy_digest -i- <<< $SEALED_SECRET
-tpm2_load -C $primary_ctx -u $seal_key_pub -r $seal_key_priv -o $seal_key_ctx
+tpm2_load -C $primary_ctx -u $seal_key_pub -r $seal_key_priv -c $seal_key_ctx
 
 # Satisfy policy and unseal data
 tpm2_startauthsession --policy-session -S $session_ctx

--- a/test/integration/tests/attestation.sh
+++ b/test/integration/tests/attestation.sh
@@ -96,7 +96,7 @@ tpm2_quote -Q -C $context_ak -l $digestAlg:$debug_pcr_list -q $loaded_randomness
 
 
 # Verify quote
-tpm2_checkquote -Q -u $output_ak_pub_pem -m $output_quote -s $output_quotesig -F $output_quotepcr -g $digestAlg -q $loaded_randomness
+tpm2_checkquote -Q -u $output_ak_pub_pem -m $output_quote -s $output_quotesig -f $output_quotepcr -g $digestAlg -q $loaded_randomness
 
 
 # Save U key from verifier

--- a/test/integration/tests/certify.sh
+++ b/test/integration/tests/certify.sh
@@ -18,7 +18,7 @@ cleanup "no-shut-down"
 
 tpm2_clear -Q
 
-tpm2_createprimary -Q -C e -g sha256 -G rsa -o primary.ctx
+tpm2_createprimary -Q -C e -g sha256 -G rsa -c primary.ctx
 
 tpm2_create -Q -g sha256 -G rsa -u certify.pub -r certify.priv  -C primary.ctx
 

--- a/test/integration/tests/certify.sh
+++ b/test/integration/tests/certify.sh
@@ -22,7 +22,7 @@ tpm2_createprimary -Q -C e -g sha256 -G rsa -c primary.ctx
 
 tpm2_create -Q -g sha256 -G rsa -u certify.pub -r certify.priv  -C primary.ctx
 
-tpm2_load -Q -C primary.ctx -u certify.pub -r certify.priv -n certify.name -o certify.ctx
+tpm2_load -Q -C primary.ctx -u certify.pub -r certify.priv -n certify.name -c certify.ctx
 
 tpm2_certify -Q -C primary.ctx -c certify.ctx -g sha256 -o attest.out -s sig.out
 

--- a/test/integration/tests/changeauth.sh
+++ b/test/integration/tests/changeauth.sh
@@ -39,7 +39,7 @@ tpm2_clear $lockPasswd
 # Test changing an objects auth
 tpm2_createprimary -Q -C o -c primary.ctx
 tpm2_create -Q -C primary.ctx -p foo -u key.pub -r key.priv
-tpm2_load -Q -C primary.ctx -u key.pub -r key.priv -o key.ctx
+tpm2_load -Q -C primary.ctx -u key.pub -r key.priv -c key.ctx
 tpm2_changeauth -C primary.ctx -p foo -c key.ctx -r new.priv bar
 
 exit 0

--- a/test/integration/tests/changeauth.sh
+++ b/test/integration/tests/changeauth.sh
@@ -37,7 +37,7 @@ tpm2_changeauth -c l $lockPasswd
 tpm2_clear $lockPasswd
 
 # Test changing an objects auth
-tpm2_createprimary -Q -C o -o primary.ctx
+tpm2_createprimary -Q -C o -c primary.ctx
 tpm2_create -Q -C primary.ctx -p foo -u key.pub -r key.priv
 tpm2_load -Q -C primary.ctx -u key.pub -r key.priv -o key.ctx
 tpm2_changeauth -C primary.ctx -p foo -c key.ctx -r new.priv bar

--- a/test/integration/tests/checkquote.sh
+++ b/test/integration/tests/checkquote.sh
@@ -58,6 +58,6 @@ getrandom 20
 tpm2_quote -C $handle_ak -l sha256:15,16,22 -q $loaded_randomness -m $output_quote -s $output_quotesig -f $output_quotepcr -g $digestAlg -P "$akpw"
 
 # Verify quote
-tpm2_checkquote -u $output_ak_pub_pem -m $output_quote -s $output_quotesig -F $output_quotepcr -g $digestAlg -q $loaded_randomness
+tpm2_checkquote -u $output_ak_pub_pem -m $output_quote -s $output_quotesig -f $output_quotepcr -g $digestAlg -q $loaded_randomness
 
 exit 0

--- a/test/integration/tests/create.sh
+++ b/test/integration/tests/create.sh
@@ -21,7 +21,7 @@ start_up
 
 cleanup "no-shut-down"
 
-tpm2_createprimary -Q -C o -g sha1 -G rsa -o context.out
+tpm2_createprimary -Q -C o -g sha1 -G rsa -c context.out
 
 # Keep the algorithm specifiers mixed to test friendly and raw
 # values.

--- a/test/integration/tests/create.sh
+++ b/test/integration/tests/create.sh
@@ -49,7 +49,7 @@ test "$policy_orig" == "$policy_new"
 # Test the extended format specifiers
 #
 tpm2_create -Q -C context.out -g sha256 -G aes256cbc -u key.pub -r key.priv
-tpm2_load -Q -C context.out -u key.pub -r key.priv -o key1.ctx
+tpm2_load -Q -C context.out -u key.pub -r key.priv -c key1.ctx
 tpm2_readpublic -c key1.ctx > out.yaml
 keybits=$(yaml_get_kv out.yaml "sym-keybits")
 mode=$(yaml_get_kv out.yaml "sym-mode" "value")
@@ -57,7 +57,7 @@ test "$keybits" -eq "256"
 test "$mode" == "cbc"
 
 tpm2_create -Q -C context.out -g sha256 -G aes128ofb -u key.pub -r key.priv
-tpm2_load -Q -C context.out -u key.pub -r key.priv -o key2.ctx
+tpm2_load -Q -C context.out -u key.pub -r key.priv -c key2.ctx
 tpm2_readpublic -c key2.ctx > out.yaml
 keybits=$(yaml_get_kv out.yaml "sym-keybits")
 mode=$(yaml_get_kv out.yaml "sym-mode" "value")

--- a/test/integration/tests/create.sh
+++ b/test/integration/tests/create.sh
@@ -73,7 +73,7 @@ for alg in "rsa1024:rsaes" "ecc384:ecdaa4-sha256"; do
 done
 
 # Test createloaded support
-tpm2_create -C context.out -u key.pub -r key.priv -o key.ctx
+tpm2_create -C context.out -u key.pub -r key.priv -c key.ctx
 tpm2_readpublic -c key.ctx 2>/dev/null
 
 exit 0

--- a/test/integration/tests/createprimary.sh
+++ b/test/integration/tests/createprimary.sh
@@ -24,11 +24,11 @@ cleanup "no-shut-down"
 # values.
 for gAlg in `populate_hash_algs 'and alg != "keyedhash"'`; do
     for GAlg in rsa xor ecc aes; do
-        echo tpm2_createprimary -Q -g $gAlg -G $GAlg -o context.out
-        tpm2_createprimary -Q -g $gAlg -G $GAlg -o context.out
+        echo tpm2_createprimary -Q -g $gAlg -G $GAlg -c context.out
+        tpm2_createprimary -Q -g $gAlg -G $GAlg -c context.out
         cleanup "no-shut-down" "keep-context"
         for Atype in o e n; do
-            tpm2_createprimary -Q -C $Atype -g $gAlg -G $GAlg -o context.out
+            tpm2_createprimary -Q -C $Atype -g $gAlg -G $GAlg -c context.out
             cleanup "no-shut-down" "keep-context"
         done
     done
@@ -39,7 +39,7 @@ policy_orig="f28230c080bbe417141199e36d18978228d8948fc10a6a24921b9eba6bb1d988"
 #test for createprimary objects with policy authorization structures
 echo -n "$policy_orig" | xxd -r -p > policy.bin
 
-tpm2_createprimary -Q -C o -G rsa -g sha256 -o context.out -L policy.bin \
+tpm2_createprimary -Q -C o -G rsa -g sha256 -c context.out -L policy.bin \
   -a 'restricted|decrypt|fixedtpm|fixedparent|sensitivedataorigin'
 
 tpm2_readpublic -c context.out > pub.out
@@ -53,13 +53,13 @@ test "$policy_orig" == "$policy_new"
 printf '\x00\x01' > ud.1
 dd if=/dev/zero bs=256 count=1 of=ud.2
 cat ud.1 ud.2 > unique.dat
-tpm2_createprimary -C o -G rsa2048:aes128cfb -g sha256 -o prim.ctx \
+tpm2_createprimary -C o -G rsa2048:aes128cfb -g sha256 -c prim.ctx \
   -a 'restricted|decrypt|fixedtpm|fixedparent|sensitivedataorigin|userwithauth|noda' \
   -u unique.dat
 test -f prim.ctx
 
 # Test that -g/-G do not need to be specified.
-tpm2_createprimary -Q -o context.out
+tpm2_createprimary -Q -c context.out
 
 # Test that -o does not need to be specified.
 tpm2_createprimary -Q

--- a/test/integration/tests/duplicate.sh
+++ b/test/integration/tests/duplicate.sh
@@ -52,7 +52,7 @@ create_duplication_policy
 tpm2_create -Q -C primary.ctx -g sha256 -G rsa -r key.prv -u key.pub -L policy.dat -a "sensitivedataorigin|sign|decrypt"
 tpm2_load -Q -C primary.ctx -r key.prv -u key.pub -o key.ctx
 
-tpm2_loadexternal -Q -C o -u new_parent.pub -o new_parent.ctx
+tpm2_loadexternal -Q -C o -u new_parent.pub -c new_parent.ctx
 
 ## Null parent, Null Sym Alg
 start_duplication_session

--- a/test/integration/tests/duplicate.sh
+++ b/test/integration/tests/duplicate.sh
@@ -42,7 +42,7 @@ dump_duplication_session() {
 
 dd if=/dev/urandom of=sym_key_in.bin bs=1 count=16 status=none
 
-tpm2_createprimary -Q -C o -g sha256 -G rsa -o primary.ctx
+tpm2_createprimary -Q -C o -g sha256 -G rsa -c primary.ctx
 
 # Create a new parent, we will only use the public portion
 tpm2_create -Q -C primary.ctx -g sha256 -G rsa -r new_parent.prv -u new_parent.pub -a "decrypt|fixedparent|fixedtpm|restricted|sensitivedataorigin"

--- a/test/integration/tests/duplicate.sh
+++ b/test/integration/tests/duplicate.sh
@@ -50,7 +50,7 @@ tpm2_create -Q -C primary.ctx -g sha256 -G rsa -r new_parent.prv -u new_parent.p
 # Create the key we want to duplicate
 create_duplication_policy
 tpm2_create -Q -C primary.ctx -g sha256 -G rsa -r key.prv -u key.pub -L policy.dat -a "sensitivedataorigin|sign|decrypt"
-tpm2_load -Q -C primary.ctx -r key.prv -u key.pub -o key.ctx
+tpm2_load -Q -C primary.ctx -r key.prv -u key.pub -c key.ctx
 
 tpm2_loadexternal -Q -C o -u new_parent.pub -c new_parent.ctx
 
@@ -81,7 +81,7 @@ end_duplication_session
 
 ## Repeat the tests with a key that requires encrypted duplication
 tpm2_create -Q -C primary.ctx -g sha256 -G rsa -r key2.prv -u key2.pub -L policy.dat -a "sensitivedataorigin|sign|decrypt|encryptedduplication"
-tpm2_load -Q -C primary.ctx -r key2.prv -u key2.pub -o key2.ctx
+tpm2_load -Q -C primary.ctx -r key2.prv -u key2.pub -c key2.ctx
 
 ## AES Sym Alg, user supplied key
 start_duplication_session

--- a/test/integration/tests/encryptdecrypt.sh
+++ b/test/integration/tests/encryptdecrypt.sh
@@ -43,7 +43,7 @@ tpm2_createprimary -Q -C e -g sha1 -G rsa -c primary.ctx
 
 tpm2_create -Q -g sha256 -G aes -u key.pub -r key.priv -C primary.ctx
 
-tpm2_load -Q -C primary.ctx -u key.pub -r key.priv -n key.name -o decrypt.ctx
+tpm2_load -Q -C primary.ctx -u key.pub -r key.priv -n key.name -c decrypt.ctx
 
 tpm2_encryptdecrypt -Q -c decrypt.ctx  -i secret.dat -o encrypt.out
 
@@ -63,7 +63,7 @@ cmp secret.dat secret2.dat
 tpm2_create -Q -G aes128cbc -u key.pub -r key.priv -C primary.ctx
 
 rm decrypt.ctx
-tpm2_load -Q -C primary.ctx -u key.pub -r key.priv -n key.name -o decrypt.ctx
+tpm2_load -Q -C primary.ctx -u key.pub -r key.priv -n key.name -c decrypt.ctx
 
 # We need to perform cbc on blocksize of 16
 echo -n "1234567812345678" > secret.dat

--- a/test/integration/tests/encryptdecrypt.sh
+++ b/test/integration/tests/encryptdecrypt.sh
@@ -39,7 +39,7 @@ echo "12345678" > secret.dat
 
 tpm2_clear -Q
 
-tpm2_createprimary -Q -C e -g sha1 -G rsa -o primary.ctx
+tpm2_createprimary -Q -C e -g sha1 -G rsa -c primary.ctx
 
 tpm2_create -Q -g sha256 -G aes -u key.pub -r key.priv -C primary.ctx
 

--- a/test/integration/tests/evictcontrol.sh
+++ b/test/integration/tests/evictcontrol.sh
@@ -18,7 +18,7 @@ cleanup "no-shut-down"
 
 tpm2_clear -Q
 
-tpm2_createprimary -Q -C e -g sha256 -G rsa -o primary.ctx
+tpm2_createprimary -Q -C e -g sha256 -G rsa -c primary.ctx
 
 tpm2_create -Q -g sha256 -G aes -u key.pub -r key.priv  -C primary.ctx
 

--- a/test/integration/tests/evictcontrol.sh
+++ b/test/integration/tests/evictcontrol.sh
@@ -22,7 +22,7 @@ tpm2_createprimary -Q -C e -g sha256 -G rsa -c primary.ctx
 
 tpm2_create -Q -g sha256 -G aes -u key.pub -r key.priv  -C primary.ctx
 
-tpm2_load -Q -C primary.ctx  -u key.pub  -r key.priv -n key.name -o key.dat
+tpm2_load -Q -C primary.ctx  -u key.pub  -r key.priv -n key.name -c key.dat
 
 # Load the context into a specific handle, delete it
 tpm2_evictcontrol -Q -c key.dat 0x81010003

--- a/test/integration/tests/hmac.sh
+++ b/test/integration/tests/hmac.sh
@@ -43,7 +43,7 @@ echo "12345678" > $file_input_data
 
 tpm2_clear
 
-tpm2_createprimary -Q -C e -g $alg_primary_obj -G $alg_primary_key -o $file_primary_key_ctx
+tpm2_createprimary -Q -C e -g $alg_primary_obj -G $alg_primary_key -c $file_primary_key_ctx
 
 tpm2_create -Q -G $alg_create_key -u $file_hmac_key_pub -r $file_hmac_key_priv  -C $file_primary_key_ctx
 
@@ -70,7 +70,7 @@ echo "12345678" > $file_input_data
 
 tpm2_clear
 
-tpm2_createprimary -Q -C e -g $alg_primary_obj -G $alg_primary_key -o $file_primary_key_ctx
+tpm2_createprimary -Q -C e -g $alg_primary_obj -G $alg_primary_key -c $file_primary_key_ctx
 
 tpm2_create -Q -G $alg_create_key -u $file_hmac_key_pub -r $file_hmac_key_priv  -C $file_primary_key_ctx
 

--- a/test/integration/tests/hmac.sh
+++ b/test/integration/tests/hmac.sh
@@ -47,7 +47,7 @@ tpm2_createprimary -Q -C e -g $alg_primary_obj -G $alg_primary_key -c $file_prim
 
 tpm2_create -Q -G $alg_create_key -u $file_hmac_key_pub -r $file_hmac_key_priv  -C $file_primary_key_ctx
 
-tpm2_load -Q -C $file_primary_key_ctx  -u $file_hmac_key_pub  -r $file_hmac_key_priv -n $file_hmac_key_name -o $file_hmac_key_ctx
+tpm2_load -Q -C $file_primary_key_ctx  -u $file_hmac_key_pub  -r $file_hmac_key_priv -n $file_hmac_key_name -c $file_hmac_key_ctx
 
 # verify that persistent object can be used via a serialized handle
 tpm2_evictcontrol -C o -c $file_hmac_key_ctx -o $file_hmac_key_handle
@@ -74,7 +74,7 @@ tpm2_createprimary -Q -C e -g $alg_primary_obj -G $alg_primary_key -c $file_prim
 
 tpm2_create -Q -G $alg_create_key -u $file_hmac_key_pub -r $file_hmac_key_priv  -C $file_primary_key_ctx
 
-tpm2_load -Q -C $file_primary_key_ctx  -u $file_hmac_key_pub  -r $file_hmac_key_priv -n $file_hmac_key_name -o $file_hmac_key_ctx
+tpm2_load -Q -C $file_primary_key_ctx  -u $file_hmac_key_pub  -r $file_hmac_key_priv -n $file_hmac_key_name -c $file_hmac_key_ctx
 
 cat $file_input_data | tpm2_hmac -Q -c $file_hmac_key_ctx -o $file_hmac_output
 

--- a/test/integration/tests/import.sh
+++ b/test/integration/tests/import.sh
@@ -132,7 +132,7 @@ run_test() {
     parent_alg=$1
     name_alg=$2
 
-    tpm2_createprimary -Q -G "$parent_alg" -g "$name_alg" -C o -o parent.ctx
+    tpm2_createprimary -Q -G "$parent_alg" -g "$name_alg" -C o -c parent.ctx
 
     # 128 bit AES is 16 bytes
     run_aes_import_test parent.ctx aes-128-cfb 16
@@ -164,7 +164,7 @@ done;
 # Test the passin options
 #
 
-tpm2_createprimary -Q -o parent.ctx
+tpm2_createprimary -Q -c parent.ctx
 
 openssl genrsa -aes128 -passout "pass:mypassword" -out "private.pem" 1024
 

--- a/test/integration/tests/import.sh
+++ b/test/integration/tests/import.sh
@@ -30,7 +30,7 @@ run_aes_import_test() {
     -r import_key.priv
 
     tpm2_load -Q -C $1 -u import_key.pub -r import_key.priv -n import_key.name \
-    -o import_key.ctx
+    -c import_key.ctx
 
     echo "plaintext" > "plain.txt"
 
@@ -54,7 +54,7 @@ run_rsa_import_test() {
     -u import_rsa_key.pub -r import_rsa_key.priv
 
     tpm2_load -Q -C $1 -u import_rsa_key.pub -r import_rsa_key.priv \
-    -n import_rsa_key.name -o import_rsa_key.ctx
+    -n import_rsa_key.name -c import_rsa_key.ctx
 
     openssl rsa -in private.pem -out public.pem -outform PEM -pubout
     openssl rsautl -encrypt -inkey public.pem -pubin -in plain.txt -out plain.rsa.enc
@@ -99,7 +99,7 @@ run_ecc_import_test() {
 
     tpm2_import -Q -G ecc -g "$name_alg" -i private.ecc.pem -C $1 -u ecc.pub -r ecc.priv
 
-    tpm2_load -Q -C $1 -u ecc.pub -r ecc.priv -n ecc.name -o ecc.ctx
+    tpm2_load -Q -C $1 -u ecc.pub -r ecc.priv -n ecc.name -c ecc.ctx
 
     # Sign in the TPM and verify with OSSL
     tpm2_sign -Q -c ecc.ctx -g sha256 -d data.in.digest -f plain -o data.out.signed

--- a/test/integration/tests/import_tpm.sh
+++ b/test/integration/tests/import_tpm.sh
@@ -100,7 +100,7 @@ test() {
 # can be imported & loaded
 for dup_key_type in aes rsa ecc; do
     for sym_key_type in aes null; do
-        tpm2_createprimary -Q -C o -g sha256 -G rsa -o primary.ctx
+        tpm2_createprimary -Q -C o -g sha256 -G rsa -c primary.ctx
         test $dup_key_type $sym_key_type
         cleanup "no-shut-down"
     done
@@ -112,7 +112,7 @@ done
 # Duplicate Kd
 # Import & Load Kd
 # Decrypt the message and verify
-tpm2_createprimary -Q -C o -g sha256 -G rsa -o primary.ctx
+tpm2_createprimary -Q -C o -g sha256 -G rsa -c primary.ctx
 # New parent ...
 create_load_new_parent
 # Key to be duplicated

--- a/test/integration/tests/import_tpm.sh
+++ b/test/integration/tests/import_tpm.sh
@@ -41,7 +41,7 @@ create_load_new_parent() {
     # Create new parent
     tpm2_create -Q -C primary.ctx -g sha256 -G rsa -r new_parent.prv -u new_parent.pub  -a "restricted|sensitivedataorigin|decrypt|userwithauth"
     # Load new parent key, only the public part
-    tpm2_loadexternal -Q -C o -u new_parent.pub -o new_parent.ctx
+    tpm2_loadexternal -Q -C o -u new_parent.pub -c new_parent.ctx
 }
 
 load_new_parent() {

--- a/test/integration/tests/import_tpm.sh
+++ b/test/integration/tests/import_tpm.sh
@@ -46,7 +46,7 @@ create_load_new_parent() {
 
 load_new_parent() {
     # Load new parent key, public & private parts
-    tpm2_load -Q -C primary.ctx -r new_parent.prv -u new_parent.pub -o new_parent.ctx
+    tpm2_load -Q -C primary.ctx -r new_parent.prv -u new_parent.pub -c new_parent.ctx
 }
 
 create_load_duplicatee() {
@@ -54,7 +54,7 @@ create_load_duplicatee() {
     create_policy dpolicy.dat duplicate
     tpm2_create -Q -C primary.ctx -g sha256 -G $1 -p foo -r key.prv -u key.pub -L dpolicy.dat -a "sensitivedataorigin|decrypt|userwithauth"
     # Load the key
-    tpm2_load -Q -C primary.ctx -r key.prv -u key.pub -o key.ctx
+    tpm2_load -Q -C primary.ctx -r key.prv -u key.pub -c key.ctx
     # Extract the public part for import later
     tpm2_readpublic -Q -c key.ctx -o dup.pub
 }
@@ -77,7 +77,7 @@ do_import_load() {
     else
         tpm2_import -Q -C new_parent.ctx -u dup.pub -i dup.dup -r dup.prv -s dup.seed  -L dpolicy.dat
     fi
-    tpm2_load -Q -C new_parent.ctx -r dup.prv -u dup.pub -o dup.ctx
+    tpm2_load -Q -C new_parent.ctx -r dup.prv -u dup.pub -c dup.ctx
 }
 
 test() {

--- a/test/integration/tests/load.sh
+++ b/test/integration/tests/load.sh
@@ -43,7 +43,7 @@ tpm2_clear
 
 #####file test
 
-tpm2_createprimary -Q -C e -g $alg_primary_obj -G $alg_primary_key -o $file_primary_key_ctx
+tpm2_createprimary -Q -C e -g $alg_primary_obj -G $alg_primary_key -c $file_primary_key_ctx
 
 tpm2_create -Q -g $alg_create_obj -G $alg_create_key -u $file_load_key_pub -r $file_load_key_priv  -C $file_primary_key_ctx
 

--- a/test/integration/tests/load.sh
+++ b/test/integration/tests/load.sh
@@ -47,7 +47,7 @@ tpm2_createprimary -Q -C e -g $alg_primary_obj -G $alg_primary_key -c $file_prim
 
 tpm2_create -Q -g $alg_create_obj -G $alg_create_key -u $file_load_key_pub -r $file_load_key_priv  -C $file_primary_key_ctx
 
-tpm2_load -Q -C $file_primary_key_ctx  -u $file_load_key_pub  -r $file_load_key_priv -n $file_load_key_name -o $file_load_key_ctx
+tpm2_load -Q -C $file_primary_key_ctx  -u $file_load_key_pub  -r $file_load_key_priv -n $file_load_key_name -c $file_load_key_ctx
 
 #####handle test
 
@@ -57,6 +57,6 @@ tpm2_evictcontrol -Q -C o -c $file_primary_key_ctx $Handle_parent
 
 tpm2_create -Q -C $Handle_parent   -g $alg_create_obj  -G $alg_create_key -u $file_load_key_pub  -r  $file_load_key_priv
 
-tpm2_load -Q -C $Handle_parent   -u $file_load_key_pub  -r $file_load_key_priv -n $file_load_key_name -o $file_load_key_ctx
+tpm2_load -Q -C $Handle_parent   -u $file_load_key_pub  -r $file_load_key_priv -n $file_load_key_name -c $file_load_key_ctx
 
 exit 0

--- a/test/integration/tests/loadexternal.sh
+++ b/test/integration/tests/loadexternal.sh
@@ -46,7 +46,7 @@ run_tss_test() {
 
     tpm2_create -Q -g $alg_create_obj -G $alg_create_key -u $file_loadexternal_key_pub -r $file_loadexternal_key_priv  -C $file_primary_key_ctx
 
-    tpm2_loadexternal -Q -C n   -u $file_loadexternal_key_pub   -o $file_loadexternal_key_ctx
+    tpm2_loadexternal -Q -C n   -u $file_loadexternal_key_pub   -c $file_loadexternal_key_ctx
 
     tpm2_evictcontrol -Q -C o -c $file_primary_key_ctx $Handle_parent
 
@@ -55,14 +55,14 @@ run_tss_test() {
 
     tpm2_create -Q -C $Handle_parent   -g $alg_create_obj  -G $alg_create_key -u $file_loadexternal_key_pub  -r  $file_loadexternal_key_priv
 
-    tpm2_loadexternal -Q -C n   -u $file_loadexternal_key_pub -o $file_loadexternal_key_ctx
+    tpm2_loadexternal -Q -C n   -u $file_loadexternal_key_pub -c $file_loadexternal_key_ctx
 
     # Test with default hierarchy (and handle)
     cleanup "keep_handle" "no-shut-down"
 
     tpm2_create -Q -C $Handle_parent -g $alg_create_obj -G $alg_create_key -u $file_loadexternal_key_pub -r  $file_loadexternal_key_priv
 
-    tpm2_loadexternal -Q -u $file_loadexternal_key_pub -o $file_loadexternal_key_ctx
+    tpm2_loadexternal -Q -u $file_loadexternal_key_pub -c $file_loadexternal_key_ctx
 
     cleanup "no-shut-down"
 }
@@ -76,14 +76,14 @@ run_rsa_test() {
     echo "hello world" > plain.txt
     openssl rsautl -encrypt -inkey public.pem -pubin -in plain.txt -out plain.rsa.enc
 
-    tpm2_loadexternal -G rsa -C n -p foo -r private.pem -o key.ctx
+    tpm2_loadexternal -G rsa -C n -p foo -r private.pem -c key.ctx
 
     tpm2_rsadecrypt -c key.ctx -p foo -i plain.rsa.enc -o plain.rsa.dec
 
     diff plain.txt plain.rsa.dec
 
     # try encrypting with the public key and decrypting with the private
-    tpm2_loadexternal -G rsa -C n -p foo -u public.pem -o key.ctx
+    tpm2_loadexternal -G rsa -C n -p foo -u public.pem -c key.ctx
 
     tpm2_rsaencrypt -c key.ctx plain.txt -o plain.rsa.enc
 
@@ -105,7 +105,7 @@ run_aes_test() {
 
     dd if=/dev/urandom of=sym.key bs=1 count=$(($1 / 8)) 2>/dev/null
 
-    tpm2_loadexternal -G aes -r sym.key -n name.bin -o key.ctx > stdout.yaml
+    tpm2_loadexternal -G aes -r sym.key -n name.bin -c key.ctx > stdout.yaml
 
     local name1=$(yaml_get_kv "stdout.yaml" "name")
     local name2="0x$(xxd -c 256 -p name.bin)"
@@ -141,14 +141,14 @@ run_ecc_test() {
     sha256sum data.in.raw | awk '{ print "000000 " $1 }' | xxd -r -c 32 > data.in.digest
 
     # Load the private key for signing
-    tpm2_loadexternal -Q -G ecc -r private.ecc.pem -o key.ctx
+    tpm2_loadexternal -Q -G ecc -r private.ecc.pem -c key.ctx
 
     # Sign in the TPM and verify with OSSL
     tpm2_sign -Q -c key.ctx -g sha256 -d data.in.digest -f plain -o data.out.signed
     openssl dgst -verify public.ecc.pem -keyform pem -sha256 -signature data.out.signed data.in.raw
 
     # Sign with openssl and verify with TPM but only with the public portion of an object loaded
-    tpm2_loadexternal -Q -G ecc -u public.ecc.pem -o key.ctx
+    tpm2_loadexternal -Q -G ecc -u public.ecc.pem -c key.ctx
     openssl dgst -sha256 -sign private.ecc.pem -out data.out.signed data.in.raw
     tpm2_verifysignature -Q -c key.ctx -g sha256 -m data.in.raw -f ecdsa -s data.out.signed
 
@@ -160,9 +160,9 @@ run_rsa_passin_test() {
     openssl genrsa -aes128 -passout "pass:mypassword" -out "private.pem" 1024
 
     if [ "$2" != "stdin" ]; then
-        cmd="tpm2_loadexternal -Q -G rsa -r $1 -o key.ctx --passin $2"
+        cmd="tpm2_loadexternal -Q -G rsa -r $1 -c key.ctx --passin $2"
     else
-        cmd="tpm2_loadexternal -Q -G rsa -r $1 -o key.ctx --passin $2 < $3"
+        cmd="tpm2_loadexternal -Q -G rsa -r $1 -c key.ctx --passin $2 < $3"
     fi;
 
     eval $cmd

--- a/test/integration/tests/loadexternal.sh
+++ b/test/integration/tests/loadexternal.sh
@@ -42,7 +42,7 @@ tpm2_clear
 
 run_tss_test() {
 
-    tpm2_createprimary -Q -C e -g $alg_primary_obj -G $alg_primary_key -o $file_primary_key_ctx
+    tpm2_createprimary -Q -C e -g $alg_primary_obj -G $alg_primary_key -c $file_primary_key_ctx
 
     tpm2_create -Q -g $alg_create_obj -G $alg_create_key -u $file_loadexternal_key_pub -r $file_loadexternal_key_priv  -C $file_primary_key_ctx
 

--- a/test/integration/tests/output_formats.sh
+++ b/test/integration/tests/output_formats.sh
@@ -100,7 +100,7 @@ done
 #
 tpm2_createprimary -c primary.ctx
 tpm2_create -Q -C primary.ctx -G ecc -u ecc.pub -r ecc.priv
-tpm2_load -C primary.ctx -u ecc.pub -r ecc.priv -o ecc.ctx
+tpm2_load -C primary.ctx -u ecc.pub -r ecc.priv -c ecc.ctx
 
 for fmt in pem der; do
 

--- a/test/integration/tests/output_formats.sh
+++ b/test/integration/tests/output_formats.sh
@@ -98,7 +98,7 @@ done
 #
 # Test ECC keys
 #
-tpm2_createprimary -o primary.ctx
+tpm2_createprimary -c primary.ctx
 tpm2_create -Q -C primary.ctx -G ecc -u ecc.pub -r ecc.priv
 tpm2_load -C primary.ctx -u ecc.pub -r ecc.priv -o ecc.ctx
 

--- a/test/integration/tests/quote.sh
+++ b/test/integration/tests/quote.sh
@@ -55,7 +55,7 @@ cleanup "no-shut-down"
 
 tpm2_clear
 
-tpm2_createprimary -Q -C e -g $alg_primary_obj -G $alg_primary_key -o $file_primary_key_ctx
+tpm2_createprimary -Q -C e -g $alg_primary_obj -G $alg_primary_key -c $file_primary_key_ctx
 
 tpm2_create -Q -g $alg_create_obj -G $alg_create_key -u $file_quote_key_pub -r $file_quote_key_priv  -C $file_primary_key_ctx
 

--- a/test/integration/tests/quote.sh
+++ b/test/integration/tests/quote.sh
@@ -59,7 +59,7 @@ tpm2_createprimary -Q -C e -g $alg_primary_obj -G $alg_primary_key -c $file_prim
 
 tpm2_create -Q -g $alg_create_obj -G $alg_create_key -u $file_quote_key_pub -r $file_quote_key_priv  -C $file_primary_key_ctx
 
-tpm2_load -Q -C $file_primary_key_ctx  -u $file_quote_key_pub  -r $file_quote_key_priv -n $file_quote_key_name -o $file_quote_key_ctx
+tpm2_load -Q -C $file_primary_key_ctx  -u $file_quote_key_pub  -r $file_quote_key_priv -n $file_quote_key_name -c $file_quote_key_ctx
 
 tpm2_quote -C $file_quote_key_ctx  -l $alg_quote:16,17,18 -q $nonce -m $toss_out -s $toss_out -f $toss_out -g $alg_primary_obj > $out
 

--- a/test/integration/tests/readpublic.sh
+++ b/test/integration/tests/readpublic.sh
@@ -34,7 +34,7 @@ cleanup "no-shut-down"
 
 tpm2_clear
 
-tpm2_createprimary -Q -C e -g $alg_primary_obj -G $alg_primary_key -o $file_primary_key_ctx
+tpm2_createprimary -Q -C e -g $alg_primary_obj -G $alg_primary_key -c $file_primary_key_ctx
 
 tpm2_create -Q -g $alg_create_obj -G $alg_create_key -u $file_readpub_key_pub -r $file_readpub_key_priv  -C $file_primary_key_ctx
 

--- a/test/integration/tests/readpublic.sh
+++ b/test/integration/tests/readpublic.sh
@@ -38,7 +38,7 @@ tpm2_createprimary -Q -C e -g $alg_primary_obj -G $alg_primary_key -c $file_prim
 
 tpm2_create -Q -g $alg_create_obj -G $alg_create_key -u $file_readpub_key_pub -r $file_readpub_key_priv  -C $file_primary_key_ctx
 
-tpm2_load -Q -C $file_primary_key_ctx  -u $file_readpub_key_pub  -r $file_readpub_key_priv -n $file_readpub_key_name -o $file_readpub_key_ctx
+tpm2_load -Q -C $file_primary_key_ctx  -u $file_readpub_key_pub  -r $file_readpub_key_priv -n $file_readpub_key_name -c $file_readpub_key_ctx
 
 tpm2_readpublic -Q -c $file_readpub_key_ctx -o $file_readpub_output
 

--- a/test/integration/tests/rsadecrypt.sh
+++ b/test/integration/tests/rsadecrypt.sh
@@ -41,7 +41,7 @@ tpm2_createprimary -Q -C e -g $alg_hash -G $alg_primary_key -c $file_primary_key
 
 tpm2_create -Q -g $alg_hash -p foo -G $alg_rsaencrypt_key -u $file_rsaencrypt_key_pub -r $file_rsaencrypt_key_priv  -C $file_primary_key_ctx
 
-tpm2_loadexternal -Q -C n -u $file_rsaencrypt_key_pub -o $file_rsaencrypt_key_ctx
+tpm2_loadexternal -Q -C n -u $file_rsaencrypt_key_pub -c $file_rsaencrypt_key_ctx
 
 tpm2_rsaencrypt -Q -c $file_rsaencrypt_key_ctx -o $file_rsa_en_output_data < $file_input_data
 

--- a/test/integration/tests/rsadecrypt.sh
+++ b/test/integration/tests/rsadecrypt.sh
@@ -37,7 +37,7 @@ echo "12345678" > $file_input_data
 
 tpm2_clear
 
-tpm2_createprimary -Q -C e -g $alg_hash -G $alg_primary_key -o $file_primary_key_ctx
+tpm2_createprimary -Q -C e -g $alg_hash -G $alg_primary_key -c $file_primary_key_ctx
 
 tpm2_create -Q -g $alg_hash -p foo -G $alg_rsaencrypt_key -u $file_rsaencrypt_key_pub -r $file_rsaencrypt_key_priv  -C $file_primary_key_ctx
 

--- a/test/integration/tests/rsadecrypt.sh
+++ b/test/integration/tests/rsadecrypt.sh
@@ -45,7 +45,7 @@ tpm2_loadexternal -Q -C n -u $file_rsaencrypt_key_pub -c $file_rsaencrypt_key_ct
 
 tpm2_rsaencrypt -Q -c $file_rsaencrypt_key_ctx -o $file_rsa_en_output_data < $file_input_data
 
-tpm2_load -Q -C $file_primary_key_ctx -u $file_rsaencrypt_key_pub -r $file_rsaencrypt_key_priv  -n $file_rsaencrypt_key_name  -o $file_rsadecrypt_key_ctx
+tpm2_load -Q -C $file_primary_key_ctx -u $file_rsaencrypt_key_pub -r $file_rsaencrypt_key_priv  -n $file_rsaencrypt_key_name  -c $file_rsadecrypt_key_ctx
 
 tpm2_rsadecrypt -Q -c $file_rsadecrypt_key_ctx -p foo -i  $file_rsa_en_output_data -o  $file_rsa_de_output_data
 

--- a/test/integration/tests/rsaencrypt.sh
+++ b/test/integration/tests/rsaencrypt.sh
@@ -38,7 +38,7 @@ tpm2_createprimary -Q -C e -g $alg_hash -G $alg_primary_key -c $file_primary_key
 
 tpm2_create -Q -g $alg_hash -G $alg_rsaencrypt_key -u $file_rsaencrypt_key_pub -r $file_rsaencrypt_key_priv  -C $file_primary_key_ctx
 
-tpm2_loadexternal -Q -C n   -u $file_rsaencrypt_key_pub  -o $file_rsaencrypt_key_ctx
+tpm2_loadexternal -Q -C n   -u $file_rsaencrypt_key_pub  -c $file_rsaencrypt_key_ctx
 
 #./tpm2_rsaencrypt -c context_loadexternal_out6.out -I secret.data -o rsa_en.out
 tpm2_rsaencrypt -Q -c $file_rsaencrypt_key_ctx -o $file_rsa_en_output_data $file_input_data

--- a/test/integration/tests/rsaencrypt.sh
+++ b/test/integration/tests/rsaencrypt.sh
@@ -34,7 +34,7 @@ echo "12345678" > $file_input_data
 
 tpm2_clear
 
-tpm2_createprimary -Q -C e -g $alg_hash -G $alg_primary_key -o $file_primary_key_ctx
+tpm2_createprimary -Q -C e -g $alg_hash -G $alg_primary_key -c $file_primary_key_ctx
 
 tpm2_create -Q -g $alg_hash -G $alg_rsaencrypt_key -u $file_rsaencrypt_key_pub -r $file_rsaencrypt_key_priv  -C $file_primary_key_ctx
 

--- a/test/integration/tests/sign.sh
+++ b/test/integration/tests/sign.sh
@@ -42,7 +42,7 @@ test_symmetric() {
 
     tpm2_clear
 
-    tpm2_createprimary -Q -C e -g $alg_hash -G $alg_primary_key -o $file_primary_key_ctx
+    tpm2_createprimary -Q -C e -g $alg_hash -G $alg_primary_key -c $file_primary_key_ctx
 
     tpm2_create -Q -g $alg_hash -G $alg_signing_key -u $file_signing_key_pub -r $file_signing_key_priv -C $file_primary_key_ctx
 
@@ -205,7 +205,7 @@ test_asymmetric() {
 
     tpm2_clear
 
-    tpm2_createprimary -Q -C e -g $alg_hash -G $alg_primary_key -o $file_primary_key_ctx
+    tpm2_createprimary -Q -C e -g $alg_hash -G $alg_primary_key -c $file_primary_key_ctx
 
     tpm2_create -Q -g $alg_hash -G $alg_signing_key -u $file_signing_key_pub -r $file_signing_key_priv -C $file_primary_key_ctx
 
@@ -262,7 +262,7 @@ cleanup "no-shut-down"
 
 echo "12345678" > $file_input_data
 
-tpm2_createprimary -Q -o $file_primary_key_ctx
+tpm2_createprimary -Q -c $file_primary_key_ctx
 tpm2_create -Q -C $file_primary_key_ctx -u $file_signing_key_pub -r $file_signing_key_priv -p "mypassword"
 tpm2_load -Q -C $file_primary_key_ctx -u $file_signing_key_pub -r $file_signing_key_priv -n $file_signing_key_name -o $file_signing_key_ctx
 

--- a/test/integration/tests/sign.sh
+++ b/test/integration/tests/sign.sh
@@ -46,7 +46,7 @@ test_symmetric() {
 
     tpm2_create -Q -g $alg_hash -G $alg_signing_key -u $file_signing_key_pub -r $file_signing_key_priv -C $file_primary_key_ctx
 
-    tpm2_load -Q -C $file_primary_key_ctx -u $file_signing_key_pub -r $file_signing_key_priv -n $file_signing_key_name -o $file_signing_key_ctx
+    tpm2_load -Q -C $file_primary_key_ctx -u $file_signing_key_pub -r $file_signing_key_priv -n $file_signing_key_name -c $file_signing_key_ctx
 
     tpm2_sign -Q -c $file_signing_key_ctx -g $alg_hash -m $file_input_data -o $file_output_data
 
@@ -209,7 +209,7 @@ test_asymmetric() {
 
     tpm2_create -Q -g $alg_hash -G $alg_signing_key -u $file_signing_key_pub -r $file_signing_key_priv -C $file_primary_key_ctx
 
-    tpm2_load -Q -C $file_primary_key_ctx -u $file_signing_key_pub -r $file_signing_key_priv -n $file_signing_key_name -o $file_signing_key_ctx
+    tpm2_load -Q -C $file_primary_key_ctx -u $file_signing_key_pub -r $file_signing_key_priv -n $file_signing_key_name -c $file_signing_key_ctx
 
     tpm2_readpublic -Q -c $file_signing_key_ctx --format=pem -o $file_signing_key_pub_pem
 
@@ -264,7 +264,7 @@ echo "12345678" > $file_input_data
 
 tpm2_createprimary -Q -c $file_primary_key_ctx
 tpm2_create -Q -C $file_primary_key_ctx -u $file_signing_key_pub -r $file_signing_key_priv -p "mypassword"
-tpm2_load -Q -C $file_primary_key_ctx -u $file_signing_key_pub -r $file_signing_key_priv -n $file_signing_key_name -o $file_signing_key_ctx
+tpm2_load -Q -C $file_primary_key_ctx -u $file_signing_key_pub -r $file_signing_key_priv -n $file_signing_key_name -c $file_signing_key_ctx
 
 # Negative test, remove error handler
 trap - ERR

--- a/test/integration/tests/unseal.sh
+++ b/test/integration/tests/unseal.sh
@@ -40,7 +40,7 @@ echo $secret > $file_input_data
 
 tpm2_clear
 
-tpm2_createprimary -Q -C e -g $alg_primary_obj -G $alg_primary_key -o $file_primary_key_ctx
+tpm2_createprimary -Q -C e -g $alg_primary_obj -G $alg_primary_key -c $file_primary_key_ctx
 
 tpm2_create -Q -g $alg_create_obj -u $file_unseal_key_pub -r $file_unseal_key_priv -i $file_input_data -C $file_primary_key_ctx
 

--- a/test/integration/tests/unseal.sh
+++ b/test/integration/tests/unseal.sh
@@ -44,7 +44,7 @@ tpm2_createprimary -Q -C e -g $alg_primary_obj -G $alg_primary_key -c $file_prim
 
 tpm2_create -Q -g $alg_create_obj -u $file_unseal_key_pub -r $file_unseal_key_priv -i $file_input_data -C $file_primary_key_ctx
 
-tpm2_load -Q -C $file_primary_key_ctx  -u $file_unseal_key_pub  -r $file_unseal_key_priv -n $file_unseal_key_name -o $file_unseal_key_ctx
+tpm2_load -Q -C $file_primary_key_ctx  -u $file_unseal_key_pub  -r $file_unseal_key_priv -n $file_unseal_key_name -c $file_unseal_key_ctx
 
 tpm2_unseal -Q -c $file_unseal_key_ctx -o $file_unseal_output_data
 
@@ -56,7 +56,7 @@ rm $file_unseal_key_pub $file_unseal_key_priv $file_unseal_key_name $file_unseal
 
 cat $file_input_data | tpm2_create -Q -g $alg_create_obj -u $file_unseal_key_pub -r $file_unseal_key_priv -i- -C $file_primary_key_ctx
 
-tpm2_load -Q -C $file_primary_key_ctx  -u $file_unseal_key_pub  -r $file_unseal_key_priv -n $file_unseal_key_name -o $file_unseal_key_ctx
+tpm2_load -Q -C $file_primary_key_ctx  -u $file_unseal_key_pub  -r $file_unseal_key_priv -n $file_unseal_key_name -c $file_unseal_key_ctx
 
 tpm2_unseal -Q -c $file_unseal_key_ctx -o $file_unseal_output_data
 
@@ -73,7 +73,7 @@ tpm2_createpolicy -Q --policy-pcr -l ${alg_pcr_policy}:${pcr_ids} -f $file_pcr_v
 tpm2_create -Q -g $alg_create_obj -u $file_unseal_key_pub -r $file_unseal_key_priv -i- -C $file_primary_key_ctx -L $file_policy \
   -a 'fixedtpm|fixedparent' <<< $secret
 
-tpm2_load -Q -C $file_primary_key_ctx  -u $file_unseal_key_pub  -r $file_unseal_key_priv -n $file_unseal_key_name -o $file_unseal_key_ctx
+tpm2_load -Q -C $file_primary_key_ctx  -u $file_unseal_key_pub  -r $file_unseal_key_priv -n $file_unseal_key_name -c $file_unseal_key_ctx
 
 unsealed=`tpm2_unseal -V --object-context $file_unseal_key_ctx -p pcr:${alg_pcr_policy}:${pcr_ids}+$file_pcr_value`
 
@@ -113,7 +113,7 @@ tpm2_createpolicy -Q --policy-pcr -l ${alg_pcr_policy}:${pcr_ids} -f $file_pcr_v
 
 tpm2_create -Q -g $alg_create_obj -u $file_unseal_key_pub -r $file_unseal_key_priv -i- -C $file_primary_key_ctx -L $file_policy -p secretpass <<< $secret
 
-tpm2_load -Q -C $file_primary_key_ctx  -u $file_unseal_key_pub  -r $file_unseal_key_priv -n $file_unseal_key_name -o $file_unseal_key_ctx
+tpm2_load -Q -C $file_primary_key_ctx  -u $file_unseal_key_pub  -r $file_unseal_key_priv -n $file_unseal_key_name -c $file_unseal_key_ctx
 
 unsealed=`tpm2_unseal -c $file_unseal_key_ctx -p secretpass`
 

--- a/test/integration/tests/verifysignature.sh
+++ b/test/integration/tests/verifysignature.sh
@@ -40,7 +40,7 @@ echo "12345678" > $file_input_data
 
 tpm2_clear
 
-tpm2_createprimary -Q -C e -g $alg_hash -G $alg_primary_key -o $file_primary_key_ctx
+tpm2_createprimary -Q -C e -g $alg_hash -G $alg_primary_key -c $file_primary_key_ctx
 
 tpm2_create -Q -g $alg_hash -G $alg_signing_key -u $file_signing_key_pub -r $file_signing_key_priv -C $file_primary_key_ctx
 

--- a/test/integration/tests/verifysignature.sh
+++ b/test/integration/tests/verifysignature.sh
@@ -44,7 +44,7 @@ tpm2_createprimary -Q -C e -g $alg_hash -G $alg_primary_key -c $file_primary_key
 
 tpm2_create -Q -g $alg_hash -G $alg_signing_key -u $file_signing_key_pub -r $file_signing_key_priv -C $file_primary_key_ctx
 
-tpm2_load -Q -C $file_primary_key_ctx -u $file_signing_key_pub -r $file_signing_key_priv -n $file_signing_key_name -o $file_signing_key_ctx
+tpm2_load -Q -C $file_primary_key_ctx -u $file_signing_key_pub -r $file_signing_key_priv -n $file_signing_key_name -c $file_signing_key_ctx
 
 tpm2_sign -Q -c $file_signing_key_ctx -g $alg_hash -m $file_input_data -o $file_output_data
 

--- a/test/integration/tests/verifysignature.sh
+++ b/test/integration/tests/verifysignature.sh
@@ -56,7 +56,7 @@ rm -f $file_verify_tk_data
 tpm2_verifysignature -Q -c $file_signing_key_ctx -d $file_input_data_hash -s $file_output_data -t $file_verify_tk_data
 
 rm -f $file_verify_tk_data $file_signing_key_ctx -rf
-tpm2_loadexternal -Q -C n -u $file_signing_key_pub -o $file_signing_key_ctx
+tpm2_loadexternal -Q -C n -u $file_signing_key_pub -c $file_signing_key_ctx
 
 tpm2_verifysignature -Q -c $file_signing_key_ctx -g $alg_hash -m $file_input_data -s $file_output_data -t $file_verify_tk_data
 

--- a/tools/misc/tpm2_checkquote.c
+++ b/tools/misc/tpm2_checkquote.c
@@ -348,7 +348,7 @@ bool tpm2_tool_onstart(tpm2_options **opts) {
     };
 
 
-    *opts = tpm2_options_new("g:m:f:s:t:u:F:q:", ARRAY_LEN(topts), topts,
+    *opts = tpm2_options_new("g:m:f:s:u:F:q:", ARRAY_LEN(topts), topts,
                              on_option, NULL, TPM2_OPTIONS_NO_SAPI);
 
     return *opts != NULL;

--- a/tools/misc/tpm2_checkquote.c
+++ b/tools/misc/tpm2_checkquote.c
@@ -303,7 +303,7 @@ static bool on_option(char key, char *value) {
 		ctx.flags.msg = 1;
 	}
 		break;
-	case 'f': {
+	case 'F': {
 		ctx.format = tpm2_alg_util_from_optarg(value, tpm2_alg_util_flags_sig);
 		if (ctx.format == TPM2_ALG_ERROR) {
 		    LOG_ERR("Unknown signing scheme, got: \"%s\"", value);
@@ -325,7 +325,7 @@ static bool on_option(char key, char *value) {
 		ctx.sig_file_path = value;
 		ctx.flags.sig = 1;
 		break;
-	case 'F':
+	case 'f':
 		ctx.pcr_file_path = value;
 		ctx.flags.pcr = 1;
 		break;
@@ -338,17 +338,17 @@ static bool on_option(char key, char *value) {
 bool tpm2_tool_onstart(tpm2_options **opts) {
 
     const struct option topts[] = {
-            { "halg",           required_argument, NULL, 'g' },
-            { "message",        required_argument, NULL, 'm' },
-            { "format",         required_argument, NULL, 'f' },
-            { "signature",      required_argument, NULL, 's' },
-            { "pcr-input-file", required_argument, NULL, 'F' },
-            { "pubfile",        required_argument, NULL, 'u' },
-            { "qualify-data",   required_argument, NULL, 'q' },
+            { "hash-algorithm",     required_argument, NULL, 'g' },
+            { "message",            required_argument, NULL, 'm' },
+            { "format",             required_argument, NULL, 'F' },
+            { "signature",          required_argument, NULL, 's' },
+            { "pcr",                required_argument, NULL, 'f' },
+            { "public",             required_argument, NULL, 'u' },
+            { "qualification",      required_argument, NULL, 'q' },
     };
 
 
-    *opts = tpm2_options_new("g:m:f:s:u:F:q:", ARRAY_LEN(topts), topts,
+    *opts = tpm2_options_new("g:m:F:s:u:f:q:", ARRAY_LEN(topts), topts,
                              on_option, NULL, TPM2_OPTIONS_NO_SAPI);
 
     return *opts != NULL;

--- a/tools/misc/tpm2_print.c
+++ b/tools/misc/tpm2_print.c
@@ -344,8 +344,8 @@ static bool on_option(char key, char *value) {
 
 bool tpm2_tool_onstart(tpm2_options **opts) {
     static const struct option topts[] = {
-        { "type",        required_argument, NULL, 't' },
-        { "in-file",        optional_argument, NULL, 'i' },
+        { "type",  required_argument, NULL, 't' },
+        { "input", optional_argument, NULL, 'i' },
     };
 
     *opts = tpm2_options_new("i:t:", ARRAY_LEN(topts), topts,

--- a/tools/tpm2_create.c
+++ b/tools/tpm2_create.c
@@ -186,7 +186,7 @@ static bool on_option(char key, char *value) {
     case 'C':
         ctx.parent.ctx_path = value;
         break;
-    case 'o':
+    case 'c':
         ctx.object.ctx_path = value;
         break;
     };
@@ -201,16 +201,16 @@ bool tpm2_tool_onstart(tpm2_options **opts) {
       { "key-auth",             required_argument, NULL, 'p' },
       { "hash-algorithm",       required_argument, NULL, 'g' },
       { "key-algorithm",        required_argument, NULL, 'G' },
-      { "object-attributes",    required_argument, NULL, 'a' },
+      { "attributes",    required_argument, NULL, 'a' },
       { "sealing-input",        required_argument, NULL, 'i' },
       { "policy",               required_argument, NULL, 'L' },
       { "public",               required_argument, NULL, 'u' },
       { "private",              required_argument, NULL, 'r' },
       { "parent-context",       required_argument, NULL, 'C' },
-      { "key-context",          required_argument, NULL, 'o' },
+      { "key-context",          required_argument, NULL, 'c' },
     };
 
-    *opts = tpm2_options_new("P:p:g:G:a:i:L:u:r:C:o:", ARRAY_LEN(topts), topts,
+    *opts = tpm2_options_new("P:p:g:G:a:i:L:u:r:C:c:", ARRAY_LEN(topts), topts,
                              on_option, NULL, 0);
 
     return *opts != NULL;

--- a/tools/tpm2_createprimary.c
+++ b/tools/tpm2_createprimary.c
@@ -82,7 +82,7 @@ static bool on_option(char key, char *value) {
     case 'G':
         ctx.alg = value;
         break;
-    case 'o':
+    case 'c':
         ctx.context_file = value;
         break;
     case 'u':
@@ -111,13 +111,13 @@ bool tpm2_tool_onstart(tpm2_options **opts) {
         { "key-auth",             required_argument, NULL, 'p' },
         { "hash-algorithm",       required_argument, NULL, 'g' },
         { "key-algorithm",        required_argument, NULL, 'G' },
-        { "key-context",          required_argument, NULL, 'o' },
+        { "key-context",          required_argument, NULL, 'c' },
         { "policy",               required_argument, NULL, 'L' },
-        { "object-attributes",    required_argument, NULL, 'a' },
+        { "attributes",    required_argument, NULL, 'a' },
         { "unique-data",          required_argument, NULL, 'u' },
     };
 
-    *opts = tpm2_options_new("C:P:p:g:G:o:L:a:u:", ARRAY_LEN(topts), topts,
+    *opts = tpm2_options_new("C:P:p:g:G:c:L:a:u:", ARRAY_LEN(topts), topts,
             on_option, NULL, 0);
 
     return *opts != NULL;

--- a/tools/tpm2_import.c
+++ b/tools/tpm2_import.c
@@ -294,7 +294,7 @@ bool tpm2_tool_onstart(tpm2_options **opts) {
       { "parent-public",      required_argument, NULL, 'U'},
       { "private",            required_argument, NULL, 'r'},
       { "public",             required_argument, NULL, 'u'},
-      { "object-attributes",  required_argument, NULL, 'a'},
+      { "attributes",  required_argument, NULL, 'a'},
       { "hash-algorithm",     required_argument, NULL, 'g'},
       { "seed",               required_argument, NULL, 's'},
       { "policy",             required_argument, NULL, 'L'},

--- a/tools/tpm2_load.c
+++ b/tools/tpm2_load.c
@@ -105,7 +105,7 @@ static bool on_option(char key, char *value) {
     case 'C':
         ctx.parent.ctx_path = value;
         break;
-    case 'o':
+    case 'c':
         ctx.context_file = value;
         if(ctx.context_file == NULL || ctx.context_file[0] == '\0') {
             return false;
@@ -124,11 +124,11 @@ bool tpm2_tool_onstart(tpm2_options **opts) {
       { "public",               required_argument, NULL, 'u' },
       { "private",              required_argument, NULL, 'r' },
       { "name",                 required_argument, NULL, 'n' },
-      { "key-context",          required_argument, NULL, 'o' },
+      { "key-context",          required_argument, NULL, 'c' },
       { "parent-context",       required_argument, NULL, 'C' },
     };
 
-    *opts = tpm2_options_new("P:u:r:n:C:o:", ARRAY_LEN(topts), topts,
+    *opts = tpm2_options_new("P:u:r:n:C:c:", ARRAY_LEN(topts), topts,
                              on_option, NULL, 0);
 
     return *opts != NULL;

--- a/tools/tpm2_loadexternal.c
+++ b/tools/tpm2_loadexternal.c
@@ -91,7 +91,7 @@ static bool on_option(char key, char *value) {
     case 'r':
         ctx.private_key_path = value;
         break;
-    case 'o':
+    case 'c':
         ctx.context_file_path = value;
         break;
     case 'a':
@@ -126,8 +126,8 @@ bool tpm2_tool_onstart(tpm2_options **opts) {
       { "hierarchy",          required_argument, NULL, 'C'},
       { "public",             required_argument, NULL, 'u'},
       { "private",            required_argument, NULL, 'r'},
-      { "key-context",        required_argument, NULL, 'o'},
-      { "object-attributes",  required_argument, NULL, 'a'},
+      { "key-context",        required_argument, NULL, 'c'},
+      { "attributes",  required_argument, NULL, 'a'},
       { "policy",             required_argument, NULL, 'L'},
       { "auth",               required_argument, NULL, 'p'},
       { "hash-algorithm",     required_argument, NULL, 'g'},
@@ -136,7 +136,7 @@ bool tpm2_tool_onstart(tpm2_options **opts) {
       { "passin",             required_argument, NULL,  0 },
     };
 
-    *opts = tpm2_options_new("C:u:r:o:a:p:L:g:G:n:", ARRAY_LEN(topts), topts, on_option,
+    *opts = tpm2_options_new("C:u:r:c:a:p:L:g:G:n:", ARRAY_LEN(topts), topts, on_option,
                              NULL, 0);
 
     return *opts != NULL;

--- a/tools/tpm2_policyauthorize.c
+++ b/tools/tpm2_policyauthorize.c
@@ -36,13 +36,13 @@ static tpm2_policyauthorize_ctx ctx;
 static bool on_option(char key, char *value) {
 
     switch (key) {
-    case 'o':
+    case 'L':
         ctx.out_policy_dgst_path = value;
         break;
     case 'S':
         ctx.session_path = value;
         break;
-    case 'L':
+    case 'i':
         ctx.policy_digest_path = value;
         break;
     case 'q':
@@ -61,15 +61,15 @@ static bool on_option(char key, char *value) {
 bool tpm2_tool_onstart(tpm2_options **opts) {
 
     static struct option topts[] = {
-        { "policy-output",      required_argument, NULL, 'o' },
-        { "session",            required_argument, NULL, 'S' },
         { "policy",             required_argument, NULL, 'L' },
-        { "qualification-data", required_argument, NULL, 'q' },
+        { "session",            required_argument, NULL, 'S' },
+        { "input",              required_argument, NULL, 'i' },
+        { "qualification",      required_argument, NULL, 'q' },
         { "name",               required_argument, NULL, 'n' },
         { "ticket",             required_argument, NULL, 't' },
     };
 
-    *opts = tpm2_options_new("o:S:L:q:n:t:", ARRAY_LEN(topts), topts, on_option,
+    *opts = tpm2_options_new("L:S:i:q:n:t:", ARRAY_LEN(topts), topts, on_option,
                              NULL, 0);
 
     return *opts != NULL;

--- a/tools/tpm2_quote.c
+++ b/tools/tpm2_quote.c
@@ -277,7 +277,7 @@ bool tpm2_tool_onstart(tpm2_options **opts) {
         { "ak-auth",              required_argument, NULL, 'P' },
         { "pcr-index",            required_argument, NULL, 'i' },
         { "pcr-list",             required_argument, NULL, 'l' },
-        { "qualification-data",   required_argument, NULL, 'q' },
+        { "qualification",        required_argument, NULL, 'q' },
         { "signature",            required_argument, NULL, 's' },
         { "message",              required_argument, NULL, 'm' },
         { "pcr",                  required_argument, NULL, 'f' },


### PR DESCRIPTION
Fixes #1602 

1. Rename options for tpm2_checkquote.
2. Rename options for tpm2_print.
3. Change context short option from -o to -c in tpm2_create, tpm2_createprimary, tpm2_load, tpm2_loadexternal.
 4. qualification-data should become qualification in tpm2_quote, tpm2_checkquote, tpm2_policyauthorize.
5. tpm2_policyauthorize: -L becomes -i as in input policy and -o becomes -L the final policy.
6. object-attributes becomes attributes in tpm2_create, tpm2_createprimary, tpm2_import, tpm2_loadexternal.