### PR TITLE
selftest and bash examples for manpage audit

### DIFF
--- a/man/tpm2_activatecredential.1.md
+++ b/man/tpm2_activatecredential.1.md
@@ -62,7 +62,7 @@ These options control the object verification:
 
 # EXAMPLES
 
-```
+```bash
 TPM2_RH_ENDORSEMENT=0x4000000B
 tpm2_startauthsession --policy-session -S session.ctx
 tpm2_policysecret -S session.ctx -c $TPM2_RH_ENDORSEMENT

--- a/man/tpm2_certify.1.md
+++ b/man/tpm2_certify.1.md
@@ -78,7 +78,7 @@ These options control the certification:
 
 # EXAMPLES
 
-```
+```bash
 tpm2_certify -H 0x81010002 -P 0x0011 -p 0x00FF -g 0x00B -a <fileName> -s <fileName>
 
 tpm2_certify -C obj.context -c key.context -P 0x0011 -p 0x00FF -g 0x00B -a <fileName> -s <fileName>

--- a/man/tpm2_changeauth.1.md
+++ b/man/tpm2_changeauth.1.md
@@ -52,26 +52,26 @@ see section "Authorization Formatting".
 # EXAMPLES
 
 ## Set owner, endorsement and lockout authorizations to newpass
-```
+```bash
 tpm2_changeauth -c owner newpass
 tpm2_changeauth -c endorsement newpass
 tpm2_changeauth -c lockout newpass
 ```
 
 ## Change owner, endorsement and lockout authorizations from newpass to a new value
-```
+```bash
 tpm2_changeauth -c o -p newpass newerpass
 tpm2_changeauth -c e -p newpass newerpass
 tpm2_changeauth -c l -p newpass newerpass
 ```
 
 ## Set owner authorization to empty password
-```
+```bash
 tpm2_changeauth -c o -p oldpass
 ```
 
 ## Modify authorization for a loadable transient object
-```
+```bash
 tpm2_createprimary -Q -C o -c prim.ctx
 
 tpm2_create -Q -g sha256 -G aes -u key.pub -r key.priv -C prim.ctx
@@ -85,7 +85,7 @@ tpm2_changeauth -c key.ctx -C prim.ctx -r key.priv newkeyauth
 
 Requires Extended Session Support.
 
-```
+```bash
 tpm2_startauthsession -S session.ctx
 
 tpm2_policycommandcode -S session.ctx -L policy.nvchange nvchangeauth

--- a/man/tpm2_checkquote.1.md
+++ b/man/tpm2_checkquote.1.md
@@ -75,7 +75,7 @@ provided, verify that the qualifying data and PCR values match those in the quot
 # EXAMPLES
 
 ## Generate a quote with a TPM, then verify it
-```
+```bash
 tpm2_createek -c 0x81010009 -G rsa -u ekpub.pem -f pem
 
 tpm2_createak -C 0x81010009 -k 0x8101000a -G rsa -s rsassa -D sha256 -p akpub.pem -f pem -n ak.name

--- a/man/tpm2_clear.1.md
+++ b/man/tpm2_clear.1.md
@@ -36,12 +36,12 @@ lockout hierarchy
 
 ## Set owner, endorsement and lockout authorizations to an empty value
 
-```
+```bash
 tpm2_clear lockoutpasswd
 ```
 
 ## Clear the authorization values on the platform hierarchy
-```
+```bash
 tpm2_clear -c p
 ```
 

--- a/man/tpm2_clearcontrol.1.md
+++ b/man/tpm2_clearcontrol.1.md
@@ -47,12 +47,12 @@ tpm2_clear command.
 # EXAMPLES
 
 ## Set the disableClear to block the lockout authorization's access to TPM clear
-```
+```bash
 tpm2_clearcontrol -C l s
 ```
 
 ## Clear the disableClear to unblock lockout authorization for TPM clear operation
-```
+```bash
 tpm2_clearcontrol -C p c
 ```
 

--- a/man/tpm2_createak.1.md
+++ b/man/tpm2_createak.1.md
@@ -105,7 +105,7 @@ loaded-key:
 
 ### Create an Attestation Key and make it persistent
 
-```
+```bash
 tpm2_createek -c ek.handle -G rsa -u ek.pub
 tpm2_createak -C ek.handle -c ak.ctx -u ak.pub -n ak.name
 tpm2_evictcontrol -c 0x81010002 -o ak.ctx

--- a/man/tpm2_createek.1.md
+++ b/man/tpm2_createek.1.md
@@ -84,12 +84,12 @@ Refer to:
 # EXAMPLES
 
 ### Create an Endorsement Key and make it persistent
-```
+```bash
 tpm2_createek -P abc123 -w abc123 -p passwd -c 0x81010001 -G rsa -u ek.pub
 ```
 
 ### Create a transient Endorsement Key, flush it, and reload it.
