### PR TITLE
 tcti: use separate rc variable for Tss2_TctiLdr_* 

### DIFF
--- a/lib/tpm2_options.c
+++ b/lib/tpm2_options.c
@@ -218,7 +218,7 @@ tpm2_option_code tpm2_handle_options (int argc, char **argv,
      * grep -rn case\ \'[a-zA-Z]\' | awk '{print $3}' | sed s/\'//g | sed s/\://g | sort | uniq | less
      */
     struct option long_options [] = {
-        { "tcti",          optional_argument, NULL, 'T' },
+        { "tcti",          required_argument, NULL, 'T' },
         { "help",          optional_argument, NULL, 'h' },
         { "verbose",       no_argument,       NULL, 'V' },
         { "quiet",         no_argument,       NULL, 'Q' },

--- a/lib/tpm2_options.c
+++ b/lib/tpm2_options.c
@@ -207,6 +207,7 @@ tpm2_option_code tpm2_handle_options (int argc, char **argv,
         TSS2_TCTI_CONTEXT **tcti) {
 
     tpm2_option_code rc = tpm2_option_code_err;
+    TSS2_RC rc_tcti;
     bool result = false;
     bool show_help = false;
     bool manpager = true;
@@ -339,8 +340,8 @@ tpm2_option_code tpm2_handle_options (int argc, char **argv,
                 }
                 goto none;
             }
-            rc = Tss2_TctiLdr_Initialize(tcti_conf_option, tcti);
-            if (rc != TSS2_RC_SUCCESS || !*tcti) {
+            rc_tcti = Tss2_TctiLdr_Initialize(tcti_conf_option, tcti);
+            if (rc_tcti != TSS2_RC_SUCCESS || !*tcti) {
               LOG_ERR("Could not load tcti, got: \"%s\"", tcti_conf_option);
               goto out;
             }
@@ -378,8 +379,8 @@ out:
         }
         if (tcti_conf_option && strcmp(tcti_conf_option, "none")) {
             TSS2_TCTI_INFO *info = NULL;
-            rc = Tss2_TctiLdr_GetInfo (tcti_conf_option, &info);
-            if (rc == TSS2_RC_SUCCESS && info) {
+            rc_tcti = Tss2_TctiLdr_GetInfo (tcti_conf_option, &info);
+            if (rc_tcti == TSS2_RC_SUCCESS && info) {
                 printf("\ntcti-help(%s): %s\n", info->name, info->config_help);
             }
             Tss2_TctiLdr_FreeInfo (&info);

--- a/test/unit/test_options.c
+++ b/test/unit/test_options.c
@@ -179,6 +179,30 @@ static void test_tcti_long_option_no_errata(void **state) {
     assert_int_equal(oc, tpm2_option_code_continue);
 }
 
+static void test_invalid_tcti_no_errata(void **state) {
+    UNUSED(state);
+
+    char *argv[] = {
+        "program",
+        "-T",      // Set TCTI to something specific
+        "tctiinvalid",
+        "-Z"       // Disable errata getenv call
+    };
+
+    int argc = ARRAY_LEN(argv);
+
+    tpm2_options *tool_opts = NULL;
+    tpm2_option_flags flags = { .all = 0 };
+    TSS2_TCTI_CONTEXT *tcti = NULL;
+
+    will_return(__wrap_Tss2_TctiLdr_Initialize, TSS2_TCTI_RC_NOT_SUPPORTED);
+
+    tpm2_option_code oc = tpm2_handle_options(argc, argv, tool_opts, &flags,
+            &tcti);
+    assert_int_equal(oc, tpm2_option_code_err);
+}
+
+
 /*
  * link required symbol, but tpm2_tool.c declares it AND main, which
  * we have a main below for cmocka tests.
@@ -194,6 +218,7 @@ int main(int argc, char *argv[]) {
             cmocka_unit_test(test_null_tcti_getenv_with_errata),
             cmocka_unit_test(test_tcti_short_option_no_errata),
             cmocka_unit_test(test_tcti_long_option_no_errata),
+            cmocka_unit_test(test_invalid_tcti_no_errata),
     };
 
     return cmocka_run_group_tests(tests, NULL, NULL);


### PR DESCRIPTION
As described in #1617, the tools currently return with a zero exit status signalling success if the TCTI could not be initialised. This is because the variable `rc` is used for both return codes of type `TSS2_RC` as well as `tpm2_option_code` internally used by tpm2-tools. Using separate variables for both types fixes the problem. I also added a unit test to verify that an invalid TCTI results in a non-zero exit status.

While fixing this issue, I noticed that for the long option only `--tcti=<value>` is accepted while `--tcti <value>` does not work. This is because 56710b6e1c4d3e02ff77ad367c216a59b51ca765 changed the long option from `required_argument` to `optional_argument`, and optional arguments only work with the equals sign syntax. Since this does not match the definition of the short option `-T` as required in `common_short_opts` and using `-T`/`--tcti` without an argument does not make sense anyway, we use required_argument and add a unit test for the case without equals sign.
