### PR TITLE
man/tpm2_pcrread: remove spurious -L in example

### DIFF
--- a/man/tpm2_pcrread.1.md
+++ b/man/tpm2_pcrread.1.md
@@ -29,7 +29,7 @@ Output is written in a YAML format to stdout, with each algorithm followed by
 a PCR index and its value. As a simple example assume just sha1 and sha256
 support and only 1 PCR. The output would be:
 ```
-$ tpm2_pcrread -L sha1:0+sha256:0
+$ tpm2_pcrread sha1:0+sha256:0
 sha1 :
   0  : 0000000000000000000000000000000000000003
 sha256 :


### PR DESCRIPTION
While working on #1638, I noticed an example on the `tpm2_pcrread` man page that has not been updated to the latest syntax yet.