### PR TITLE
Fix LGTM alerts

### DIFF
--- a/lib/tpm2_policy.c
+++ b/lib/tpm2_policy.c
@@ -247,12 +247,12 @@ tool_rc tpm2_policy_build_policyauthorize(
 }
 
 tool_rc tpm2_policy_build_policyor(ESYS_CONTEXT *ectx,
-    tpm2_session *policy_session, TPML_DIGEST policy_list) {
+    tpm2_session *policy_session, TPML_DIGEST *policy_list) {
 
     ESYS_TR sess_handle = tpm2_session_get_handle(policy_session);
     return tpm2_policy_or(ectx, sess_handle,
                     ESYS_TR_NONE, ESYS_TR_NONE, ESYS_TR_NONE,
-                    &policy_list);
+                    policy_list);
 }
 
 tool_rc tpm2_policy_build_policypassword(ESYS_CONTEXT *ectx,

--- a/lib/tpm2_policy.h
+++ b/lib/tpm2_policy.h
@@ -71,7 +71,7 @@ tool_rc tpm2_policy_build_policyauthorize(
  *   tool_rc indicating status.
  */
 tool_rc tpm2_policy_build_policyor(ESYS_CONTEXT *ectx,
-    tpm2_session *policy_session, TPML_DIGEST policy_list);
+    tpm2_session *policy_session, TPML_DIGEST *policy_list);
 
 /**
  * Enables secret (password/hmac) based authorization to a policy.

--- a/tools/misc/tpm2_checkquote.c
+++ b/tools/misc/tpm2_checkquote.c
@@ -43,7 +43,7 @@ struct tpm2_verifysig_ctx {
     tpm2_loaded_object key_context_object;
 };
 
-tpm2_verifysig_ctx ctx = {
+static tpm2_verifysig_ctx ctx = {
         .format = TPM2_ALG_ERROR,
         .halg = TPM2_ALG_SHA1,
         .msgHash = TPM2B_TYPE_INIT(TPM2B_DIGEST, buffer),

--- a/tools/misc/tpm2_rc_decode.c
+++ b/tools/misc/tpm2_rc_decode.c
@@ -14,7 +14,7 @@ struct tpm2_rc_ctx {
     TSS2_RC rc;
 };
 
-tpm2_rc_ctx ctx;
+static tpm2_rc_ctx ctx;
 
 static bool str_to_tpm_rc(const char *rc_str, TSS2_RC *rc) {
 

--- a/tools/tpm2_rsadecrypt.c
+++ b/tools/tpm2_rsadecrypt.c
@@ -26,7 +26,7 @@ struct tpm_rsadecrypt_ctx {
     TPMT_RSA_DECRYPT scheme;
 };
 
-tpm_rsadecrypt_ctx ctx = {
+static tpm_rsadecrypt_ctx ctx = {
     .scheme = { .scheme = TPM2_ALG_RSAES }
 };
 

--- a/tools/tpm2_send.c
+++ b/tools/tpm2_send.c
@@ -16,7 +16,7 @@ struct tpm2_send_ctx {
     FILE *output;
 };
 
-tpm2_send_ctx ctx;
+static tpm2_send_ctx ctx;
 
 static bool read_command_from_file(FILE *f, tpm2_command_header **c,
         UINT32 *size) {

--- a/tools/tpm2_verifysignature.c
+++ b/tools/tpm2_verifysignature.c
@@ -35,7 +35,7 @@ struct tpm2_verifysig_ctx {
     tpm2_loaded_object key_context_object;
 };
 
-tpm2_verifysig_ctx ctx = {
+static tpm2_verifysig_ctx ctx = {
         .format = TPM2_ALG_ERROR,
         .msgHash = NULL,
         .halg = TPM2_ALG_SHA1


### PR DESCRIPTION
The newly added LGTM analysis (#1620) found [some alerts](https://lgtm.com/projects/g/tpm2-software/tpm2-tools/alerts/). Nothing really critical, but it might be nice to keep the number of alerts close to zero to see real problems more easily.