### PR TITLE
Fix uninitiailized return vars

### DIFF
--- a/tools/tpm2_nvread.c
+++ b/tools/tpm2_nvread.c
@@ -26,7 +26,7 @@ static tpm_nvread_ctx ctx;
 static tool_rc nv_read(ESYS_CONTEXT *ectx, tpm2_option_flags flags) {
 
     UINT8* data_buffer = NULL;
-    UINT16 bytes_written;
+    UINT16 bytes_written = 0;
     tool_rc rc = tpm2_util_nv_read(ectx, ctx.nv_index, ctx.size_to_read,
                     ctx.offset, ctx.auth_hierarchy.object.handle,
                     ctx.auth_hierarchy.object.session, &data_buffer,

--- a/tools/tpm2_nvwrite.c
+++ b/tools/tpm2_nvwrite.c
@@ -95,7 +95,7 @@ static tool_rc nv_write(ESYS_CONTEXT *ectx) {
 }
 
 static bool on_option(char key, char *value) {
-    bool result;
+    bool result = false;
     char *input_file;
     switch (key) {
     case 'C':


### PR DESCRIPTION
This fixes build failures when the gcc -Wmaybe-uninitialized option is enabled.