### PR TITLE
 tpm2_nvreadlock: use index auth if no --hierarchy is specified

### DIFF
--- a/man/tpm2_nvincrement.1.md
+++ b/man/tpm2_nvincrement.1.md
@@ -16,10 +16,9 @@ handle range "TPM2_HR_NV_INDEX".
 
 # OPTIONS
 
-  * **-C**, **\--hierarchy**=_AUTH_:
+  * **-C**, **\--hierarchy**=_AUTH_HANDLE_:
 
-    Specifies the handle used to authorize. Defaults to **o**, **TPM_RH_OWNER**,
-    when no value has been specified.
+    Specifies the hierarchy used to authorize.
     Supported options are:
       * **o** for **TPM_RH_OWNER**
       * **p** for **TPM_RH_PLATFORM**

--- a/man/tpm2_nvread.1.md
+++ b/man/tpm2_nvread.1.md
@@ -16,16 +16,15 @@ index can be specified as raw handle or an offset value to the nv handle range
 
 # OPTIONS
 
-  * **-C**, **\--hierarchy**=_AUTH_:
+  * **-C**, **\--hierarchy**=_AUTH_HANDLE_:
 
-    Specifies the hierarchy used to authorize. Defaults to **o**, **TPM_RH_OWNER**,
-    when no value has been specified.
+    Specifies the hierarchy used to authorize.
     Supported options are:
       * **o** for **TPM_RH_OWNER**
       * **p** for **TPM_RH_PLATFORM**
       * **`<num>`** where a hierarchy handle or nv-index may be used.
 
-    When **-a** isn't explicitly passed the index handle will be used to
+    When **-C** isn't explicitly passed the index handle will be used to
     authorize against the index. The index auth value is set via the
     **-p** option to **tpm2_nvdefine**(1).
 

--- a/man/tpm2_nvreadlock.1.md
+++ b/man/tpm2_nvreadlock.1.md
@@ -17,14 +17,17 @@ value to the nv handle range "TPM2_HR_NV_INDEX".
 
 # OPTIONS
 
-  * **-C**, **\--hierarchy**=_AUTH\_HANDLE_:
+  * **-C**, **\--hierarchy**=_AUTH_HANDLE_:
 
-    Specifies the hierarchy used to authorize:
-    * **o** for **TPM_RH_OWNER**
-    * **p** for **TPM_RH_PLATFORM**
-    Defaults to **o**, **TPM_RH_OWNER**, when no value has been
-    specified.
-    * **`<num>`** where a hierarchy handle may be used.
+    Specifies the hierarchy used to authorize.
+    Supported options are:
+      * **o** for **TPM_RH_OWNER**
+      * **p** for **TPM_RH_PLATFORM**
+      * **`<num>`** where a hierarchy handle or nv-index may be used.
+
+    When **-C** isn't explicitly passed the index handle will be used to
+    authorize against the index. The index auth value is set via the
+    **-p** option to **tpm2_nvdefine**(1).
 
   * **-P**, **\--auth**=_AUTH\_VALUE_:
 

--- a/man/tpm2_nvwrite.1.md
+++ b/man/tpm2_nvwrite.1.md
@@ -20,16 +20,15 @@ raw handle or an offset value to the nv handle range "TPM2_HR_NV_INDEX".
 
     Specifies the input file with data to write to NV.
 
-  * **-C**, **\--hierarchy**=_AUTH\_HANDLE_:
+  * **-C**, **\--hierarchy**=_AUTH_HANDLE_:
 
-    Specifies the handle used to authorize. Defaults to **o**, **TPM_RH_OWNER**,
-    when no value has been specified.
+    Specifies the hierarchy used to authorize.
     Supported options are:
       * **o** for **TPM_RH_OWNER**
       * **p** for **TPM_RH_PLATFORM**
       * **`<num>`** where a hierarchy handle or nv-index may be used.
 
-    When **-a** isn't explicitly passed the index handle will be used to
+    When **-C** isn't explicitly passed the index handle will be used to
     authorize against the index. The index auth value is set via the
     **-p** option to **tpm2_nvdefine**(1).
 

--- a/tools/tpm2_nvincrement.c
+++ b/tools/tpm2_nvincrement.c
@@ -13,18 +13,15 @@ struct tpm_nvincrement_ctx {
         tpm2_loaded_object object;
     } auth_hierarchy;
 
-    bool is_auth_hierarchy_specified;
     TPM2_HANDLE nv_index;
 };
