### PR TITLE
ci: make check TESTS='' with default settings

### DIFF
--- a/.ci/docker.run
+++ b/.ci/docker.run
@@ -53,8 +53,11 @@ fi
 # make distcheck, so only do this with gcc.
 # Do a make distcheck in the root, clear it and than
 # cd to the variant directory.
-if [ "$CC" == "gcc" ]; then
-    ./configure
+if [[ "$CC" != clang* ]]; then
+    ./configure --enable-unit
+    # build with default options and build tests to see if any compilation
+    # errors arise with default config.
+    make check TESTS=""
     make distcheck
     make distclean
 fi
@@ -65,7 +68,7 @@ pushd ./build
 
 # Run scan-build for gcc only.
 # Scan-build does not work with clang because of asan linking errors.
-if [[ "$CC" == gcc* ]]; then
+if [[ "$CC" != clang ]]; then
     scan-build ../configure --enable-unit $config_flags
     scan-build --status-bugs make -j$(nproc)
 


### PR DESCRIPTION
There was never a make check run with the default configure flags, and
thus we were losing Wall Werror type messages. There was also some
issues in the if gcc check, so correct those too.

See PR as an example:
  - https://github.com/tpm2-software/tpm2-tools/pull/1682

Now we get error:
test/unit/test_options.c:255:26: error: unused parameter 'unused_param' [-Werror=unused-parameter]
 void unused_function(int unused_param) {

Signed-off-by: William Roberts <william.c.roberts@intel.com>