### PR TITLE
[3.X] lib/tpm2_policy: fix population of pcr_values->digests[].size

### DIFF
--- a/lib/tpm2_policy.c
+++ b/lib/tpm2_policy.c
@@ -78,9 +78,9 @@ static bool evaluate_populate_pcr_digests(TPML_PCR_SELECTION *pcr_selections,
          * Once iterated through all banks, creates an file offsets map for all pcr indices
          */
         for (k=0; k < total_indices_for_this_alg; k++) {
-            pcr_values->digests[dgst_cnt+k].size = dgst_size;
+            pcr_values->digests[dgst_cnt].size = dgst_size;
+            dgst_cnt++;
         }
-        dgst_cnt++;
 
         total_indices_for_this_alg=0;
     }


### PR DESCRIPTION
One of the issues addressed in #1638 is already present in tpm2-tools 3.X, leading to errors like
```
$ tpm2_unseal -L sha256:0+sha1:0 -F file
ERROR: Failed parse_policy_type_and_send_command
ERROR: Building PCR policy failed: 0x1c4
ERROR: Unable to run tpm2_unseal
```
Backport the fix to 3.X as well, also see #1390.