-```
+```bash
 tpm2_createek -G rsa -u ek.pub
 
 # Check that it is loaded in transient memory

--- a/man/tpm2_createpolicy.1.md
+++ b/man/tpm2_createpolicy.1.md
@@ -61,7 +61,7 @@ These options control creating the policy authorization session:
 # EXAMPLES
 
 ## Create a authorization policy tied to a specific PCR index
-```
+```bash
 tpm2_createpolicy \--policy-pcr -l 0x4:0 -L policy.file -f pcr0.bin
 ```
 

--- a/man/tpm2_createprimary.1.md
+++ b/man/tpm2_createprimary.1.md
@@ -93,7 +93,7 @@ with the created primary.
 # EXAMPLES
 
 ## Create an ECC primary object
-```
+```bash
 tpm2_createprimary -C o -g sha256 -G ecc -c context.out
 ```
 
@@ -103,7 +103,7 @@ See : https://trustedcomputinggroup.org/wp-content/uploads/TCG-TPM-v2.0-Provisio
 
 Where unique.dat contains the binary-formatted data: 0x00 0x01 (0x00 * 256)
 
-```
+```bash
 tpm2_createprimary -C o -G rsa2048:aes128cfb -g sha256 -c prim.ctx \
   -a 'restricted|decrypt|fixedtpm|fixedparent|sensitivedataorigin|userwithauth|noda' \
   -u unique.dat

--- a/man/tpm2_dictionarylockout.1.md
+++ b/man/tpm2_dictionarylockout.1.md
@@ -54,7 +54,7 @@ dictionary-attack-lockout state.
 
 # EXAMPLES
 
-```
+```bash
 tpm2_dictionarylockout -c -p passwd
 
 tpm2_dictionarylockout -s -n 5 -t 6 -l 7 -p passwd

--- a/man/tpm2_duplicate.1.md
+++ b/man/tpm2_duplicate.1.md
@@ -65,7 +65,7 @@ These options control the key importation process:
 # EXAMPLES
 
 To duplicate a key, one needs the key to duplicate, created with a policy that allows duplication and a new parent:
-```
+```bash
 tpm2_startauthsession -S session.dat
 tpm2_policycommandcode -S session.dat -L policy.dat duplicate
 tpm2_flushcontext session.dat

--- a/man/tpm2_evictcontrol.1.md
+++ b/man/tpm2_evictcontrol.1.md
@@ -69,17 +69,17 @@ within the TPM. If an object is *persisted* then the object is resident at the
 # EXAMPLES
 
 ## To make a transient handle persistent at address 0x81010002
-```
+```bash
 tpm2_evictcontrol -C o -c object.context -P abc123 0x81010002
 ```
 
 ## To evict a persistent handle
-```
+```bash
 tpm2_evictcontrol -C o -c 0x81010002 -P abc123
 ```
 
 ## To make a transient handle persistent and output a serialized persistent handle.
-```
+```bash
 tpm2_createprimary -c primary.ctx
 tpm2_evictcontrol -C o -c primary.ctx -o primary.handle
 ```

--- a/man/tpm2_flushcontext.1.md
+++ b/man/tpm2_flushcontext.1.md
@@ -63,7 +63,7 @@ tpm2_flushcontext \--transient-object
 ```
 
 ## Flush a Session
-```
+```bash
 tpm2_startauthsession -S session.dat
 
 tpm2_flushcontext session.dat

--- a/man/tpm2_getcap.1.md
+++ b/man/tpm2_getcap.1.md
@@ -76,12 +76,12 @@ Currently supported capability groups are:
 # EXAMPLES
 
 ## To list the fixed properties of the TPM
-```
+```bash
 tpm2_getcap properties-fixed
 ```
 
 ## To list the supported capability arguments to **-c**
-```
+```bash
 tpm2_getcap -l
 ```
 

--- a/man/tpm2_getmanufec.1.md
+++ b/man/tpm2_getmanufec.1.md
@@ -91,7 +91,7 @@ provided by setting the curl mode verbose, see
 
 # EXAMPLES
 