-static tpm_nvincrement_ctx ctx = {
-    .is_auth_hierarchy_specified = false,
-};
+static tpm_nvincrement_ctx ctx;
 
 static bool on_arg(int argc, char **argv) {
-    /* If the users doesn't specify an authorization hierarchy use the index
+    /* If the user doesn't specify an authorization hierarchy use the index
     * passed to -x/--index for the authorization index.
     */
-    if (!ctx.is_auth_hierarchy_specified) {
+    if (!ctx.auth_hierarchy.ctx_path) {
         ctx.auth_hierarchy.ctx_path = argv[0];
     }
     return on_arg_nv_index(argc, argv, &ctx.nv_index);
@@ -35,7 +32,6 @@ static bool on_option(char key, char *value) {
     switch (key) {
     case 'C':
         ctx.auth_hierarchy.ctx_path = value;
-        ctx.is_auth_hierarchy_specified = true;
         break;
     case 'P':
         ctx.auth_hierarchy.auth_str = value;

--- a/tools/tpm2_nvread.c
+++ b/tools/tpm2_nvread.c
@@ -15,16 +15,13 @@ struct tpm_nvread_ctx {
     } auth_hierarchy;
 
     TPM2_HANDLE nv_index;
-    bool is_auth_hierarchy_specified;
 
     UINT32 size_to_read;
     UINT32 offset;
     char *output_file;
 };
 
-static tpm_nvread_ctx ctx = {
-    .is_auth_hierarchy_specified = false,
-};
+static tpm_nvread_ctx ctx;
 
 static tool_rc nv_read(ESYS_CONTEXT *ectx, tpm2_option_flags flags) {
 
@@ -61,10 +58,10 @@ out:
 }
 
 static bool on_arg(int argc, char **argv) {
-    /* If the users doesn't specify an authorization hierarchy use the index
+    /* If the user doesn't specify an authorization hierarchy use the index
     * passed to -x/--index for the authorization index.
     */
-    if (!ctx.is_auth_hierarchy_specified) {
+    if (!ctx.auth_hierarchy.ctx_path) {
         ctx.auth_hierarchy.ctx_path = argv[0];
     }
     return on_arg_nv_index(argc, argv, &ctx.nv_index);
@@ -78,7 +75,6 @@ static bool on_option(char key, char *value) {
 
     case 'C':
         ctx.auth_hierarchy.ctx_path = value;
-        ctx.is_auth_hierarchy_specified = true;
         break;
     case 'o':
         ctx.output_file = value;

--- a/tools/tpm2_nvreadlock.c
+++ b/tools/tpm2_nvreadlock.c
@@ -17,13 +17,16 @@ struct tpm_nvreadlock_ctx {
     TPM2_HANDLE nv_index;
 };
 
-static tpm_nvreadlock_ctx ctx = {
-    .auth_hierarchy.ctx_path = "owner",
-};
+static tpm_nvreadlock_ctx ctx;
 
 
 static bool on_arg(int argc, char **argv) {
-
+    /* If the user doesn't specify an authorization hierarchy use the index
+    * passed to -x/--index for the authorization index.
+    */
+    if (!ctx.auth_hierarchy.ctx_path) {
+        ctx.auth_hierarchy.ctx_path = argv[0];
+    }
     return on_arg_nv_index(argc, argv, &ctx.nv_index);
 }
 

--- a/tools/tpm2_nvwrite.c
+++ b/tools/tpm2_nvwrite.c
@@ -18,7 +18,6 @@ struct tpm_nvwrite_ctx {
     } auth_hierarchy;
 
     TPM2_HANDLE nv_index;
-    bool is_auth_hierarchy_specified;
 
     BYTE nv_buffer[TPM2_MAX_NV_BUFFER_SIZE];
     FILE *input_file;
@@ -26,9 +25,7 @@ struct tpm_nvwrite_ctx {
     UINT16 offset;
 };
 
-static tpm_nvwrite_ctx ctx = {
-    .is_auth_hierarchy_specified = false,
-};
+static tpm_nvwrite_ctx ctx;
 
 static tool_rc nv_write(ESYS_CONTEXT *ectx) {
 
@@ -103,7 +100,6 @@ static bool on_option(char key, char *value) {
     switch (key) {
     case 'C':
         ctx.auth_hierarchy.ctx_path = value;
-        ctx.is_auth_hierarchy_specified = true;
         break;
     case 'P':
         ctx.auth_hierarchy.auth_str = value;
@@ -139,10 +135,10 @@ static bool on_option(char key, char *value) {
 }
 
 static bool on_arg(int argc, char **argv) {
-    /* If the users doesn't specify an authorization hierarchy use the index
+    /* If the user doesn't specify an authorization hierarchy use the index
     * passed to -x/--index for the authorization index.
     */
-    if (!ctx.is_auth_hierarchy_specified) {
+    if (!ctx.auth_hierarchy.ctx_path) {
         ctx.auth_hierarchy.ctx_path = argv[0];
     }
     return on_arg_nv_index(argc, argv, &ctx.nv_index);


### PR DESCRIPTION
Consider the following example:
```
tpm2_createpolicy --policy-pcr --pcr-list sha256:0,1,2,3 --policy policy.data
tpm2_nvdefine --size 5 --attributes 'policyread|ownerwrite|read_stclear' --policy policy.data 0x1500018
echo test | tpm2_nvwrite --hierarchy o --input - 0x1500018
tpm2_nvread --auth pcr:sha256:0,1,2,3 0x1500018
tpm2_nvreadlock --auth pcr:sha256:0,1,2,3 0x1500018
```
The last command fails with
```
WARNING:esys:src/tss2-esys/api/Esys_NV_ReadLock.c:303:Esys_NV_ReadLock_Finish() Received TPM Error 
ERROR:esys:src/tss2-esys/api/Esys_NV_ReadLock.c:109:Esys_NV_ReadLock() Esys Finish ErrorCode (0x0000012f) 
ERROR: Failed to lock NVRAM area at index 0x1500018
ERROR: Esys_NV_ReadLock(0x12F) - tpm:error(2.0): authValue or authPolicy is not available for selected entity
ERROR: Unable to run tpm2_nvreadlock
```
In contrast to `tpm2_nvread`, you need to explicitly specify the NV index in `--hierarchy` for the command to work:
```
tpm2_nvreadlock --hierarchy 0x1500018 --auth pcr:sha256:0,1,2,3 0x1500018
```
This pull request brings the behaviour of `tpm2_nvreadlock` in line with `tpm2_nvread`, `tpm2_nvwrite` and `tpm2_nvincrement` so that above example works as expected. The code is directly taken from these tools. Additionally the man pages of the NV tools are updated to have a unified, up-to-date description for `-C`/`--hierarchy`.