### PR TITLE
Fix tpm2_encryptdecrypt pcks7 padding scheme

### DIFF
--- a/lib/tpm2.c
+++ b/lib/tpm2.c
@@ -1372,7 +1372,7 @@ tool_rc tpm2_encryptdecrypt(
                 iv_out);
     }
 
-    if (tpm2_error_get(rval) == TPM2_RC_COMMAND_CODE) {
+    if (rval != TPM2_RC_SUCCESS) {
         if (*version == 2) {
             LOG_PERR(Esys_EncryptDecrypt2, rval);
         } else {

--- a/tools/tpm2_encryptdecrypt.c
+++ b/tools/tpm2_encryptdecrypt.c
@@ -74,11 +74,20 @@ static bool evaluate_pkcs7_padding_requirements(uint16_t remaining_bytes,
     }
 
     /*
+     * If no ctx.mode was specified, the default cfb was set.
+     */
+    if (ctx.mode != TPM2_ALG_CBC && ctx.mode != TPM2_ALG_ECB) {
+        return false;
+    }
+
+    /*
      * Is last block?
      */
     if (!(remaining_bytes <= TPM2_MAX_DIGEST_BUFFER && remaining_bytes > 0)) {
         return false;
     }
+
+    LOG_WARN("Processing pkcs7 padding.");
 
     return true;
 }
@@ -279,14 +288,6 @@ static bool setup_alg_mode_and_iv_and_padding(ESYS_CONTEXT *ectx, TPM2B_IV *iv) 
         } else {
             ctx.mode = objmode;
         }
-    }
-
-    if (ctx.is_padding_option_enabled && !ctx.is_decrypt &&
-        public->publicArea.parameters.symDetail.sym.algorithm == TPM2_ALG_AES &&
-        (ctx.mode == TPM2_ALG_CBC ||
-         ctx.mode == TPM2_ALG_ECB)) {
-
-        LOG_WARN("pkcs7 padding is required and will be applied to input data.");
     }
 
     free(public);

--- a/tools/tpm2_encryptdecrypt.c
+++ b/tools/tpm2_encryptdecrypt.c
@@ -284,8 +284,7 @@ static bool setup_alg_mode_and_iv_and_padding(ESYS_CONTEXT *ectx, TPM2B_IV *iv) 
     if (ctx.is_padding_option_enabled && !ctx.is_decrypt &&
         public->publicArea.parameters.symDetail.sym.algorithm == TPM2_ALG_AES &&
         (ctx.mode == TPM2_ALG_CBC ||
-         ctx.mode == TPM2_ALG_ECB ||
-         ctx.mode == TPM2_ALG_CFB)) {
+         ctx.mode == TPM2_ALG_ECB)) {
 
         LOG_WARN("pkcs7 padding is required and will be applied to input data.");
     }

--- a/tools/tpm2_encryptdecrypt.c
+++ b/tools/tpm2_encryptdecrypt.c
@@ -286,13 +286,7 @@ static bool setup_alg_mode_and_iv_and_padding(ESYS_CONTEXT *ectx, TPM2B_IV *iv) 
         (ctx.mode == TPM2_ALG_CBC ||
          ctx.mode == TPM2_ALG_ECB ||
          ctx.mode == TPM2_ALG_CFB)) {
-        /*
-         * https://tools.ietf.org/html/rfc2315 section 10.3 Content-encryption
-         * The pkcs#7 requirement of 256 bit max block length for padding
-         * applies cleanly since TPM2_MAX_SYM_KEY_BYTES = 32
-         */
-        ctx.padded_block_len =
-            public->publicArea.parameters.symDetail.sym.keyBits.sym/8;
+
         LOG_WARN("pkcs7 padding is required and will be applied to input data.");
     }
 

--- a/tools/tpm2_encryptdecrypt.c
+++ b/tools/tpm2_encryptdecrypt.c
@@ -170,6 +170,9 @@ static tool_rc encrypt_decrypt(ESYS_CONTEXT *ectx, TPM2B_IV *iv_start) {
     uint8_t pad_data = 0;
 
     uint16_t remaining_bytes = ctx.input_data_size;
+    if (ctx.mode == TPM2_ALG_ECB) {
+        iv_in = NULL;
+    }
     while (remaining_bytes > 0) {
         in_data.size =
             remaining_bytes > TPM2_MAX_DIGEST_BUFFER ?
@@ -194,8 +197,10 @@ static tool_rc encrypt_decrypt(ESYS_CONTEXT *ectx, TPM2B_IV *iv_start) {
          * Copy iv_out iv_in to use it in next loop iteration.
          * This copy is also output from the tool for further chaining.
          */
-        *iv_in = *iv_out;
-        free(iv_out);
+        if (ctx.mode != TPM2_ALG_ECB) {
+            *iv_in = *iv_out;
+            free(iv_out);
+        }
 
         strip_pkcs7_padding_data_from_output(&pad_data, out_data, &remaining_bytes);
 


### PR DESCRIPTION
Fixes #1547 

In order to make the tpm2_encryptdecrypt interoperable with openssl, below fixes have been implemented:
1. Do not apply pkcs7 padding to all aes modes and in particular to aes cfb mode
2. The input iv for aes ecb mode should be set to null
3. Padded block length was wrongly set to key size; instead it should have been fixed to AES block length of 16 bytes or 128 bits.