### PR TITLE
manpage audit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## Changelog
 ### next
+  * tpm2_rsadecrypt: drop -i input option and make argument.
   * tpm2_rsaencrypt: make output binary and either stdout or file based on -o.
   * tpm2_makecredential: long option output becomes credential-blob
   * tpm2_quote: -F becomes -f.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## Changelog
 ### next
+  * tpm2_sign:
+     - Drop -m and -d option arguments and make them sole argument.
+     - Remove the -m option and make -d toggle if input is a digest.
   * tpm2_encryptdecrypt: drop -i input option and make argument.
   * tpm2_rsadecrypt: drop -i input option and make argument.
   * tpm2_rsaencrypt: make output binary and either stdout or file based on -o.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## Changelog
 ### next
+  * tpm2_encryptdecrypt: drop -i input option and make argument.
   * tpm2_rsadecrypt: drop -i input option and make argument.
   * tpm2_rsaencrypt: make output binary and either stdout or file based on -o.
   * tpm2_makecredential: long option output becomes credential-blob

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Changelog
 ### next
+  * tpm2_rsadecrypt: add -l for specifying label.
+  * tpm2_rsaencrypt: add -l for specifying label.
   * tpm2_sign:
      - Drop -m and -d option arguments and make them sole argument.
      - Remove the -m option and make -d toggle if input is a digest.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## Changelog
 ### next
+  * tpm2_rsaencrypt: make output binary and either stdout or file based on -o.
   * tpm2_makecredential: long option output becomes credential-blob
   * tpm2_quote: -F becomes -f.
   * tpm2_quote: -f becomes -o.