-```
+```bash
 tpm2_getmanufec -P abc123 -w abc123 -p passwd -H 0x81010001 -G rsa -O -N -U -E ECcert.bin -o ek.bin https://tpm.manufacturer.com/ekcertserver/
 
 tpm2_getmanufec -P 1a1b1c -w 1a1b1c -p 123abc -H 0x81010001 -G rsa -O -N -U -E ECcert.bin -o ek.bin https://tpm.manufacturer.com/ekcertserver/

--- a/man/tpm2_getrandom.1.md
+++ b/man/tpm2_getrandom.1.md
@@ -46,12 +46,12 @@ and **--hex** options respectively.
 # EXAMPLES
 
 ## Generate a random 20 bytes and output the binary data to a file
-```
+```bash
 tpm2_getrandom -o random.out 20
 ```
 
 ## Generate a random 8 bytes and output the hex formatted data to stdout
-```
+```bash
 tpm2_getrandom 8
 ```
 

--- a/man/tpm2_gettestresult.1.md
+++ b/man/tpm2_gettestresult.1.md
@@ -10,7 +10,7 @@
 
 # DESCRIPTION
 
-**tpm2_gettestresult**(1) will return the result of the tests conducted by the TPM
+**tpm2_gettestresult**(1) will return the result of the tests conducted by the TPM.
 
 Error code will state if the test executed successfully or have failed.
 
@@ -32,7 +32,7 @@ This tool accepts no tool specific options.
 
 ## Get the result of the TPM testing
 
-```
+```bash
 tpm2_gettestresult
 ```
 

--- a/man/tpm2_hash.1.md
+++ b/man/tpm2_hash.1.md
@@ -62,7 +62,7 @@ and **--hex** options respectively.
 # EXAMPLES
 
 ## Hash a file with sha1 hash algorithm and save the hash and ticket to a file
-```
+```bash
 tpm2_hash -C e -g sha1 -o hash.bin -t ticket.bin data.txt
 ```
 

--- a/man/tpm2_hierarchycontrol.1.md
+++ b/man/tpm2_hierarchycontrol.1.md
@@ -47,27 +47,27 @@ Note: If password option is missing, assume NULL.
 # EXAMPLES
 
 ## Set phEnableNV with platform hierarchy and its authorization
-```
+```bash
 tpm2_hierarchycontrol -C p phEnableNV set -P pass
 ```
 
 ## clear phEnableNV with platform hierarchy
-```
+```bash
 tpm2_hierarchycontrol -C p phEnableNV clear
 ```
 
 ## Set shEnable with platform hierarchy
-```
+```bash
 tpm2_hierarchycontrol -C p shEnable set
 ```
 
 ## Set shEnable with owner hierarchy
-```
+```bash
 tpm2_hierarchycontrol -C o shEnable set
 ```
 
 ## Check current TPMA_STARTUP_CLEAR Bits
-```
+```bash
 tpm2_getcap properties-variable
 ```
 

--- a/man/tpm2_hmac.1.md
+++ b/man/tpm2_hmac.1.md
@@ -66,7 +66,7 @@ and **--hex** options respectively.
 # EXAMPLES
 
 ## Setup
-```
+```bash
 # create a primary object
 tpm2_createprimary -o primary.ctx
 
@@ -78,7 +78,7 @@ tpm2_create -C primary.ctx -Ghmac -o hmac.key
 Perform an hmac using the key's default scheme (hash algorithm) and
 output to stdout in hexidecimal format.
 
-```
+```bash
 tpm2_hmac -c hmac.key --hex data.in
 e6eda48a53a9ddbb92f788f6d98e0372d63a408afb11aca43f522a2475a32805
 ```

--- a/man/tpm2_import.1.md
+++ b/man/tpm2_import.1.md
@@ -113,7 +113,7 @@ These options control the key importation process:
 # EXAMPLES
 
 ## To import a key, one needs to have a parent key
-```
+```bash
 tpm2_createprimary -Grsa2048:aes128cfb -C o -c parent.ctx
 ```
 
@@ -121,28 +121,28 @@ Create your key and and import it. If you already have a key, just use that
 and skip creating it.
 
 ## Import an AES 128 key
-```
+```bash
 dd if=/dev/urandom of=sym.key bs=1 count=16
 
 tpm2_import -C parent.ctx -i sym.key -u key.pub -r key.priv
 ```
 
 ## Import an RSA key
