### PR TITLE
Add ability to use multiple banks in the PCR mini language

### DIFF
--- a/lib/tpm2_auth_util.c
+++ b/lib/tpm2_auth_util.c
@@ -175,7 +175,7 @@ static tool_rc handle_pcr(ESYS_CONTEXT *ectx, const char *policy, tpm2_session *
 
     const char *pcr_str = dup;
     const char *raw_path = NULL;
-    char *split = strchr(dup, '+');
+    char *split = strchr(dup, '=');
     if (split) {
         *split = '\0';
         raw_path = split + 1;

--- a/lib/tpm2_policy.c
+++ b/lib/tpm2_policy.c
@@ -54,9 +54,9 @@ static bool evaluate_populate_pcr_digests(TPML_PCR_SELECTION *pcr_selections,
          */
         UINT8 k;
         for (k = 0; k < total_indices_for_this_alg; k++) {
-            pcr_values->digests[dgst_cnt + k].size = dgst_size;
+            pcr_values->digests[dgst_cnt].size = dgst_size;
+            dgst_cnt++;
         }
-        dgst_cnt++;
     }
 
     //Check if the input pcrs file size is the same size as the pcr selection setlist

--- a/man/common/authorizations.md
+++ b/man/common/authorizations.md
@@ -90,7 +90,7 @@ session:session.ctx+hex:11223344
 
 You can satisfy a PCR policy using the "pcr:" prefix and the PCR minilanguage. The PCR
 minilanguage is as follows:
-`<pcr-spec>+<raw-pcr-file>`
+`<pcr-spec>=<raw-pcr-file>`
 
 The PCR spec is documented in in the section "PCR bank specifiers".
 

--- a/man/tpm2_unseal.1.md
+++ b/man/tpm2_unseal.1.md
@@ -48,7 +48,7 @@ tpm2_unseal -c item.context -p abc123 -o out.dat
 
 tpm2_unseal -c 0x81010001 -p "hex:123abc" -o out.dat
 
-tpm2_unseal -c item.context -p pcr:sha256:0,1+pcr.value -o out.dat
+tpm2_unseal -c item.context -p pcr:sha256:0,1=pcr.value -o out.dat
 ```
 
 # NOTES

--- a/test/integration/tests/nv.sh
+++ b/test/integration/tests/nv.sh
@@ -91,9 +91,9 @@ tpm2_createpolicy -Q --policy-pcr -l ${alg_pcr_policy}:${pcr_ids} -f $file_pcr_v
 tpm2_nvdefine -Q   0x1500016 -C 0x40000001 -s 32 -L $file_policy -a "policyread|policywrite"
 
 # Write with index authorization for now, since tpm2_nvwrite does not support pcr policy.
-echo -n "policy locked" | tpm2_nvwrite -Q   0x1500016 -C 0x1500016 -P pcr:${alg_pcr_policy}:${pcr_ids}+$file_pcr_value -i -
+echo -n "policy locked" | tpm2_nvwrite -Q   0x1500016 -C 0x1500016 -P pcr:${alg_pcr_policy}:${pcr_ids}=$file_pcr_value -i -
 
-str=`tpm2_nvread   0x1500016 -C 0x1500016 -P pcr:${alg_pcr_policy}:${pcr_ids}+$file_pcr_value -s 13`
+str=`tpm2_nvread   0x1500016 -C 0x1500016 -P pcr:${alg_pcr_policy}:${pcr_ids}=$file_pcr_value -s 13`
 
 test "policy locked" == "$str"
 

--- a/test/integration/tests/nv.sh
+++ b/test/integration/tests/nv.sh
@@ -7,8 +7,7 @@ nv_test_index=0x1500018
 large_file_name="nv.test_large_w"
 large_file_read_name="nv.test_large_r"
 
-alg_pcr_policy=sha1
-pcr_ids="0,1,2,3"
+pcr_specification=sha256:0,1,2,3+sha1:0,1,2,3
 file_pcr_value=pcr.bin
 file_policy=policy.data
 
@@ -84,16 +83,16 @@ cmp nv.test_w cmp.dat
 
 tpm2_nvundefine   $nv_test_index -C o
 
-tpm2_pcrread -Q -o $file_pcr_value ${alg_pcr_policy}:${pcr_ids}
+tpm2_pcrread -Q -o $file_pcr_value $pcr_specification
 
-tpm2_createpolicy -Q --policy-pcr -l ${alg_pcr_policy}:${pcr_ids} -f $file_pcr_value -L $file_policy
+tpm2_createpolicy -Q --policy-pcr -l $pcr_specification -f $file_pcr_value -L $file_policy
 
 tpm2_nvdefine -Q   0x1500016 -C 0x40000001 -s 32 -L $file_policy -a "policyread|policywrite"
 
 # Write with index authorization for now, since tpm2_nvwrite does not support pcr policy.
-echo -n "policy locked" | tpm2_nvwrite -Q   0x1500016 -C 0x1500016 -P pcr:${alg_pcr_policy}:${pcr_ids}=$file_pcr_value -i -
+echo -n "policy locked" | tpm2_nvwrite -Q   0x1500016 -C 0x1500016 -P pcr:$pcr_specification=$file_pcr_value -i -
 
-str=`tpm2_nvread   0x1500016 -C 0x1500016 -P pcr:${alg_pcr_policy}:${pcr_ids}=$file_pcr_value -s 13`
+str=`tpm2_nvread   0x1500016 -C 0x1500016 -P pcr:$pcr_specification=$file_pcr_value -s 13`
 
 test "policy locked" == "$str"
 

--- a/test/integration/tests/nvinc.sh
+++ b/test/integration/tests/nvinc.sh
@@ -65,9 +65,9 @@ tpm2_nvdefine -Q   0x1500016 -C 0x40000001 -s 8 -L $file_policy -a "policyread|p
 echo -n -e '\x00\x00\x00\x00\x00\x00\x00\x03' > nv.test_inc
 
 # Counter is initialised to highest value previously seen (in this case 2) then incremented
-tpm2_nvincrement -Q   0x1500016 -C 0x1500016 -P pcr:${alg_pcr_policy}:${pcr_ids}+$file_pcr_value
+tpm2_nvincrement -Q   0x1500016 -C 0x1500016 -P pcr:${alg_pcr_policy}:${pcr_ids}=$file_pcr_value
 
-tpm2_nvread   0x1500016 -C 0x1500016 -P pcr:${alg_pcr_policy}:${pcr_ids}+$file_pcr_value -s 8 > cmp.dat
+tpm2_nvread   0x1500016 -C 0x1500016 -P pcr:${alg_pcr_policy}:${pcr_ids}=$file_pcr_value -s 8 > cmp.dat
 
 cmp nv.test_inc cmp.dat
 

--- a/test/integration/tests/nvinc.sh
+++ b/test/integration/tests/nvinc.sh
@@ -5,8 +5,7 @@ source helpers.sh
 
 nv_test_index=0x1500018
 
-alg_pcr_policy=sha1
-pcr_ids="0,1,2,3"
+pcr_specification=sha256:0,1,2,3+sha1:0,1,2,3
 file_pcr_value=pcr.bin
 file_policy=policy.data
 
@@ -55,9 +54,9 @@ cmp nv.test_inc cmp.dat
 tpm2_nvundefine   $nv_test_index -C o
 
 
-tpm2_pcrread -Q -o $file_pcr_value ${alg_pcr_policy}:${pcr_ids}
+tpm2_pcrread -Q -o $file_pcr_value $pcr_specification
 
-tpm2_createpolicy -Q --policy-pcr -l ${alg_pcr_policy}:${pcr_ids} -f $file_pcr_value -L $file_policy
+tpm2_createpolicy -Q --policy-pcr -l $pcr_specification -f $file_pcr_value -L $file_policy
 
 tpm2_nvdefine -Q   0x1500016 -C 0x40000001 -s 8 -L $file_policy -a "policyread|policywrite|nt=1"
 
@@ -65,9 +64,9 @@ tpm2_nvdefine -Q   0x1500016 -C 0x40000001 -s 8 -L $file_policy -a "policyread|p
 echo -n -e '\x00\x00\x00\x00\x00\x00\x00\x03' > nv.test_inc
 
 # Counter is initialised to highest value previously seen (in this case 2) then incremented
-tpm2_nvincrement -Q   0x1500016 -C 0x1500016 -P pcr:${alg_pcr_policy}:${pcr_ids}=$file_pcr_value
+tpm2_nvincrement -Q   0x1500016 -C 0x1500016 -P pcr:$pcr_specification=$file_pcr_value
 
-tpm2_nvread   0x1500016 -C 0x1500016 -P pcr:${alg_pcr_policy}:${pcr_ids}=$file_pcr_value -s 8 > cmp.dat
+tpm2_nvread   0x1500016 -C 0x1500016 -P pcr:$pcr_specification=$file_pcr_value -s 8 > cmp.dat
 
 cmp nv.test_inc cmp.dat
 

--- a/test/integration/tests/unseal.sh
+++ b/test/integration/tests/unseal.sh
@@ -75,7 +75,7 @@ tpm2_create -Q -g $alg_create_obj -u $file_unseal_key_pub -r $file_unseal_key_pr
 
 tpm2_load -Q -C $file_primary_key_ctx  -u $file_unseal_key_pub  -r $file_unseal_key_priv -n $file_unseal_key_name -c $file_unseal_key_ctx
 
-unsealed=`tpm2_unseal -V --object-context $file_unseal_key_ctx -p pcr:${alg_pcr_policy}:${pcr_ids}+$file_pcr_value`
+unsealed=`tpm2_unseal -V --object-context $file_unseal_key_ctx -p pcr:${alg_pcr_policy}:${pcr_ids}=$file_pcr_value`
 
 test "$unsealed" == "$secret"
 


### PR DESCRIPTION
Fix #1635 by changing the separator for `raw-pcr-file` from `+` to `=`. The equals sign was chosen as the new separator to have a syntax somewhat similar to `tpm2_pcrextend`.

While fixing this issue, I came across a different, unrelated problem with using multiple banks: the feature to use a `raw-pcr-file` of expected PCR values is broken due to a [broken loop counter in `tpm2_policy.c`](https://github.com/tpm2-software/tpm2-tools/blob/d381875156eb9352b1a1ef4cc7d0c903cba878b6/lib/tpm2_policy.c#L56-L59), resulting in errors like
```
$ tpm2_unseal -p pcr:sha256:0+sha1:0=file
WARNING:esys:src/tss2-esys/api/Esys_PolicyPCR.c:288:Esys_PolicyPCR_Finish() Received TPM Error
ERROR:esys:src/tss2-esys/api/Esys_PolicyPCR.c:100:Esys_PolicyPCR() Esys Finish ErrorCode (0x000001c4)
ERROR on line: "53" in file: "lib/log.h": Esys_PolicyPCR(0x1C4) - tpm:parameter(1):value is out of range or is not correct for the context
ERROR on line: "67" in file: "tools/tpm2_unseal.c": Invalid item handle authorization
ERROR on line: "145" in file: "tools/tpm2_tool.c": Unable to run tpm2_unseal
```
A fix for this has already been proposed by @maage in #1389 and #1390, I cherry-picked the second commit from there.

To make sure PCR specifications with multiple banks get some more test coverage in the future, I replaced the previously used PCR specification `sha1:0,1,2,3` by `sha256:0,1,2,3+sha1:0,1,2,3` in the integration tests.