--- a/lib/tpm2_util.h
+++ b/lib/tpm2_util.h
@@ -429,4 +429,6 @@ enum tpm2_handle_flags {
 bool tpm2_util_handle_from_optarg(const char *value,
         TPMI_RH_PROVISION *hierarchy, tpm2_handle_flags flags);
 
+bool tpm2_util_get_label(const char *value, TPM2B_DATA *label);
+
 #endif /* STRING_BYTES_H */

--- a/man/tpm2_encryptdecrypt.1.md
+++ b/man/tpm2_encryptdecrypt.1.md
@@ -6,12 +6,13 @@
 
 # SYNOPSIS
 
-**tpm2_encryptdecrypt** [*OPTIONS*]
+**tpm2_encryptdecrypt** [*OPTIONS*] _FILE_
 
 # DESCRIPTION
 
 **tpm2_encryptdecrypt**(1) - Performs symmetric encryption or decryption with a
-specified symmetric key.
+specified symmetric key on the contents of _FILE_.
+If _FILE_ is not specified, defaults to *stdin*.
 
 # OPTIONS
 
@@ -35,11 +36,6 @@ specified symmetric key.
     Enable pkcs7 padding for applicable AES encryption modes cfb/cbc/ecb.
     Applicable only to encryption and for input data with last block shorter
     than encryption block length.
-
-  * **-i**, **\--input**=_INPUT\_FILE_:
-
-    Optional. Specifies the input file path for either the encrypted or decrypted
-    data, depending on option **-D**. If not specified, defaults to **stdin**.
 
   * **-o**, **\--output**=_OUT\_FILE_:
 
@@ -74,11 +70,20 @@ specified symmetric key.
 
 # EXAMPLES
 
+# Create an AES key
+```bash
+tpm2_createprimary -c primary.ctx
+tpm2_create -C primary.ctx -Gaes128 -u key.pub -r key.priv
+tpm2_load -C primary.ctx -u key.pub -r key.priv -c key.ctx
 ```
-tpm2_encryptdecrypt -c 0x81010001 -p abc123 -i <filePath> -o <filePath>
-tpm2_encryptdecrypt -c key.dat -p abc123 -i <filePath> -o <filePath>
-tpm2_encryptdecrypt -c 0x81010001 -p 123abca  -i <filePath> -o <filePath>
-tpm2_encryptdecrypt -c 0x81010001 --enable-pkcs7-padding -i <filePath> -o <filePath>
+
+# Encrypt and Decrypt some data
+```bash
+echo "my secret" > secret.dat
+tpm2_encryptdecrypt -c key.ctx -o secret.enc secret.dat
+tpm2_encryptdecrypt -d -c key.ctx -o secret.dec secret.enc
+cat secret.dec
+my secret
 ```
 
 [returns](common/returns.md)

--- a/man/tpm2_policycommandcode.1.md
+++ b/man/tpm2_policycommandcode.1.md
@@ -205,7 +205,7 @@ tpm2_flushcontext session.dat
 ```bash
 echo "Encrypt Me" > plain.txt
 
-tpm2_encryptdecrypt -i plain.txt -o enc.txt -c sealkey.ctx
+tpm2_encryptdecrypt plain.txt -o enc.txt -c sealkey.ctx plain.txt
 ERROR: Esys_EncryptDecrypt2(0x12F) - tpm:error(2.0): authValue or authPolicy is not available for selected entity
 ```
 

--- a/man/tpm2_policypassword.1.md
+++ b/man/tpm2_policypassword.1.md
@@ -65,7 +65,7 @@ tpm2_create -g sha256 -G aes -u key.pub -r key.priv -C prim.ctx -L policy.dat \
 tpm2_load -C prim.ctx -u key.pub -r key.priv -n key.name -c key.ctx
 
 echo "plaintext" > plain.txt
-tpm2_encryptdecrypt -c key.ctx -o encrypt.out -i plain.txt -p testpswd
+tpm2_encryptdecrypt -c key.ctx -o encrypt.out plain.txt -p testpswd plain.txt
 ```
 
 ## Authenticate with password and the policy
@@ -74,8 +74,8 @@ tpm2_startauthsession \--policy-session -S session.dat
 
 tpm2_policypassword -S session.dat -L policy.dat
 
-tpm2_encryptdecrypt -c key.ctx -o encrypt.out -i plain.txt \
-  -p session:session.dat+testpswd
+tpm2_encryptdecrypt -c key.ctx -o encrypt.out \
+  -p session:session.dat+testpswd plain.txt
 
 tpm2_flushcontext session.dat
 ```

--- a/man/tpm2_rsadecrypt.1.md
+++ b/man/tpm2_rsadecrypt.1.md
@@ -11,7 +11,7 @@
 # DESCRIPTION
 
 **tpm2_rsadecrypt**(1) - Performs RSA decryption using the indicated padding scheme according to
-IETF RFC 3447 (PKCS#1). The scheme of keyHandle should not be **TPM_ALG_NULL**.
+IETF RFC 3447 (PKCS#1).
 
 The key referenced by key-context is **required** to be:
 
@@ -44,9 +44,9 @@ The key referenced by key-context is **required** to be:
 
     Optional, set the padding scheme (defaults to rsaes).
 
-    * null  - TPM_ALG_NULL
-    * rsaes - TPM_ALG_RSAES
-    * oaep  - TPM_ALG_OAEP
+    * null  - TPM_ALG_NULL uses the key's scheme if set.
+    * rsaes - TPM_ALG_RSAES which is RSAES_PKCSV1.5.
+    * oaep  - TPM_ALG_OAEP which is RSAES_OAEP.
 
 [common options](common/options.md)
 
@@ -58,8 +58,24 @@ The key referenced by key-context is **required** to be:
 
 # EXAMPLES
 
+## Create an RSA key and load it
+```bash
+tpm2_createprimary -c primary.ctx
+tpm2_create -C primary.ctx -Grsa2048 -u key.pub -r key.priv
+tpm2_load -C primary.ctx -u key.pub -r key.priv -c key.ctx
 ```
-tpm2_rsadecrypt -C 0x81010001 -i encrypted.in -o plain.out
+
+## Encrypt using RSA
+```bash
+echo "my message" > msg.dat
+tpm2_rsaencrypt -c key.ctx -o msg.enc msg.dat
+```
+
+## Decrypt using RSA
+```bash
+tpm2_rsadecrypt -c key.ctx -o msg.ptext -i msg.enc
+cat msg.ptext
+my message
 ```
 
 [returns](common/returns.md)

--- a/man/tpm2_rsadecrypt.1.md
+++ b/man/tpm2_rsadecrypt.1.md
@@ -45,6 +45,12 @@ The key referenced by key-context is **required** to be:
     * rsaes - TPM_ALG_RSAES which is RSAES_PKCSV1.5.
     * oaep  - TPM_ALG_OAEP which is RSAES_OAEP.
 
+  * **-l**, **\--label**=_LABEL\_DATA_:
+
+    Optional, set the label data. Can either be a string or file path. The TPM requires the last
+    byte of the label to be zero, this is handled internally to the tool. No other embedded 0
+    bytes can exist or the TPM will truncate your label.
+
 [common options](common/options.md)
 
 [common tcti options](common/tcti.md)

--- a/man/tpm2_rsadecrypt.1.md
+++ b/man/tpm2_rsadecrypt.1.md
@@ -6,12 +6,13 @@
 
 # SYNOPSIS
 
-**tpm2_rsadecrypt** [*OPTIONS*]
+**tpm2_rsadecrypt** [*OPTIONS*] _FILE_
 
 # DESCRIPTION
 
-**tpm2_rsadecrypt**(1) - Performs RSA decryption using the indicated padding scheme according to
-IETF RFC 3447 (PKCS#1).
+**tpm2_rsadecrypt**(1) - Performs RSA decryption on the contents of _FILE_
+using the indicated padding scheme according to IETF RFC 3447 (PKCS#1).
+Input defaults to *stdin* if not specified.
 
 The key referenced by key-context is **required** to be:
 
@@ -31,10 +32,6 @@ The key referenced by key-context is **required** to be:
     Optional authorization value to use the key specified by **-k**.
     Authorization values should follow the "authorization formatting standards",
     see section "Authorization Formatting".
-
-  * **-i**, **\--input**=_INPUT\FILE_:
-
-    Input file path, containing the data to be decrypted.
 
   * **-o**, **\--output**=_OUTPUT\_FILE_:
 
@@ -73,7 +70,7 @@ tpm2_rsaencrypt -c key.ctx -o msg.enc msg.dat
 
 ## Decrypt using RSA
 ```bash
-tpm2_rsadecrypt -c key.ctx -o msg.ptext -i msg.enc
+tpm2_rsadecrypt -c key.ctx -o msg.ptext msg.enc
 cat msg.ptext
 my message
 ```

--- a/man/tpm2_rsaencrypt.1.md
+++ b/man/tpm2_rsaencrypt.1.md
@@ -40,6 +40,12 @@ The key referenced by key-context is **required** to be:
     * rsaes - TPM_ALG_RSAES which is RSAES_PKCSV1.5.
     * oaep  - TPM_ALG_OAEP which is RSAES_OAEP.
 
+  * **-l**, **\--label**=_LABEL\_DATA_:
+
+    Optional, set the label data. Can either be a string or file path. The TPM requires the last
+    byte of the label to be zero, this is handled internally to the tool. No other embedded 0
+    bytes can exist or the TPM will truncate your label.
+
 [common options](common/options.md)
 
 [common tcti options](common/tcti.md)

--- a/man/tpm2_rsaencrypt.1.md
+++ b/man/tpm2_rsaencrypt.1.md
@@ -29,9 +29,8 @@ The key referenced by key-context is **required** to be:
 
   * **-o**, **\--output**=_OUTPUT\_FILE_:
 
-    Output file path, record the decrypted data. The default is to print an
-    xxd compatible hexdump to stdout. If a file is specified, raw binary
-    output is performed.
+    Optional output file path to record the decrypted data to. The default is to print
+    the binary encrypted data to stdout.
 
   * **-g**, **\--scheme**=_PADDING\_SCHEME_:
 

--- a/man/tpm2_rsaencrypt.1.md
+++ b/man/tpm2_rsaencrypt.1.md
@@ -63,7 +63,7 @@ tpm2_rsaencrypt -c key.ctx -o msg.enc msg.dat
 
 ## Decrypt using RSA
 ```bash
-tpm2_rsadecrypt -c key.ctx -o msg.ptext -i msg.enc
+tpm2_rsadecrypt -c key.ctx -o msg.ptext msg.enc
 cat msg.ptext
 my message
 ```

--- a/man/tpm2_rsaencrypt.1.md
+++ b/man/tpm2_rsaencrypt.1.md
@@ -11,13 +11,13 @@
 # DESCRIPTION
 
 **tpm2_rsaencrypt**(1) - Performs RSA encryption on the contents of _FILE_
-(defaulting to stdin) using the indicated padding scheme according to
-IETF RFC 3447 (PKCS#1). The scheme of keyHandle should not be **TPM_ALG_NULL**.
+using the indicated padding scheme according to IETF RFC 3447 (PKCS#1).
+Input defaults to *stdin* if not specified.
 
 The key referenced by key-context is **required** to be:
 
 1. An RSA key
-2. Have the attribute *decrypt* **SET** in it's attributes.
+2. Have the attribute *encrypt* **SET** in it's attributes.
 
 # OPTIONS
 
@@ -36,9 +36,9 @@ The key referenced by key-context is **required** to be:
 
     Optional, set the padding scheme (defaults to rsaes).
 
-    * null  - TPM_ALG_NULL
-    * rsaes - TPM_ALG_RSAES
-    * oaep  - TPM_ALG_OAEP
+    * null  - TPM_ALG_NULL uses the key's scheme if set.
+    * rsaes - TPM_ALG_RSAES which is RSAES_PKCSV1.5.
+    * oaep  - TPM_ALG_OAEP which is RSAES_OAEP.
 
 [common options](common/options.md)
 
@@ -48,8 +48,24 @@ The key referenced by key-context is **required** to be:
 
 # EXAMPLES
 
+## Create an RSA key and load it
+```bash
+tpm2_createprimary -c primary.ctx
+tpm2_create -C primary.ctx -Grsa2048 -u key.pub -r key.priv
+tpm2_load -C primary.ctx -u key.pub -r key.priv -c key.ctx
 ```
-tpm2_rsaencrypt -C 0x81010001 -o encrypted.out
+
+## Encrypt using RSA
+```bash
+echo "my message" > msg.dat
+tpm2_rsaencrypt -c key.ctx -o msg.enc msg.dat
+```
+
+## Decrypt using RSA
+```bash
+tpm2_rsadecrypt -c key.ctx -o msg.ptext -i msg.enc
+cat msg.ptext
+my message
 ```
 
 [returns](common/returns.md)

--- a/man/tpm2_send.1.md
+++ b/man/tpm2_send.1.md
@@ -34,7 +34,7 @@ program to decode and display the response in a human readable form.
 
 Send the contents of *tpm2-command.bin* to a device and collect the response as *tpm2-response.bin*.
 
-```
+```bash
 tpm2_send < tpm2-command.bin > tpm2-response.bin
 
 tpm2_send < tpm2-command.bin -o tpm2-response.bin

--- a/man/tpm2_startauthsession.1.md
+++ b/man/tpm2_startauthsession.1.md
@@ -60,19 +60,19 @@ This will work with direct TPM access, but note that internally this calls a *Co
 # EXAMPLES
 
 ## Start a *trial* session and save the session data to a file
-```
+```bash
 tpm2_startauthsession -S mysession.ctx
 ```
 
 ## Start a *policy* session and save the session data to a file
-```
-tpm2_startauthsession \--policy-session -S mysession.ctx
+```bash
+tpm2_startauthsession --policy-session -S mysession.ctx
 ```
 
 ## Start an encrypted and bound *policy* session and save the session data to a file
-```
+```bash
 tpm2_createprimary -c primary.ctx
-tpm2_startauthsession \--policy-session -c primary.ctx -S mysession.ctx
+tpm2_startauthsession --policy-session -c primary.ctx -S mysession.ctx
 ```
 
 [returns](common/returns.md)

--- a/man/tpm2_startup.1.md
+++ b/man/tpm2_startup.1.md
@@ -25,9 +25,13 @@
 
 # EXAMPLES
 
-```
+## Send a TPM Startup Command with flags TPM2\_SU\_STATE
+```bash
 tpm2_startup
+```
 
+## Send a TPM Startup Command with flags TPM2\_SU\_CLEAR
+```bash
 tpm2_startup -c
 ```
 

--- a/man/tpm2_stirrandom.1.md
+++ b/man/tpm2_stirrandom.1.md
@@ -35,19 +35,19 @@ This command has no option
 # EXAMPLES
 
 ## Inject from stdin using echo
-```
+```bash
 echo -n "myrandomdata" | tpm2_stirrandom
 ```
 
 ## Inject 64 bytes from stdin using a file
-```
+```bash
 dd if=/dev/urandom bs=1 count=64 > myrandom.bin
 
 tpm2_stirrandom < ./myrandom.bin
 ```
 
 ## Inject bytes from a file and reading up to 128 bytes
-```
+```bash
 dd if=/dev/urandom of=./myrandom.bin bs=1 count=42
 
 tpm2_stirrandom ./myrandom.bin

--- a/test/integration/tests/abrmd_policycommandcode.sh
+++ b/test/integration/tests/abrmd_policycommandcode.sh
@@ -67,7 +67,7 @@ rm $file_session_data
 cmp -s $file_output_data $file_input_data
 
 # Test that other operations fail
-if tpm2_encryptdecrypt -i $file_input_data -o $file_output_data -c $file_unseal_key_ctx; then
+if tpm2_encryptdecrypt -o $file_output_data -c $file_unseal_key_ctx $file_input_data; then
     echo "tpm2_policycommandcode: Should have failed!"
     exit 1
 else

--- a/test/integration/tests/abrmd_policypassword.sh
+++ b/test/integration/tests/abrmd_policypassword.sh
@@ -43,12 +43,12 @@ tpm2_create -g sha256 -G aes -u $key_pub -r $key_priv -C $primary_key_ctx \
   -L $policypassword -p $testpswd
 
 tpm2_load -C $primary_key_ctx -u $key_pub -r $key_priv -c $key_ctx
-tpm2_encryptdecrypt -c $key_ctx -o $encrypted_txt -i $plain_txt -p $testpswd
+tpm2_encryptdecrypt -c $key_ctx -o $encrypted_txt -p $testpswd $plain_txt
 
 tpm2_startauthsession --policy-session -S $session_ctx
 tpm2_policypassword -S $session_ctx -L $policypassword
-tpm2_encryptdecrypt -c $key_ctx -i $encrypted_txt -o $decrypted_txt -d \
-  -p session:$session_ctx+$testpswd
+tpm2_encryptdecrypt -c $key_ctx -o $decrypted_txt -d \
+  -p session:$session_ctx+$testpswd $encrypted_txt
 tpm2_flushcontext $session_ctx
 rm $session_ctx
 

--- a/test/integration/tests/import.sh
+++ b/test/integration/tests/import.sh
@@ -34,7 +34,7 @@ run_aes_import_test() {
 
     echo "plaintext" > "plain.txt"
 
-    tpm2_encryptdecrypt -c import_key.ctx  -i plain.txt -o plain.enc
+    tpm2_encryptdecrypt -c import_key.ctx -o plain.enc plain.txt
 
     openssl enc -in plain.enc -out plain.dec.ssl -d -K `xxd -c 256 -p sym.key` -iv 0 -$2
 

--- a/test/integration/tests/import.sh
+++ b/test/integration/tests/import.sh
@@ -68,7 +68,7 @@ run_rsa_import_test() {
 
     sha256sum data.in.raw | awk '{ print "000000 " $1 }' | xxd -r -c 32 > data.in.digest
 
-    tpm2_sign -Q -c import_rsa_key.ctx -g sha256 -d data.in.digest -f plain -o data.out.signed
+    tpm2_sign -Q -c import_rsa_key.ctx -g sha256 -d -f plain -o data.out.signed data.in.digest
 
     openssl dgst -verify public.pem -keyform pem -sha256 -signature data.out.signed data.in.raw
 
@@ -102,7 +102,7 @@ run_ecc_import_test() {
     tpm2_load -Q -C $1 -u ecc.pub -r ecc.priv -n ecc.name -c ecc.ctx
 
     # Sign in the TPM and verify with OSSL
-    tpm2_sign -Q -c ecc.ctx -g sha256 -d data.in.digest -f plain -o data.out.signed
+    tpm2_sign -Q -c ecc.ctx -g sha256 -d -f plain -o data.out.signed data.in.digest
     openssl dgst -verify public.ecc.pem -keyform pem -sha256 -signature data.out.signed data.in.raw
 
     # Sign with openssl and verify with TPM.

--- a/test/integration/tests/import.sh
+++ b/test/integration/tests/import.sh
@@ -59,7 +59,7 @@ run_rsa_import_test() {
     openssl rsa -in private.pem -out public.pem -outform PEM -pubout
     openssl rsautl -encrypt -inkey public.pem -pubin -in plain.txt -out plain.rsa.enc
 
-    tpm2_rsadecrypt -c import_rsa_key.ctx -i plain.rsa.enc -o plain.rsa.dec
+    tpm2_rsadecrypt -c import_rsa_key.ctx -o plain.rsa.dec plain.rsa.enc
 
     diff plain.txt plain.rsa.dec
 

--- a/test/integration/tests/import_tpm.sh
+++ b/test/integration/tests/import_tpm.sh
@@ -129,7 +129,7 @@ load_new_parent
 # Import & load the duplicate
 do_import_load null
 # Decrypt the secret message using duplicated key
-tpm2_rsadecrypt -Q -p foo -c dup.ctx -i cipher.txt -o recovered.txt
+tpm2_rsadecrypt -Q -p foo -c dup.ctx -o recovered.txt cipher.txt
 # Check we got it right ...
 diff recovered.txt plain.txt
 # Cleanup

--- a/test/integration/tests/loadexternal.sh
+++ b/test/integration/tests/loadexternal.sh
@@ -78,7 +78,7 @@ run_rsa_test() {
 
     tpm2_loadexternal -G rsa -C n -p foo -r private.pem -c key.ctx
 
-    tpm2_rsadecrypt -c key.ctx -p foo -i plain.rsa.enc -o plain.rsa.dec
+    tpm2_rsadecrypt -c key.ctx -p foo -o plain.rsa.dec plain.rsa.enc
 
     diff plain.txt plain.rsa.dec
 

--- a/test/integration/tests/loadexternal.sh
+++ b/test/integration/tests/loadexternal.sh
@@ -114,7 +114,7 @@ run_aes_test() {
 
     echo "plaintext" > "plain.txt"
 
-    tpm2_encryptdecrypt -c key.ctx -i plain.txt -o plain.enc
+    tpm2_encryptdecrypt -c key.ctx -o plain.enc plain.txt
 
     openssl enc -in plain.enc -out plain.dec.ssl -d -K `xxd -c 256 -p sym.key` \
 	-iv 0 -aes-$1-cfb

--- a/test/integration/tests/loadexternal.sh
+++ b/test/integration/tests/loadexternal.sh
@@ -144,7 +144,7 @@ run_ecc_test() {
     tpm2_loadexternal -Q -G ecc -r private.ecc.pem -c key.ctx
 
     # Sign in the TPM and verify with OSSL
-    tpm2_sign -Q -c key.ctx -g sha256 -d data.in.digest -f plain -o data.out.signed
+    tpm2_sign -Q -c key.ctx -g sha256 -d -f plain -o data.out.signed data.in.digest
     openssl dgst -verify public.ecc.pem -keyform pem -sha256 -signature data.out.signed data.in.raw
 
     # Sign with openssl and verify with TPM but only with the public portion of an object loaded

--- a/test/integration/tests/output_formats.sh
+++ b/test/integration/tests/output_formats.sh
@@ -79,7 +79,7 @@ tpm2_hash -Q -C e -g $alg_hash -t "$file_hash_ticket" -o "$file_hash_result" "$f
 
 for fmt in tss plain; do
     this_sig="${file_sig_base}.${fmt}"
-    tpm2_sign -Q -c $handle_ak -g $alg_hash -m "${file_hash_input}" -f $fmt -o "${this_sig}" -t "${file_hash_ticket}"
+    tpm2_sign -Q -c $handle_ak -g $alg_hash -f $fmt -o "${this_sig}" -t "${file_hash_ticket}" "${file_hash_input}"
 
     if [ "$fmt" = plain ]; then
         openssl dgst -verify "$file_pubak_pem" -keyform pem -${alg_hash} -signature "$this_sig" "$file_hash_input" > /dev/null

--- a/test/integration/tests/rsadecrypt.sh
+++ b/test/integration/tests/rsadecrypt.sh
@@ -47,15 +47,15 @@ tpm2_rsaencrypt -Q -c $file_rsaencrypt_key_ctx -o $file_rsa_en_output_data < $fi
 
 tpm2_load -Q -C $file_primary_key_ctx -u $file_rsaencrypt_key_pub -r $file_rsaencrypt_key_priv  -n $file_rsaencrypt_key_name  -c $file_rsadecrypt_key_ctx
 
-tpm2_rsadecrypt -Q -c $file_rsadecrypt_key_ctx -p foo -i  $file_rsa_en_output_data -o  $file_rsa_de_output_data
+tpm2_rsadecrypt -Q -c $file_rsadecrypt_key_ctx -p foo -o  $file_rsa_de_output_data $file_rsa_en_output_data
 
 # Test the diffeent padding schemes ...
 
 tpm2_rsaencrypt -Q -c $file_rsaencrypt_key_ctx -o $file_rsa_en_output_data  -g rsaes < $file_input_data
-tpm2_rsadecrypt -Q -c $file_rsadecrypt_key_ctx -p foo -i  $file_rsa_en_output_data -o  $file_rsa_de_output_data -g rsaes
+tpm2_rsadecrypt -Q -c $file_rsadecrypt_key_ctx -p foo -o  $file_rsa_de_output_data -g rsaes $file_rsa_en_output_data
 
 tpm2_rsaencrypt -Q -c $file_rsaencrypt_key_ctx -o $file_rsa_en_output_data  -g null < $file_input_data
-tpm2_rsadecrypt -Q -c $file_rsadecrypt_key_ctx -p foo -i  $file_rsa_en_output_data -o  $file_rsa_de_output_data -g null
+tpm2_rsadecrypt -Q -c $file_rsadecrypt_key_ctx -p foo -o  $file_rsa_de_output_data -g null $file_rsa_en_output_data
 
 trap - ERR
 tpm2_rsaencrypt -Q -c $file_rsaencrypt_key_ctx -o $file_rsa_en_output_data  -g oaep < $file_input_data
@@ -64,7 +64,7 @@ if [ $? -eq 0 ]; then
     exit 1
 fi
 
-tpm2_rsadecrypt -Q -c $file_rsadecrypt_key_ctx -p foo -i  $file_rsa_en_output_data -o  $file_rsa_de_output_data -g oaep
+tpm2_rsadecrypt -Q -c $file_rsadecrypt_key_ctx -p foo -o  $file_rsa_de_output_data -g oaep $file_rsa_en_output_data
 if [ $? -eq 0 ]; then
     echo "tpm2_rsadecrypt should fail with 'hash algorithm not supported or not appropriate'"
     exit 1

--- a/test/integration/tests/rsadecrypt.sh
+++ b/test/integration/tests/rsadecrypt.sh
@@ -21,7 +21,7 @@ cleanup() {
     rm -f $file_input_data $file_primary_key_ctx $file_rsaencrypt_key_pub \
     $file_rsaencrypt_key_priv $file_rsaencrypt_key_ctx $file_rsaencrypt_key_name \
     $file_output_data $file_rsa_en_output_data $file_rsa_de_output_data \
-    $file_rsadecrypt_key_ctx
+    $file_rsadecrypt_key_ctx label.dat
 
     if [ "$1" != "no-shut-down" ]; then
         shut_down
@@ -56,6 +56,15 @@ tpm2_rsadecrypt -Q -c $file_rsadecrypt_key_ctx -p foo -o  $file_rsa_de_output_da
 
 tpm2_rsaencrypt -Q -c $file_rsaencrypt_key_ctx -o $file_rsa_en_output_data  -g null < $file_input_data
 tpm2_rsadecrypt -Q -c $file_rsadecrypt_key_ctx -p foo -o  $file_rsa_de_output_data -g null $file_rsa_en_output_data
+
+# Test the label option with a string
+tpm2_rsaencrypt -Q -c $file_rsaencrypt_key_ctx -l mylabel -o $file_rsa_en_output_data < $file_input_data
+tpm2_rsadecrypt -Q -c $file_rsadecrypt_key_ctx -l mylabel -p foo -o $file_rsa_de_output_data $file_rsa_en_output_data
+
+# Test the label option with a file
+echo "my file label" > label.dat
+tpm2_rsaencrypt -Q -c $file_rsaencrypt_key_ctx -l label.dat -o $file_rsa_en_output_data < $file_input_data
+tpm2_rsadecrypt -Q -c $file_rsadecrypt_key_ctx -l label.dat -p foo -o $file_rsa_de_output_data $file_rsa_en_output_data
 
 trap - ERR
 tpm2_rsaencrypt -Q -c $file_rsaencrypt_key_ctx -o $file_rsa_en_output_data  -g oaep < $file_input_data

--- a/test/integration/tests/rsaencrypt.sh
+++ b/test/integration/tests/rsaencrypt.sh
@@ -43,7 +43,7 @@ tpm2_loadexternal -Q -C n   -u $file_rsaencrypt_key_pub  -c $file_rsaencrypt_key
 #./tpm2_rsaencrypt -c context_loadexternal_out6.out -I secret.data -o rsa_en.out
 tpm2_rsaencrypt -Q -c $file_rsaencrypt_key_ctx -o $file_rsa_en_output_data $file_input_data
 
-# Test stdout for -o and ensure that output is xxd format, test that stdin pipe works as well.
-cat $file_input_data | tpm2_rsaencrypt -c $file_rsaencrypt_key_ctx | xxd -r > /dev/null
+# Test stdout output and test that stdin pipe works as well.
+cat $file_input_data | tpm2_rsaencrypt -c $file_rsaencrypt_key_ctx > /dev/null
 
 exit 0

--- a/test/integration/tests/sign.sh
+++ b/test/integration/tests/sign.sh
@@ -48,13 +48,13 @@ test_symmetric() {
 
     tpm2_load -Q -C $file_primary_key_ctx -u $file_signing_key_pub -r $file_signing_key_priv -n $file_signing_key_name -c $file_signing_key_ctx
 
-    tpm2_sign -Q -c $file_signing_key_ctx -g $alg_hash -m $file_input_data -o $file_output_data
+    tpm2_sign -Q -c $file_signing_key_ctx -g $alg_hash -o $file_output_data $file_input_data
 
     rm -f $file_output_data
 
     tpm2_evictcontrol -Q -C o -c $file_signing_key_ctx $handle_signing_key
 
-    tpm2_sign -Q -c $handle_signing_key -g $alg_hash -m $file_input_data -o $file_output_data
+    tpm2_sign -Q -c $handle_signing_key -g $alg_hash -o $file_output_data $file_input_data
 
     rm -f $file_output_data
 
@@ -62,7 +62,7 @@ test_symmetric() {
 
     tpm2_hash -Q -C e -g $alg_hash -o $file_output_hash -t $file_output_ticket $file_input_data
 
-    tpm2_sign -Q -c $handle_signing_key -g $alg_hash -o $file_output_data -m $file_input_data -t $file_output_ticket
+    tpm2_sign -Q -c $handle_signing_key -g $alg_hash -o $file_output_data -t $file_output_ticket $file_input_data
 
     rm -f $file_output_data
 
@@ -70,21 +70,17 @@ test_symmetric() {
 
     sha256sum $file_input_data | awk '{ print "000000 " $1 }' | xxd -r -c 32 > $file_input_digest
 
-    tpm2_sign -Q -c $handle_signing_key -g $alg_hash -d $file_input_digest -o $file_output_data
+    tpm2_sign -Q -c $handle_signing_key -g $alg_hash -d -o $file_output_data $file_input_digest
 
     rm -f $file_output_data
-
-    # test with digest + message/validation (warning generated)
-
-    tpm2_sign -Q -c $handle_signing_key -g $alg_hash -d $file_input_digest -o $file_output_data -m $file_input_data -t $file_output_ticket |& grep -q ^WARN
 }
 
 create_signature() {
     local sign_scheme=$1
     if [ "$sign_scheme" = "" ]; then
-        tpm2_sign -Q -c $file_signing_key_ctx -g $alg_hash -m $file_input_data -f plain -o $file_output_data
+        tpm2_sign -Q -c $file_signing_key_ctx -g $alg_hash -f plain -o $file_output_data $file_input_data
     else
-        tpm2_sign -Q -c $file_signing_key_ctx -g $alg_hash -s $sign_scheme -m $file_input_data -f plain -o $file_output_data
+        tpm2_sign -Q -c $file_signing_key_ctx -g $alg_hash -s $sign_scheme -f plain -o $file_output_data $file_input_data
     fi
 }
 
@@ -269,7 +265,7 @@ tpm2_load -Q -C $file_primary_key_ctx -u $file_signing_key_pub -r $file_signing_
 # Negative test, remove error handler
 trap - ERR
 
-tpm2_sign -Q -p "badpassword" -c $file_signing_key_ctx -g $alg_hash -m $file_input_data -o $file_output_data
+tpm2_sign -Q -p "badpassword" -c $file_signing_key_ctx -g $alg_hash -o $file_output_data $file_input_data
 if [ $? != 3]; then
     echo "Expected RC 3, got: $?" 1>&2
 fi

--- a/test/integration/tests/verifysignature.sh
+++ b/test/integration/tests/verifysignature.sh
@@ -46,7 +46,7 @@ tpm2_create -Q -g $alg_hash -G $alg_signing_key -u $file_signing_key_pub -r $fil
 
 tpm2_load -Q -C $file_primary_key_ctx -u $file_signing_key_pub -r $file_signing_key_priv -n $file_signing_key_name -c $file_signing_key_ctx
 
-tpm2_sign -Q -c $file_signing_key_ctx -g $alg_hash -m $file_input_data -o $file_output_data
+tpm2_sign -Q -c $file_signing_key_ctx -g $alg_hash -o $file_output_data $file_input_data
 
 tpm2_verifysignature -Q -c $file_signing_key_ctx -g $alg_hash -m $file_input_data -s $file_output_data -t $file_verify_tk_data
 

--- a/tools/tpm2_rsaencrypt.c
+++ b/tools/tpm2_rsaencrypt.c
@@ -80,7 +80,7 @@ static bool on_option(char key, char *value) {
 static bool on_args(int argc, char **argv) {
 
     if (argc > 1) {
-        LOG_ERR("Only supports one hash input file, got: %d", argc);
+        LOG_ERR("Only supports one input file, got: %d", argc);
         return false;
     }
 
@@ -106,7 +106,7 @@ bool tpm2_tool_onstart(tpm2_options **opts) {
 static tool_rc init(ESYS_CONTEXT *context) {
 
     if (!ctx.context_arg) {
-        LOG_ERR("Expected option C");
+        LOG_ERR("Expected option c");
         return tool_rc_option_error;
     }
 

--- a/tools/tpm2_sign.c
+++ b/tools/tpm2_sign.c
@@ -28,20 +28,18 @@ struct tpm_sign_ctx {
     char *outFilePath;
     BYTE *msg;
     UINT16 length;
-    char *inMsgFileName;
+    char *input_file;
     tpm2_convert_sig_fmt sig_format;
 
     struct {
-        UINT8 m : 1;
+        UINT8 d : 1;
         UINT8 t : 1;
         UINT8 o : 1;
-        UINT8 D : 1;
     } flags;
 };
 
 static tpm_sign_ctx ctx = {
         .halg = TPM2_ALG_SHA1,
-        .digest = NULL,
         .sig_scheme = TPM2_ALG_NULL
 };
 
@@ -50,18 +48,7 @@ static tool_rc sign_and_save(ESYS_CONTEXT *ectx) {
     TPMT_SIGNATURE *signature;
     bool result;
 
-    tool_rc rc = tool_rc_general_error;
-
-    if (!ctx.flags.D) {
-      tool_rc tmp_rc = tpm2_hash_compute_data(ectx, ctx.halg, TPM2_RH_NULL,
-              ctx.msg, ctx.length, &ctx.digest, NULL);
-      if (tmp_rc != tool_rc_success) {
-          LOG_ERR("Compute message hash failed!");
-          return tmp_rc;
-      }
-    }
-
-    rc = tpm2_sign(ectx, &ctx.signing_key.object, ctx.digest, &ctx.in_scheme,
+    tool_rc rc = tpm2_sign(ectx, &ctx.signing_key.object, ctx.digest, &ctx.in_scheme,
       &ctx.validation, &signature);
     if (rc != tool_rc_success) {
       goto out;
@@ -70,6 +57,7 @@ static tool_rc sign_and_save(ESYS_CONTEXT *ectx) {
     result = tpm2_convert_sig_save(signature, ctx.sig_format,
                 ctx.outFilePath);
     if (!result) {
+        rc = tool_rc_general_error;
         goto out;
     }
 
@@ -89,11 +77,6 @@ static tool_rc init(ESYS_CONTEXT *ectx) {
         option_fail = true;
     }
 
-    if (!ctx.flags.m && !ctx.flags.D) {
-        LOG_ERR("Expected options m or D");
-        option_fail = true;
-    }
-
     if (!ctx.flags.o) {
         LOG_ERR("Expected option o");
         option_fail = true;
@@ -103,11 +86,12 @@ static tool_rc init(ESYS_CONTEXT *ectx) {
         return tool_rc_option_error;
     }
 
-    if (ctx.flags.D && (ctx.flags.t || ctx.flags.m)) {
-        LOG_WARN("Option D provided, options m and t are ignored.");
+    if (ctx.flags.d && ctx.flags.t) {
+        LOG_WARN("When using a pre-computed digest the validation ticket"
+                " is ignored.");
     }
 
-    if (ctx.flags.D || !ctx.flags.t) {
+    if (ctx.flags.d || !ctx.flags.t) {
         ctx.validation.tag = TPM2_ST_HASHCHECK;
         ctx.validation.hierarchy = TPM2_RH_NULL;
         memset(&ctx.validation.digest, 0, sizeof(ctx.validation.digest));
@@ -123,39 +107,38 @@ static tool_rc init(ESYS_CONTEXT *ectx) {
         return rc;
     }
 
-    /*
-     * Process the msg file if needed
-     */
-    if (ctx.flags.m && !ctx.flags.D) {
-      unsigned long file_size;
-      bool result = files_get_file_size_path(ctx.inMsgFileName, &file_size);
-      if (!result) {
-          return tool_rc_general_error;
-      }
-      if (file_size == 0) {
-          LOG_ERR("The message file \"%s\" is empty!", ctx.inMsgFileName);
+    /* Process the msg file if needed */
+    if (!ctx.flags.d) {
+      FILE *input = ctx.input_file ? fopen(ctx.input_file, "rb") : stdin;
+      if (!input) {
+          LOG_ERR("Could not open file \"%s\"", ctx.input_file);
           return tool_rc_general_error;
       }
 
-      if (file_size > UINT16_MAX) {
-          LOG_ERR(
-                  "The message file \"%s\" is too large, got: %lu bytes, expected less than: %u bytes!",
-                  ctx.inMsgFileName, file_size, UINT16_MAX + 1);
-          return tool_rc_general_error;
+      rc = tpm2_hash_file(ectx, ctx.halg, TPM2_RH_NULL, input,
+              &ctx.digest, NULL);
+      if (input != stdin) {
+          fclose(input);
       }
+      if (rc != tool_rc_success) {
+          LOG_ERR("Could not hash input");
+      }
+      return rc;
+      /* we don't need to perform the digest, just read it */
+    }
 
-      ctx.msg = (BYTE*) calloc(required_argument, file_size);
-      if (!ctx.msg) {
-          LOG_ERR("oom");
-          return tool_rc_general_error;
-      }
+    /* else process it as a pre-computed digest */
+    ctx.digest = malloc(sizeof(TPM2B_DIGEST));
+    if (!ctx.digest) {
+        LOG_ERR("oom");
+        return tool_rc_general_error;
+    }
 
-      ctx.length = file_size;
-      result = files_load_bytes_from_path(ctx.inMsgFileName, ctx.msg, &ctx.length);
-      if (!result) {
-          free(ctx.msg);
-          return tool_rc_general_error;
-      }
+    ctx.digest->size = sizeof(ctx.digest->buffer);
+    bool result = files_load_bytes_from_buffer_or_file_or_stdin(NULL,
+            ctx.input_file, &ctx.digest->size, ctx.digest->buffer);
+    if (!result) {
+        return tool_rc_general_error;
     }
 
     return tool_rc_success;
@@ -170,14 +153,13 @@ static bool on_option(char key, char *value) {
     case 'p':
         ctx.signing_key.auth_str = value;
         break;
-    case 'g': {
+    case 'g':
         ctx.halg = tpm2_alg_util_from_optarg(value, tpm2_alg_util_flags_hash);
         if (ctx.halg == TPM2_ALG_ERROR) {
             LOG_ERR("Could not convert to number or lookup algorithm, got: \"%s\"",
                     value);
             return false;
         }
-    }
         break;
     case 's': {
         ctx.sig_scheme = tpm2_alg_util_from_optarg(value, tpm2_alg_util_flags_sig);
@@ -187,19 +169,8 @@ static bool on_option(char key, char *value) {
         }
     }
         break;
-    case 'd': {
-        ctx.digest = malloc(sizeof(TPM2B_DIGEST));
-        ctx.digest->size = sizeof(TPM2B_DIGEST);
-        if (!files_load_bytes_from_path(value, ctx.digest->buffer, &ctx.digest->size)) {
-            LOG_ERR("Could not load digest from file \"%s\"!", value);
-            return false;
-        }
-        ctx.flags.D = 1;
-    }
-        break;
-    case 'm':
-        ctx.inMsgFileName = value;
-        ctx.flags.m = 1;
+    case 'd':
+        ctx.flags.d = 1;
         break;
     case 't': {
         bool result = files_load_validation(value, &ctx.validation);
@@ -209,10 +180,9 @@ static bool on_option(char key, char *value) {
         ctx.flags.t = 1;
     }
         break;
-    case 'o': {
+    case 'o':
         ctx.outFilePath = value;
         ctx.flags.o = 1;
-    }
         break;
     case 'f':
         ctx.sig_format = tpm2_convert_sig_fmt_from_optarg(value);
@@ -226,22 +196,33 @@ static bool on_option(char key, char *value) {
     return true;
 }
 
+static bool on_args(int argc, char *argv[]) {
+
+    if (argc != 1) {
+        LOG_ERR("Expected one input file, got: %d", argc);
+        return false;
+    }
+
+    ctx.input_file = argv[0];
+
+    return true;
+}
+
 bool tpm2_tool_onstart(tpm2_options **opts) {
 
     static const struct option topts[] = {
       { "auth",                 required_argument, NULL, 'p' },
       { "hash-algorithm",       required_argument, NULL, 'g' },
       { "scheme",               required_argument, NULL, 's' },
-      { "message",              required_argument, NULL, 'm' },
-      { "digest",               required_argument, NULL, 'd' },
+      { "digest",               no_argument,       NULL, 'd' },
       { "signature",            required_argument, NULL, 'o' },
       { "ticket",               required_argument, NULL, 't' },
       { "key-context",          required_argument, NULL, 'c' },
       { "format",               required_argument, NULL, 'f' }
     };
 
-    *opts = tpm2_options_new("p:g:m:d:t:o:c:f:s:", ARRAY_LEN(topts), topts,
-                             on_option, NULL, 0);
+    *opts = tpm2_options_new("p:g:dt:o:c:f:s:", ARRAY_LEN(topts), topts,
+                             on_option, on_args, 0);
 
     return *opts != NULL;
 }


### PR DESCRIPTION
  * tpm2_sign:
     - Drop -m and -d option arguments and make them sole argument.
     - Remove the -m option and make -d toggle if input is a digest.
  * tpm2_encryptdecrypt: drop -i input option and make argument.
  * tpm2_rsadecrypt: drop -i input option and make argument.
  * tpm2_rsaencrypt: make output binary and either stdout or file based on -o.
  * tpm2_rsadecrypt: add support for label via -l.
  * tpm2_rsaencrypt: add support for label via -l.