-```
+```bash
 openssl genrsa -out private.pem 2048
 
 tpm2_import -C parent.ctx -G rsa -i private.pem -u key.pub -r key.priv
 ```
 
 ## Import an ECC key
-```
+```bash
 openssl ecparam -name prime256v1 -genkey -noout -out private.ecc.pem
 
 tpm2_import -C parent.ctx -G ecc -i private.ecc.pem -u key.pub -r key.priv
 ```
 
 ## Import a duplicated key
-```
+```bash
 tpm2_import -C parent.ctx -i key.dup -u key.pub -r key.priv -L policy.dat
 ```
 

--- a/man/tpm2_incrementalselftest.1.md
+++ b/man/tpm2_incrementalselftest.1.md
@@ -12,7 +12,7 @@
 
 **tpm2_incrementalselftest**(1) Request the TPM to perform testing on specified algorithm
 and print a list of algorithm scheduled to be tested *OR* remain to be tested but not
-scheduled
+scheduled.
 
 The main interest of this command is to reduce delays that might occur on cryptographic
 operations as TPM must test the algorithm prior using it.
@@ -53,13 +53,13 @@ This tool accepts no tool specific options.
 
 ## Request testing of RSA algorithm
 
-```
+```bash
 tpm2_incrementalselftest rsa
 ```
 
 ## Request testing of multiple algorithms
 
-```
+```bash
 tpm2_incrementalselftest rsa ecc xor aes cbc
 ```
 
@@ -72,7 +72,7 @@ e.g : One TPM might only test AES with CTR mode if "aes ctr" is specified. An ot
 also test complete AES mode list AND test ctr mode.
 
 If an algorithm has already been tested, this command won't permit re-executing the test. Only
-issuing **tpm2_selftest**(1) in full-test mode enabled will force retesting.
+issuing **tpm2_selftest**(1) in full-test mode enabled will force re-testing.
 
 [returns](common/returns.md)
 

--- a/man/tpm2_makecredential.1.md
+++ b/man/tpm2_makecredential.1.md
@@ -40,7 +40,7 @@ the **none** TCTI option.
 
 # EXAMPLES
 
-```
+```bash
 tpm2_makecredential -e <keyFile> -s <secFile> -n <hexString> -o <outFile>
 ```
 

--- a/man/tpm2_nvdefine.1.md
+++ b/man/tpm2_nvdefine.1.md
@@ -62,7 +62,7 @@ to the nv handle range "TPM2_HR_NV_INDEX".
 
 # EXAMPLES
 
-```
+```bash
 tpm2_nvdefine   0x1500016 -C 0x40000001 -s 32 -a 0x2000A
 
 tpm2_nvdefine   0x1500016 -C 0x40000001 -s 32 -a ownerread|ownerwrite|policywrite -p 1a1b1c

--- a/man/tpm2_nvincrement.1.md
+++ b/man/tpm2_nvincrement.1.md
@@ -46,7 +46,7 @@ handle range "TPM2_HR_NV_INDEX".
 
 ## To increment the counter at index *0x150016*
 
-```
+```bash
 tpm2_nvdefine -C 0x1500016 -s 8 -a "ownerread|policywrite|ownerwrite|nt=1" \
 0x1500016 -p index
 

--- a/man/tpm2_nvread.1.md
+++ b/man/tpm2_nvread.1.md
@@ -59,7 +59,7 @@ index can be specified as raw handle or an offset value to the nv handle range
 # EXAMPLES
 
 ## Read 32 bytes from an index starting at offset 0
-```
+```bash
 tpm2_nvdefine -Q  1 -C o -s 32 -a "ownerread|policywrite|ownerwrite"
 
 echo "please123abc" > nv.test_w

--- a/man/tpm2_nvreadlock.1.md
+++ b/man/tpm2_nvreadlock.1.md
@@ -44,7 +44,7 @@ value to the nv handle range "TPM2_HR_NV_INDEX".
 # EXAMPLES
 
 ## Lock an index
-```
+```bash
 tpm2_nvdefine -Q   1 -C o -s 32 -a "ownerread|policywrite|ownerwrite|read_stclear"
 
 echo "foobar" > nv.readlock

--- a/man/tpm2_nvreadpublic.1.md
+++ b/man/tpm2_nvreadpublic.1.md
@@ -56,7 +56,7 @@ This tool takes no tool specific options.
 
 ## List the defined NV indices to stdout
 
