### PR TITLE
DO NOT MERGE - demonstrate undetected error in unit tests

### DIFF
--- a/test/unit/test_options.c
+++ b/test/unit/test_options.c
@@ -250,3 +250,7 @@ int main(int argc, char *argv[]) {
 
     return cmocka_run_group_tests(tests, NULL, NULL);
 }
+
+/* this function will yield compiler warnings (= errors due to -Werror) */
+void unused_function(int unused_param) {
+}


### PR DESCRIPTION
Warnings (i.e. errors due to -Werror) can be introduced to unit tests and will not be detected by travis. This is a demonstration.