### PR TITLE
[3.X] Backport "Limit selected PCRs to 8" (PR #780)

### DIFF
--- a/lib/tpm2_policy.c
+++ b/lib/tpm2_policy.c
@@ -58,6 +58,11 @@ static bool evaluate_populate_pcr_digests(TPML_PCR_SELECTION *pcr_selections,
             total_indices_for_this_alg += tpm2_util_pop_count(group_val);
         }
 
+        if(pcr_values->count + total_indices_for_this_alg > ARRAY_LEN(pcr_values->digests)) {
+            LOG_ERR("Number of PCR is limited to %zu", ARRAY_LEN(pcr_values->digests));
+            return false;
+        }
+
         //digest size returned per the hashAlg type
         unsigned dgst_size = tpm2_alg_util_get_hash_size(pcr_selections->pcrSelections[i].hash);
         if (!dgst_size) {


### PR DESCRIPTION
Backport #780 to avoid a crash of `tpm2_createpolicy` if more than 8 PCRs are specified.

Fixes: #1632