-```
+```bash
 tpm2_nvreadpublic
 ```
 

--- a/man/tpm2_nvundefine.1.md
+++ b/man/tpm2_nvundefine.1.md
@@ -39,7 +39,7 @@ be specified as raw handle or an offset value to the nv handle range
 
 # EXAMPLES
 
-```
+```bash
 tpm2_nvdefine   0x1500016 -C 0x40000001 -s 32 -a 0x2000A
 
 tpm2_nvundefine   0x1500016 -C 0x40000001

--- a/man/tpm2_nvwrite.1.md
+++ b/man/tpm2_nvwrite.1.md
@@ -53,7 +53,7 @@ raw handle or an offset value to the nv handle range "TPM2_HR_NV_INDEX".
 # EXAMPLES
 
 ## Write the file nv.data to index *0x01000001*
-```
+```bash
 tpm2_nvdefine -Q   1 -C o -s 32 -a "ownerread|policywrite|ownerwrite"
 
 echo "please123abc" > nv.test_w

--- a/man/tpm2_pcrallocate.1.md
+++ b/man/tpm2_pcrallocate.1.md
@@ -44,12 +44,12 @@ The new allocations become effective after the next reboot.
 # EXAMPLES
 
 ## To allocate the two default banks (SHA1 and SHA256)
-```
+```bash
 tpm2_pcrallocate
 ```
 
 ## To make a custom allocation with a platform authorization
-```
+```bash
 tpm2_pcrallocate -P abc sha1:7,8,9,10,16,17,18,19+sha256:all
 ```
 

--- a/man/tpm2_pcrextend.1.md
+++ b/man/tpm2_pcrextend.1.md
@@ -47,17 +47,17 @@ This tool accepts no tool specific options.
 # EXAMPLES
 
 ## Extend PCR 4's SHA1 bank with a hash
-```
+```bash
 tpm2_pcrextend 4:sha=f1d2d2f924e986ac86fdf7b36c94bcdf32beec15
 ```
 
 ## Extend PCR 4's SHA1 and SHA256 banks with hashes
-```
+```bash
 tpm2_pcrextend 4:sha=f1d2d2f924e986ac86fdf7b36c94bcdf32beec15,sha256:b5bb9d8014a0f9b1d61e21e796d78dccdf1352f23cd32812f4850b878ae4944c
 ```
 
 ## Extend PCR 4's SHA1 and PCR 7's SHA256 bank with hashes
-```
+```bash
 tpm2_pcrextend 4:sha=f1d2d2f924e986ac86fdf7b36c94bcdf32beec15 7:sha256:b5bb9d8014a0f9b1d61e21e796d78dccdf1352f23cd32812f4850b878ae4944c
 ```
 

--- a/man/tpm2_pcrreset.1.md
+++ b/man/tpm2_pcrreset.1.md
@@ -30,12 +30,12 @@ This tool accepts no tool specific options.
 # EXAMPLES
 
 ## Reset a single PCR
-```
+```bash
 tpm2_pcrreset 23
 ```
 
 ## Reset multiple PCRs
-```
+```bash
 tpm2_pcrreset 16 23
 ```
 

--- a/man/tpm2_policyor.1.md
+++ b/man/tpm2_policyor.1.md
@@ -56,12 +56,12 @@ and seal a secret. Unsealing with either of the PCR sets should be successful.
 ## Create two unique pcr policies with corresponding unique sets of pcrs.
 
 ### Start with pcr value 0
-```
+```bash
 tpm2_pcrreset 23
 ```
 
 ### PCR1 policy
-```
+```bash
 tpm2_startauthsession -S session.ctx
 
 tpm2_policypcr -S session.ctx -l sha1:23 -L set1.pcr0.policy
@@ -72,7 +72,7 @@ rm session.ctx
 ```
 
 ### PCR2 policy
-```
+```bash
 tpm2_pcrextend 23:sha1=f1d2d2f924e986ac86fdf7b36c94bcdf32beec15
 
 tpm2_startauthsession -S session.ctx
@@ -85,7 +85,7 @@ rm session.ctx
 ```
 
 ## Create a policyOR resulting from compounding the two unique pcr policies in an OR fashion
-```
+```bash
 tpm2_startauthsession -S session.ctx
 
 tpm2_policyor -S session.ctx -L policyOR -l sha256:set1.pcr0.policy,set2.pcr0.policy
@@ -96,7 +96,7 @@ rm session.ctx
 ```
 
 ## Create a sealing object with auth policyOR created above.
-```
+```bash
 tpm2_createprimary -C o -c prim.ctx
 
 tpm2_create -g sha256 -u sealkey.pub -r sealkey.priv -L policyOR -C prim.ctx -i- <<< "secretpass"
