### PR TITLE
tpm2_policy: update policy tools output

### DIFF
--- a/lib/tpm2_policy.c
+++ b/lib/tpm2_policy.c
@@ -19,7 +19,7 @@ static bool evaluate_populate_pcr_digests(TPML_PCR_SELECTION *pcr_selections,
     unsigned dgst_cnt = 0;
 
     //Iterating the number of pcr banks selected
-    UINT32 i;
+    UINT8 i;
     for (i = 0; i < pcr_selections->count; i++) {
 
         UINT8 total_indices_for_this_alg = 0;
@@ -52,7 +52,7 @@ static bool evaluate_populate_pcr_digests(TPML_PCR_SELECTION *pcr_selections,
          * Populating the digest sizes in the PCR digest list per algorithm bank
          * Once iterated through all banks, creates an file offsets map for all pcr indices
          */
-        UINT32 k;
+        UINT8 k;
         for (k = 0; k < total_indices_for_this_alg; k++) {
             pcr_values->digests[dgst_cnt + k].size = dgst_size;
         }

--- a/lib/tpm2_policy.h
+++ b/lib/tpm2_policy.h
@@ -184,4 +184,23 @@ tool_rc tpm2_policy_build_policyduplicationselect(ESYS_CONTEXT *ectx,
     const char *new_parent_name_path,
     TPMI_YES_NO is_include_obj);
 
+/**
+ * Policy tools need to:
+ *  - get the policy digest
+ *  - print the policy digest
+ *  - optionally save the digest to a file
+ *  This routine serves a common helper so all policy tools
+ *  behave in the same way.
+ * @param ectx
+ *  The Enhanced system api (ESAPI_) context.
+ * @param session
+ *  The policy session to get the digest of.
+ * @param save_path
+ *  The path to optionally save the digest too.
+ * @return
+ *  A tool_rc indicating status.
+ */
+tool_rc tpm2_policy_tool_finish(ESYS_CONTEXT *ectx, tpm2_session *session,
+        const char *save_path);
+
 #endif /* TPM2_POLICY_H_ */

--- a/tools/tpm2_policyauthorize.c
+++ b/tools/tpm2_policyauthorize.c
@@ -111,26 +111,7 @@ tool_rc tpm2_tool_onrun(ESYS_CONTEXT *ectx, tpm2_option_flags flags) {
         return rc;
     }
 
-    rc = tpm2_policy_get_digest(ectx, ctx.session, &ctx.policy_digest);
-    if (rc != tool_rc_success) {
-        LOG_ERR("Could not build tpm policy");
-        return rc;
-    }
-
-    tpm2_util_hexdump(ctx.policy_digest->buffer, ctx.policy_digest->size);
-    tpm2_tool_output("\n");
-
-    if (ctx.out_policy_dgst_path) {
-        bool result = files_save_bytes_to_file(ctx.out_policy_dgst_path,
-                    ctx.policy_digest->buffer, ctx.policy_digest->size);
-        if (!result) {
-            LOG_ERR("Failed to save policy digest into file \"%s\"",
-                    ctx.out_policy_dgst_path);
-            return tool_rc_general_error;
-        }
-    }
-
-    return tool_rc_success;
+    return tpm2_policy_tool_finish(ectx, ctx.session, ctx.out_policy_dgst_path);
 }
 
 tool_rc tpm2_tool_onstop(ESYS_CONTEXT *ectx) {

--- a/tools/tpm2_policycommandcode.c
+++ b/tools/tpm2_policycommandcode.c
@@ -96,27 +96,7 @@ tool_rc tpm2_tool_onrun(ESYS_CONTEXT *ectx, tpm2_option_flags flags) {
         return rc;
     }
 
-    rc = tpm2_policy_get_digest(ectx, ctx.session, &ctx.policy_digest);
-    if (rc != tool_rc_success) {
-        LOG_ERR("Could not build tpm policy");
-        return rc;
-    }
-
-    tpm2_util_hexdump(ctx.policy_digest->buffer, ctx.policy_digest->size);
-    tpm2_tool_output("\n");
-
-    if (ctx.out_policy_dgst_path) {
-        bool result = files_save_bytes_to_file(ctx.out_policy_dgst_path,
-                ctx.policy_digest->buffer, ctx.policy_digest->size);
-        if (!result) {
-            LOG_ERR("Failed to save policy digest into file \"%s\"",
-                    ctx.out_policy_dgst_path);
-            return tool_rc_general_error;
-        }
-    }
-
-    return tool_rc_success;
-
+    return tpm2_policy_tool_finish(ectx, ctx.session, ctx.out_policy_dgst_path);
 }
 
 tool_rc tpm2_tool_onstop(ESYS_CONTEXT *ectx) {

--- a/tools/tpm2_policyduplicationselect.c
+++ b/tools/tpm2_policyduplicationselect.c
@@ -99,26 +99,7 @@ tool_rc tpm2_tool_onrun(ESYS_CONTEXT *ectx, tpm2_option_flags flags) {
         return rc;
     }
 
-    rc = tpm2_policy_get_digest(ectx, s, &ctx.policy_digest);
-    if (rc != tool_rc_success) {
-        LOG_ERR("Could not build tpm policy");
-        return rc;
-    }
-
-    tpm2_util_hexdump(ctx.policy_digest->buffer, ctx.policy_digest->size);
-    tpm2_tool_output("\n");
-
-    if (ctx.out_policy_dgst_path) {
-        bool result = files_save_bytes_to_file(ctx.out_policy_dgst_path,
-                    ctx.policy_digest->buffer, ctx.policy_digest->size);
-        if (!result) {
-            LOG_ERR("Failed to save policy digest into file \"%s\"",
-                    ctx.out_policy_dgst_path);
-            return tool_rc_general_error;
-        }
-    }
-
-    return tool_rc_success;
+    return tpm2_policy_tool_finish(ectx, ctx.session, ctx.out_policy_dgst_path);
 }
 
 tool_rc tpm2_tool_onstop(ESYS_CONTEXT *ectx) {

--- a/tools/tpm2_policylocality.c
+++ b/tools/tpm2_policylocality.c
@@ -97,26 +97,7 @@ tool_rc tpm2_tool_onrun(ESYS_CONTEXT *ectx, tpm2_option_flags flags) {
         return rc;
     }
 
-    rc = tpm2_policy_get_digest(ectx, ctx.session, &ctx.policy_digest);
-    if (rc != tool_rc_success) {
-        LOG_ERR("Could not build tpm policy");
-        return rc;
-    }
-
-    tpm2_util_hexdump(ctx.policy_digest->buffer, ctx.policy_digest->size);
-    tpm2_tool_output("\n");
-
-    if (ctx.out_policy_dgst_path) {
-        bool result = files_save_bytes_to_file(ctx.out_policy_dgst_path,
-                    ctx.policy_digest->buffer, ctx.policy_digest->size);
-        if (!result) {
-            LOG_ERR("Failed to save policy digest into file \"%s\"",
-                    ctx.out_policy_dgst_path);
-            return tool_rc_general_error;
-        }
-    }
-
-    return tool_rc_success;
+    return tpm2_policy_tool_finish(ectx, ctx.session, ctx.out_policy_dgst_path);
 }
 
 tool_rc tpm2_tool_onstop(ESYS_CONTEXT *ectx) {

--- a/tools/tpm2_policyor.c
+++ b/tools/tpm2_policyor.c
@@ -104,26 +104,7 @@ tool_rc tpm2_tool_onrun(ESYS_CONTEXT *ectx, tpm2_option_flags flags) {
         return rc;
     }
 
-    rc = tpm2_policy_get_digest(ectx, ctx.session, &ctx.policy_digest);
-    if (rc != tool_rc_success) {
-        LOG_ERR("Could not build tpm policy");
-        return rc;
-    }
-
-    tpm2_util_hexdump(ctx.policy_digest->buffer, ctx.policy_digest->size);
-    tpm2_tool_output("\n");
-
-    if (ctx.out_policy_dgst_path) {
-        bool result = files_save_bytes_to_file(ctx.out_policy_dgst_path,
-                    ctx.policy_digest->buffer, ctx.policy_digest->size);
-        if (!result) {
-            LOG_ERR("Failed to save policy digest into file \"%s\"",
-                    ctx.out_policy_dgst_path);
-            return tool_rc_general_error;
-        }
-    }
-
-    return tool_rc_success;
+    return tpm2_policy_tool_finish(ectx, ctx.session, ctx.out_policy_dgst_path);
 }
 
 tool_rc tpm2_tool_onstop(ESYS_CONTEXT *ectx) {

--- a/tools/tpm2_policypassword.c
+++ b/tools/tpm2_policypassword.c
@@ -76,26 +76,7 @@ tool_rc tpm2_tool_onrun(ESYS_CONTEXT *ectx, tpm2_option_flags flags) {
         return rc;
     }
 
-    rc = tpm2_policy_get_digest(ectx, ctx.session, &ctx.policy_digest);
-    if (rc != tool_rc_success) {
-        LOG_ERR("Could not build tpm policy");
-        return rc;
-    }
-
-    tpm2_util_hexdump(ctx.policy_digest->buffer, ctx.policy_digest->size);
-    tpm2_tool_output("\n");
-
-    if (ctx.out_policy_dgst_path) {
-        bool result = files_save_bytes_to_file(ctx.out_policy_dgst_path,
-                    ctx.policy_digest->buffer, ctx.policy_digest->size);
-        if (!result) {
-            LOG_ERR("Failed to save policy digest into file \"%s\"",
-                    ctx.out_policy_dgst_path);
-            return tool_rc_general_error;
-        }
-    }
-
-    return tool_rc_success;
+    return tpm2_policy_tool_finish(ectx, ctx.session, ctx.out_policy_dgst_path);
 }
 
 tool_rc tpm2_tool_onstop(ESYS_CONTEXT *ectx) {

--- a/tools/tpm2_policypcr.c
+++ b/tools/tpm2_policypcr.c
@@ -92,32 +92,7 @@ tool_rc tpm2_tool_onrun(ESYS_CONTEXT *ectx, tpm2_option_flags flags) {
         return rc;
     }
 
-    rc = tpm2_policy_get_digest(ectx, ctx.session,
-            &ctx.policy_digest);
-    if (rc != tool_rc_success) {
-        LOG_ERR("Could not build tpm policy");
-        return rc;
-    }
-
-    tpm2_tool_output("policy-digest: 0x");
-    UINT16 i;
-    for(i = 0; i < ctx.policy_digest->size; i++) {
-        tpm2_tool_output("%02X", ctx.policy_digest->buffer[i]);
-    }
-    tpm2_tool_output("\n");
-
-    if (ctx.policy_out_path) {
-        bool result = files_save_bytes_to_file(ctx.policy_out_path,
-                    (UINT8 *) &ctx.policy_digest->buffer,
-                    ctx.policy_digest->size);
-        if (!result) {
-            LOG_ERR("Failed to save policy digest into file \"%s\"",
-                    ctx.policy_out_path);
-            return tool_rc_general_error;
-        }
-    }
-
-    return tool_rc_success;
+    return tpm2_policy_tool_finish(ectx, ctx.session, ctx.policy_out_path);
 }
 
 tool_rc tpm2_tool_onstop(ESYS_CONTEXT *ectx) {

--- a/tools/tpm2_policysecret.c
+++ b/tools/tpm2_policysecret.c
@@ -140,28 +140,7 @@ tool_rc tpm2_tool_onrun(ESYS_CONTEXT *ectx, tpm2_option_flags flags) {
         return rc;
     }
 
-    if (rc != tool_rc_success) {
-        return rc;
-    }
-
-    rc = tpm2_policy_get_digest(ectx, ctx.extended_session, &ctx.policy_digest);
-    if (rc != tool_rc_success) {
-        LOG_ERR("Could not build tpm policy");
-        return rc;
-    }
-
-    tpm2_util_hexdump(ctx.policy_digest->buffer, ctx.policy_digest->size);
-    tpm2_tool_output("\n");
-
-    if(ctx.out_policy_dgst_path) {
-        result = files_save_bytes_to_file(ctx.out_policy_dgst_path,
-                    ctx.policy_digest->buffer, ctx.policy_digest->size);
-        if (!result) {
-            return tool_rc_general_error;
-        }
-    }
-
-    return tool_rc_success;
+    return tpm2_policy_tool_finish(ectx, ctx.extended_session, ctx.out_policy_dgst_path);
 }
 
 tool_rc tpm2_tool_onstop(ESYS_CONTEXT *ectx) {


### PR DESCRIPTION
Make sure that policy tools have consistent output behavior by creating a
common output routine.

Fixes: #1623

Signed-off-by: William Roberts <william.c.roberts@intel.com>