### PR TITLE
Nv tool changes from #1042

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Changelog
 ### next
+  * tpm2_nvlist: Renaming the tool
+    - tpm2_nvlist is now tpm2_nvreadpublic
   * tpm2_nvundefine: short option changed to argument
     -x used to specify nv index is now an argument
   * tpm2_nvrelease: Renaming the tool

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Changelog
 ### next
+  * tpm2_nvwrite: short option changed to argument
+    -x used to specify nv index is now an argument
   * tpm2_nvwrite: input file changed from argument to option
     -i or --input is now the method to specify file data to write
   * tpm2_nvlist: Renaming the tool

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Changelog
 ### next
+  * tpm2_nvreadlock: short option changed to argument
+    -x used to specify nv index is now an argument
   * tpm2_nvread: short option changed to argument
     -x used to specify nv index is now an argument
   * tpm2_nvincrement: short option changed to argument

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Changelog
 ### next
+  * tpm2_nvwrite: input file changed from argument to option
+    -i or --input is now the method to specify file data to write
   * tpm2_nvlist: Renaming the tool
     - tpm2_nvlist is now tpm2_nvreadpublic
   * tpm2_nvundefine: short option changed to argument

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Changelog
 ### next
+  * tpm2_nvundefine: short option changed to argument
+    -x used to specify nv index is now an argument
   * tpm2_nvrelease: Renaming the tool
     - tpm2_nvrelease is now tpm2_nvundefine
   * tpm2_nvreadlock: short option changed to argument

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Changelog
 ### next
+  * tpm2_nvdefine: short option changed to argument
+    -x used to specify nv index is now an argument
   * tpm2_hierarchycontrol: new tool added for enabling or disabling the use
     of a hierarchy and its associated NV storage.
   * tpm2_quote: long option changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Changelog
 ### next
+  * tpm2_nvrelease: Renaming the tool
+    - tpm2_nvrelease is now tpm2_nvundefine
   * tpm2_nvreadlock: short option changed to argument
     -x used to specify nv index is now an argument
   * tpm2_nvread: short option changed to argument

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Changelog
 ### next
+  * tpm2_nvread: short option changed to argument
+    -x used to specify nv index is now an argument
   * tpm2_nvincrement: short option changed to argument
     -x used to specify nv index is now an argument
   * tpm2_nvdefine: short option changed to argument

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Changelog
 ### next
+  * tpm2_nvincrement: short option changed to argument
+    -x used to specify nv index is now an argument
   * tpm2_nvdefine: short option changed to argument
     -x used to specify nv index is now an argument
   * tpm2_hierarchycontrol: new tool added for enabling or disabling the use

--- a/Makefile.am
+++ b/Makefile.am
@@ -62,7 +62,7 @@ bin_PROGRAMS = \
     tools/tpm2_nvlist \
     tools/tpm2_nvread \
     tools/tpm2_nvreadlock \
-    tools/tpm2_nvrelease \
+    tools/tpm2_nvundefine \
     tools/tpm2_nvwrite \
     tools/tpm2_pcrallocate \
     tools/tpm2_pcrevent \
@@ -128,7 +128,7 @@ tools_tpm2_nvreadlock_SOURCES = tools/tpm2_nvreadlock.c $(TOOL_SRC)
 tools_tpm2_nvwrite_SOURCES = tools/tpm2_nvwrite.c $(TOOL_SRC)
 tools_tpm2_nvdefine_SOURCES = tools/tpm2_nvdefine.c $(TOOL_SRC)
 tools_tpm2_nvincrement_SOURCES = tools/tpm2_nvincrement.c $(TOOL_SRC)
-tools_tpm2_nvrelease_SOURCES = tools/tpm2_nvrelease.c $(TOOL_SRC)
+tools_tpm2_nvundefine_SOURCES = tools/tpm2_nvundefine.c $(TOOL_SRC)
 tools_tpm2_hmac_SOURCES = tools/tpm2_hmac.c $(TOOL_SRC)
 tools_tpm2_certify_SOURCES = tools/tpm2_certify.c $(TOOL_SRC)
 tools_tpm2_readpublic_SOURCES = tools/tpm2_readpublic.c $(TOOL_SRC)
@@ -320,7 +320,7 @@ if HAVE_MAN_PAGES
     man/man1/tpm2_nvlist.1 \
     man/man1/tpm2_nvread.1 \
     man/man1/tpm2_nvreadlock.1 \
-    man/man1/tpm2_nvrelease.1 \
+    man/man1/tpm2_nvundefine.1 \
     man/man1/tpm2_nvwrite.1 \
     man/man1/tpm2_pcrallocate.1 \
     man/man1/tpm2_pcrevent.1 \

--- a/Makefile.am
+++ b/Makefile.am
@@ -59,7 +59,7 @@ bin_PROGRAMS = \
     tools/tpm2_makecredential \
     tools/tpm2_nvdefine \
     tools/tpm2_nvincrement \
-    tools/tpm2_nvlist \
+    tools/tpm2_nvreadpublic \
     tools/tpm2_nvread \
     tools/tpm2_nvreadlock \
     tools/tpm2_nvundefine \
@@ -122,7 +122,7 @@ tools_tpm2_createak_SOURCES = tools/tpm2_createak.c $(TOOL_SRC)
 tools_tpm2_hash_SOURCES = tools/tpm2_hash.c $(TOOL_SRC)
 tools_tpm2_activatecredential_SOURCES = tools/tpm2_activatecredential.c $(TOOL_SRC)
 tools_tpm2_makecredential_SOURCES = tools/tpm2_makecredential.c $(TOOL_SRC)
-tools_tpm2_nvlist_SOURCES = tools/tpm2_nvlist.c $(TOOL_SRC)
+tools_tpm2_nvreadpublic_SOURCES = tools/tpm2_nvreadpublic.c $(TOOL_SRC)
 tools_tpm2_nvread_SOURCES = tools/tpm2_nvread.c $(TOOL_SRC)
 tools_tpm2_nvreadlock_SOURCES = tools/tpm2_nvreadlock.c $(TOOL_SRC)
 tools_tpm2_nvwrite_SOURCES = tools/tpm2_nvwrite.c $(TOOL_SRC)
@@ -317,7 +317,7 @@ if HAVE_MAN_PAGES
     man/man1/tpm2_makecredential.1 \
     man/man1/tpm2_nvdefine.1 \
     man/man1/tpm2_nvincrement.1 \
-    man/man1/tpm2_nvlist.1 \
+    man/man1/tpm2_nvreadpublic.1 \
     man/man1/tpm2_nvread.1 \
     man/man1/tpm2_nvreadlock.1 \
     man/man1/tpm2_nvundefine.1 \

--- a/lib/tpm2.c
+++ b/lib/tpm2.c
@@ -1691,7 +1691,7 @@ tool_rc tpm2_nvreadlock(
     return tool_rc_success;
 }
 