@@ -105,7 +105,7 @@ tpm2_load -C prim.ctx -c sealkey.ctx -u sealkey.pub -r sealkey.priv
 ```
 
 ## Attempt unsealing by satisfying the policyOR by satisfying SECOND of the two policies.
-```
+```bash
 tpm2_startauthsession -S session.ctx --policy-session
 
 tpm2_policypcr -S session.ctx -l sha1:23
@@ -122,19 +122,19 @@ rm session.ctx
 ```
 
 ## Extend the pcr to emulate tampering of the system software and hence the pcr value.
-```
+```bash
 tpm2_pcrextend 23:sha1=f1d2d2f924e986ac86fdf7b36c94bcdf32beec15
 ```
 
 ## Attempt unsealing by trying to satisy the policOR by attempting to satisy one of the two policies.
-```
+```bash
 tpm2_startauthsession -S session.ctx --policy-session
 
 tpm2_policypcr -S session.ctx -l sha1:23
 ```
 
 ### This should fail
-```
+```bash
 tpm2_policyor -S session.ctx -L policyOR -l sha256:set1.pcr0.policy,set2.pcr0.policy
 
 tpm2_flushcontext session.ctx
@@ -143,12 +143,12 @@ rm session.ctx
 ```
 
 ## Reset pcr to get back to the first set of pcr value
-```
+```bash
 tpm2_pcrreset 23
 ```
 
 ## Attempt unsealing by satisfying the policyOR by satisfying FIRST of the two policies.
-```
+```bash
 tpm2_startauthsession -S session.ctx --policy-session
 
 tpm2_policypcr -S session.ctx -l sha1:23

--- a/man/tpm2_selftest.1.md
+++ b/man/tpm2_selftest.1.md
@@ -17,6 +17,11 @@ Self-test can be executed in two modes :
 * Simple test - TPM will test functions that require testing
 * Full test - TPM will test all functions regardless of what has already been tested
 
+Once the TPM receives this request, the TPM will return TPM\_RC\_TESTING for any command
+that requires a test. If a test fails, the TPM will return TPM\_RC\_FAILURE for any
+command other than TPM2\_GetTestResult() and TPM2\_GetCapability() during this time.
+The TPM will remain in failure mode until the next TPM initialization.
+
 # OPTIONS
 
 * **-f**, **\--fulltest** : Run self-test in full mode
@@ -28,12 +33,12 @@ Self-test can be executed in two modes :
 # EXAMPLES
 
 ## Perform a simple TPM self-test
-```
+```bash
 tpm2_selftest
 ```
 
 ## Perform a complete TPM self-test
-```
+```bash
 tpm2_selftest -f
 ```
 

--- a/man/tpm2_testparms.1.md
+++ b/man/tpm2_testparms.1.md
@@ -34,12 +34,12 @@ This tool accepts no tool specific options.
 # EXAMPLES
 
 ## Check whether if "rsa" is supported
-```
+```bash
 tpm2_testparms rsa
 ```
 
 ## Check that ECDSA using P-256 with AES-128 CTR mode is available
-```
+```bash
 tpm2_testparms ecc256:ecdsa:aes128ctr
 ```
 

--- a/man/tpm2_unseal.1.md
+++ b/man/tpm2_unseal.1.md
@@ -41,7 +41,7 @@
 
 # EXAMPLES
 
-```
+```bash
 tpm2_unseal -c 0x81010001 -p abc123 -o out.dat
 
 tpm2_unseal -c item.context -p abc123 -o out.dat

--- a/man/tpm2_verifysignature.1.md
+++ b/man/tpm2_verifysignature.1.md
@@ -78,7 +78,7 @@ symmetric key, both the public and private portions need to be loaded.
 # EXAMPLES
 
 ## Sign and verify with the TPM using the *endorsement* hierarchy
-```
+```bash
 tpm2_createprimary -C e -c primary.ctx
 
 tpm2_create -G rsa -u rsa.pub -r rsa.priv -C primary.ctx
@@ -93,7 +93,7 @@ tpm2_verifysignature -c rsa.ctx -g sha256 -m message.dat -s sig.rssa
 ```
 
 ## Sign with openssl and verify with the TPM
-```
+```bash
 # Generate an ECC key
 openssl ecparam -name prime256v1 -genkey -noout -out private.ecc.pem
 


### PR DESCRIPTION
- audit the selftest set of tools
- make sure EXAMPLES have ```bash decorator