-tool_rc tpm2_nvrelease(
+tool_rc tpm2_nvundefine(
     ESYS_CONTEXT *esysContext,
     tpm2_loaded_object *auth_hierarchy_obj,
     TPM2_HANDLE nv_index) {

--- a/lib/tpm2.h
+++ b/lib/tpm2.h
@@ -466,7 +466,7 @@ tool_rc tpm2_nvreadlock(
     tpm2_loaded_object *auth_hierarchy_obj,
     TPM2_HANDLE nv_index);
 
-tool_rc tpm2_nvrelease(
+tool_rc tpm2_nvundefine(
     ESYS_CONTEXT *esysContext,
     tpm2_loaded_object *auth_hierarchy_obj,
     TPM2_HANDLE nv_index);

--- a/lib/tpm2_nv_util.h
+++ b/lib/tpm2_nv_util.h
@@ -242,4 +242,31 @@ out:
     return rc;
 }
 
+static inline bool on_arg_nv_index(int argc, char **argv,
+    TPMI_RH_NV_INDEX *nvIndex) {
+
+    if (argc > 1) {
+        LOG_ERR("Specify single value for NV Index");
+        return false;
+    }
+
+    if (!argc) {
+        LOG_ERR("Specify at least a single value for NV Index");
+        return false;
+    }
+
+    bool result = tpm2_hierarchy_from_optarg(argv[0], nvIndex,
+        TPM2_HANDLES_FLAGS_NV);
+    if (!result) {
+        LOG_ERR("Could not convert NV index to number, got: \"%s\"", argv[0]);
+        return false;
+    }
+    if (*nvIndex == 0) {
+            LOG_ERR("NV Index cannot be 0");
+            return false;
+    }
+
+    return true;
+}
+
 #endif /* LIB_TPM2_NV_UTIL_H_ */

--- a/man/tpm2_changeauth.1.md
+++ b/man/tpm2_changeauth.1.md
@@ -92,7 +92,7 @@ tpm2_policycommandcode -S session.ctx -L policy.nvchange nvchangeauth
 tpm2_flushcontext session.ctx
 
 NVIndex=0x1500015
-tpm2_nvdefine -x $NVIndex -a o -s 32 -t "authread|authwrite" -L policy.nvchange
+tpm2_nvdefine   $NVIndex -a o -s 32 -t "authread|authwrite" -L policy.nvchange
 tpm2_startauthsession \--policy-session -S session.ctx
 
 tpm2_policycommandcode -S session.ctx -L policy.nvchange nvchangeauth

--- a/man/tpm2_nvdefine.1.md
+++ b/man/tpm2_nvdefine.1.md
@@ -6,17 +6,15 @@
 
 # SYNOPSIS
 
-**tpm2_nvdefine** [*OPTIONS*]
+**tpm2_nvdefine** [*OPTIONS*] _NV\_INDEX_
 
 # DESCRIPTION
 
-**tpm2_nvdefine**(1) - Define an NV index with given auth value.
+**tpm2_nvdefine**(1) - Define an NV index with given auth value. The index is
+specified as an argument. It can be specified as raw handle or an offset value
+to the nv handle range "TPM2_HR_NV_INDEX".
 
 # OPTIONS
-
-  * **-x**, **\--index**=_NV\_INDEX_:
-
-    Specifies the index to define the space at.
 
   * **-C**, **\--hierarchy**=_AUTH\_HIERARCHY_:
 
@@ -65,9 +63,9 @@
 # EXAMPLES
 
 ```
-tpm2_nvdefine -x 0x1500016 -C 0x40000001 -s 32 -a 0x2000A
+tpm2_nvdefine   0x1500016 -C 0x40000001 -s 32 -a 0x2000A
 
-tpm2_nvdefine -x 0x1500016 -C 0x40000001 -s 32 -a ownerread|ownerwrite|policywrite -p 1a1b1c
+tpm2_nvdefine   0x1500016 -C 0x40000001 -s 32 -a ownerread|ownerwrite|policywrite -p 1a1b1c
 ```
 
 [returns](common/returns.md)

--- a/man/tpm2_nvincrement.1.md
+++ b/man/tpm2_nvincrement.1.md
@@ -48,6 +48,9 @@ handle range "TPM2_HR_NV_INDEX".
 ## To increment the counter at index *0x150016*
 
 ```
+tpm2_nvdefine -C 0x1500016 -s 8 -a "ownerread|policywrite|ownerwrite|nt=1" \
+0x1500016 -p index
+
 tpm2_nvincrement   0x1500016 -P "index"
 ```
 

--- a/man/tpm2_nvincrement.1.md
+++ b/man/tpm2_nvincrement.1.md
@@ -6,17 +6,15 @@
 
 # SYNOPSIS
 
-**tpm2_nvincrement** [*OPTIONS*]
+**tpm2_nvincrement** [*OPTIONS*] _NV\_INDEX_
 
 # DESCRIPTION
 
-**tpm2_nvincrement**(1) - Increment a counter at a Non-Volatile (NV) index.
+**tpm2_nvincrement**(1) - Increment value of a Non-Volatile (NV) index setup as
+a counter. The index can be specified as raw handle or an offset value to the nv
+handle range "TPM2_HR_NV_INDEX".
 
 # OPTIONS
-
-  * **-x**, **\--index**=_NV\_INDEX_:
-
-    Specifies the index to define the space at.
 
   * **-C**, **\--hierarchy**=_AUTH_:
 
@@ -50,7 +48,7 @@
 ## To increment the counter at index *0x150016*
 
 ```
-tpm2_nvincrement -x 0x1500016 -P "index"
+tpm2_nvincrement   0x1500016 -P "index"
 ```
 
 [returns](common/returns.md)

--- a/man/tpm2_nvread.1.md
+++ b/man/tpm2_nvread.1.md
@@ -65,7 +65,7 @@ tpm2_nvdefine -Q  1 -C o -s 32 -a "ownerread|policywrite|ownerwrite"
 
 echo "please123abc" > nv.test_w
 
-tpm2_nvwrite -Q -x $nv_test_index -C o nv.test_w
+tpm2_nvwrite -Q -x $nv_test_index -C o -i nv.test_w
 
 tpm2_nvread -Q  1 -C o -s 32 -o 0
 ```

--- a/man/tpm2_nvread.1.md
+++ b/man/tpm2_nvread.1.md
@@ -61,7 +61,13 @@ index can be specified as raw handle or an offset value to the nv handle range
 
 ## Read 32 bytes from an index starting at offset 0
 ```
-tpm2_nvread   0x1500016 -a 0x40000001 -s 32
+tpm2_nvdefine -Q  1 -C o -s 32 -a "ownerread|policywrite|ownerwrite"
+
+echo "please123abc" > nv.test_w
+
+tpm2_nvwrite -Q -x $nv_test_index -C o nv.test_w
+
+tpm2_nvread -Q  1 -C o -s 32 -o 0
 ```
 
 [returns](common/returns.md)

--- a/man/tpm2_nvread.1.md
+++ b/man/tpm2_nvread.1.md
@@ -65,7 +65,7 @@ tpm2_nvdefine -Q  1 -C o -s 32 -a "ownerread|policywrite|ownerwrite"
 
 echo "please123abc" > nv.test_w
 
-tpm2_nvwrite -Q -x $nv_test_index -C o -i nv.test_w
+tpm2_nvwrite -Q   $nv_test_index -C o -i nv.test_w
 
 tpm2_nvread -Q  1 -C o -s 32 -o 0
 ```

--- a/man/tpm2_nvread.1.md
+++ b/man/tpm2_nvread.1.md
@@ -6,17 +6,15 @@
 
 # SYNOPSIS
 
-**tpm2_nvread** [*OPTIONS*]
+**tpm2_nvread** [*OPTIONS*] _NV\_INDEX_
 
 # DESCRIPTION
 
-**tpm2_nvread**(1) - Read the data stored in a Non-Volatile (NV)s index.
+**tpm2_nvread**(1) - Read the data stored in a Non-Volatile (NV)s index. The
+index can be specified as raw handle or an offset value to the nv handle range
+"TPM2_HR_NV_INDEX".
 
 # OPTIONS
-
-  * **-x**, **\--index**=_NV\_INDEX_:
-
-    Specifies the index to define the space at.
 
   * **-C**, **\--hierarchy**=_AUTH_:
 
@@ -63,7 +61,7 @@
 
 ## Read 32 bytes from an index starting at offset 0
 ```
-tpm2_nvread -x 0x1500016 -a 0x40000001 -s 32
+tpm2_nvread   0x1500016 -a 0x40000001 -s 32
 ```
 
 [returns](common/returns.md)

--- a/man/tpm2_nvreadlock.1.md
+++ b/man/tpm2_nvreadlock.1.md
@@ -6,18 +6,16 @@
 
 # SYNOPSIS
 
-**tpm2_nvreadlock** [*OPTIONS*]
+**tpm2_nvreadlock** [*OPTIONS*] _NV\_INDEX_
 
 # DESCRIPTION
 
-**tpm2_nvreadlock**(1) - Lock the Non-Volatile (NV) index for further reads. The lock on the NV
-index is unlocked when the TPM is restarted and the NV index becomes readable again.
+**tpm2_nvreadlock**(1) - Lock the Non-Volatile (NV) index for further reads. The
+lock on the NN index is unlocked when the TPM is restarted and the NV index
+becomes readable again. The index can be specified as raw handle or an offset
+value to the nv handle range "TPM2_HR_NV_INDEX".
 
 # OPTIONS
-
-  * **-x**, **\--index**=_NV\_INDEX_:
-
-    Specifies the index to define the space at.
 
   * **-C**, **\--hierarchy**=_AUTH\_HANDLE_:
 
@@ -44,7 +42,7 @@ index is unlocked when the TPM is restarted and the NV index becomes readable ag
 
 ## Lock an index protected by a password
 ```
-tpm2_nvreadlock -x 0x1500016 -C 0x40000001 -P passwd
+tpm2_nvreadlock   0x1500016 -C 0x40000001 -P passwd
 ```
 
 [returns](common/returns.md)

--- a/man/tpm2_nvreadlock.1.md
+++ b/man/tpm2_nvreadlock.1.md
@@ -46,7 +46,7 @@ tpm2_nvdefine -Q   1 -C o -s 32 -a "ownerread|policywrite|ownerwrite|read_stclea
 
 echo "foobar" > nv.readlock
 
-tpm2_nvwrite -Q -x 0x01000001 -C o nv.readlock
+tpm2_nvwrite -Q -x 0x01000001 -C o -i nv.readlock
 
 tpm2_nvread -Q   1 -C o -s 6 -o 0
 

--- a/man/tpm2_nvreadlock.1.md
+++ b/man/tpm2_nvreadlock.1.md
@@ -46,7 +46,7 @@ tpm2_nvdefine -Q   1 -C o -s 32 -a "ownerread|policywrite|ownerwrite|read_stclea
 
 echo "foobar" > nv.readlock
 
-tpm2_nvwrite -Q -x 0x01000001 -C o -i nv.readlock
+tpm2_nvwrite -Q   0x01000001 -C o -i nv.readlock
 
 tpm2_nvread -Q   1 -C o -s 6 -o 0
 

--- a/man/tpm2_nvreadlock.1.md
+++ b/man/tpm2_nvreadlock.1.md
@@ -40,9 +40,17 @@ value to the nv handle range "TPM2_HR_NV_INDEX".
 
 # EXAMPLES
 
-## Lock an index protected by a password
+## Lock an index
 ```
-tpm2_nvreadlock   0x1500016 -C 0x40000001 -P passwd
+tpm2_nvdefine -Q   1 -C o -s 32 -a "ownerread|policywrite|ownerwrite|read_stclear"
+
+echo "foobar" > nv.readlock
+
+tpm2_nvwrite -Q -x 0x01000001 -C o nv.readlock
+
+tpm2_nvread -Q   1 -C o -s 6 -o 0
+
+tpm2_nvreadlock -Q   1 -C o
 ```
 
 [returns](common/returns.md)

--- a/man/tpm2_nvreadpublic.1.md
+++ b/man/tpm2_nvreadpublic.1.md
@@ -1,16 +1,16 @@
-% tpm2_nvlist(1) tpm2-tools | General Commands Manual
+% tpm2_nvreadpublic(1) tpm2-tools | General Commands Manual
 
 # NAME
 
-**tpm2_nvlist**(1) - Display all defined Non-Volatile (NV)s indices.
+**tpm2_nvreadpublic**(1) - Display all defined Non-Volatile (NV)s indices.
 
 # SYNOPSIS
 
-**tpm2_nvlist** [*OPTIONS*]
+**tpm2_nvreadpublic** [*OPTIONS*]
 
 # DESCRIPTION
 
-**tpm2_nvlist**(1) - Display all defined Non-Volatile (NV)s indices to stdout in a YAML format.
+**tpm2_nvreadpublic**(1) - Display all defined Non-Volatile (NV)s indices to stdout in a YAML format.
 
 Display metadata for all defined NV indices. Metadata includes:
 
@@ -57,7 +57,7 @@ This tool takes no tool specific options.
 ## List the defined NV indices to stdout
 
 ```
-tpm2_nvlist
+tpm2_nvreadpublic
 ```
 
 [returns](common/returns.md)

--- a/man/tpm2_nvundefine.1.md
+++ b/man/tpm2_nvundefine.1.md
@@ -40,7 +40,9 @@ be specified as raw handle or an offset value to the nv handle range
 # EXAMPLES
 
 ```
-tpm2_nvundefine   0x1500016 -C 0x40000001 -P passwd
+tpm2_nvdefine   0x1500016 -C 0x40000001 -s 32 -a 0x2000A
+
+tpm2_nvundefine   0x1500016 -C 0x40000001
 ```
 
 [returns](common/returns.md)

--- a/man/tpm2_nvundefine.1.md
+++ b/man/tpm2_nvundefine.1.md
@@ -11,13 +11,11 @@
 # DESCRIPTION
 
 **tpm2_nvundefine**(1) - Undefine a Non-Volatile (NV) index that was previously
-defined with **tpm2_nvdefine**(1).
+defined with **tpm2_nvdefine**(1). The index is specified as an argument. It can
+be specified as raw handle or an offset value to the nv handle range
+"TPM2_HR_NV_INDEX".
 
 # OPTIONS
-
-  * **-x**, **\--index**=_NV\_INDEX_:
-
-    Specifies the nv index to undefine.
 
   * **-C**, **\--hierarchy**=_AUTH\_HANDLE_:
 
@@ -42,7 +40,7 @@ defined with **tpm2_nvdefine**(1).
 # EXAMPLES
 
 ```
-tpm2_nvundefine -x 0x1500016 -C 0x40000001 -P passwd
+tpm2_nvundefine   0x1500016 -C 0x40000001 -P passwd
 ```
 
 [returns](common/returns.md)

--- a/man/tpm2_nvundefine.1.md
+++ b/man/tpm2_nvundefine.1.md
@@ -1,23 +1,23 @@
-% tpm2_nvrelease(1) tpm2-tools | General Commands Manual
+% tpm2_nvundefine(1) tpm2-tools | General Commands Manual
 
 # NAME
 
-**tpm2_nvrelease**(1) - Release a Non-Volatile (NV) index.
+**tpm2_nvundefine**(1) - Undefine a Non-Volatile (NV) index.
 
 # SYNOPSIS
 
-**tpm2_nvrelease** [*OPTIONS*]
+**tpm2_nvundefine** [*OPTIONS*]
 
 # DESCRIPTION
 
-**tpm2_nvrelease**(1) - Release a Non-Volatile (NV) index that was previously
+**tpm2_nvundefine**(1) - Undefine a Non-Volatile (NV) index that was previously
 defined with **tpm2_nvdefine**(1).
 
 # OPTIONS
 
   * **-x**, **\--index**=_NV\_INDEX_:
 
-    Specifies the index to release.
+    Specifies the nv index to undefine.
 
   * **-C**, **\--hierarchy**=_AUTH\_HANDLE_:
 
@@ -42,7 +42,7 @@ defined with **tpm2_nvdefine**(1).
 # EXAMPLES
 
 ```
-tpm2_nvrelease -x 0x1500016 -C 0x40000001 -P passwd
+tpm2_nvundefine -x 0x1500016 -C 0x40000001 -P passwd
 ```
 
 [returns](common/returns.md)

--- a/man/tpm2_nvwrite.1.md
+++ b/man/tpm2_nvwrite.1.md
@@ -53,9 +53,13 @@ raw handle or an offset value to the nv handle range "TPM2_HR_NV_INDEX".
 
 # EXAMPLES
 
-## Write the file nv.data to index *0x150016*
+## Write the file nv.data to index *0x01000001*
 ```
-tpm2_nvwrite 0x1500016 -P "index" -i nv.data
+tpm2_nvdefine -Q   1 -C o -s 32 -a "ownerread|policywrite|ownerwrite"
+
+echo "please123abc" > nv.test_w
+
+tpm2_nvwrite -Q   1 -C o -i nv.test_w
 ```
 
 [returns](common/returns.md)

--- a/man/tpm2_nvwrite.1.md
+++ b/man/tpm2_nvwrite.1.md
@@ -6,22 +6,19 @@
 
 # SYNOPSIS
 
-**tpm2_nvwrite** [*OPTIONS*]
+**tpm2_nvwrite** [*OPTIONS*] _NV\_INDEX_
 
 # DESCRIPTION
 
 **tpm2_nvwrite**(1) - Write data specified via _FILE_ to a Non-Volatile (NV) index.
-If _FILE_ is not specified, it defaults to stdin.
+If _FILE_ is not specified, it defaults to stdin. The index can be specified as
+raw handle or an offset value to the nv handle range "TPM2_HR_NV_INDEX".
 
 # OPTIONS
 
   * **-i**, **\--input**=_FILE_:
 
     Specifies the input file with data to write to NV.
-
-  * **-x**, **\--index**=_NV\_INDEX_:
-
-    Specifies the index to define the space at.
 
   * **-C**, **\--hierarchy**=_AUTH\_HANDLE_:
 
@@ -58,7 +55,7 @@ If _FILE_ is not specified, it defaults to stdin.
 
 ## Write the file nv.data to index *0x150016*
 ```
-tpm2_nvwrite -x 0x1500016 -P "index" -i nv.data
+tpm2_nvwrite 0x1500016 -P "index" -i nv.data
 ```
 
 [returns](common/returns.md)

--- a/man/tpm2_nvwrite.1.md
+++ b/man/tpm2_nvwrite.1.md
@@ -6,7 +6,7 @@
 
 # SYNOPSIS
 
-**tpm2_nvwrite** [*OPTIONS*] _FILE_
+**tpm2_nvwrite** [*OPTIONS*]
 
 # DESCRIPTION
 
@@ -14,6 +14,10 @@
 If _FILE_ is not specified, it defaults to stdin.
 
 # OPTIONS
+
+  * **-i**, **\--input**=_FILE_:
+
+    Specifies the input file with data to write to NV.
 
   * **-x**, **\--index**=_NV\_INDEX_:
 
@@ -54,7 +58,7 @@ If _FILE_ is not specified, it defaults to stdin.
 
 ## Write the file nv.data to index *0x150016*
 ```
-tpm2_nvwrite -x 0x1500016 -P "index" -f nv.data
+tpm2_nvwrite -x 0x1500016 -P "index" -i nv.data
 ```
 
 [returns](common/returns.md)

--- a/scripts/utils/analyze.py
+++ b/scripts/utils/analyze.py
@@ -159,7 +159,7 @@ class ToolConflictor(object):
                 "gname": "nv",
                 "tools-in-group": [
                     "tpm2_nvreadlock", "tpm2_nvundefine", "tpm2_nvdefine",
-                    "tpm2_nvread", "tpm2_nvwrite", "tpm2_nvlist", "tpm2_nvincrement"
+                    "tpm2_nvread", "tpm2_nvwrite", "tpm2_nvreadpublic", "tpm2_nvincrement"
                 ],
                 "tools": [],
                 "conflict": None,

--- a/scripts/utils/analyze.py
+++ b/scripts/utils/analyze.py
@@ -158,7 +158,7 @@ class ToolConflictor(object):
             {
                 "gname": "nv",
                 "tools-in-group": [
-                    "tpm2_nvreadlock", "tpm2_nvrelease", "tpm2_nvdefine",
+                    "tpm2_nvreadlock", "tpm2_nvundefine", "tpm2_nvdefine",
                     "tpm2_nvread", "tpm2_nvwrite", "tpm2_nvlist", "tpm2_nvincrement"
                 ],
                 "tools": [],

--- a/test/integration/tests/attestation.sh
+++ b/test/integration/tests/attestation.sh
@@ -98,7 +98,7 @@ tpm2_checkquote -Q -u $output_ak_pub_pem -m $output_quote -s $output_quotesig -f
 
 
 # Save U key from verifier
-tpm2_nvdefine -Q -x $handle_nv -C $handle_hier -s 32 -a "ownerread|ownerwrite" -p "indexpass" -P "$ownerpw"
+tpm2_nvdefine -Q   $handle_nv -C $handle_hier -s 32 -a "ownerread|ownerwrite" -p "indexpass" -P "$ownerpw"
 tpm2_nvwrite -Q -x $handle_nv -C $handle_hier -P "$ownerpw" $file_input_key
 tpm2_nvread -Q -x $handle_nv -C $handle_hier -s 32 -P "$ownerpw"
 

--- a/test/integration/tests/attestation.sh
+++ b/test/integration/tests/attestation.sh
@@ -41,7 +41,7 @@ cleanup() {
   tpm2_evictcontrol -Q -C o -c $handle_ek -P "$ownerpw" 2>/dev/null || true
   tpm2_evictcontrol -Q -C o -c $context_ak -P "$ownerpw" 2>/dev/null || true
 
-  tpm2_nvundefine -Q -x $handle_nv -C $handle_hier -P "$ownerpw" 2>/dev/null || true
+  tpm2_nvundefine -Q   $handle_nv -C $handle_hier -P "$ownerpw" 2>/dev/null || true
 
   if [ $(ina "$@" "no-shut-down") -ne 0 ]; then
     shut_down

--- a/test/integration/tests/attestation.sh
+++ b/test/integration/tests/attestation.sh
@@ -99,7 +99,7 @@ tpm2_checkquote -Q -u $output_ak_pub_pem -m $output_quote -s $output_quotesig -f
 
 # Save U key from verifier
 tpm2_nvdefine -Q   $handle_nv -C $handle_hier -s 32 -a "ownerread|ownerwrite" -p "indexpass" -P "$ownerpw"
-tpm2_nvwrite -Q -x $handle_nv -C $handle_hier -P "$ownerpw" $file_input_key
+tpm2_nvwrite -Q -x $handle_nv -C $handle_hier -P "$ownerpw" -i $file_input_key
 tpm2_nvread -Q   $handle_nv -C $handle_hier -s 32 -P "$ownerpw"
 
 exit 0

--- a/test/integration/tests/attestation.sh
+++ b/test/integration/tests/attestation.sh
@@ -41,7 +41,7 @@ cleanup() {
   tpm2_evictcontrol -Q -C o -c $handle_ek -P "$ownerpw" 2>/dev/null || true
   tpm2_evictcontrol -Q -C o -c $context_ak -P "$ownerpw" 2>/dev/null || true
 
-  tpm2_nvrelease -Q -x $handle_nv -C $handle_hier -P "$ownerpw" 2>/dev/null || true
+  tpm2_nvundefine -Q -x $handle_nv -C $handle_hier -P "$ownerpw" 2>/dev/null || true
 
   if [ $(ina "$@" "no-shut-down") -ne 0 ]; then
     shut_down

--- a/test/integration/tests/attestation.sh
+++ b/test/integration/tests/attestation.sh
@@ -99,7 +99,7 @@ tpm2_checkquote -Q -u $output_ak_pub_pem -m $output_quote -s $output_quotesig -f
 
 # Save U key from verifier
 tpm2_nvdefine -Q   $handle_nv -C $handle_hier -s 32 -a "ownerread|ownerwrite" -p "indexpass" -P "$ownerpw"
-tpm2_nvwrite -Q -x $handle_nv -C $handle_hier -P "$ownerpw" -i $file_input_key
+tpm2_nvwrite -Q   $handle_nv -C $handle_hier -P "$ownerpw" -i $file_input_key
 tpm2_nvread -Q   $handle_nv -C $handle_hier -s 32 -P "$ownerpw"
 
 exit 0

--- a/test/integration/tests/attestation.sh
+++ b/test/integration/tests/attestation.sh
@@ -100,6 +100,6 @@ tpm2_checkquote -Q -u $output_ak_pub_pem -m $output_quote -s $output_quotesig -f
 # Save U key from verifier
 tpm2_nvdefine -Q   $handle_nv -C $handle_hier -s 32 -a "ownerread|ownerwrite" -p "indexpass" -P "$ownerpw"
 tpm2_nvwrite -Q -x $handle_nv -C $handle_hier -P "$ownerpw" $file_input_key
-tpm2_nvread -Q -x $handle_nv -C $handle_hier -s 32 -P "$ownerpw"
+tpm2_nvread -Q   $handle_nv -C $handle_hier -s 32 -P "$ownerpw"
 
 exit 0

--- a/test/integration/tests/createek.sh
+++ b/test/integration/tests/createek.sh
@@ -38,12 +38,12 @@ ek_template_index=0x01c00004
 
 # Define RSA EK template
 nbytes=$(wc -c $TPM2_TOOLS_TEST_FIXTURES/ek-template-default.bin | cut -f1 -d' ')
-tpm2_nvdefine -Q -x $ek_template_index -C o -s $nbytes -a "ownerread|policywrite|ownerwrite"
+tpm2_nvdefine -Q   $ek_template_index -C o -s $nbytes -a "ownerread|policywrite|ownerwrite"
 tpm2_nvwrite -Q -x $ek_template_index -C o $TPM2_TOOLS_TEST_FIXTURES/ek-template-default.bin
 
 # Define RSA EK nonce
 echo -n -e '\0' > ek.nonce
-tpm2_nvdefine -Q -x $ek_nonce_index -C o -s 1 -a "ownerread|policywrite|ownerwrite"
+tpm2_nvdefine -Q   $ek_nonce_index -C o -s 1 -a "ownerread|policywrite|ownerwrite"
 tpm2_nvwrite -Q -x $ek_nonce_index -C o ek.nonce
 
 tpm2_createek -t -G rsa -u ek.pub -c ek.ctx

--- a/test/integration/tests/createek.sh
+++ b/test/integration/tests/createek.sh
@@ -39,12 +39,12 @@ ek_template_index=0x01c00004
 # Define RSA EK template
 nbytes=$(wc -c $TPM2_TOOLS_TEST_FIXTURES/ek-template-default.bin | cut -f1 -d' ')
 tpm2_nvdefine -Q   $ek_template_index -C o -s $nbytes -a "ownerread|policywrite|ownerwrite"
-tpm2_nvwrite -Q -x $ek_template_index -C o $TPM2_TOOLS_TEST_FIXTURES/ek-template-default.bin
+tpm2_nvwrite -Q -x $ek_template_index -C o -i $TPM2_TOOLS_TEST_FIXTURES/ek-template-default.bin
 
 # Define RSA EK nonce
 echo -n -e '\0' > ek.nonce
 tpm2_nvdefine -Q   $ek_nonce_index -C o -s 1 -a "ownerread|policywrite|ownerwrite"
-tpm2_nvwrite -Q -x $ek_nonce_index -C o ek.nonce
+tpm2_nvwrite -Q -x $ek_nonce_index -C o -i ek.nonce
 
 tpm2_createek -t -G rsa -u ek.pub -c ek.ctx
 

--- a/test/integration/tests/createek.sh
+++ b/test/integration/tests/createek.sh
@@ -39,12 +39,12 @@ ek_template_index=0x01c00004
 # Define RSA EK template
 nbytes=$(wc -c $TPM2_TOOLS_TEST_FIXTURES/ek-template-default.bin | cut -f1 -d' ')
 tpm2_nvdefine -Q   $ek_template_index -C o -s $nbytes -a "ownerread|policywrite|ownerwrite"
-tpm2_nvwrite -Q -x $ek_template_index -C o -i $TPM2_TOOLS_TEST_FIXTURES/ek-template-default.bin
+tpm2_nvwrite -Q   $ek_template_index -C o -i $TPM2_TOOLS_TEST_FIXTURES/ek-template-default.bin
 
 # Define RSA EK nonce
 echo -n -e '\0' > ek.nonce
 tpm2_nvdefine -Q   $ek_nonce_index -C o -s 1 -a "ownerread|policywrite|ownerwrite"
-tpm2_nvwrite -Q -x $ek_nonce_index -C o -i ek.nonce
+tpm2_nvwrite -Q   $ek_nonce_index -C o -i ek.nonce
 
 tpm2_createek -t -G rsa -u ek.pub -c ek.ctx
 

--- a/test/integration/tests/nv.sh
+++ b/test/integration/tests/nv.sh
@@ -45,7 +45,7 @@ tpm2_nvwrite -Q -x $nv_test_index -C o nv.test_w
 
 tpm2_nvread -Q   $nv_test_index -C o -s 32 -o 0
 
-tpm2_nvlist > nv.out
+tpm2_nvreadpublic > nv.out
 yaml_get_kv nv.out "$nv_test_index" > /dev/null
 
 
@@ -124,7 +124,7 @@ tpm2_nvread   $nv_test_index -C o > $large_file_read_name
 
 cmp -s $large_file_read_name $large_file_name
 
-tpm2_nvlist > nv.out
+tpm2_nvreadpublic > nv.out
 yaml_get_kv nv.out "$nv_test_index" > /dev/null
 
 tpm2_nvundefine -Q   $nv_test_index -C o

--- a/test/integration/tests/nv.sh
+++ b/test/integration/tests/nv.sh
@@ -41,7 +41,7 @@ tpm2_nvdefine -Q   $nv_test_index -C o -s 32 -a "ownerread|policywrite|ownerwrit
 
 echo "please123abc" > nv.test_w
 
-tpm2_nvwrite -Q -x $nv_test_index -C o -i nv.test_w
+tpm2_nvwrite -Q   $nv_test_index -C o -i nv.test_w
 
 tpm2_nvread -Q   $nv_test_index -C o -s 32 -o 0
 
@@ -60,7 +60,7 @@ echo -n "foo" > foo.dat
 dd if=foo.dat of=nv.test_w bs=1 seek=4 conv=notrunc 2>/dev/null
 
 # Test a pipe input
-cat foo.dat | tpm2_nvwrite -Q -x $nv_test_index -C o --offset 4 -i -
+cat foo.dat | tpm2_nvwrite -Q   $nv_test_index -C o --offset 4 -i -
 
 tpm2_nvread   $nv_test_index -C o -s 13 > cmp.dat
 
@@ -71,7 +71,7 @@ cmp nv.test_w cmp.dat
 
 trap - ERR
 
-tpm2_nvwrite -Q -x $nv_test_index -C o -o 30 -i foo.dat 2>/dev/null
+tpm2_nvwrite -Q   $nv_test_index -C o -o 30 -i foo.dat 2>/dev/null
 if [ $? -eq 0 ]; then
   echo "Writing past the public size shouldn't work!"
   exit 1
@@ -91,7 +91,7 @@ tpm2_createpolicy -Q --policy-pcr -l ${alg_pcr_policy}:${pcr_ids} -f $file_pcr_v
 tpm2_nvdefine -Q   0x1500016 -C 0x40000001 -s 32 -L $file_policy -a "policyread|policywrite"
 
 # Write with index authorization for now, since tpm2_nvwrite does not support pcr policy.
-echo -n "policy locked" | tpm2_nvwrite -Q -x 0x1500016 -C 0x1500016 -P pcr:${alg_pcr_policy}:${pcr_ids}+$file_pcr_value -i -
+echo -n "policy locked" | tpm2_nvwrite -Q   0x1500016 -C 0x1500016 -P pcr:${alg_pcr_policy}:${pcr_ids}+$file_pcr_value -i -
 
 str=`tpm2_nvread   0x1500016 -C 0x1500016 -P pcr:${alg_pcr_policy}:${pcr_ids}+$file_pcr_value -s 13`
 
@@ -118,7 +118,7 @@ tpm2_nvdefine -Q   $nv_test_index -C o -s $large_file_size -a 0x2000A
 base64 /dev/urandom | head -c $(($large_file_size)) > $large_file_name
 
 # Test file input redirection
-tpm2_nvwrite -Q -x $nv_test_index -C o -i -< $large_file_name
+tpm2_nvwrite -Q   $nv_test_index -C o -i -< $large_file_name
 
 tpm2_nvread   $nv_test_index -C o > $large_file_read_name
 
@@ -136,7 +136,7 @@ tpm2_nvdefine -Q   $nv_test_index -C o -s 32 -a "ownerread|policywrite|ownerwrit
 
 echo "foobar" > nv.readlock
 
-tpm2_nvwrite -Q -x $nv_test_index -C o -i nv.readlock
+tpm2_nvwrite -Q   $nv_test_index -C o -i nv.readlock
 
 tpm2_nvread -Q   $nv_test_index -C o -s 6 -o 0
 
@@ -169,20 +169,20 @@ tpm2_nvdefine   0x1500015 -C 0x40000001 -s 32 \
   -p "index" -P "owner"
 
 # Use index password write/read, implicit -a
-tpm2_nvwrite -Q -x 0x1500015 -P "index" -i nv.test_w
+tpm2_nvwrite -Q   0x1500015 -P "index" -i nv.test_w
 tpm2_nvread -Q   0x1500015 -P "index"
 
 # Use index password write/read, explicit -a
-tpm2_nvwrite -Q -x 0x1500015 -C 0x1500015 -P "index" -i nv.test_w
+tpm2_nvwrite -Q   0x1500015 -C 0x1500015 -P "index" -i nv.test_w
 tpm2_nvread -Q   0x1500015 -C 0x1500015 -P "index"
 
 # use owner password
-tpm2_nvwrite -Q -x 0x1500015 -C 0x40000001 -P "owner" -i nv.test_w
+tpm2_nvwrite -Q   0x1500015 -C 0x40000001 -P "owner" -i nv.test_w
 tpm2_nvread -Q   0x1500015 -C 0x40000001 -P "owner"
 
 # Check a bad password fails
 trap - ERR
-tpm2_nvwrite -Q -x 0x1500015 -C 0x1500015 -P "wrong" -i nv.test_w 2>/dev/null
+tpm2_nvwrite -Q   0x1500015 -C 0x1500015 -P "wrong" -i nv.test_w 2>/dev/null
 if [ $? -eq 0 ];then
  echo "nvwrite with bad password should fail!"
  exit 1

--- a/test/integration/tests/nv.sh
+++ b/test/integration/tests/nv.sh
@@ -33,11 +33,11 @@ cleanup "no-shut-down"
 tpm2_clear
 
 #Test default values for the hierarchy "-a" parameter
-tpm2_nvdefine -Q -x $nv_test_index -s 32 -a "ownerread|policywrite|ownerwrite"
+tpm2_nvdefine -Q   $nv_test_index -s 32 -a "ownerread|policywrite|ownerwrite"
 tpm2_nvrelease -Q -x $nv_test_index
 
 #Test writing and reading
-tpm2_nvdefine -Q -x $nv_test_index -C o -s 32 -a "ownerread|policywrite|ownerwrite"
+tpm2_nvdefine -Q   $nv_test_index -C o -s 32 -a "ownerread|policywrite|ownerwrite"
 
 echo "please123abc" > nv.test_w
 
@@ -88,7 +88,7 @@ tpm2_pcrlist -Q -l ${alg_pcr_policy}:${pcr_ids} -o $file_pcr_value
 
 tpm2_createpolicy -Q --policy-pcr -l ${alg_pcr_policy}:${pcr_ids} -f $file_pcr_value -L $file_policy
 
-tpm2_nvdefine -Q -x 0x1500016 -C 0x40000001 -s 32 -L $file_policy -a "policyread|policywrite"
+tpm2_nvdefine -Q   0x1500016 -C 0x40000001 -s 32 -L $file_policy -a "policyread|policywrite"
 
 # Write with index authorization for now, since tpm2_nvwrite does not support pcr policy.
 echo -n "policy locked" | tpm2_nvwrite -Q -x 0x1500016 -C 0x1500016 -P pcr:${alg_pcr_policy}:${pcr_ids}+$file_pcr_value
@@ -113,7 +113,7 @@ large_file_size=`yaml_get_kv cap.out "TPM2_PT_NV_INDEX_MAX" "raw"`
 nv_test_index=0x1000000
 
 # Create an nv space with attributes 1010 = TPMA_NV_PPWRITE and TPMA_NV_AUTHWRITE
-tpm2_nvdefine -Q -x $nv_test_index -C o -s $large_file_size -a 0x2000A
+tpm2_nvdefine -Q   $nv_test_index -C o -s $large_file_size -a 0x2000A
 
 base64 /dev/urandom | head -c $(($large_file_size)) > $large_file_name
 
@@ -132,7 +132,7 @@ tpm2_nvrelease -Q -x $nv_test_index -C o
 #
 # Test NV access locked
 #
-tpm2_nvdefine -Q -x $nv_test_index -C o -s 32 -a "ownerread|policywrite|ownerwrite|read_stclear"
+tpm2_nvdefine -Q   $nv_test_index -C o -s 32 -a "ownerread|policywrite|ownerwrite|read_stclear"
 
 echo "foobar" > nv.readlock
 
@@ -164,7 +164,7 @@ trap onerror ERR
 
 tpm2_changeauth -c o owner
 
-tpm2_nvdefine -x 0x1500015 -C 0x40000001 -s 32 \
+tpm2_nvdefine   0x1500015 -C 0x40000001 -s 32 \
   -a "policyread|policywrite|authread|authwrite|ownerwrite|ownerread" \
   -p "index" -P "owner"
 
@@ -194,7 +194,7 @@ trap onerror ERR
 tpm2_nvrelease -x 0x1500015 -C 0x40000001 -P "owner"
 
 # Check nv index can be specified simply as an offset
-tpm2_nvdefine -Q -C o -s 32 -a "ownerread|ownerwrite" -x 1 -P "owner"
+tpm2_nvdefine -Q -C o -s 32 -a "ownerread|ownerwrite"   1 -P "owner"
 tpm2_nvrelease -x 0x01000001 -C o -P "owner"
 
 exit 0

--- a/test/integration/tests/nv.sh
+++ b/test/integration/tests/nv.sh
@@ -13,9 +13,9 @@ file_pcr_value=pcr.bin
 file_policy=policy.data
 
 cleanup() {
-  tpm2_nvrelease -Q -x $nv_test_index -C o 2>/dev/null || true
-  tpm2_nvrelease -Q -x 0x1500016 -C 0x40000001 2>/dev/null || true
-  tpm2_nvrelease -Q -x 0x1500015 -C 0x40000001 -P owner 2>/dev/null || true
+  tpm2_nvundefine -Q -x $nv_test_index -C o 2>/dev/null || true
+  tpm2_nvundefine -Q -x 0x1500016 -C 0x40000001 2>/dev/null || true
+  tpm2_nvundefine -Q -x 0x1500015 -C 0x40000001 -P owner 2>/dev/null || true
 
   rm -f policy.bin test.bin nv.test_w $large_file_name $large_file_read_name \
         nv.readlock foo.dat cmp.dat $file_pcr_value $file_policy nv.out cap.out
@@ -34,7 +34,7 @@ tpm2_clear
 
 #Test default values for the hierarchy "-a" parameter
 tpm2_nvdefine -Q   $nv_test_index -s 32 -a "ownerread|policywrite|ownerwrite"
-tpm2_nvrelease -Q -x $nv_test_index
+tpm2_nvundefine -Q -x $nv_test_index
 
 #Test writing and reading
 tpm2_nvdefine -Q   $nv_test_index -C o -s 32 -a "ownerread|policywrite|ownerwrite"
@@ -82,7 +82,7 @@ tpm2_nvread   $nv_test_index -C o -s 13 > cmp.dat
 
 cmp nv.test_w cmp.dat
 
-tpm2_nvrelease -x $nv_test_index -C o
+tpm2_nvundefine -x $nv_test_index -C o
 
 tpm2_pcrlist -Q -l ${alg_pcr_policy}:${pcr_ids} -o $file_pcr_value
 
@@ -102,7 +102,7 @@ trap - ERR
 tpm2_nvread   0x1500016 -C 0x1500016 -P "index" 2>/dev/null
 trap onerror ERR
 
-tpm2_nvrelease -Q -x 0x1500016 -C 0x40000001
+tpm2_nvundefine -Q -x 0x1500016 -C 0x40000001
 
 #
 # Test large writes
@@ -127,7 +127,7 @@ cmp -s $large_file_read_name $large_file_name
 tpm2_nvlist > nv.out
 yaml_get_kv nv.out "$nv_test_index" > /dev/null
 
-tpm2_nvrelease -Q -x $nv_test_index -C o
+tpm2_nvundefine -Q -x $nv_test_index -C o
 
 #
 # Test NV access locked
@@ -188,13 +188,13 @@ if [ $? -eq 0 ];then
  exit 1
 fi
 
-# Check using authorisation with tpm2_nvrelease
+# Check using authorisation with tpm2_nvundefine
 trap onerror ERR
 
-tpm2_nvrelease -x 0x1500015 -C 0x40000001 -P "owner"
+tpm2_nvundefine -x 0x1500015 -C 0x40000001 -P "owner"
 
 # Check nv index can be specified simply as an offset
 tpm2_nvdefine -Q -C o -s 32 -a "ownerread|ownerwrite"   1 -P "owner"
-tpm2_nvrelease -x 0x01000001 -C o -P "owner"
+tpm2_nvundefine -x 0x01000001 -C o -P "owner"
 
 exit 0

--- a/test/integration/tests/nv.sh
+++ b/test/integration/tests/nv.sh
@@ -43,7 +43,7 @@ echo "please123abc" > nv.test_w
 
 tpm2_nvwrite -Q -x $nv_test_index -C o nv.test_w
 
-tpm2_nvread -Q -x $nv_test_index -C o -s 32 -o 0
+tpm2_nvread -Q   $nv_test_index -C o -s 32 -o 0
 
 tpm2_nvlist > nv.out
 yaml_get_kv nv.out "$nv_test_index" > /dev/null
@@ -62,7 +62,7 @@ dd if=foo.dat of=nv.test_w bs=1 seek=4 conv=notrunc 2>/dev/null
 # Test a pipe input
 cat foo.dat | tpm2_nvwrite -Q -x $nv_test_index -C o --offset 4
 
-tpm2_nvread -x $nv_test_index -C o -s 13 > cmp.dat
+tpm2_nvread   $nv_test_index -C o -s 13 > cmp.dat
 
 cmp nv.test_w cmp.dat
 
@@ -78,7 +78,7 @@ if [ $? -eq 0 ]; then
 fi
 trap onerror ERR
 
-tpm2_nvread -x $nv_test_index -C o -s 13 > cmp.dat
+tpm2_nvread   $nv_test_index -C o -s 13 > cmp.dat
 
 cmp nv.test_w cmp.dat
 
@@ -93,13 +93,13 @@ tpm2_nvdefine -Q   0x1500016 -C 0x40000001 -s 32 -L $file_policy -a "policyread|
 # Write with index authorization for now, since tpm2_nvwrite does not support pcr policy.
 echo -n "policy locked" | tpm2_nvwrite -Q -x 0x1500016 -C 0x1500016 -P pcr:${alg_pcr_policy}:${pcr_ids}+$file_pcr_value
 
-str=`tpm2_nvread -x 0x1500016 -C 0x1500016 -P pcr:${alg_pcr_policy}:${pcr_ids}+$file_pcr_value -s 13`
+str=`tpm2_nvread   0x1500016 -C 0x1500016 -P pcr:${alg_pcr_policy}:${pcr_ids}+$file_pcr_value -s 13`
 
 test "policy locked" == "$str"
 
 # this should fail because authread is not allowed
 trap - ERR
-tpm2_nvread -x 0x1500016 -C 0x1500016 -P "index" 2>/dev/null
+tpm2_nvread   0x1500016 -C 0x1500016 -P "index" 2>/dev/null
 trap onerror ERR
 
 tpm2_nvrelease -Q -x 0x1500016 -C 0x40000001
@@ -120,7 +120,7 @@ base64 /dev/urandom | head -c $(($large_file_size)) > $large_file_name
 # Test file input redirection
 tpm2_nvwrite -Q -x $nv_test_index -C o < $large_file_name
 
-tpm2_nvread -x $nv_test_index -C o > $large_file_read_name
+tpm2_nvread   $nv_test_index -C o > $large_file_read_name
 
 cmp -s $large_file_read_name $large_file_name
 
@@ -138,14 +138,14 @@ echo "foobar" > nv.readlock
 
 tpm2_nvwrite -Q -x $nv_test_index -C o nv.readlock
 
-tpm2_nvread -Q -x $nv_test_index -C o -s 6 -o 0
+tpm2_nvread -Q   $nv_test_index -C o -s 6 -o 0
 
 tpm2_nvreadlock -Q -x $nv_test_index -C o
 
 # Reset ERR signal handler to test for expected nvread error
 trap - ERR
 
-tpm2_nvread -Q -x $nv_test_index -C o -s 6 -o 0 2> /dev/null
+tpm2_nvread -Q   $nv_test_index -C o -s 6 -o 0 2> /dev/null
 if [ $? != 1 ];then
  echo "nvread didn't fail!"
  exit 1
@@ -170,15 +170,15 @@ tpm2_nvdefine   0x1500015 -C 0x40000001 -s 32 \
 
 # Use index password write/read, implicit -a
 tpm2_nvwrite -Q -x 0x1500015 -P "index" nv.test_w
-tpm2_nvread -Q -x 0x1500015 -P "index"
+tpm2_nvread -Q   0x1500015 -P "index"
 
 # Use index password write/read, explicit -a
 tpm2_nvwrite -Q -x 0x1500015 -C 0x1500015 -P "index" nv.test_w
-tpm2_nvread -Q -x 0x1500015 -C 0x1500015 -P "index"
+tpm2_nvread -Q   0x1500015 -C 0x1500015 -P "index"
 
 # use owner password
 tpm2_nvwrite -Q -x 0x1500015 -C 0x40000001 -P "owner" nv.test_w
-tpm2_nvread -Q -x 0x1500015 -C 0x40000001 -P "owner"
+tpm2_nvread -Q   0x1500015 -C 0x40000001 -P "owner"
 
 # Check a bad password fails
 trap - ERR

--- a/test/integration/tests/nv.sh
+++ b/test/integration/tests/nv.sh
@@ -13,9 +13,9 @@ file_pcr_value=pcr.bin
 file_policy=policy.data
 
 cleanup() {
-  tpm2_nvundefine -Q -x $nv_test_index -C o 2>/dev/null || true
-  tpm2_nvundefine -Q -x 0x1500016 -C 0x40000001 2>/dev/null || true
-  tpm2_nvundefine -Q -x 0x1500015 -C 0x40000001 -P owner 2>/dev/null || true
+  tpm2_nvundefine -Q   $nv_test_index -C o 2>/dev/null || true
+  tpm2_nvundefine -Q   0x1500016 -C 0x40000001 2>/dev/null || true
+  tpm2_nvundefine -Q   0x1500015 -C 0x40000001 -P owner 2>/dev/null || true
 
   rm -f policy.bin test.bin nv.test_w $large_file_name $large_file_read_name \
         nv.readlock foo.dat cmp.dat $file_pcr_value $file_policy nv.out cap.out
@@ -34,7 +34,7 @@ tpm2_clear
 
 #Test default values for the hierarchy "-a" parameter
 tpm2_nvdefine -Q   $nv_test_index -s 32 -a "ownerread|policywrite|ownerwrite"
-tpm2_nvundefine -Q -x $nv_test_index
+tpm2_nvundefine -Q   $nv_test_index
 
 #Test writing and reading
 tpm2_nvdefine -Q   $nv_test_index -C o -s 32 -a "ownerread|policywrite|ownerwrite"
@@ -82,7 +82,7 @@ tpm2_nvread   $nv_test_index -C o -s 13 > cmp.dat
 
 cmp nv.test_w cmp.dat
 
-tpm2_nvundefine -x $nv_test_index -C o
+tpm2_nvundefine   $nv_test_index -C o
 
 tpm2_pcrlist -Q -l ${alg_pcr_policy}:${pcr_ids} -o $file_pcr_value
 
@@ -102,7 +102,7 @@ trap - ERR
 tpm2_nvread   0x1500016 -C 0x1500016 -P "index" 2>/dev/null
 trap onerror ERR
 
-tpm2_nvundefine -Q -x 0x1500016 -C 0x40000001
+tpm2_nvundefine -Q   0x1500016 -C 0x40000001
 
 #
 # Test large writes
@@ -127,7 +127,7 @@ cmp -s $large_file_read_name $large_file_name
 tpm2_nvlist > nv.out
 yaml_get_kv nv.out "$nv_test_index" > /dev/null
 
-tpm2_nvundefine -Q -x $nv_test_index -C o
+tpm2_nvundefine -Q   $nv_test_index -C o
 
 #
 # Test NV access locked
@@ -191,10 +191,10 @@ fi
 # Check using authorisation with tpm2_nvundefine
 trap onerror ERR
 
-tpm2_nvundefine -x 0x1500015 -C 0x40000001 -P "owner"
+tpm2_nvundefine   0x1500015 -C 0x40000001 -P "owner"
 
 # Check nv index can be specified simply as an offset
 tpm2_nvdefine -Q -C o -s 32 -a "ownerread|ownerwrite"   1 -P "owner"
-tpm2_nvundefine -x 0x01000001 -C o -P "owner"
+tpm2_nvundefine   0x01000001 -C o -P "owner"
 
 exit 0

--- a/test/integration/tests/nv.sh
+++ b/test/integration/tests/nv.sh
@@ -41,7 +41,7 @@ tpm2_nvdefine -Q   $nv_test_index -C o -s 32 -a "ownerread|policywrite|ownerwrit
 
 echo "please123abc" > nv.test_w
 
-tpm2_nvwrite -Q -x $nv_test_index -C o nv.test_w
+tpm2_nvwrite -Q -x $nv_test_index -C o -i nv.test_w
 
 tpm2_nvread -Q   $nv_test_index -C o -s 32 -o 0
 
@@ -60,7 +60,7 @@ echo -n "foo" > foo.dat
 dd if=foo.dat of=nv.test_w bs=1 seek=4 conv=notrunc 2>/dev/null
 
 # Test a pipe input
-cat foo.dat | tpm2_nvwrite -Q -x $nv_test_index -C o --offset 4
+cat foo.dat | tpm2_nvwrite -Q -x $nv_test_index -C o --offset 4 -i -
 
 tpm2_nvread   $nv_test_index -C o -s 13 > cmp.dat
 
@@ -71,7 +71,7 @@ cmp nv.test_w cmp.dat
 
 trap - ERR
 
-tpm2_nvwrite -Q -x $nv_test_index -C o -o 30 foo.dat 2>/dev/null
+tpm2_nvwrite -Q -x $nv_test_index -C o -o 30 -i foo.dat 2>/dev/null
 if [ $? -eq 0 ]; then
   echo "Writing past the public size shouldn't work!"
   exit 1
@@ -91,7 +91,7 @@ tpm2_createpolicy -Q --policy-pcr -l ${alg_pcr_policy}:${pcr_ids} -f $file_pcr_v
 tpm2_nvdefine -Q   0x1500016 -C 0x40000001 -s 32 -L $file_policy -a "policyread|policywrite"
 
 # Write with index authorization for now, since tpm2_nvwrite does not support pcr policy.
-echo -n "policy locked" | tpm2_nvwrite -Q -x 0x1500016 -C 0x1500016 -P pcr:${alg_pcr_policy}:${pcr_ids}+$file_pcr_value
+echo -n "policy locked" | tpm2_nvwrite -Q -x 0x1500016 -C 0x1500016 -P pcr:${alg_pcr_policy}:${pcr_ids}+$file_pcr_value -i -
 
 str=`tpm2_nvread   0x1500016 -C 0x1500016 -P pcr:${alg_pcr_policy}:${pcr_ids}+$file_pcr_value -s 13`
 
@@ -118,7 +118,7 @@ tpm2_nvdefine -Q   $nv_test_index -C o -s $large_file_size -a 0x2000A
 base64 /dev/urandom | head -c $(($large_file_size)) > $large_file_name
 
 # Test file input redirection
-tpm2_nvwrite -Q -x $nv_test_index -C o < $large_file_name
+tpm2_nvwrite -Q -x $nv_test_index -C o -i -< $large_file_name
 
 tpm2_nvread   $nv_test_index -C o > $large_file_read_name
 
@@ -136,7 +136,7 @@ tpm2_nvdefine -Q   $nv_test_index -C o -s 32 -a "ownerread|policywrite|ownerwrit
 
 echo "foobar" > nv.readlock
 
-tpm2_nvwrite -Q -x $nv_test_index -C o nv.readlock
+tpm2_nvwrite -Q -x $nv_test_index -C o -i nv.readlock
 
 tpm2_nvread -Q   $nv_test_index -C o -s 6 -o 0
 
@@ -169,20 +169,20 @@ tpm2_nvdefine   0x1500015 -C 0x40000001 -s 32 \
   -p "index" -P "owner"
 
 # Use index password write/read, implicit -a
-tpm2_nvwrite -Q -x 0x1500015 -P "index" nv.test_w
+tpm2_nvwrite -Q -x 0x1500015 -P "index" -i nv.test_w
 tpm2_nvread -Q   0x1500015 -P "index"
 
 # Use index password write/read, explicit -a
-tpm2_nvwrite -Q -x 0x1500015 -C 0x1500015 -P "index" nv.test_w
+tpm2_nvwrite -Q -x 0x1500015 -C 0x1500015 -P "index" -i nv.test_w
 tpm2_nvread -Q   0x1500015 -C 0x1500015 -P "index"
 
 # use owner password
-tpm2_nvwrite -Q -x 0x1500015 -C 0x40000001 -P "owner" nv.test_w
+tpm2_nvwrite -Q -x 0x1500015 -C 0x40000001 -P "owner" -i nv.test_w
 tpm2_nvread -Q   0x1500015 -C 0x40000001 -P "owner"
 
 # Check a bad password fails
 trap - ERR
-tpm2_nvwrite -Q -x 0x1500015 -C 0x1500015 -P "wrong" nv.test_w 2>/dev/null
+tpm2_nvwrite -Q -x 0x1500015 -C 0x1500015 -P "wrong" -i nv.test_w 2>/dev/null
 if [ $? -eq 0 ];then
  echo "nvwrite with bad password should fail!"
  exit 1

--- a/test/integration/tests/nv.sh
+++ b/test/integration/tests/nv.sh
@@ -193,4 +193,8 @@ trap onerror ERR
 
 tpm2_nvrelease -x 0x1500015 -C 0x40000001 -P "owner"
 
+# Check nv index can be specified simply as an offset
+tpm2_nvdefine -Q -C o -s 32 -a "ownerread|ownerwrite" -x 1 -P "owner"
+tpm2_nvrelease -x 0x01000001 -C o -P "owner"
+
 exit 0

--- a/test/integration/tests/nv.sh
+++ b/test/integration/tests/nv.sh
@@ -140,7 +140,7 @@ tpm2_nvwrite -Q -x $nv_test_index -C o nv.readlock
 
 tpm2_nvread -Q   $nv_test_index -C o -s 6 -o 0
 
-tpm2_nvreadlock -Q -x $nv_test_index -C o
+tpm2_nvreadlock -Q   $nv_test_index -C o
 
 # Reset ERR signal handler to test for expected nvread error
 trap - ERR

--- a/test/integration/tests/nvinc.sh
+++ b/test/integration/tests/nvinc.sh
@@ -30,7 +30,7 @@ cleanup "no-shut-down"
 
 tpm2_clear
 
-tpm2_nvdefine -Q -x $nv_test_index -C o -s 8 -a "ownerread|policywrite|ownerwrite|nt=1"
+tpm2_nvdefine -Q   $nv_test_index -C o -s 8 -a "ownerread|policywrite|ownerwrite|nt=1"
 
 tpm2_nvincrement -Q -x $nv_test_index -C o
 
@@ -59,7 +59,7 @@ tpm2_pcrlist -Q -l ${alg_pcr_policy}:${pcr_ids} -o $file_pcr_value
 
 tpm2_createpolicy -Q --policy-pcr -l ${alg_pcr_policy}:${pcr_ids} -f $file_pcr_value -L $file_policy
 
-tpm2_nvdefine -Q -x 0x1500016 -C 0x40000001 -s 8 -L $file_policy -a "policyread|policywrite|nt=1"
+tpm2_nvdefine -Q   0x1500016 -C 0x40000001 -s 8 -L $file_policy -a "policyread|policywrite|nt=1"
 
 # Increment with index authorization for now, since tpm2_nvincrement does not support pcr policy.
 echo -n -e '\x00\x00\x00\x00\x00\x00\x00\x03' > nv.test_inc
@@ -82,7 +82,7 @@ tpm2_nvrelease -Q -x 0x1500016 -C 0x40000001
 #
 # Test NV access locked
 #
-tpm2_nvdefine -Q -x $nv_test_index -C o -s 8 -a "ownerread|policywrite|ownerwrite|read_stclear|nt=1"
+tpm2_nvdefine -Q   $nv_test_index -C o -s 8 -a "ownerread|policywrite|ownerwrite|read_stclear|nt=1"
 
 tpm2_nvincrement -Q -x $nv_test_index -C o
 
@@ -112,7 +112,7 @@ trap onerror ERR
 
 tpm2_changeauth -c o owner
 
-tpm2_nvdefine -x 0x1500015 -C 0x40000001 -s 8 \
+tpm2_nvdefine   0x1500015 -C 0x40000001 -s 8 \
   -a "policyread|policywrite|authread|authwrite|ownerwrite|ownerread|nt=1" \
   -p "index" -P "owner"
 

--- a/test/integration/tests/nvinc.sh
+++ b/test/integration/tests/nvinc.sh
@@ -36,7 +36,7 @@ tpm2_nvincrement -Q   $nv_test_index -C o
 
 tpm2_nvread -Q   $nv_test_index -C o -s 8
 
-tpm2_nvlist > nv.out
+tpm2_nvreadpublic > nv.out
 yaml_get_kv nv.out "$nv_test_index" > /dev/null
 
 # Test writing to and reading from an offset by:

--- a/test/integration/tests/nvinc.sh
+++ b/test/integration/tests/nvinc.sh
@@ -34,7 +34,7 @@ tpm2_nvdefine -Q   $nv_test_index -C o -s 8 -a "ownerread|policywrite|ownerwrite
 
 tpm2_nvincrement -Q   $nv_test_index -C o
 
-tpm2_nvread -Q -x $nv_test_index -C o -s 8
+tpm2_nvread -Q   $nv_test_index -C o -s 8
 
 tpm2_nvlist > nv.out
 yaml_get_kv nv.out "$nv_test_index" > /dev/null
@@ -48,7 +48,7 @@ echo -n -e '\x00\x00\x00\x00\x00\x00\x00\x02' > nv.test_inc
 
 tpm2_nvincrement -Q   $nv_test_index -C o
 
-tpm2_nvread -x $nv_test_index -C o -s 8 > cmp.dat
+tpm2_nvread   $nv_test_index -C o -s 8 > cmp.dat
 
 cmp nv.test_inc cmp.dat
 
@@ -67,13 +67,13 @@ echo -n -e '\x00\x00\x00\x00\x00\x00\x00\x03' > nv.test_inc
 # Counter is initialised to highest value previously seen (in this case 2) then incremented
 tpm2_nvincrement -Q   0x1500016 -C 0x1500016 -P pcr:${alg_pcr_policy}:${pcr_ids}+$file_pcr_value
 
-tpm2_nvread -x 0x1500016 -C 0x1500016 -P pcr:${alg_pcr_policy}:${pcr_ids}+$file_pcr_value -s 8 > cmp.dat
+tpm2_nvread   0x1500016 -C 0x1500016 -P pcr:${alg_pcr_policy}:${pcr_ids}+$file_pcr_value -s 8 > cmp.dat
 
 cmp nv.test_inc cmp.dat
 
 # this should fail because authread is not allowed
 trap - ERR
-tpm2_nvread -x 0x1500016 -C 0x1500016 -P "index" 2>/dev/null
+tpm2_nvread   0x1500016 -C 0x1500016 -P "index" 2>/dev/null
 trap onerror ERR
 
 tpm2_nvrelease -Q -x 0x1500016 -C 0x40000001
@@ -86,14 +86,14 @@ tpm2_nvdefine -Q   $nv_test_index -C o -s 8 -a "ownerread|policywrite|ownerwrite
 
 tpm2_nvincrement -Q   $nv_test_index -C o
 
-tpm2_nvread -Q -x $nv_test_index -C o -s 8
+tpm2_nvread -Q   $nv_test_index -C o -s 8
 
 tpm2_nvreadlock -Q -x $nv_test_index -C o
 
 # Reset ERR signal handler to test for expected nvread error
 trap - ERR
 
-tpm2_nvread -Q -x $nv_test_index -C o -s 8 2> /dev/null
+tpm2_nvread -Q   $nv_test_index -C o -s 8 2> /dev/null
 if [ $? != 1 ];then
  echo "nvread didn't fail!"
  exit 1
@@ -118,15 +118,15 @@ tpm2_nvdefine   0x1500015 -C 0x40000001 -s 8 \
 
 # Use index password write/read, implicit -C
 tpm2_nvincrement -Q   0x1500015 -P "index"
-tpm2_nvread -Q -x 0x1500015 -P "index"
+tpm2_nvread -Q   0x1500015 -P "index"
 
 # Use index password write/read, explicit -C
 tpm2_nvincrement -Q   0x1500015 -C 0x1500015 -P "index"
-tpm2_nvread -Q -x 0x1500015 -C 0x1500015 -P "index"
+tpm2_nvread -Q   0x1500015 -C 0x1500015 -P "index"
 
 # use owner password
 tpm2_nvincrement -Q   0x1500015 -C 0x40000001 -P "owner"
-tpm2_nvread -Q -x 0x1500015 -C 0x40000001 -P "owner"
+tpm2_nvread -Q   0x1500015 -C 0x40000001 -P "owner"
 
 # Check a bad password fails
 trap - ERR

--- a/test/integration/tests/nvinc.sh
+++ b/test/integration/tests/nvinc.sh
@@ -11,9 +11,9 @@ file_pcr_value=pcr.bin
 file_policy=policy.data
 
 cleanup() {
-  tpm2_nvundefine -Q -x $nv_test_index -C o 2>/dev/null || true
-  tpm2_nvundefine -Q -x 0x1500016 -C 0x40000001 2>/dev/null || true
-  tpm2_nvundefine -Q -x 0x1500015 -C 0x40000001 -P owner 2>/dev/null || true
+  tpm2_nvundefine -Q   $nv_test_index -C o 2>/dev/null || true
+  tpm2_nvundefine -Q   0x1500016 -C 0x40000001 2>/dev/null || true
+  tpm2_nvundefine -Q   0x1500015 -C 0x40000001 -P owner 2>/dev/null || true
 
   rm -f policy.bin test.bin nv.test_inc nv.readlock foo.dat cmp.dat \
         $file_pcr_value $file_policy nv.out cap.out
@@ -52,7 +52,7 @@ tpm2_nvread   $nv_test_index -C o -s 8 > cmp.dat
 
 cmp nv.test_inc cmp.dat
 
-tpm2_nvundefine -x $nv_test_index -C o
+tpm2_nvundefine   $nv_test_index -C o
 
 
 tpm2_pcrlist -Q -l ${alg_pcr_policy}:${pcr_ids} -o $file_pcr_value
@@ -76,7 +76,7 @@ trap - ERR
 tpm2_nvread   0x1500016 -C 0x1500016 -P "index" 2>/dev/null
 trap onerror ERR
 
-tpm2_nvundefine -Q -x 0x1500016 -C 0x40000001
+tpm2_nvundefine -Q   0x1500016 -C 0x40000001
 
 
 #
@@ -139,6 +139,6 @@ fi
 # Check using authorisation with tpm2_nvundefine
 trap onerror ERR
 
-tpm2_nvundefine -x 0x1500015 -C 0x40000001 -P "owner"
+tpm2_nvundefine   0x1500015 -C 0x40000001 -P "owner"
 
 exit 0

--- a/test/integration/tests/nvinc.sh
+++ b/test/integration/tests/nvinc.sh
@@ -32,7 +32,7 @@ tpm2_clear
 
 tpm2_nvdefine -Q   $nv_test_index -C o -s 8 -a "ownerread|policywrite|ownerwrite|nt=1"
 
-tpm2_nvincrement -Q -x $nv_test_index -C o
+tpm2_nvincrement -Q   $nv_test_index -C o
 
 tpm2_nvread -Q -x $nv_test_index -C o -s 8
 
@@ -46,7 +46,7 @@ yaml_get_kv nv.out "$nv_test_index" > /dev/null
 
 echo -n -e '\x00\x00\x00\x00\x00\x00\x00\x02' > nv.test_inc
 
-tpm2_nvincrement -Q -x $nv_test_index -C o
+tpm2_nvincrement -Q   $nv_test_index -C o
 
 tpm2_nvread -x $nv_test_index -C o -s 8 > cmp.dat
 
@@ -65,7 +65,7 @@ tpm2_nvdefine -Q   0x1500016 -C 0x40000001 -s 8 -L $file_policy -a "policyread|p
 echo -n -e '\x00\x00\x00\x00\x00\x00\x00\x03' > nv.test_inc
 
 # Counter is initialised to highest value previously seen (in this case 2) then incremented
-tpm2_nvincrement -Q -x 0x1500016 -C 0x1500016 -P pcr:${alg_pcr_policy}:${pcr_ids}+$file_pcr_value
+tpm2_nvincrement -Q   0x1500016 -C 0x1500016 -P pcr:${alg_pcr_policy}:${pcr_ids}+$file_pcr_value
 
 tpm2_nvread -x 0x1500016 -C 0x1500016 -P pcr:${alg_pcr_policy}:${pcr_ids}+$file_pcr_value -s 8 > cmp.dat
 
@@ -84,7 +84,7 @@ tpm2_nvrelease -Q -x 0x1500016 -C 0x40000001
 #
 tpm2_nvdefine -Q   $nv_test_index -C o -s 8 -a "ownerread|policywrite|ownerwrite|read_stclear|nt=1"
 
-tpm2_nvincrement -Q -x $nv_test_index -C o
+tpm2_nvincrement -Q   $nv_test_index -C o
 
 tpm2_nvread -Q -x $nv_test_index -C o -s 8
 
@@ -117,20 +117,20 @@ tpm2_nvdefine   0x1500015 -C 0x40000001 -s 8 \
   -p "index" -P "owner"
 
 # Use index password write/read, implicit -C
-tpm2_nvincrement -Q -x 0x1500015 -P "index"
+tpm2_nvincrement -Q   0x1500015 -P "index"
 tpm2_nvread -Q -x 0x1500015 -P "index"
 
 # Use index password write/read, explicit -C
-tpm2_nvincrement -Q -x 0x1500015 -C 0x1500015 -P "index"
+tpm2_nvincrement -Q   0x1500015 -C 0x1500015 -P "index"
 tpm2_nvread -Q -x 0x1500015 -C 0x1500015 -P "index"
 
 # use owner password
-tpm2_nvincrement -Q -x 0x1500015 -C 0x40000001 -P "owner"
+tpm2_nvincrement -Q   0x1500015 -C 0x40000001 -P "owner"
 tpm2_nvread -Q -x 0x1500015 -C 0x40000001 -P "owner"
 
 # Check a bad password fails
 trap - ERR
-tpm2_nvincrement -Q -x 0x1500015 -C 0x1500015 -P "wrong" 2>/dev/null
+tpm2_nvincrement -Q   0x1500015 -C 0x1500015 -P "wrong" 2>/dev/null
 if [ $? -eq 0 ];then
  echo "nvincrement with bad password should fail!"
  exit 1

--- a/test/integration/tests/nvinc.sh
+++ b/test/integration/tests/nvinc.sh
@@ -88,7 +88,7 @@ tpm2_nvincrement -Q   $nv_test_index -C o
 
 tpm2_nvread -Q   $nv_test_index -C o -s 8
 
-tpm2_nvreadlock -Q -x $nv_test_index -C o
+tpm2_nvreadlock -Q   $nv_test_index -C o
 
 # Reset ERR signal handler to test for expected nvread error
 trap - ERR

--- a/test/integration/tests/nvinc.sh
+++ b/test/integration/tests/nvinc.sh
@@ -11,9 +11,9 @@ file_pcr_value=pcr.bin
 file_policy=policy.data
 
 cleanup() {
-  tpm2_nvrelease -Q -x $nv_test_index -C o 2>/dev/null || true
-  tpm2_nvrelease -Q -x 0x1500016 -C 0x40000001 2>/dev/null || true
-  tpm2_nvrelease -Q -x 0x1500015 -C 0x40000001 -P owner 2>/dev/null || true
+  tpm2_nvundefine -Q -x $nv_test_index -C o 2>/dev/null || true
+  tpm2_nvundefine -Q -x 0x1500016 -C 0x40000001 2>/dev/null || true
+  tpm2_nvundefine -Q -x 0x1500015 -C 0x40000001 -P owner 2>/dev/null || true
 
   rm -f policy.bin test.bin nv.test_inc nv.readlock foo.dat cmp.dat \
         $file_pcr_value $file_policy nv.out cap.out
@@ -52,7 +52,7 @@ tpm2_nvread   $nv_test_index -C o -s 8 > cmp.dat
 
 cmp nv.test_inc cmp.dat
 
-tpm2_nvrelease -x $nv_test_index -C o
+tpm2_nvundefine -x $nv_test_index -C o
 
 
 tpm2_pcrlist -Q -l ${alg_pcr_policy}:${pcr_ids} -o $file_pcr_value
@@ -76,7 +76,7 @@ trap - ERR
 tpm2_nvread   0x1500016 -C 0x1500016 -P "index" 2>/dev/null
 trap onerror ERR
 
-tpm2_nvrelease -Q -x 0x1500016 -C 0x40000001
+tpm2_nvundefine -Q -x 0x1500016 -C 0x40000001
 
 
 #
@@ -136,9 +136,9 @@ if [ $? -eq 0 ];then
  exit 1
 fi
 
-# Check using authorisation with tpm2_nvrelease
+# Check using authorisation with tpm2_nvundefine
 trap onerror ERR
 
-tpm2_nvrelease -x 0x1500015 -C 0x40000001 -P "owner"
+tpm2_nvundefine -x 0x1500015 -C 0x40000001 -P "owner"
 
 exit 0

--- a/tools/tpm2_nvdefine.c
+++ b/tools/tpm2_nvdefine.c
@@ -1,10 +1,12 @@
 /* SPDX-License-Identifier: BSD-3-Clause */
+#include <stdlib.h>
 
 #include "files.h"
 #include "log.h"
 #include "tpm2.h"
 #include "tpm2_attr_util.h"
 #include "tpm2_auth_util.h"
+#include "tpm2_nv_util.h"
 #include "tpm2_options.h"
 
 typedef struct tpm_nvdefine_ctx tpm_nvdefine_ctx;
@@ -15,7 +17,7 @@ struct tpm_nvdefine_ctx {
         tpm2_loaded_object object;
     } auth_hierarchy;
 
-    UINT32 nvIndex;
+    TPMI_RH_NV_INDEX nvIndex;
     UINT16 size;
     TPMA_NV nvAttribute;
     TPM2B_AUTH nvAuth;
@@ -72,20 +74,6 @@ static bool on_option(char key, char *value) {
     bool result;
 
     switch (key) {
-    case 'x':
-        result = tpm2_hierarchy_from_optarg(value, &ctx.nvIndex,
-            TPM2_HANDLES_FLAGS_NV);
-        if (!result) {
-            LOG_ERR("Could not convert NV index to number, got: \"%s\"",
-                    value);
-            return false;
-        }
-
-        if (ctx.nvIndex == 0) {
-                LOG_ERR("NV Index cannot be 0");
-                return false;
-        }
-        break;
         case 'C':
             ctx.auth_hierarchy.ctx_path = value;
         break;
@@ -122,10 +110,14 @@ static bool on_option(char key, char *value) {
     return true;
 }
 
+static bool on_arg(int argc, char **argv) {
+
+    return on_arg_nv_index(argc, argv, &ctx.nvIndex);
+}
+
 bool tpm2_tool_onstart(tpm2_options **opts) {
 
     const struct option topts[] = {
-        { "index",                  required_argument,  NULL,   'x' },
         { "hierarchy",              required_argument,  NULL,   'C' },
         { "size",                   required_argument,  NULL,   's' },
         { "attributes",             required_argument,  NULL,   'a' },
@@ -134,8 +126,8 @@ bool tpm2_tool_onstart(tpm2_options **opts) {
         { "policy",                 required_argument,  NULL,   'L' },
     };
 
-    *opts = tpm2_options_new("x:C:s:a:P:p:L:", ARRAY_LEN(topts), topts,
-                             on_option, NULL, 0);
+    *opts = tpm2_options_new("C:s:a:P:p:L:", ARRAY_LEN(topts), topts,
+                             on_option, on_arg, 0);
 
     return *opts != NULL;
 }

--- a/tools/tpm2_nvdefine.c
+++ b/tools/tpm2_nvdefine.c
@@ -73,7 +73,8 @@ static bool on_option(char key, char *value) {
 
     switch (key) {
     case 'x':
-        result = tpm2_util_string_to_uint32(value, &ctx.nvIndex);
+        result = tpm2_hierarchy_from_optarg(value, &ctx.nvIndex,
+            TPM2_HANDLES_FLAGS_NV);
         if (!result) {
             LOG_ERR("Could not convert NV index to number, got: \"%s\"",
                     value);

--- a/tools/tpm2_nvreadlock.c
+++ b/tools/tpm2_nvreadlock.c
@@ -1,7 +1,9 @@
 /* SPDX-License-Identifier: BSD-3-Clause */
+#include <stdlib.h>
 
 #include "log.h"
 #include "tpm2.h"
+#include "tpm2_nv_util.h"
 #include "tpm2_options.h"
 
 typedef struct tpm_nvreadlock_ctx tpm_nvreadlock_ctx;
@@ -19,24 +21,16 @@ static tpm_nvreadlock_ctx ctx = {
     .auth_hierarchy.ctx_path = "owner",
 };
 
+
+static bool on_arg(int argc, char **argv) {
+
+    return on_arg_nv_index(argc, argv, &ctx.nv_index);
+}
+
 static bool on_option(char key, char *value) {
 
-    bool result;
-
     switch (key) {
-    case 'x':
-        result = tpm2_util_string_to_uint32(value, &ctx.nv_index);
-        if (!result) {
-            LOG_ERR("Could not convert NV index to number, got: \"%s\"",
-                    value);
-            return false;
-        }
 
-        if (ctx.nv_index == 0) {
-            LOG_ERR("NV Index cannot be 0");
-            return false;
-        }
-        break;
     case 'C':
         ctx.auth_hierarchy.ctx_path = value;
         break;
@@ -51,13 +45,12 @@ static bool on_option(char key, char *value) {
 bool tpm2_tool_onstart(tpm2_options **opts) {
 
     const struct option topts[] = {
-        { "index",                required_argument, NULL, 'x' },
         { "hierarchy",            required_argument, NULL, 'C' },
         { "auth",                 required_argument, NULL, 'P' },
     };
 
-    *opts = tpm2_options_new("x:C:P:", ARRAY_LEN(topts), topts,
-                             on_option, NULL, 0);
+    *opts = tpm2_options_new("C:P:", ARRAY_LEN(topts), topts,
+                             on_option, on_arg, 0);
 
     return *opts != NULL;
 }

--- a/tools/tpm2_nvreadpublic.c
+++ b/tools/tpm2_nvreadpublic.c
@@ -45,7 +45,7 @@ static void print_nv_public(TPM2B_NV_PUBLIC *nv_public) {
     free(attrs);
 }
 
-static tool_rc nv_list(ESYS_CONTEXT *context) {
+static tool_rc nv_readpublic(ESYS_CONTEXT *context) {
 
     TPMS_CAPABILITY_DATA *capabilityData;
     UINT32 property = tpm2_util_hton_32(TPM2_HT_NV_INDEX);
@@ -93,5 +93,5 @@ tool_rc tpm2_tool_onrun(ESYS_CONTEXT *context, tpm2_option_flags flags) {
 
     UNUSED(flags);
 
-    return nv_list(context);
+    return nv_readpublic(context);
 }

--- a/tools/tpm2_nvundefine.c
+++ b/tools/tpm2_nvundefine.c
@@ -4,8 +4,8 @@
 #include "tpm2.h"
 #include "tpm2_options.h"
 
-typedef struct tpm_nvrelease_ctx tpm_nvrelease_ctx;
-struct tpm_nvrelease_ctx {
+typedef struct tpm_nvundefine_ctx tpm_nvundefine_ctx;
+struct tpm_nvundefine_ctx {
     struct {
         const char *ctx_path;
         const char *auth_str;
@@ -15,7 +15,7 @@ struct tpm_nvrelease_ctx {
     TPM2_HANDLE nv_index;
 };
 
-static tpm_nvrelease_ctx ctx = {
+static tpm_nvundefine_ctx ctx = {
     .auth_hierarchy.ctx_path = "owner",
 };
 
@@ -74,7 +74,7 @@ tool_rc tpm2_tool_onrun(ESYS_CONTEXT *ectx, tpm2_option_flags flags) {
         return rc;
     }
 
-    return tpm2_nvrelease(ectx, &ctx.auth_hierarchy.object, ctx.nv_index);
+    return tpm2_nvundefine(ectx, &ctx.auth_hierarchy.object, ctx.nv_index);
 }
 
 tool_rc tpm2_tool_onstop(ESYS_CONTEXT *ectx) {

--- a/tools/tpm2_nvwrite.c
+++ b/tools/tpm2_nvwrite.c
@@ -18,6 +18,7 @@ struct tpm_nvwrite_ctx {
     } auth_hierarchy;
 
     TPM2_HANDLE nv_index;
+    bool is_auth_hierarchy_specified;
 
     BYTE nv_buffer[TPM2_MAX_NV_BUFFER_SIZE];
     FILE *input_file;
@@ -25,7 +26,9 @@ struct tpm_nvwrite_ctx {
     UINT16 offset;
 };
 
-static tpm_nvwrite_ctx ctx;
+static tpm_nvwrite_ctx ctx = {
+    .is_auth_hierarchy_specified = false,
+};
 
 static tool_rc nv_write(ESYS_CONTEXT *ectx) {
 
@@ -98,26 +101,9 @@ static bool on_option(char key, char *value) {
     bool result;
     char *input_file;
     switch (key) {
-    case 'x':
-        result = tpm2_util_string_to_uint32(value, &ctx.nv_index);
-        if (!result) {
-            LOG_ERR("Could not convert NV index to number, got: \"%s\"",
-                    value);
-            return false;
-        }
-
-        if (ctx.nv_index == 0) {
-            LOG_ERR("NV Index cannot be 0");
-            return false;
-        }
-        /*
-         * If the users doesn't specify an authorization hierarchy use the index
-         * passed to -x/--index for the authorization index.
-         */
-        ctx.auth_hierarchy.ctx_path = value;
-        break;
     case 'C':
         ctx.auth_hierarchy.ctx_path = value;
+        ctx.is_auth_hierarchy_specified = true;
         break;
     case 'P':
         ctx.auth_hierarchy.auth_str = value;
@@ -152,18 +138,27 @@ static bool on_option(char key, char *value) {
     return true;
 }
 
+static bool on_arg(int argc, char **argv) {
+    /* If the users doesn't specify an authorization hierarchy use the index
+    * passed to -x/--index for the authorization index.
+    */
+    if (!ctx.is_auth_hierarchy_specified) {
+        ctx.auth_hierarchy.ctx_path = argv[0];
+    }
+    return on_arg_nv_index(argc, argv, &ctx.nv_index);
+}
+
 bool tpm2_tool_onstart(tpm2_options **opts) {
 
     const struct option topts[] = {
-        { "index",                required_argument, NULL, 'x' },
         { "hierarchy",            required_argument, NULL, 'C' },
         { "auth",                 required_argument, NULL, 'P' },
         { "input",                required_argument, NULL, 'i' },
         { "offset",               required_argument, NULL,  0  },
     };
 
-    *opts = tpm2_options_new("x:C:P:i:", ARRAY_LEN(topts), topts, on_option,
-        NULL, 0);
+    *opts = tpm2_options_new("C:P:i:", ARRAY_LEN(topts), topts, on_option,
+        on_arg, 0);
 
     return *opts != NULL;
 }


### PR DESCRIPTION
Progresses #1042 

tpm2_nvdefine
  -x as an argument

tpm2_nvincrement
 -x as an argument
 manpage example needs to be complete with nvdefine.

 tpm2_nvlist rename it to tpm2_nvreadpublic.

tpm2_nvread
 -x as an argument
 manpage example needs to be complete.

tpm2_nvreadlock
 -x as an argument
 manpage example needs to be complete.

tpm2_nvrelease
rename to tpm2_undefine
 -x as an argument
 manpage example needs to be complete.
