### PR TITLE
Fix bash script coding guideline

### DIFF
--- a/test/integration/tests/abrmd_extended-sessions.sh
+++ b/test/integration/tests/abrmd_extended-sessions.sh
@@ -7,7 +7,7 @@ alg_primary_key=ecc
 alg_create_obj=sha256
 alg_pcr_policy=sha1
 
-pcr_ids="0,1,2,3"
+pcr_ids=0,1,2,3
 
 file_pcr_value=pcr.bin
 file_input_data=secret.data
@@ -15,12 +15,14 @@ file_policy=policy.data
 file_primary_key_ctx=context.p_"$alg_primary_obj"_"$alg_primary_key"
 file_unseal_key_pub=opu_"$alg_create_obj"
 file_unseal_key_priv=opr_"$alg_create_obj"
-file_unseal_key_ctx=ctx_load_out_"$alg_primary_obj"_"$alg_primary_key"-"$alg_create_obj"
-file_unseal_key_name=name.load_"$alg_primary_obj"_"$alg_primary_key"-"$alg_create_obj"
+file_unseal_key_ctx=ctx_load_out_"$alg_primary_obj"_"$alg_primary_key"-\
+"$alg_create_obj"
+file_unseal_key_name=name.load_"$alg_primary_obj"_"$alg_primary_key"-\
+"$alg_create_obj"
 file_unseal_output_data=usl_"$file_unseal_key_ctx"
-file_session_file="session.dat"
+file_session_file=session.dat
 
-secret="12345678"
+secret=12345678
 
 cleanup() {
     rm -f $file_input_data $file_primary_key_ctx $file_unseal_key_pub \
@@ -45,42 +47,53 @@ echo $secret > $file_input_data
 tpm2_clear
 
 #
-# Test an extended policy session beyond client connections. This is ONLY supported by abrmd
-# since version: https://github.com/tpm2-software/tpm2-abrmd/releases/tag/1.2.0
-# However, bug: https://github.com/tpm2-software/tpm2-abrmd/issues/285 applies
+# Test an extended policy session beyond client connections. This is ONLY
+# supported by abrmd since version: https://github.com/tpm2-software/tpm2-abrmd/
+# releases/tag/1.2.0 However, bug: https://github.com/tpm2-software/tpm2-abrmd/
+# issues/285 applies.
 #
 # The test works by:
-# Step 1: Creating a trial session and updating it with a policyPCR event to generate
-#   a policy hash.
+# Step 1: Creating a trial session and updating it with a policyPCR event to
+# generate a policy hash.
 #
-# Step 2: Creating an object and using that policy hash as the policy to satisfy for usage.
+# Step 2: Creating an object and using that policy hash as the policy to satisfy
+# for usage.
 #
-# Step 3: Creating an actual policy session and using pcrpolicy event to update the policy.
+# Step 3: Creating an actual policy session and using pcrpolicy event to update
+# the policy.
 #
-# Step 4: Using that actual policy session from step 3 in tpm2_unseal to unseal the object.
+# Step 4: Using that actual policy session from step 3 in tpm2_unseal to unseal
+# the object.
 #
 
-tpm2_createprimary -Q -C e -g $alg_primary_obj -G $alg_primary_key -c $file_primary_key_ctx
+tpm2_createprimary -Q -C e -g $alg_primary_obj -G $alg_primary_key \
+-c $file_primary_key_ctx
 
 tpm2_pcrread -Q -o $file_pcr_value ${alg_pcr_policy}:${pcr_ids}
 
 tpm2_startauthsession -Q -S $file_session_file
 
-tpm2_policypcr -Q -S $file_session_file -l ${alg_pcr_policy}:${pcr_ids} -f $file_pcr_value -L $file_policy
+tpm2_policypcr -Q -S $file_session_file -l ${alg_pcr_policy}:${pcr_ids} \
+-f $file_pcr_value -L $file_policy
 
 tpm2_flushcontext $file_session_file
 
-tpm2_create -Q -g $alg_create_obj -u $file_unseal_key_pub -r $file_unseal_key_priv -i- -C $file_primary_key_ctx -L $file_policy \
-  -a 'fixedtpm|fixedparent' <<< $secret
+tpm2_create -Q -g $alg_create_obj -u $file_unseal_key_pub \
+-r $file_unseal_key_priv -i- -C $file_primary_key_ctx -L $file_policy \
+-a 'fixedtpm|fixedparent' <<< $secret
 
-tpm2_load -Q -C $file_primary_key_ctx -u $file_unseal_key_pub -r $file_unseal_key_priv -n $file_unseal_key_name -c $file_unseal_key_ctx
+tpm2_load -Q -C $file_primary_key_ctx -u $file_unseal_key_pub \
+-r $file_unseal_key_priv -n $file_unseal_key_name -c $file_unseal_key_ctx
 
 rm $file_session_file
 
-# Start a REAL encrypted and bound policy session (-a option) and perform a pcr policy event
-tpm2_startauthsession --policy-session -c $file_primary_key_ctx -S $file_session_file
+# Start a REAL encrypted and bound policy session (-a option) and perform a pcr
+# policy event
+tpm2_startauthsession --policy-session -c $file_primary_key_ctx \
+-S $file_session_file
 
-tpm2_policypcr -Q -S $file_session_file -l ${alg_pcr_policy}:${pcr_ids} -f $file_pcr_value -L $file_policy
+tpm2_policypcr -Q -S $file_session_file -l ${alg_pcr_policy}:${pcr_ids} \
+-f $file_pcr_value -L $file_policy
 
 unsealed=`tpm2_unseal -p"session:$file_session_file" -c $file_unseal_key_ctx`
 
@@ -90,7 +103,8 @@ test "$unsealed" == "$secret"
 tpm2_policyrestart -S $file_session_file
 
 # negative test, clear the error handler
-if tpm2_unseal -p"session:$file_session_file" -c $file_unseal_key_ctx 2>/dev/null; then
+if tpm2_unseal -p"session:$file_session_file" \
+-c $file_unseal_key_ctx 2>/dev/null; then
     echo "Expected tpm2_unseal to fail after policy reset"
     exit 1
 else

--- a/test/integration/tests/abrmd_policyauthorize.sh
+++ b/test/integration/tests/abrmd_policyauthorize.sh
@@ -2,22 +2,22 @@
 
 source helpers.sh
 
-pcr_ids="0"
+pcr_ids=0
 alg_pcr_policy=sha256
 file_pcr_value=pcr.bin
 file_policy=policy.data
 file_authorized_policy_1=auth_policy_1.data
 file_authorized_policy_2=auth_policy_2.data
-file_session_file="session.dat"
-file_private_key="private.pem"
-file_public_key="public.pem"
-file_verifying_key_public="verifying_key_public"
-file_verifying_key_name="verifying_key_name"
-file_verifying_key_ctx="verifying_key_ctx"
-file_policyref="policyref"
+file_session_file=session.dat
+file_private_key=private.pem
+file_public_key=public.pem
+file_verifying_key_public=verifying_key_public
+file_verifying_key_name=verifying_key_name
+file_verifying_key_ctx=verifying_key_ctx
+file_policyref=policyref
 
 cleanup() {
-    rm -f  $file_pcr_value $file_policy $file_session_file $file_private_key \
+    rm -f $file_pcr_value $file_policy $file_session_file $file_private_key \
     $file_public_key $file_verifying_key_public $file_verifying_key_name \
     $file_verifying_key_ctx $file_policyref $file_authorized_policy_1 \
     $file_authorized_policy_2
@@ -36,7 +36,7 @@ cleanup "no-shutdown"
 
 generate_policy_authorize () {
     tpm2_startauthsession -Q -S $file_session_file
-    tpm2_policyauthorize -Q -S $file_session_file  -L $3 -i $1 -q $2 -n $4
+    tpm2_policyauthorize -Q -S $file_session_file -L $3 -i $1 -q $2 -n $4
     tpm2_flushcontext $file_session_file
     rm $file_session_file
 }
@@ -44,30 +44,32 @@ generate_policy_authorize () {
 openssl genrsa -out $file_private_key 2048 2>/dev/null
 openssl rsa -in $file_private_key -out $file_public_key -pubout 2>/dev/null
 tpm2_loadexternal -G rsa -C n -u $file_public_key -c $file_verifying_key_ctx \
-  -n $file_verifying_key_name
+-n $file_verifying_key_name
 
 dd if=/dev/urandom of=$file_policyref bs=1 count=32 2>/dev/null
 
 tpm2_pcrread -Q -o $file_pcr_value ${alg_pcr_policy}:${pcr_ids}
 tpm2_startauthsession -Q -S $file_session_file
-tpm2_policypcr -Q -S $file_session_file -l ${alg_pcr_policy}:${pcr_ids} -f $file_pcr_value -L $file_policy
+tpm2_policypcr -Q -S $file_session_file -l ${alg_pcr_policy}:${pcr_ids} \
+-f $file_pcr_value -L $file_policy
 tpm2_flushcontext $file_session_file
 rm $file_session_file
 
-generate_policy_authorize $file_policy $file_policyref $file_authorized_policy_1 \
-  $file_verifying_key_name
+generate_policy_authorize $file_policy $file_policyref \
+$file_authorized_policy_1 $file_verifying_key_name
 
-tpm2_pcrextend  \
-  0:sha256=e7011b851ee967e2d24e035ae41b0ada2decb182e4f7ad8411f2bf564c56fd6f
+tpm2_pcrextend \
+0:sha256=e7011b851ee967e2d24e035ae41b0ada2decb182e4f7ad8411f2bf564c56fd6f
 
 tpm2_pcrread -Q -o $file_pcr_value ${alg_pcr_policy}:${pcr_ids}
 tpm2_startauthsession -Q -S $file_session_file
-tpm2_policypcr -Q -S $file_session_file -l ${alg_pcr_policy}:${pcr_ids} -f $file_pcr_value -L $file_policy
+tpm2_policypcr -Q -S $file_session_file -l ${alg_pcr_policy}:${pcr_ids} \
+-f $file_pcr_value -L $file_policy
 tpm2_flushcontext $file_session_file
 rm $file_session_file
 
-generate_policy_authorize $file_policy $file_policyref $file_authorized_policy_2 \
-  $file_verifying_key_name
+generate_policy_authorize $file_policy $file_policyref \
+$file_authorized_policy_2 $file_verifying_key_name
 
 diff $file_authorized_policy_1 $file_authorized_policy_2
 

--- a/test/integration/tests/abrmd_policycommandcode.sh
+++ b/test/integration/tests/abrmd_policycommandcode.sh
@@ -12,12 +12,12 @@ file_unseal_key_name=sealkey.name
 file_output_data=unsealed.data
 file_session_data=session.dat
 
-secret="12345678"
+secret=12345678
 
 cleanup() {
-    rm -f  $file_primary_key_ctx $file_input_data $file_policy $file_unseal_key_pub\
-    $file_unseal_key_priv $file_unseal_key_ctx $file_unseal_key_name\
-    $file_output_data $file_session_data
+    rm -f $file_primary_key_ctx $file_input_data $file_policy \
+    $file_unseal_key_pub $file_unseal_key_priv $file_unseal_key_ctx \
+    $file_unseal_key_name $file_output_data $file_session_data
 
     if [ "${1}" != "no-shutdown" ]; then
         shut_down
@@ -44,13 +44,13 @@ tpm2_flushcontext $file_session_data
 rm $file_session_data
 
 echo "tpm2_create -C $file_primary_key_ctx -u $file_unseal_key_pub \
-  -r $file_unseal_key_priv -L $file_policy -i- <<< $secret"
+-r $file_unseal_key_priv -L $file_policy -i- <<< $secret"
 
 tpm2_create -C $file_primary_key_ctx -u $file_unseal_key_pub \
-  -r $file_unseal_key_priv -L $file_policy -i- <<< $secret
+-r $file_unseal_key_priv -L $file_policy -i- <<< $secret
 
 tpm2_load -C $file_primary_key_ctx -u $file_unseal_key_pub \
-  -r $file_unseal_key_priv -n $file_unseal_key_name -c $file_unseal_key_ctx
+-r $file_unseal_key_priv -n $file_unseal_key_name -c $file_unseal_key_ctx
 
 
 # Ensure unsealing passes with proper policy
@@ -67,7 +67,8 @@ rm $file_session_data
 cmp -s $file_output_data $file_input_data
 
 # Test that other operations fail
-if tpm2_encryptdecrypt -o $file_output_data -c $file_unseal_key_ctx $file_input_data; then
+if tpm2_encryptdecrypt -o $file_output_data -c $file_unseal_key_ctx \
+$file_input_data; then
     echo "tpm2_policycommandcode: Should have failed!"
     exit 1
 else

--- a/test/integration/tests/abrmd_policyduplicationselect.sh
+++ b/test/integration/tests/abrmd_policyduplicationselect.sh
@@ -19,7 +19,7 @@ unintended_new_parent_name=dst2_n.name
 
 
 cleanup() {
-  rm -f  $source_parent_object $new_parent_object $new_parent_name \
+  rm -f $source_parent_object $new_parent_object $new_parent_name \
   $duplicable_object_private $duplicable_object_public $duplicable_object \
   $policy_duplication_select $duplicated_object_private $policy_session \
   $duplicated_object_seed $duplicable_object_name \
@@ -49,8 +49,8 @@ tpm2_readpublic -c $new_parent_object -n $new_parent_name -Q
 
 tpm2_startauthsession -S $policy_session
 
-tpm2_policyduplicationselect -S $policy_session  -N $new_parent_name \
-  -L $policy_duplication_select -Q
+tpm2_policyduplicationselect -S $policy_session -N $new_parent_name \
+-L $policy_duplication_select -Q
 
 tpm2_flushcontext $policy_session
 
@@ -58,23 +58,23 @@ rm $policy_session
 
 # Create the object to be duplicated using the policy
 tpm2_create -C $source_parent_object -g sha256 -G rsa \
-  -r $duplicable_object_private -u $duplicable_object_public \
-  -L $policy_duplication_select -a "sensitivedataorigin|sign|decrypt" \
-  -c $duplicable_object -Q
+-r $duplicable_object_private -u $duplicable_object_public \
+-L $policy_duplication_select -a "sensitivedataorigin|sign|decrypt" \
+-c $duplicable_object -Q
 
 # Satisfy the policy and duplicate the object
 tpm2_readpublic -c $duplicable_object -n $duplicable_object_name -Q
 
 tpm2_startauthsession -S $policy_session --policy-session
 
-tpm2_policyduplicationselect -S $policy_session  -N $new_parent_name \
-  -n $duplicable_object_name -Q
+tpm2_policyduplicationselect -S $policy_session -N $new_parent_name \
+-n $duplicable_object_name -Q
 
 tpm2_duplicate -C $new_parent_object -c $duplicable_object -G null \
-  -p session:$policy_session -r $duplicated_object_private \
-  -s $duplicated_object_seed
+-p session:$policy_session -r $duplicated_object_private \
+-s $duplicated_object_seed
 
-tpm2_flushcontext  $policy_session
+tpm2_flushcontext $policy_session
 
 rm $policy_session
 
@@ -85,20 +85,20 @@ tpm2_readpublic -c $new_parent_object -n $unintended_new_parent_name -Q
 
 tpm2_startauthsession -S $policy_session --policy-session
 
-tpm2_policyduplicationselect -S $policy_session  -N $unintended_new_parent_name \
-  -n $duplicable_object_name -Q
+tpm2_policyduplicationselect -S $policy_session -N $unintended_new_parent_name \
+-n $duplicable_object_name -Q
 
 ## Disable error reporting for expected failures to follow
 trap - ERR
 
 tpm2_duplicate -C $unintended_new_parent_object -c $duplicable_object -G null \
-  -p session:$policy_session -r $duplicated_object_private \
-  -s $duplicated_object_seed
+-p session:$policy_session -r $duplicated_object_private \
+-s $duplicated_object_seed
 
 ## Restore error reporting
 trap onerror ERR
 
-tpm2_flushcontext  $policy_session
+tpm2_flushcontext $policy_session
 
 rm $policy_session
 

--- a/test/integration/tests/abrmd_policypassword.sh
+++ b/test/integration/tests/abrmd_policypassword.sh
@@ -15,8 +15,8 @@ decrypted_txt=dec.txt
 testpswd=testpswd
 
 cleanup() {
-    rm -f  $policypassword $session_ctx $o_policy_digest $primary_key_ctx $key_ctx\
-    $key_pub $key_priv $plain_txt $encrypted_txt $decrypted_txt
+    rm -f $policypassword $session_ctx $o_policy_digest $primary_key_ctx \
+    $key_ctx $key_pub $key_priv $plain_txt $encrypted_txt $decrypted_txt
 
     tpm2_flushcontext $session_ctx 2>/dev/null || true
 
@@ -40,7 +40,7 @@ rm $session_ctx
 tpm2_createprimary -C o -c $primary_key_ctx
 
 tpm2_create -g sha256 -G aes -u $key_pub -r $key_priv -C $primary_key_ctx \
-  -L $policypassword -p $testpswd
+-L $policypassword -p $testpswd
 
 tpm2_load -C $primary_key_ctx -u $key_pub -r $key_priv -c $key_ctx
 tpm2_encryptdecrypt -c $key_ctx -o $encrypted_txt -p $testpswd $plain_txt
@@ -48,7 +48,7 @@ tpm2_encryptdecrypt -c $key_ctx -o $encrypted_txt -p $testpswd $plain_txt
 tpm2_startauthsession --policy-session -S $session_ctx
 tpm2_policypassword -S $session_ctx -L $policypassword
 tpm2_encryptdecrypt -c $key_ctx -o $decrypted_txt -d \
-  -p session:$session_ctx+$testpswd $encrypted_txt
+-p session:$session_ctx+$testpswd $encrypted_txt
 tpm2_flushcontext $session_ctx
 rm $session_ctx
 

--- a/test/integration/tests/abrmd_policysecret.sh
+++ b/test/integration/tests/abrmd_policysecret.sh
@@ -3,7 +3,7 @@
 source helpers.sh
 
 TPM_RH_OWNER=0x40000001
-SEALED_SECRET="SEALED-SECRET"
+SEALED_SECRET=SEALED-SECRET
 session_ctx=session.ctx
 o_policy_digest=policy.digest
 primary_ctx=prim.ctx
@@ -12,7 +12,7 @@ seal_key_priv=sealing_key.priv
 seal_key_ctx=sealing_key.ctx
 
 cleanup() {
-    rm -f  $session_ctx $o_policy_digest $primary_ctx $seal_key_pub $seal_key_priv\
+    rm -f $session_ctx $o_policy_digest $primary_ctx $seal_key_pub $seal_key_priv\
     $seal_key_ctx
 
     tpm2_flushcontext $session_ctx 2>/dev/null || true
@@ -40,14 +40,15 @@ tpm2_flushcontext $session_ctx
 rm $session_ctx
 
 # Create and Load Object
-tpm2_createprimary -Q -C o  -c $primary_ctx -P ownerauth
-tpm2_create -Q -g sha256 -u $seal_key_pub -r $seal_key_priv -C $primary_ctx\
-  -L $o_policy_digest -i- <<< $SEALED_SECRET
+tpm2_createprimary -Q -C o -c $primary_ctx -P ownerauth
+tpm2_create -Q -g sha256 -u $seal_key_pub -r $seal_key_priv -C $primary_ctx \
+-L $o_policy_digest -i- <<< $SEALED_SECRET
 tpm2_load -C $primary_ctx -u $seal_key_pub -r $seal_key_priv -c $seal_key_ctx
 
 # Satisfy policy and unseal data
 tpm2_startauthsession --policy-session -S $session_ctx
-echo -n "ownerauth" | tpm2_policysecret -S $session_ctx -c $TPM_RH_OWNER -L $o_policy_digest file:-
+echo -n "ownerauth" | tpm2_policysecret -S $session_ctx -c $TPM_RH_OWNER \
+-L $o_policy_digest file:-
 unsealed=`tpm2_unseal -p"session:$session_ctx" -c $seal_key_ctx`
 tpm2_flushcontext $session_ctx
 rm $session_ctx
@@ -55,7 +56,7 @@ rm $session_ctx
 test "$unsealed" == "$SEALED_SECRET"
 
 if [ $? != 0 ]; then
-  echo "Failed policysecret integration test where in ref object password was set."
+  echo "Failed policysecret integration test where ref object password was set."
 fi
 
 #Test the policy with auth reference object password not set
@@ -71,7 +72,7 @@ rm $session_ctx
 test "$unsealed" == "$SEALED_SECRET"
 
 if [ $? != 0 ]; then
-  echo "Failed policysecret integration test where in ref object is passwordless."
+  echo "Failed policysecret integration test for passwordless reference object."
 fi
 
 exit 0

--- a/test/integration/tests/activecredential.sh
+++ b/test/integration/tests/activecredential.sh
@@ -3,8 +3,8 @@
 source helpers.sh
 
 cleanup() {
-    rm -f secret.data ek.pub ak.pub ak.name mkcred.out actcred.out ak.out\
-     ak.ctx session.ctx
+    rm -f secret.data ek.pub ak.pub ak.name mkcred.out actcred.out ak.out \
+    ak.ctx session.ctx
 
     # Evict persistent handles, we want them to always succeed and never trip
     # the onerror trap.
@@ -20,12 +20,12 @@ start_up
 
 cleanup "no-shut-down"
 
-echo "12345678" > secret.data
+echo 12345678 > secret.data
 
 tpm2_createek -Q -c 0x81010009 -G rsa -u ek.pub
 
-tpm2_createak -C 0x81010009 -c ak.ctx -G rsa -g sha256 -s rsassa -u ak.pub\
-    -n ak.name -p akpass> ak.out
+tpm2_createak -C 0x81010009 -c ak.ctx -G rsa -g sha256 -s rsassa -u ak.pub \
+-n ak.name -p akpass> ak.out
 
 # Capture the yaml output and verify that its the same as the name output
 loaded_key_name_yaml=`python << pyscript
@@ -44,13 +44,14 @@ loaded_key_name=`cat ak.name | xxd -p -c $file_size`
 
 test "$loaded_key_name_yaml" == "$loaded_key_name"
 
-tpm2_makecredential -Q -e ek.pub  -s secret.data -n $loaded_key_name -o mkcred.out
+tpm2_makecredential -Q -e ek.pub -s secret.data -n $loaded_key_name \
+-o mkcred.out
 
 TPM2_RH_ENDORSEMENT=0x4000000B
 tpm2_startauthsession --policy-session -S session.ctx
 tpm2_policysecret -S session.ctx -c $TPM2_RH_ENDORSEMENT
-tpm2_activatecredential -Q -c ak.ctx -C 0x81010009 -i mkcred.out -o actcred.out\
-	-p akpass -P"session:session.ctx"
+tpm2_activatecredential -Q -c ak.ctx -C 0x81010009 -i mkcred.out \
+-o actcred.out -p akpass -P"session:session.ctx"
 tpm2_flushcontext session.ctx
 
 exit 0

--- a/test/integration/tests/attestation.sh
+++ b/test/integration/tests/attestation.sh
@@ -32,16 +32,17 @@ output_quotesig=quotesig.out
 output_quotepcr=quotepcr.out
 
 cleanup() {
-  rm -f $file_input_data $file_input_key $output_ek_pub $output_ek_pub_pem $output_ak_pub \
-        $output_ak_pub_pem $output_ak_pub_name $output_mkcredential \
-        $output_actcredential $output_quote $output_quotesig $output_quotepcr $context_ak \
-        rand.out session.ctx
+  rm -f $file_input_data $file_input_key $output_ek_pub $output_ek_pub_pem \
+  $output_ak_pub $output_ak_pub_pem $output_ak_pub_name $output_mkcredential \
+  $output_actcredential $output_quote $output_quotesig $output_quotepcr \
+  $context_ak rand.out session.ctx
 
   tpm2_pcrreset -Q $debug_pcr
   tpm2_evictcontrol -Q -C o -c $handle_ek -P "$ownerpw" 2>/dev/null || true
   tpm2_evictcontrol -Q -C o -c $context_ak -P "$ownerpw" 2>/dev/null || true
 
-  tpm2_nvundefine -Q   $handle_nv -C $handle_hier -P "$ownerpw" 2>/dev/null || true
+  tpm2_nvundefine -Q $handle_nv -C $handle_hier \
+  -P "$ownerpw" 2>/dev/null || true
 
   if [ $(ina "$@" "no-shut-down") -ne 0 ]; then
     shut_down
@@ -52,8 +53,8 @@ trap cleanup EXIT
 start_up
 cleanup "no-shut-down"
 
-echo "12345678" > $file_input_data
-echo "1234567890123456789012345678901" > $file_input_key
+echo 12345678 > $file_input_data
+echo 1234567890123456789012345678901 > $file_input_key
 
 getrandom() {
   loaded_randomness=`tpm2_getrandom --hex $1`
@@ -63,24 +64,28 @@ tpm2_changeauth -c o "$ownerpw"
 tpm2_changeauth -c e "$endorsepw"
 
 # Key generation
-tpm2_createek -Q -c $handle_ek -G $ek_alg -u $output_ek_pub_pem -f pem -p "$ekpw" -w "$ownerpw" -P "$endorsepw"
+tpm2_createek -Q -c $handle_ek -G $ek_alg -u $output_ek_pub_pem -f pem \
+-p "$ekpw" -w "$ownerpw" -P "$endorsepw"
 tpm2_readpublic -Q -c $handle_ek -o $output_ek_pub
 
-tpm2_createak -Q -C $handle_ek -c $context_ak -G $ak_alg -g $digestAlg\
-  -s $signAlg -u $output_ak_pub_pem -f pem -n $output_ak_pub_name -p "$akpw"\
-  -P "$endorsepw"
+tpm2_createak -Q -C $handle_ek -c $context_ak -G $ak_alg -g $digestAlg \
+-s $signAlg -u $output_ak_pub_pem -f pem -n $output_ak_pub_name -p "$akpw" \
+-P "$endorsepw"
 tpm2_readpublic -Q -c $context_ak -o $output_ak_pub
 
 
 # Validate keys (registrar)
 file_size=`stat --printf="%s" $output_ak_pub_name`
 loaded_key_name=`cat $output_ak_pub_name | xxd -p -c $file_size`
-tpm2_makecredential -Q -T none -e $output_ek_pub -s $file_input_data -n $loaded_key_name -o $output_mkcredential
+tpm2_makecredential -Q -T none -e $output_ek_pub -s $file_input_data \
+-n $loaded_key_name -o $output_mkcredential
 
 TPM2_RH_ENDORSEMENT=0x4000000B
 tpm2_startauthsession --policy-session -S session.ctx
 tpm2_policysecret -S session.ctx -c $TPM2_RH_ENDORSEMENT $endorsepw
-tpm2_activatecredential -Q -c $context_ak -C $handle_ek -i $output_mkcredential -o $output_actcredential -p "$akpw" -P "session:session.ctx"
+tpm2_activatecredential -Q -c $context_ak -C $handle_ek \
+-i $output_mkcredential -o $output_actcredential -p "$akpw" \
+-P "session:session.ctx"
 tpm2_flushcontext session.ctx
 diff $file_input_data $output_actcredential
 
@@ -90,16 +95,20 @@ tpm2_pcrreset -Q $debug_pcr
 tpm2_pcrextend -Q $debug_pcr:sha256=$rand_pcr_value
 tpm2_pcrread -Q
 getrandom 20
-tpm2_quote -Q -c $context_ak -l $digestAlg:$debug_pcr_list -q $loaded_randomness -m $output_quote -s $output_quotesig -o $output_quotepcr -g $digestAlg -p "$akpw"
+tpm2_quote -Q -c $context_ak -l $digestAlg:$debug_pcr_list \
+-q $loaded_randomness -m $output_quote -s $output_quotesig -o $output_quotepcr \
+-g $digestAlg -p "$akpw"
 
 
 # Verify quote
-tpm2_checkquote -Q -u $output_ak_pub_pem -m $output_quote -s $output_quotesig -f $output_quotepcr -g $digestAlg -q $loaded_randomness
+tpm2_checkquote -Q -u $output_ak_pub_pem -m $output_quote -s $output_quotesig \
+-f $output_quotepcr -g $digestAlg -q $loaded_randomness
 
 
 # Save U key from verifier
-tpm2_nvdefine -Q   $handle_nv -C $handle_hier -s 32 -a "ownerread|ownerwrite" -p "indexpass" -P "$ownerpw"
-tpm2_nvwrite -Q   $handle_nv -C $handle_hier -P "$ownerpw" -i $file_input_key
-tpm2_nvread -Q   $handle_nv -C $handle_hier -s 32 -P "$ownerpw"
+tpm2_nvdefine -Q $handle_nv -C $handle_hier -s 32 -a "ownerread|ownerwrite" \
+-p "indexpass" -P "$ownerpw"
+tpm2_nvwrite -Q $handle_nv -C $handle_hier -P "$ownerpw" -i $file_input_key
+tpm2_nvread -Q $handle_nv -C $handle_hier -s 32 -P "$ownerpw"
 
 exit 0

--- a/test/integration/tests/certify.sh
+++ b/test/integration/tests/certify.sh
@@ -4,7 +4,7 @@ source helpers.sh
 
 cleanup() {
     rm -f primary.ctx certify.ctx certify.pub certify.priv certify.name \
-          attest.out sig.out &>/dev/null
+    attest.out sig.out &>/dev/null
 
     if [ "$1" != "no-shut-down" ]; then
         shut_down
@@ -20,9 +20,10 @@ tpm2_clear -Q
 
 tpm2_createprimary -Q -C e -g sha256 -G rsa -c primary.ctx
 
-tpm2_create -Q -g sha256 -G rsa -u certify.pub -r certify.priv  -C primary.ctx
+tpm2_create -Q -g sha256 -G rsa -u certify.pub -r certify.priv -C primary.ctx
 
-tpm2_load -Q -C primary.ctx -u certify.pub -r certify.priv -n certify.name -c certify.ctx
+tpm2_load -Q -C primary.ctx -u certify.pub -r certify.priv -n certify.name \
+-c certify.ctx
 
 tpm2_certify -Q -C primary.ctx -c certify.ctx -g sha256 -o attest.out -s sig.out
 

--- a/test/integration/tests/checkquote.sh
+++ b/test/integration/tests/checkquote.sh
@@ -20,10 +20,8 @@ output_quotesig=quotesig.out
 output_quotepcr=quotepcr.out
 
 cleanup() {
-  rm -f $output_ek_pub_pem \
-        $output_ak_pub_pem $output_ak_pub_name \
-        $output_quote $output_quotesig $output_quotepcr rand.out \
-        $ak_ctx
+  rm -f $output_ek_pub_pem $output_ak_pub_pem $output_ak_pub_name \
+  $output_quote $output_quotesig $output_quotepcr rand.out $ak_ctx
 
   tpm2_pcrreset 16
   tpm2_evictcontrol -C o -c $handle_ek 2>/dev/null || true
@@ -49,15 +47,17 @@ getrandom() {
 # Key generation
 tpm2_createek -c $handle_ek -G $ek_alg -u $output_ek_pub_pem -f pem -p "$ekpw"
 
-tpm2_createak -C $handle_ek -c $ak_ctx -G $ak_alg -g $digestAlg -s $signAlg\
-  -u $output_ak_pub_pem -f pem -n $output_ak_pub_name -p "$akpw"
+tpm2_createak -C $handle_ek -c $ak_ctx -G $ak_alg -g $digestAlg -s $signAlg \
+-u $output_ak_pub_pem -f pem -n $output_ak_pub_name -p "$akpw"
 tpm2_evictcontrol -Q -c $ak_ctx $handle_ak
 
 # Quoting
 getrandom 20
-tpm2_quote -c $handle_ak -l sha256:15,16,22 -q $loaded_randomness -m $output_quote -s $output_quotesig -o $output_quotepcr -g $digestAlg -p "$akpw"
+tpm2_quote -c $handle_ak -l sha256:15,16,22 -q $loaded_randomness \
+-m $output_quote -s $output_quotesig -o $output_quotepcr -g $digestAlg -p "$akpw"
 
 # Verify quote
-tpm2_checkquote -u $output_ak_pub_pem -m $output_quote -s $output_quotesig -f $output_quotepcr -g $digestAlg -q $loaded_randomness
+tpm2_checkquote -u $output_ak_pub_pem -m $output_quote -s $output_quotesig \
+-f $output_quotepcr -g $digestAlg -q $loaded_randomness
 
 exit 0

--- a/test/integration/tests/create.sh
+++ b/test/integration/tests/create.sh
@@ -27,7 +27,8 @@ tpm2_createprimary -Q -C o -g sha1 -G rsa -c context.out
 # values.
 for gAlg in `populate_hash_algs`; do
     for GAlg in rsa keyedhash ecc aes; do
-        echo "tpm2_create -Q -C context.out -g $gAlg -G $GAlg -u key.pub -r key.priv"
+        echo "tpm2_create -Q -C context.out -g $gAlg -G $GAlg -u key.pub \
+        -r key.priv"
         tpm2_create -Q -C context.out -g $gAlg -G $GAlg -u key.pub -r key.priv
         cleanup "keep-context" "no-shut-down"
     done
@@ -35,11 +36,11 @@ done
 
 cleanup "keep-context" "no-shut-down"
 
-policy_orig="f28230c080bbe417141199e36d18978228d8948fc10a6a24921b9eba6bb1d988"
+policy_orig=f28230c080bbe417141199e36d18978228d8948fc10a6a24921b9eba6bb1d988
 echo "$policy_orig" | xxd -r -p > policy.bin
 
-tpm2_create -C context.out -g sha256 -G rsa -L policy.bin -u key.pub -r key.priv \
-  -a 'sign|fixedtpm|fixedparent|sensitivedataorigin' > out.pub
+tpm2_create -C context.out -g sha256 -G rsa -L policy.bin -u key.pub \
+-r key.priv -a 'sign|fixedtpm|fixedparent|sensitivedataorigin' > out.pub
 
 policy_new=$(yaml_get_kv out.pub "authorization policy")
 

--- a/test/integration/tests/createak.sh
+++ b/test/integration/tests/createak.sh
@@ -25,10 +25,12 @@ cleanup "no-shut-down"
 
 tpm2_createek -Q -c 0x8101000b -G rsa -u ek.pub
 
-tpm2_createak -Q -C 0x8101000b -c ak.ctx -G rsa -g sha256 -s rsassa -u ak.pub -n ak.name
+tpm2_createak -Q -C 0x8101000b -c ak.ctx -G rsa -g sha256 -s rsassa -u ak.pub \
+-n ak.name
 
 # Find a vacant persistent handle
-tpm2_createak -C 0x8101000b -c ak.ctx -G rsa -g sha256 -s rsassa -u ak.pub -n ak.name
+tpm2_createak -C 0x8101000b -c ak.ctx -G rsa -g sha256 -s rsassa -u ak.pub \
+-n ak.name
 tpm2_evictcontrol -c ak.ctx > ak.log
 phandle=`yaml_get_kv ak.log "persistent-handle"`
 tpm2_evictcontrol -Q -C o -c $phandle

--- a/test/integration/tests/createek.sh
+++ b/test/integration/tests/createek.sh
@@ -37,14 +37,18 @@ ek_nonce_index=0x01c00003
 ek_template_index=0x01c00004
 
 # Define RSA EK template
-nbytes=$(wc -c $TPM2_TOOLS_TEST_FIXTURES/ek-template-default.bin | cut -f1 -d' ')
-tpm2_nvdefine -Q   $ek_template_index -C o -s $nbytes -a "ownerread|policywrite|ownerwrite"
-tpm2_nvwrite -Q   $ek_template_index -C o -i $TPM2_TOOLS_TEST_FIXTURES/ek-template-default.bin
+nbytes=$(wc -c $TPM2_TOOLS_TEST_FIXTURES/ek-template-default.bin | \
+cut -f1 -d' ')
+tpm2_nvdefine -Q $ek_template_index -C o -s $nbytes \
+-a "ownerread|policywrite|ownerwrite"
+tpm2_nvwrite -Q $ek_template_index -C o \
+-i $TPM2_TOOLS_TEST_FIXTURES/ek-template-default.bin
 
 # Define RSA EK nonce
 echo -n -e '\0' > ek.nonce
-tpm2_nvdefine -Q   $ek_nonce_index -C o -s 1 -a "ownerread|policywrite|ownerwrite"
-tpm2_nvwrite -Q   $ek_nonce_index -C o -i ek.nonce
+tpm2_nvdefine -Q $ek_nonce_index -C o -s 1 \
+-a "ownerread|policywrite|ownerwrite"
+tpm2_nvwrite -Q $ek_nonce_index -C o -i ek.nonce
 
 tpm2_createek -t -G rsa -u ek.pub -c ek.ctx
 

--- a/test/integration/tests/createpolicy.sh
+++ b/test/integration/tests/createpolicy.sh
@@ -15,11 +15,14 @@ trap cleanup EXIT
 
 start_up
 
-declare -A digestlengths=(["sha1"]=20 ["sha256"]=32)
-declare -A expected_policy_digest=(["sha1"]="f28230c080bbe417141199e36d18978228d8948fc10a6a24921b9eba6bb1d988"
-                                   ["sha256"]="33e36e786c878632494217c3f490e74ca0a3a122a8a4f3c5302500df3b32b3b8")
+declare -A digestlengths=\
+([sha1]=20
+ [sha256]=32)
+declare -A expected_policy_digest=\
+([sha1]=f28230c080bbe417141199e36d18978228d8948fc10a6a24921b9eba6bb1d988
+ [sha256]=33e36e786c878632494217c3f490e74ca0a3a122a8a4f3c5302500df3b32b3b8)
 
-tpm2_pcrread -V "sha1"
+tpm2_pcrread -V sha1
 
 for halg in ${!digestlengths[@]}
 do
@@ -32,8 +35,10 @@ do
     tpm2_createpolicy --policy-pcr -l $halg:0 -f pcr.in -L policy.out
 
     # Test the policy creation hashes against expected
-    if [ $(xxd -p policy.out | tr -d '\n' ) != "${expected_policy_digest[${halg}]}" ]; then
-        echo "Failure: Creating Policy Digest with PCR policy for index 0 and ${halg} pcr index hash"
+    if [ $(xxd -p policy.out | tr -d '\n' ) != \
+    "${expected_policy_digest[${halg}]}" ]; then
+        echo "Failure: Creating Policy Digest with PCR policy for index 0 and \
+        ${halg} pcr index hash"
         echo "Got: $(xxd -p policy.out | tr -d '\n')"
         echo "Expected: ${expected_policy_digest[${halg}]}"
         exit 1

--- a/test/integration/tests/createprimary.sh
+++ b/test/integration/tests/createprimary.sh
@@ -34,7 +34,7 @@ for gAlg in `populate_hash_algs 'and alg != "keyedhash"'`; do
     done
 done
 
-policy_orig="f28230c080bbe417141199e36d18978228d8948fc10a6a24921b9eba6bb1d988"
+policy_orig=f28230c080bbe417141199e36d18978228d8948fc10a6a24921b9eba6bb1d988
 
 #test for createprimary objects with policy authorization structures
 echo -n "$policy_orig" | xxd -r -p > policy.bin
@@ -54,8 +54,8 @@ printf '\x00\x01' > ud.1
 dd if=/dev/zero bs=256 count=1 of=ud.2
 cat ud.1 ud.2 > unique.dat
 tpm2_createprimary -C o -G rsa2048:aes128cfb -g sha256 -c prim.ctx \
-  -a 'restricted|decrypt|fixedtpm|fixedparent|sensitivedataorigin|userwithauth|noda' \
-  -u unique.dat
+-a "restricted|decrypt|fixedtpm|fixedparent|sensitivedataorigin|userwithauth|\
+noda" -u unique.dat
 test -f prim.ctx
 
 # Test that -g/-G do not need to be specified.

--- a/test/integration/tests/dictionarylockout.sh
+++ b/test/integration/tests/dictionarylockout.sh
@@ -21,7 +21,8 @@ tpm2_dictionarylockout -s -n 5 -t 6 -l 7
 tpm2_getcap properties-variable > $out
 v=$(yaml_get_kv "$out" "TPM2_PT_MAX_AUTH_FAIL")
 if [ $v -ne 5 ];then
-  echo "Failure: setting up the number of allowed tries in the lockout parameters"
+  echo "Failure: setting up the number of allowed tries in the lockout \
+  parameters"
   exit 1
 fi
 
@@ -33,7 +34,8 @@ fi
 
 v=$(yaml_get_kv "$out" "TPM2_PT_LOCKOUT_RECOVERY")
 if [ $v -ne 7 ];then
-  echo "Failure: setting up the lockout recovery period in the lockout parameters"
+  echo "Failure: setting up the lockout recovery period in the lockout \
+  parameters"
   exit 1
 fi
 

--- a/test/integration/tests/duplicate.sh
+++ b/test/integration/tests/duplicate.sh
@@ -3,13 +3,9 @@
 source helpers.sh
 
 cleanup() {
-    rm -f primary.ctx \
-          new_parent.prv new_parent.pub new_parent.ctx \
-          policy.dat session.dat \
-          key.prv key.pub key.ctx \
-          duppriv.bin dupseed.dat \
-          key2.prv key2.pub key2.ctx \
-          sym_key_in.bin
+    rm -f primary.ctx new_parent.prv new_parent.pub new_parent.ctx policy.dat \
+    session.dat key.prv key.pub key.ctx duppriv.bin dupseed.dat key2.prv \
+    key2.pub key2.ctx sym_key_in.bin
 
     if [ "$1" != "no-shut-down" ]; then
           shut_down
@@ -45,59 +41,71 @@ dd if=/dev/urandom of=sym_key_in.bin bs=1 count=16 status=none
 tpm2_createprimary -Q -C o -g sha256 -G rsa -c primary.ctx
 
 # Create a new parent, we will only use the public portion
-tpm2_create -Q -C primary.ctx -g sha256 -G rsa -r new_parent.prv -u new_parent.pub -a "decrypt|fixedparent|fixedtpm|restricted|sensitivedataorigin"
+tpm2_create -Q -C primary.ctx -g sha256 -G rsa -r new_parent.prv \
+-u new_parent.pub -a "decrypt|fixedparent|fixedtpm|restricted|\
+sensitivedataorigin"
 
 # Create the key we want to duplicate
 create_duplication_policy
-tpm2_create -Q -C primary.ctx -g sha256 -G rsa -r key.prv -u key.pub -L policy.dat -a "sensitivedataorigin|sign|decrypt"
+tpm2_create -Q -C primary.ctx -g sha256 -G rsa -r key.prv -u key.pub \
+-L policy.dat -a "sensitivedataorigin|sign|decrypt"
 tpm2_load -Q -C primary.ctx -r key.prv -u key.pub -c key.ctx
 
 tpm2_loadexternal -Q -C o -u new_parent.pub -c new_parent.ctx
 
 ## Null parent, Null Sym Alg
 start_duplication_session
-tpm2_duplicate -Q -C null -c key.ctx -G null -p "session:session.dat" -r dupprv.bin -s dupseed.dat
+tpm2_duplicate -Q -C null -c key.ctx -G null -p "session:session.dat" \
+-r dupprv.bin -s dupseed.dat
 end_duplication_session
 
 ## Null Sym Alg
 start_duplication_session
-tpm2_duplicate -Q -C new_parent.ctx -c key.ctx -G null -p "session:session.dat" -r dupprv.bin -s dupseed.dat
+tpm2_duplicate -Q -C new_parent.ctx -c key.ctx -G null \
+-p "session:session.dat" -r dupprv.bin -s dupseed.dat
 end_duplication_session
 
 ## Null parent
 start_duplication_session
-tpm2_duplicate -Q -C null -c key.ctx -G aes -i sym_key_in.bin -p "session:session.dat" -r dupprv.bin -s dupseed.dat
+tpm2_duplicate -Q -C null -c key.ctx -G aes -i sym_key_in.bin \
+-p "session:session.dat" -r dupprv.bin -s dupseed.dat
 end_duplication_session
 
 ## AES Sym Alg, user supplied key
 start_duplication_session
-tpm2_duplicate -Q -C new_parent.ctx -c key.ctx -G aes -i sym_key_in.bin -p "session:session.dat" -r dupprv.bin -s dupseed.dat
+tpm2_duplicate -Q -C new_parent.ctx -c key.ctx -G aes -i sym_key_in.bin \
+-p "session:session.dat" -r dupprv.bin -s dupseed.dat
 end_duplication_session
 
 ## AES Sym Alg, no user supplied key
 start_duplication_session
-tpm2_duplicate -Q -C new_parent.ctx -c key.ctx -G aes -o sym_key_out.bin -p "session:session.dat" -r dupprv.bin -s dupseed.dat
+tpm2_duplicate -Q -C new_parent.ctx -c key.ctx -G aes -o sym_key_out.bin \
+-p "session:session.dat" -r dupprv.bin -s dupseed.dat
 end_duplication_session
 
 ## Repeat the tests with a key that requires encrypted duplication
-tpm2_create -Q -C primary.ctx -g sha256 -G rsa -r key2.prv -u key2.pub -L policy.dat -a "sensitivedataorigin|sign|decrypt|encryptedduplication"
+tpm2_create -Q -C primary.ctx -g sha256 -G rsa -r key2.prv -u key2.pub \
+-L policy.dat -a "sensitivedataorigin|sign|decrypt|encryptedduplication"
 tpm2_load -Q -C primary.ctx -r key2.prv -u key2.pub -c key2.ctx
 
 ## AES Sym Alg, user supplied key
 start_duplication_session
-tpm2_duplicate -Q -C new_parent.ctx -c key2.ctx -G aes -i sym_key_in.bin -p "session:session.dat" -r dupprv.bin -s dupseed.dat
+tpm2_duplicate -Q -C new_parent.ctx -c key2.ctx -G aes -i sym_key_in.bin \
+-p "session:session.dat" -r dupprv.bin -s dupseed.dat
 end_duplication_session
 
 ## AES Sym Alg, no user supplied key
 start_duplication_session
-tpm2_duplicate -Q -C new_parent.ctx -c key2.ctx -G aes -o sym_key_out.bin -p "session:session.dat" -r dupprv.bin -s dupseed.dat
+tpm2_duplicate -Q -C new_parent.ctx -c key2.ctx -G aes -o sym_key_out.bin \
+-p "session:session.dat" -r dupprv.bin -s dupseed.dat
 end_duplication_session
 
 trap - ERR
 
 ## Null parent - should fail (TPM_RC_HIERARCHY)
 start_duplication_session
-tpm2_duplicate -Q -C null -c key2.ctx -G aes -i sym_key_in.bin -p "session:session.dat" -r dupprv.bin -s dupseed.dat
+tpm2_duplicate -Q -C null -c key2.ctx -G aes -i sym_key_in.bin \
+-p "session:session.dat" -r dupprv.bin -s dupseed.dat
 if [ $? -eq 0 ]; then
   echo "Expected \"tpm2_duplicate -C null \" to fail."
   exit 1
@@ -106,7 +114,8 @@ dump_duplication_session
 
 ## Null Sym Alg - should fail (TPM_RC_SYMMETRIC)
 start_duplication_session
-tpm2_duplicate -Q -C new_parent.ctx -c key2.ctx -G null -p "session:session.dat" -r dupprv.bin -s dupseed.dat
+tpm2_duplicate -Q -C new_parent.ctx -c key2.ctx -G null \
+-p "session:session.dat" -r dupprv.bin -s dupseed.dat
 if [ $? -eq 0 ]; then
   echo "Expected \"tpm2_duplicate -G null \" to fail."
   exit 1

--- a/test/integration/tests/evictcontrol.sh
+++ b/test/integration/tests/evictcontrol.sh
@@ -20,7 +20,7 @@ tpm2_clear -Q
 
 tpm2_createprimary -Q -C e -g sha256 -G rsa -c primary.ctx
 
-tpm2_create -Q -g sha256 -G aes -u key.pub -r key.priv  -C primary.ctx
+tpm2_create -Q -g sha256 -G aes -u key.pub -r key.priv -C primary.ctx
 
 tpm2_load -Q -C primary.ctx  -u key.pub  -r key.priv -n key.name -c key.dat
 

--- a/test/integration/tests/getekcertificate.sh
+++ b/test/integration/tests/getekcertificate.sh
@@ -31,22 +31,26 @@ bc3e1d4084e835c7c8906a1c05b4d2d30fdbebc1dbad950fa6b165bd4b6a
 if [ -z "$(curl -V 2>/dev/null)" ]; then
     echo "curl is not not installed. Skipping connection check."
 else
-    if [ "$(curl --silent --output /dev/null --write-out %{http_code} 'https://ekop.intel.com/')" != '200' ]; then
+    if [ "$(curl --silent --output /dev/null --write-out %{http_code} \
+    'https://ekop.intel.com/')" != '200' ]; then
         echo 'No connection to https://ekop.intel.com/'
         exit 77
     fi
 fi
 
-tpm2_getekcertificate -u test_ek.pub -x -X https://ekop.intel.com/ekcertservice/ -o ECcert.bin
+tpm2_getekcertificate -u test_ek.pub -x -X -o ECcert.bin \
+https://ekop.intel.com/ekcertservice/
 
 # Test that stdoutput is the same
-tpm2_getekcertificate -u test_ek.pub -x -X https://ekop.intel.com/ekcertservice/ > ECcert2.bin
+tpm2_getekcertificate -u test_ek.pub -x https://ekop.intel.com/ekcertservice/ \
+-X > ECcert2.bin
 
 # stdout file should match -E file.
 cmp ECcert.bin ECcert2.bin
 
 # Retrieved certificate should be valid
-if [ $(md5sum ECcert.bin| awk '{ print $1 }') != "56af9eb8a271bbf7ac41b780acd91ff5" ]; then
+if [ $(md5sum ECcert.bin| awk '{ print $1 }') != \
+"56af9eb8a271bbf7ac41b780acd91ff5" ]; then
  echo "Failed: retrieving endorsement certificate"
  exit 1
 fi

--- a/test/integration/tests/hash.sh
+++ b/test/integration/tests/hash.sh
@@ -24,8 +24,8 @@ cleanup "no-shut-down"
 
 echo "T0naX0u123abc" > $hash_in_file
 
-# Test with ticket and hash output files (binary) and verify that the output hash
-# is correct. Ticket is not stable and changes run to run, don't verify it.
+# Test with ticket and hash output files (binary) and verify that the output
+# hash is correct. Ticket is not stable and changes run to run, don't verify it.
 tpm2_hash -C e -g sha1 -o $hash_out_file -t $ticket_file $hash_in_file
 
 expected=`sha1sum $hash_in_file | awk '{print $1}'`
@@ -35,7 +35,7 @@ test "$expected" == "$actual"
 
 cleanup "no-shut-down"
 
-# Test platform hierarchy with multiple files and verify output against sha256sum
+# Test platform hierarchy with multiple files & verify output against sha256sum
 # Test a file redirection as well. Output files are binary.
 echo "T0naX0u123abc" > $hash_in_file
 tpm2_hash -C p -g sha256 -o $hash_out_file -t $ticket_file < $hash_in_file
@@ -59,7 +59,8 @@ if [ "$tpm_hash_val" != "$sha1sum_val" ]; then
   exit 1
 fi
 
-# Test a file that cannot be done in 1 update call. The tpm works on a 1024 block size.
+# Test a file that cannot be done in 1 update call.
+# The tpm works on a 1024 block size.
 dd if=/dev/urandom of=$hash_in_file bs=2093 count=1 2>/dev/null
 tpm_hash_val=`tpm2_hash --hex $hash_in_file`
 sha1sum_val=`sha1sum $hash_in_file | cut -d\  -f 1-2 | tr -d '[:space:]'`

--- a/test/integration/tests/hmac.sh
+++ b/test/integration/tests/hmac.sh
@@ -24,8 +24,8 @@ cleanup() {
 
   if [ $(ina "$@" "keep-context") -ne 0 ]; then
     rm -f $file_hmac_key_ctx $file_input_data
-    # attempt to evict the hmac persistent key handle, but don't cause failures if this fails
-    # as it may not be loaded.
+    # attempt to evict the hmac persistent key handle, but don't cause failures
+    # if this fails as it may not be loaded.
     tpm2_evictcontrol -c $file_hmac_key_handle 2>/dev/null || true
   fi
 
@@ -43,16 +43,20 @@ echo "12345678" > $file_input_data
 
 tpm2_clear
 
-tpm2_createprimary -Q -C e -g $alg_primary_obj -G $alg_primary_key -c $file_primary_key_ctx
+tpm2_createprimary -Q -C e -g $alg_primary_obj -G $alg_primary_key \
+-c $file_primary_key_ctx
 
-tpm2_create -Q -G $alg_create_key -u $file_hmac_key_pub -r $file_hmac_key_priv  -C $file_primary_key_ctx
+tpm2_create -Q -G $alg_create_key -u $file_hmac_key_pub -r $file_hmac_key_priv \
+-C $file_primary_key_ctx
 
-tpm2_load -Q -C $file_primary_key_ctx  -u $file_hmac_key_pub  -r $file_hmac_key_priv -n $file_hmac_key_name -c $file_hmac_key_ctx
+tpm2_load -Q -C $file_primary_key_ctx -u $file_hmac_key_pub \
+-r $file_hmac_key_priv -n $file_hmac_key_name -c $file_hmac_key_ctx
 
 # verify that persistent object can be used via a serialized handle
 tpm2_evictcontrol -C o -c $file_hmac_key_ctx -o $file_hmac_key_handle
 
-cat $file_input_data | tpm2_hmac -Q -c $file_hmac_key_handle -o $file_hmac_output
+cat $file_input_data | tpm2_hmac -Q -c $file_hmac_key_handle \
+-o $file_hmac_output
 
 cleanup "keep-context" "no-shut-down"
 
@@ -70,16 +74,20 @@ echo "12345678" > $file_input_data
 
 tpm2_clear
 
-tpm2_createprimary -Q -C e -g $alg_primary_obj -G $alg_primary_key -c $file_primary_key_ctx
+tpm2_createprimary -Q -C e -g $alg_primary_obj -G $alg_primary_key \
+-c $file_primary_key_ctx
 
-tpm2_create -Q -G $alg_create_key -u $file_hmac_key_pub -r $file_hmac_key_priv  -C $file_primary_key_ctx
+tpm2_create -Q -G $alg_create_key -u $file_hmac_key_pub -r $file_hmac_key_priv \
+-C $file_primary_key_ctx
 
-tpm2_load -Q -C $file_primary_key_ctx  -u $file_hmac_key_pub  -r $file_hmac_key_priv -n $file_hmac_key_name -c $file_hmac_key_ctx
+tpm2_load -Q -C $file_primary_key_ctx -u $file_hmac_key_pub \
+-r $file_hmac_key_priv -n $file_hmac_key_name -c $file_hmac_key_ctx
 
 cat $file_input_data | tpm2_hmac -Q -c $file_hmac_key_ctx -o $file_hmac_output
 
 # test ticket option
-cat $file_input_data | tpm2_hmac -Q -c $file_hmac_key_ctx -o $file_hmac_output -t ticket.out
+cat $file_input_data | tpm2_hmac -Q -c $file_hmac_key_ctx -o $file_hmac_output \
+-t ticket.out
 test -f ticket.out
 
 # test no output file

--- a/test/integration/tests/import_tpm.sh
+++ b/test/integration/tests/import_tpm.sh
@@ -39,20 +39,23 @@ end_session() {
 
 create_load_new_parent() {
     # Create new parent
-    tpm2_create -Q -C primary.ctx -g sha256 -G rsa -r new_parent.prv -u new_parent.pub  -a "restricted|sensitivedataorigin|decrypt|userwithauth"
+    tpm2_create -Q -C primary.ctx -g sha256 -G rsa -r new_parent.prv \
+    -u new_parent.pub -a "restricted|sensitivedataorigin|decrypt|userwithauth"
     # Load new parent key, only the public part
     tpm2_loadexternal -Q -C o -u new_parent.pub -c new_parent.ctx
 }
 
 load_new_parent() {
     # Load new parent key, public & private parts
-    tpm2_load -Q -C primary.ctx -r new_parent.prv -u new_parent.pub -c new_parent.ctx
+    tpm2_load -Q -C primary.ctx -r new_parent.prv -u new_parent.pub \
+    -c new_parent.ctx
 }
 
 create_load_duplicatee() {
     # Create the key we want to duplicate
     create_policy dpolicy.dat duplicate
-    tpm2_create -Q -C primary.ctx -g sha256 -G $1 -p foo -r key.prv -u key.pub -L dpolicy.dat -a "sensitivedataorigin|decrypt|userwithauth"
+    tpm2_create -Q -C primary.ctx -g sha256 -G $1 -p foo -r key.prv -u key.pub \
+    -L dpolicy.dat -a "sensitivedataorigin|decrypt|userwithauth"
     # Load the key
     tpm2_load -Q -C primary.ctx -r key.prv -u key.pub -c key.ctx
     # Extract the public part for import later
@@ -63,9 +66,11 @@ do_duplication() {
     start_session dpolicy.dat duplicate
     if [ "$2" = "aes" ]
     then
-        tpm2_duplicate -Q -C new_parent.ctx -c key.ctx -G aes -o sym.key -p "session:session.dat" -r dup.dup -s dup.seed
+        tpm2_duplicate -Q -C new_parent.ctx -c key.ctx -G aes -o sym.key \
+        -p "session:session.dat" -r dup.dup -s dup.seed
     else
-        tpm2_duplicate -Q -C new_parent.ctx -c key.ctx -G null -p "session:session.dat" -r dup.dup -s dup.seed
+        tpm2_duplicate -Q -C new_parent.ctx -c key.ctx -G null \
+        -p "session:session.dat" -r dup.dup -s dup.seed
     fi
     end_session
 }
@@ -73,9 +78,11 @@ do_duplication() {
 do_import_load() {
     if [ "$2" = "aes" ]
     then
-        tpm2_import -Q -C new_parent.ctx -k sym.key -u dup.pub -i dup.dup -r dup.prv -s dup.seed  -L dpolicy.dat
+        tpm2_import -Q -C new_parent.ctx -k sym.key -u dup.pub -i dup.dup \
+        -r dup.prv -s dup.seed -L dpolicy.dat
     else
-        tpm2_import -Q -C new_parent.ctx -u dup.pub -i dup.dup -r dup.prv -s dup.seed  -L dpolicy.dat
+        tpm2_import -Q -C new_parent.ctx -u dup.pub -i dup.dup -r dup.prv \
+        -s dup.seed -L dpolicy.dat
     fi
     tpm2_load -Q -C new_parent.ctx -r dup.prv -u dup.pub -c dup.ctx
 }

--- a/test/integration/tests/incrementalselftest.sh
+++ b/test/integration/tests/incrementalselftest.sh
@@ -51,8 +51,10 @@ hashalgs="$(populate_algs "details['hash'] and not details['method'] \
                                         and not details['signing'] \
                                         and not details['symmetric'] \
                                         and alg is not None")"
-eccmethods="$(populate_algs "details['signing'] and not details['hash'] and \"ec\" in alg")"
-rsamethods="$(populate_algs "details['signing'] and not details['hash'] and \"rsa\" in alg")"
+eccmethods="$(populate_algs "details['signing'] and not details['hash'] \
+and \"ec\" in alg")"
+rsamethods="$(populate_algs "details['signing'] and not details['hash'] \
+and \"rsa\" in alg")"
 
 # Check testing of AES modes
 tpm2_incrementalselftest ${aesmodes} | grep -q "complete"

--- a/test/integration/tests/load.sh
+++ b/test/integration/tests/load.sh
@@ -14,8 +14,10 @@ alg_load=sha1
 file_primary_key_ctx=context.p_"$alg_primary_obj"_"$alg_primary_key"
 file_load_key_pub=opu_"$alg_create_obj"_"$alg_create_key"
 file_load_key_priv=opr_"$alg_create_obj"_"$alg_create_key"
-file_load_key_name=name.load_"$alg_primary_obj"_"$alg_primary_key"-"$alg_create_obj"_"$alg_create_key"
-file_load_key_ctx=ctx_load_out_"$alg_primary_obj"_"$alg_primary_key"-"$alg_create_obj"_"$alg_create_key"
+file_load_key_name=name.load_"$alg_primary_obj"_"$alg_primary_key"-\
+"$alg_create_obj"_"$alg_create_key"
+file_load_key_ctx=ctx_load_out_"$alg_primary_obj"_"$alg_primary_key"-\
+"$alg_create_obj"_"$alg_create_key"
 file_load_output=load_"$file_load_key_ctx"
 
 Handle_parent=0x81010018
@@ -23,7 +25,8 @@ Handle_ek_load=0x81010017
 
 cleanup() {
 
-  rm -f $file_load_key_pub $file_load_key_priv $file_load_key_name $file_load_key_ctx
+  rm -f $file_load_key_pub $file_load_key_priv $file_load_key_name \
+  $file_load_key_ctx
 
   tpm2_evictcontrol -Q -Co -c $Handle_parent 2>/dev/null || true
 
@@ -43,11 +46,14 @@ tpm2_clear
 
 #####file test
 
-tpm2_createprimary -Q -C e -g $alg_primary_obj -G $alg_primary_key -c $file_primary_key_ctx
+tpm2_createprimary -Q -C e -g $alg_primary_obj -G $alg_primary_key \
+-c $file_primary_key_ctx
 
-tpm2_create -Q -g $alg_create_obj -G $alg_create_key -u $file_load_key_pub -r $file_load_key_priv  -C $file_primary_key_ctx
+tpm2_create -Q -g $alg_create_obj -G $alg_create_key -u $file_load_key_pub \
+-r $file_load_key_priv -C $file_primary_key_ctx
 
-tpm2_load -Q -C $file_primary_key_ctx  -u $file_load_key_pub  -r $file_load_key_priv -n $file_load_key_name -c $file_load_key_ctx
+tpm2_load -Q -C $file_primary_key_ctx -u $file_load_key_pub \
+-r $file_load_key_priv -n $file_load_key_name -c $file_load_key_ctx
 
 #####handle test
 
@@ -55,8 +61,10 @@ cleanup "keep_ctx" "no-shut-down"
 
 tpm2_evictcontrol -Q -C o -c $file_primary_key_ctx $Handle_parent
 
-tpm2_create -Q -C $Handle_parent   -g $alg_create_obj  -G $alg_create_key -u $file_load_key_pub  -r  $file_load_key_priv
+tpm2_create -Q -C $Handle_parent -g $alg_create_obj -G $alg_create_key \
+-u $file_load_key_pub  -r $file_load_key_priv
 
-tpm2_load -Q -C $Handle_parent   -u $file_load_key_pub  -r $file_load_key_priv -n $file_load_key_name -c $file_load_key_ctx
+tpm2_load -Q -C $Handle_parent -u $file_load_key_pub -r $file_load_key_priv \
+-n $file_load_key_name -c $file_load_key_ctx
 
 exit 0

--- a/test/integration/tests/makecredential.sh
+++ b/test/integration/tests/makecredential.sh
@@ -16,8 +16,8 @@ output_ak_pub_name=ak_name_pub.out
 output_mkcredential=mkcredential.out
 
 cleanup() {
-    rm -f $output_ek_pub $output_ak_pub $output_ak_pub_name $output_mkcredential \
-          $file_input_data output_ak grep.txt $ak_ctx
+    rm -f $output_ek_pub $output_ak_pub $output_ak_pub_name \
+    $output_mkcredential $file_input_data output_ak grep.txt $ak_ctx
 
     tpm2_evictcontrol -Q -Co -c $handle_ek 2>/dev/null || true
 
@@ -35,15 +35,18 @@ echo "12345678" > $file_input_data
 
 tpm2_createek -Q -c $handle_ek -G $ek_alg -u $output_ek_pub
 
-tpm2_createak -Q -C $handle_ek -c $ak_ctx -G $ak_alg -g $digestAlg -s $signAlg -u $output_ak_pub -n $output_ak_pub_name
+tpm2_createak -Q -C $handle_ek -c $ak_ctx -G $ak_alg -g $digestAlg -s $signAlg \
+-u $output_ak_pub -n $output_ak_pub_name
 
 # Use -c in xxd so there is no line wrapping
 file_size=`stat --printf="%s" $output_ak_pub_name`
 Loadkeyname=`cat $output_ak_pub_name | xxd -p -c $file_size`
 
-tpm2_makecredential -Q -e $output_ek_pub  -s $file_input_data  -n $Loadkeyname -o $output_mkcredential
+tpm2_makecredential -Q -e $output_ek_pub -s $file_input_data -n $Loadkeyname \
+-o $output_mkcredential
 
 # use no tpm backend
-tpm2_makecredential -T none -Q -e $output_ek_pub  -s $file_input_data  -n $Loadkeyname -o $output_mkcredential
+tpm2_makecredential -T none -Q -e $output_ek_pub -s $file_input_data \
+-n $Loadkeyname -o $output_mkcredential
 
 exit 0

--- a/test/integration/tests/nvinc.sh
+++ b/test/integration/tests/nvinc.sh
@@ -29,7 +29,8 @@ cleanup "no-shut-down"
 
 tpm2_clear
 
-tpm2_nvdefine -Q   $nv_test_index -C o -s 8 -a "ownerread|policywrite|ownerwrite|nt=1"
+tpm2_nvdefine -Q   $nv_test_index -C o -s 8 \
+-a "ownerread|policywrite|ownerwrite|nt=1"
 
 tpm2_nvincrement -Q   $nv_test_index -C o
 
@@ -56,17 +57,23 @@ tpm2_nvundefine   $nv_test_index -C o
 
 tpm2_pcrread -Q -o $file_pcr_value $pcr_specification
 
-tpm2_createpolicy -Q --policy-pcr -l $pcr_specification -f $file_pcr_value -L $file_policy
+tpm2_createpolicy -Q --policy-pcr -l $pcr_specification \
+-f $file_pcr_value -L $file_policy
 
-tpm2_nvdefine -Q   0x1500016 -C 0x40000001 -s 8 -L $file_policy -a "policyread|policywrite|nt=1"
+tpm2_nvdefine -Q   0x1500016 -C 0x40000001 -s 8 -L $file_policy \
+-a "policyread|policywrite|nt=1"
 
-# Increment with index authorization for now, since tpm2_nvincrement does not support pcr policy.
+# Increment with index authorization for now, since tpm2_nvincrement does not
+# support pcr policy.
 echo -n -e '\x00\x00\x00\x00\x00\x00\x00\x03' > nv.test_inc
 
-# Counter is initialised to highest value previously seen (in this case 2) then incremented
-tpm2_nvincrement -Q   0x1500016 -C 0x1500016 -P pcr:$pcr_specification=$file_pcr_value
+# Counter is initialised to highest value previously seen (in this case 2) then
+# incremented
+tpm2_nvincrement -Q   0x1500016 -C 0x1500016 \
+-P pcr:$pcr_specification=$file_pcr_value
 
-tpm2_nvread   0x1500016 -C 0x1500016 -P pcr:$pcr_specification=$file_pcr_value -s 8 > cmp.dat
+tpm2_nvread   0x1500016 -C 0x1500016 -P pcr:$pcr_specification=$file_pcr_value \
+-s 8 > cmp.dat
 
 cmp nv.test_inc cmp.dat
 
@@ -81,7 +88,8 @@ tpm2_nvundefine -Q   0x1500016 -C 0x40000001
 #
 # Test NV access locked
 #
-tpm2_nvdefine -Q   $nv_test_index -C o -s 8 -a "ownerread|policywrite|ownerwrite|read_stclear|nt=1"
+tpm2_nvdefine -Q   $nv_test_index -C o -s 8 \
+-a "ownerread|policywrite|ownerwrite|read_stclear|nt=1"
 
 tpm2_nvincrement -Q   $nv_test_index -C o
 

--- a/test/integration/tests/output_formats.sh
+++ b/test/integration/tests/output_formats.sh
@@ -69,29 +69,35 @@ for fmt in tss pem der; do
 
 done
 
-tpm2_createak -Q -G $alg_ak -C $handle_ek -c $ak_ctx -u "$file_pubak_tss" -n "$file_pubak_name"
+tpm2_createak -Q -G $alg_ak -C $handle_ek -c $ak_ctx -u "$file_pubak_tss" \
+-n "$file_pubak_name"
 echo "tpm2_evictcontrol -Q -c $ak_ctx -o $handle_ak_file" $handle_ak
 tpm2_evictcontrol -Q -c $ak_ctx -o $handle_ak_file $handle_ak
 
 tpm2_readpublic -Q -c $handle_ak_file -f "pem" -o "$file_pubak_pem"
 
-tpm2_hash -Q -C e -g $alg_hash -t "$file_hash_ticket" -o "$file_hash_result" "$file_hash_input"
+tpm2_hash -Q -C e -g $alg_hash -t "$file_hash_ticket" -o "$file_hash_result" \
+"$file_hash_input"
 
 for fmt in tss plain; do
     this_sig="${file_sig_base}.${fmt}"
-    tpm2_sign -Q -c $handle_ak -g $alg_hash -f $fmt -o "${this_sig}" -t "${file_hash_ticket}" "${file_hash_input}"
+    tpm2_sign -Q -c $handle_ak -g $alg_hash -f $fmt -o "${this_sig}" \
+    -t "${file_hash_ticket}" "${file_hash_input}"
 
     if [ "$fmt" = plain ]; then
-        openssl dgst -verify "$file_pubak_pem" -keyform pem -${alg_hash} -signature "$this_sig" "$file_hash_input" > /dev/null
+        openssl dgst -verify "$file_pubak_pem" -keyform pem -${alg_hash} \
+        -signature "$this_sig" "$file_hash_input" > /dev/null
     fi
 done
 
 for fmt in tss plain; do
     this_sig="${file_quote_sig_base}.${fmt}"
-    tpm2_quote -Q -c $handle_ak -l "$alg_hash":0 -f $fmt -m "$file_quote_msg" -s "$this_sig"
+    tpm2_quote -Q -c $handle_ak -l "$alg_hash":0 -f $fmt -m "$file_quote_msg" \
+    -s "$this_sig"
 
     if [ "$fmt" = plain ]; then
-        openssl dgst -verify "$file_pubak_pem" -keyform pem -${alg_hash} -signature "$this_sig" "$file_quote_msg" > /dev/null
+        openssl dgst -verify "$file_pubak_pem" -keyform pem -${alg_hash} \
+        -signature "$this_sig" "$file_quote_msg" > /dev/null
     fi
 done
 

--- a/test/integration/tests/pcrallocate.sh
+++ b/test/integration/tests/pcrallocate.sh
@@ -16,7 +16,8 @@ start_up
 cleanup "no-shut-down"
 
 # Store the old banks because e.g. some TPM-simuators don't support SHA512
-OLDBANKS=$(tpm2_getcap pcrs | grep bank | sed 's/.*bank\: \(.*\)/+\1:all/' | tr -d "\n")
+OLDBANKS=$(tpm2_getcap pcrs | grep bank | sed 's/.*bank\: \(.*\)/+\1:all/' | \
+tr -d "\n")
 
 echo "OLDBANKS: $OLDBANKS"
 

--- a/test/integration/tests/pcrextend.sh
+++ b/test/integration/tests/pcrextend.sh
@@ -19,7 +19,7 @@ for alg in `tpm2_getcap pcrs | sed -r -e '1d' -e s/'\s+-\s+(\w+):.*'/'\1'/g`; do
 
   hash=${alg_hashes[$alg]}
 
-  if [ ! -z  $digests ]; then
+  if [ ! -z $digests ]; then
       digests="$digests,"
   fi
 
@@ -47,7 +47,8 @@ else
     true
 fi
 
-oversizedspec="sha1=$(tpm2_pcrread sha1 | tail +2 | cut -d':' -f2 | sed 's% %%g' | sed -z 's%\n%,sha1=%g')"
+oversizedspec="sha1=$(tpm2_pcrread sha1 | tail +2 | cut -d':' -f2 | \
+sed 's% %%g' | sed -z 's%\n%,sha1=%g')"
 
 # Over-length spec should fail
 if tpm2_pcrextend 8:${oversizedspec}; then

--- a/test/integration/tests/print.sh
+++ b/test/integration/tests/print.sh
@@ -34,7 +34,8 @@ tpm2_createak -Q -G rsa -g sha256 -s rsassa -C $ek_handle -c $ak_ctx\
   -u $ak_pubkey_file -n $ak_name_file
 
 # Take PCR quote
-tpm2_quote -Q -c $ak_ctx -l "sha256:0,2,4,9,10,11,12,17" -q "0f8beb45ac" -m $quote_file
+tpm2_quote -Q -c $ak_ctx -l "sha256:0,2,4,9,10,11,12,17" -q "0f8beb45ac" \
+-m $quote_file
 
 # Print TPM's quote file
 tpm2_print -t TPMS_ATTEST $quote_file > $print_file

--- a/test/integration/tests/quote.sh
+++ b/test/integration/tests/quote.sh
@@ -13,8 +13,10 @@ alg_quote1=0x000b
 file_primary_key_ctx=context.p_"$alg_primary_obj"_"$alg_primary_key"
 file_quote_key_pub=opu_"$alg_create_obj"_"$alg_create_key"
 file_quote_key_priv=opr_"$alg_create_obj"_"$alg_create_key"
-file_quote_key_name=name.load_"$alg_primary_obj"_"$alg_primary_key"-"$alg_create_obj"_"$alg_create_key"
-file_quote_key_ctx=ctx_load_out_"$alg_primary_obj"_"$alg_primary_key"-"$alg_create_obj"_"$alg_create_key"
+file_quote_key_name=name.load_"$alg_primary_obj"_"$alg_primary_key"-\
+"$alg_create_obj"_"$alg_create_key"
+file_quote_key_ctx=ctx_load_out_"$alg_primary_obj"_"$alg_primary_key"-\
+"$alg_create_obj"_"$alg_create_key"
 
 Handle_ak_quote=0x81010016
 Handle_ek_quote=0x81010017
@@ -55,24 +57,32 @@ cleanup "no-shut-down"
 
 tpm2_clear
 
-tpm2_createprimary -Q -C e -g $alg_primary_obj -G $alg_primary_key -c $file_primary_key_ctx
+tpm2_createprimary -Q -C e -g $alg_primary_obj -G $alg_primary_key \
+-c $file_primary_key_ctx
 
-tpm2_create -Q -g $alg_create_obj -G $alg_create_key -u $file_quote_key_pub -r $file_quote_key_priv  -C $file_primary_key_ctx
+tpm2_create -Q -g $alg_create_obj -G $alg_create_key -u $file_quote_key_pub \
+-r $file_quote_key_priv -C $file_primary_key_ctx
 
-tpm2_load -Q -C $file_primary_key_ctx  -u $file_quote_key_pub  -r $file_quote_key_priv -n $file_quote_key_name -c $file_quote_key_ctx
+tpm2_load -Q -C $file_primary_key_ctx -u $file_quote_key_pub \
+-r $file_quote_key_priv -n $file_quote_key_name -c $file_quote_key_ctx
 
-tpm2_quote -c $file_quote_key_ctx  -l $alg_quote:16,17,18 -q $nonce -m $toss_out -s $toss_out -o $toss_out -g $alg_primary_obj > $out
+tpm2_quote -c $file_quote_key_ctx -l $alg_quote:16,17,18 -q $nonce \
+-m $toss_out -s $toss_out -o $toss_out -g $alg_primary_obj > $out
 
 yaml_verify $out
 
-tpm2_quote -Q -c $file_quote_key_ctx  -l $alg_quote:16,17,18+$alg_quote1:16,17,18 -q $nonce -m $toss_out -s $toss_out -o $toss_out -g $alg_primary_obj
+tpm2_quote -Q -c $file_quote_key_ctx \
+-l $alg_quote:16,17,18+$alg_quote1:16,17,18 -q $nonce -m $toss_out \
+-s $toss_out -o $toss_out -g $alg_primary_obj
 
 #####handle testing
 tpm2_evictcontrol -Q -C o -c $file_quote_key_ctx $Handle_ak_quote
 
-tpm2_quote -Q -c $Handle_ak_quote -l $alg_quote:16,17,18 -q $nonce -m $toss_out -s $toss_out -o $toss_out -g $alg_primary_obj
+tpm2_quote -Q -c $Handle_ak_quote -l $alg_quote:16,17,18 -q $nonce \
+-m $toss_out -s $toss_out -o $toss_out -g $alg_primary_obj
 
-tpm2_quote -Q -c $Handle_ak_quote  -l $alg_quote:16,17,18+$alg_quote1:16,17,18 -q $nonce -m $toss_out -s $toss_out -o $toss_out -g $alg_primary_obj
+tpm2_quote -Q -c $Handle_ak_quote -l $alg_quote:16,17,18+$alg_quote1:16,17,18 \
+-q $nonce -m $toss_out -s $toss_out -o $toss_out -g $alg_primary_obj
 
 #####AK
 tpm2_createek -Q -c $Handle_ek_quote -G 0x01 -p ek.pub2
@@ -80,6 +90,7 @@ tpm2_createek -Q -c $Handle_ek_quote -G 0x01 -p ek.pub2
 tpm2_createak -Q -C $Handle_ek_quote -c $ak2_ctx -u ak.pub2 -n ak.name_2
 tpm2_evictcontrol -Q -C o -c $ak2_ctx $Handle_ak_quote2
 
-tpm2_quote -Q -c $Handle_ak_quote -l $alg_quote:16,17,18 -q $nonce -m $toss_out -s $toss_out -o $toss_out -g $alg_primary_obj
+tpm2_quote -Q -c $Handle_ak_quote -l $alg_quote:16,17,18 -q $nonce \
+-m $toss_out -s $toss_out -o $toss_out -g $alg_primary_obj
 
 exit 0

--- a/test/integration/tests/rc_decode.sh
+++ b/test/integration/tests/rc_decode.sh
@@ -19,7 +19,8 @@ trap - EXIT
 declare -A codes
 
 tss2_tpm2_types=''
-for dir in "$(pkg-config --variable includedir tss2-esys)" /usr/local/include /usr/include; do
+for dir in "$(pkg-config --variable includedir tss2-esys)" \
+/usr/local/include /usr/include; do
     if [ -f "$dir/tss2/tss2_tpm2_types.h" ]; then
         tss2_tpm2_types="$dir/tss2/tss2_tpm2_types.h"
         break

--- a/test/integration/tests/readpublic.sh
+++ b/test/integration/tests/readpublic.sh
@@ -10,8 +10,10 @@ alg_create_key=hmac
 file_primary_key_ctx=context.p_"$alg_primary_obj"_"$alg_primary_key"
 file_readpub_key_pub=opu_"$alg_create_obj"_"$alg_create_key"
 file_readpub_key_priv=opr_"$alg_create_obj"_"$alg_create_key"
-file_readpub_key_name=name.load_"$alg_primary_obj"_"$alg_primary_key"-"$alg_create_obj"_"$alg_create_key"
-file_readpub_key_ctx=ctx_load_out_"$alg_primary_obj"_"$alg_primary_key"-"$alg_create_obj"_"$alg_create_key"
+file_readpub_key_name=name.load_"$alg_primary_obj"_"$alg_primary_key"-\
+"$alg_create_obj"_"$alg_create_key"
+file_readpub_key_ctx=ctx_load_out_"$alg_primary_obj"_"$alg_primary_key"-\
+"$alg_create_obj"_"$alg_create_key"
 file_readpub_output=readpub_"$file_readpub_key_ctx"
 
 Handle_readpub=0x81010014
@@ -34,11 +36,14 @@ cleanup "no-shut-down"
 
 tpm2_clear
 
-tpm2_createprimary -Q -C e -g $alg_primary_obj -G $alg_primary_key -c $file_primary_key_ctx
+tpm2_createprimary -Q -C e -g $alg_primary_obj -G $alg_primary_key \
+-c $file_primary_key_ctx
 
-tpm2_create -Q -g $alg_create_obj -G $alg_create_key -u $file_readpub_key_pub -r $file_readpub_key_priv  -C $file_primary_key_ctx
+tpm2_create -Q -g $alg_create_obj -G $alg_create_key -u $file_readpub_key_pub \
+-r $file_readpub_key_priv -C $file_primary_key_ctx
 
-tpm2_load -Q -C $file_primary_key_ctx  -u $file_readpub_key_pub  -r $file_readpub_key_priv -n $file_readpub_key_name -c $file_readpub_key_ctx
+tpm2_load -Q -C $file_primary_key_ctx -u $file_readpub_key_pub \
+-r $file_readpub_key_priv -n $file_readpub_key_name -c $file_readpub_key_ctx
 
 tpm2_readpublic -Q -c $file_readpub_key_ctx -o $file_readpub_output
 

--- a/test/integration/tests/rsadecrypt.sh
+++ b/test/integration/tests/rsadecrypt.sh
@@ -19,9 +19,9 @@ alg_rsaencrypt_key=rsa
 
 cleanup() {
     rm -f $file_input_data $file_primary_key_ctx $file_rsaencrypt_key_pub \
-    $file_rsaencrypt_key_priv $file_rsaencrypt_key_ctx $file_rsaencrypt_key_name \
-    $file_output_data $file_rsa_en_output_data $file_rsa_de_output_data \
-    $file_rsadecrypt_key_ctx label.dat
+    $file_rsaencrypt_key_priv $file_rsaencrypt_key_ctx \
+    $file_rsaencrypt_key_name $file_output_data $file_rsa_en_output_data \
+    $file_rsa_de_output_data $file_rsadecrypt_key_ctx label.dat
 
     if [ "$1" != "no-shut-down" ]; then
         shut_down
@@ -37,45 +37,65 @@ echo "12345678" > $file_input_data
 
 tpm2_clear
 
-tpm2_createprimary -Q -C e -g $alg_hash -G $alg_primary_key -c $file_primary_key_ctx
+tpm2_createprimary -Q -C e -g $alg_hash -G $alg_primary_key \
+-c $file_primary_key_ctx
 
-tpm2_create -Q -g $alg_hash -p foo -G $alg_rsaencrypt_key -u $file_rsaencrypt_key_pub -r $file_rsaencrypt_key_priv  -C $file_primary_key_ctx
+tpm2_create -Q -g $alg_hash -p foo -G $alg_rsaencrypt_key \
+-u $file_rsaencrypt_key_pub -r $file_rsaencrypt_key_priv \
+-C $file_primary_key_ctx
 
-tpm2_loadexternal -Q -C n -u $file_rsaencrypt_key_pub -c $file_rsaencrypt_key_ctx
+tpm2_loadexternal -Q -C n -u $file_rsaencrypt_key_pub \
+-c $file_rsaencrypt_key_ctx
 
-tpm2_rsaencrypt -Q -c $file_rsaencrypt_key_ctx -o $file_rsa_en_output_data < $file_input_data
+tpm2_rsaencrypt -Q -c $file_rsaencrypt_key_ctx -o $file_rsa_en_output_data < \
+$file_input_data
 
-tpm2_load -Q -C $file_primary_key_ctx -u $file_rsaencrypt_key_pub -r $file_rsaencrypt_key_priv  -n $file_rsaencrypt_key_name  -c $file_rsadecrypt_key_ctx
+tpm2_load -Q -C $file_primary_key_ctx -u $file_rsaencrypt_key_pub \
+-r $file_rsaencrypt_key_priv -n $file_rsaencrypt_key_name \
+-c $file_rsadecrypt_key_ctx
 
-tpm2_rsadecrypt -Q -c $file_rsadecrypt_key_ctx -p foo -o  $file_rsa_de_output_data $file_rsa_en_output_data
+tpm2_rsadecrypt -Q -c $file_rsadecrypt_key_ctx -p foo -o \
+$file_rsa_de_output_data $file_rsa_en_output_data
 
 # Test the diffeent padding schemes ...
 
-tpm2_rsaencrypt -Q -c $file_rsaencrypt_key_ctx -o $file_rsa_en_output_data -s rsaes < $file_input_data
-tpm2_rsadecrypt -Q -c $file_rsadecrypt_key_ctx -p foo -o  $file_rsa_de_output_data -s rsaes $file_rsa_en_output_data
+tpm2_rsaencrypt -Q -c $file_rsaencrypt_key_ctx -o $file_rsa_en_output_data \
+-s rsaes < $file_input_data
+tpm2_rsadecrypt -Q -c $file_rsadecrypt_key_ctx -p foo -o \
+$file_rsa_de_output_data -s rsaes $file_rsa_en_output_data
 
-tpm2_rsaencrypt -Q -c $file_rsaencrypt_key_ctx -o $file_rsa_en_output_data -s null < $file_input_data
-tpm2_rsadecrypt -Q -c $file_rsadecrypt_key_ctx -p foo -o  $file_rsa_de_output_data -s null $file_rsa_en_output_data
+tpm2_rsaencrypt -Q -c $file_rsaencrypt_key_ctx -o $file_rsa_en_output_data \
+-s null < $file_input_data
+tpm2_rsadecrypt -Q -c $file_rsadecrypt_key_ctx -p foo -o \
+$file_rsa_de_output_data -s null $file_rsa_en_output_data
 
 # Test the label option with a string
-tpm2_rsaencrypt -Q -c $file_rsaencrypt_key_ctx -l mylabel -o $file_rsa_en_output_data < $file_input_data
-tpm2_rsadecrypt -Q -c $file_rsadecrypt_key_ctx -l mylabel -p foo -o $file_rsa_de_output_data $file_rsa_en_output_data
+tpm2_rsaencrypt -Q -c $file_rsaencrypt_key_ctx -l mylabel \
+-o $file_rsa_en_output_data < $file_input_data
+tpm2_rsadecrypt -Q -c $file_rsadecrypt_key_ctx -l mylabel -p foo \
+-o $file_rsa_de_output_data $file_rsa_en_output_data
 
 # Test the label option with a file
 echo "my file label" > label.dat
-tpm2_rsaencrypt -Q -c $file_rsaencrypt_key_ctx -l label.dat -o $file_rsa_en_output_data < $file_input_data
-tpm2_rsadecrypt -Q -c $file_rsadecrypt_key_ctx -l label.dat -p foo -o $file_rsa_de_output_data $file_rsa_en_output_data
+tpm2_rsaencrypt -Q -c $file_rsaencrypt_key_ctx -l label.dat \
+-o $file_rsa_en_output_data < $file_input_data
+tpm2_rsadecrypt -Q -c $file_rsadecrypt_key_ctx -l label.dat -p foo \
+-o $file_rsa_de_output_data $file_rsa_en_output_data
 
 trap - ERR
-tpm2_rsaencrypt -Q -c $file_rsaencrypt_key_ctx -o $file_rsa_en_output_data -s oaep < $file_input_data
+tpm2_rsaencrypt -Q -c $file_rsaencrypt_key_ctx -o $file_rsa_en_output_data \
+-s oaep < $file_input_data
 if [ $? -eq 0 ]; then
-    echo "tpm2_rsaencrypt should fail with 'hash algorithm not supported or not appropriate'"
+    echo "tpm2_rsaencrypt should fail with 'hash algorithm not supported or not\
+    appropriate'"
     exit 1
 fi
 
-tpm2_rsadecrypt -Q -c $file_rsadecrypt_key_ctx -p foo -o  $file_rsa_de_output_data -s oaep $file_rsa_en_output_data
+tpm2_rsadecrypt -Q -c $file_rsadecrypt_key_ctx -p foo -o \
+$file_rsa_de_output_data -s oaep $file_rsa_en_output_data
 if [ $? -eq 0 ]; then
-    echo "tpm2_rsadecrypt should fail with 'hash algorithm not supported or not appropriate'"
+    echo "tpm2_rsadecrypt should fail with 'hash algorithm not supported or not
+    appropriate'"
     exit 1
 fi
 

--- a/test/integration/tests/rsaencrypt.sh
+++ b/test/integration/tests/rsaencrypt.sh
@@ -34,14 +34,18 @@ echo "12345678" > $file_input_data
 
 tpm2_clear
 
-tpm2_createprimary -Q -C e -g $alg_hash -G $alg_primary_key -c $file_primary_key_ctx
+tpm2_createprimary -Q -C e -g $alg_hash -G $alg_primary_key \
+-c $file_primary_key_ctx
 
-tpm2_create -Q -g $alg_hash -G $alg_rsaencrypt_key -u $file_rsaencrypt_key_pub -r $file_rsaencrypt_key_priv  -C $file_primary_key_ctx
+tpm2_create -Q -g $alg_hash -G $alg_rsaencrypt_key -u $file_rsaencrypt_key_pub \
+-r $file_rsaencrypt_key_priv -C $file_primary_key_ctx
 
-tpm2_loadexternal -Q -C n   -u $file_rsaencrypt_key_pub  -c $file_rsaencrypt_key_ctx
+tpm2_loadexternal -Q -C n   -u $file_rsaencrypt_key_pub \
+-c $file_rsaencrypt_key_ctx
 
 #./tpm2_rsaencrypt -c context_loadexternal_out6.out -I secret.data -o rsa_en.out
-tpm2_rsaencrypt -Q -c $file_rsaencrypt_key_ctx -o $file_rsa_en_output_data $file_input_data
+tpm2_rsaencrypt -Q -c $file_rsaencrypt_key_ctx -o $file_rsa_en_output_data \
+$file_input_data
 
 # Test stdout output and test that stdin pipe works as well.
 cat $file_input_data | tpm2_rsaencrypt -c $file_rsaencrypt_key_ctx > /dev/null

--- a/test/integration/tests/sign.sh
+++ b/test/integration/tests/sign.sh
@@ -42,35 +42,44 @@ test_symmetric() {
 
     tpm2_clear
 
-    tpm2_createprimary -Q -C e -g $alg_hash -G $alg_primary_key -c $file_primary_key_ctx
+    tpm2_createprimary -Q -C e -g $alg_hash -G $alg_primary_key \
+    -c $file_primary_key_ctx
 
-    tpm2_create -Q -g $alg_hash -G $alg_signing_key -u $file_signing_key_pub -r $file_signing_key_priv -C $file_primary_key_ctx
+    tpm2_create -Q -g $alg_hash -G $alg_signing_key -u $file_signing_key_pub \
+    -r $file_signing_key_priv -C $file_primary_key_ctx
 
-    tpm2_load -Q -C $file_primary_key_ctx -u $file_signing_key_pub -r $file_signing_key_priv -n $file_signing_key_name -c $file_signing_key_ctx
+    tpm2_load -Q -C $file_primary_key_ctx -u $file_signing_key_pub \
+    -r $file_signing_key_priv -n $file_signing_key_name -c $file_signing_key_ctx
 
-    tpm2_sign -Q -c $file_signing_key_ctx -g $alg_hash -o $file_output_data $file_input_data
+    tpm2_sign -Q -c $file_signing_key_ctx -g $alg_hash \
+    -o $file_output_data $file_input_data
 
     rm -f $file_output_data
 
     tpm2_evictcontrol -Q -C o -c $file_signing_key_ctx $handle_signing_key
 
-    tpm2_sign -Q -c $handle_signing_key -g $alg_hash -o $file_output_data $file_input_data
+    tpm2_sign -Q -c $handle_signing_key -g $alg_hash -o $file_output_data \
+    $file_input_data
 
     rm -f $file_output_data
 
     # generate hash and test validation
 
-    tpm2_hash -Q -C e -g $alg_hash -o $file_output_hash -t $file_output_ticket $file_input_data
+    tpm2_hash -Q -C e -g $alg_hash -o $file_output_hash -t $file_output_ticket \
+    $file_input_data
 
-    tpm2_sign -Q -c $handle_signing_key -g $alg_hash -o $file_output_data -t $file_output_ticket $file_input_data
+    tpm2_sign -Q -c $handle_signing_key -g $alg_hash -o $file_output_data \
+    -t $file_output_ticket $file_input_data
 
     rm -f $file_output_data
 
     # test with digest, no validation
 
-    sha256sum $file_input_data | awk '{ print "000000 " $1 }' | xxd -r -c 32 > $file_input_digest
+    sha256sum $file_input_data | awk '{ print "000000 " $1 }' | xxd -r -c 32 > \
+    $file_input_digest
 
-    tpm2_sign -Q -c $handle_signing_key -g $alg_hash -d -o $file_output_data $file_input_digest
+    tpm2_sign -Q -c $handle_signing_key -g $alg_hash -d -o $file_output_data \
+    $file_input_digest
 
     rm -f $file_output_data
 }
@@ -78,9 +87,11 @@ test_symmetric() {
 create_signature() {
     local sign_scheme=$1
     if [ "$sign_scheme" = "" ]; then
-        tpm2_sign -Q -c $file_signing_key_ctx -g $alg_hash -f plain -o $file_output_data $file_input_data
+        tpm2_sign -Q -c $file_signing_key_ctx -g $alg_hash -f plain \
+        -o $file_output_data $file_input_data
     else
-        tpm2_sign -Q -c $file_signing_key_ctx -g $alg_hash -s $sign_scheme -f plain -o $file_output_data $file_input_data
+        tpm2_sign -Q -c $file_signing_key_ctx -g $alg_hash -s $sign_scheme \
+        -f plain -o $file_output_data $file_input_data
     fi
 }
 
@@ -197,17 +208,22 @@ test_asymmetric() {
 
     head -c30 /dev/urandom > $file_input_data
 
-    sha256sum $file_input_data | awk '{ print "000000 " $1 }' | xxd -r -c 32 > $file_input_digest
+    sha256sum $file_input_data | awk '{ print "000000 " $1 }' | \
+    xxd -r -c 32 > $file_input_digest
 
     tpm2_clear
 
-    tpm2_createprimary -Q -C e -g $alg_hash -G $alg_primary_key -c $file_primary_key_ctx
+    tpm2_createprimary -Q -C e -g $alg_hash -G $alg_primary_key \
+    -c $file_primary_key_ctx
 
-    tpm2_create -Q -g $alg_hash -G $alg_signing_key -u $file_signing_key_pub -r $file_signing_key_priv -C $file_primary_key_ctx
+    tpm2_create -Q -g $alg_hash -G $alg_signing_key -u $file_signing_key_pub \
+    -r $file_signing_key_priv -C $file_primary_key_ctx
 
-    tpm2_load -Q -C $file_primary_key_ctx -u $file_signing_key_pub -r $file_signing_key_priv -n $file_signing_key_name -c $file_signing_key_ctx
+    tpm2_load -Q -C $file_primary_key_ctx -u $file_signing_key_pub \
+    -r $file_signing_key_priv -n $file_signing_key_name -c $file_signing_key_ctx
 
-    tpm2_readpublic -Q -c $file_signing_key_ctx --format=pem -o $file_signing_key_pub_pem
+    tpm2_readpublic -Q -c $file_signing_key_ctx --format=pem \
+    -o $file_signing_key_pub_pem
 
     local sign_scheme
 
@@ -245,7 +261,8 @@ cleanup "no-shut-down"
 
 for key_type in $rsa_key_type $ecc_key_type
 do
-    # make sure commands failing inside the function will cause the script to fail!
+    # make sure commands failing inside the function will cause the script
+    # to fail!
     (
         set -e
         test_asymmetric $key_type
@@ -259,13 +276,16 @@ cleanup "no-shut-down"
 echo "12345678" > $file_input_data
 
 tpm2_createprimary -Q -c $file_primary_key_ctx
-tpm2_create -Q -C $file_primary_key_ctx -u $file_signing_key_pub -r $file_signing_key_priv -p "mypassword"
-tpm2_load -Q -C $file_primary_key_ctx -u $file_signing_key_pub -r $file_signing_key_priv -n $file_signing_key_name -c $file_signing_key_ctx
+tpm2_create -Q -C $file_primary_key_ctx -u $file_signing_key_pub \
+-r $file_signing_key_priv -p "mypassword"
+tpm2_load -Q -C $file_primary_key_ctx -u $file_signing_key_pub \
+-r $file_signing_key_priv -n $file_signing_key_name -c $file_signing_key_ctx
 
 # Negative test, remove error handler
 trap - ERR
 
-tpm2_sign -Q -p "badpassword" -c $file_signing_key_ctx -g $alg_hash -o $file_output_data $file_input_data
+tpm2_sign -Q -p "badpassword" -c $file_signing_key_ctx -g $alg_hash \
+-o $file_output_data $file_input_data
 if [ $? != 3]; then
     echo "Expected RC 3, got: $?" 1>&2
 fi

--- a/test/integration/tests/stirrandom.sh
+++ b/test/integration/tests/stirrandom.sh
@@ -24,19 +24,25 @@ start_up
 cleanup "no-shut-down"
 
 # Sending bytes from stdin (pipe)
-echo -n "return 4" | tpm2_stirrandom -V 2>&1 1>/dev/null | grep -q "Submitting 8 bytes to TPM"
+echo -n "return 4" | tpm2_stirrandom -V 2>&1 1>/dev/null | \
+grep -q "Submitting 8 bytes to TPM"
 
 # Sending bytes from stdin (file)
-tpm2_stirrandom -V < "${goodfile}" 2>&1 1>/dev/null | grep -q "Submitting 42 bytes to TPM"
+tpm2_stirrandom -V < "${goodfile}" 2>&1 1>/dev/null | \
+grep -q "Submitting 42 bytes to TPM"
 
 # Read more than 128 bytes from stdin (pipe)
-dd if=/dev/urandom bs=1 count=256 | tpm2_stirrandom -V 2>&1 1>/dev/null | grep -q "Submitting 128 bytes to TPM"
+dd if=/dev/urandom bs=1 count=256 | tpm2_stirrandom -V 2>&1 1>/dev/null | \
+grep -q "Submitting 128 bytes to TPM"
 
 # Read more than 128 bytes from stdin (file)
-dd if=/dev/urandom bs=1 count=256 | tpm2_stirrandom -V < "${bigfile}" 2>&1 1>/dev/null | grep -q "Submitting 128 bytes to TPM"
+dd if=/dev/urandom bs=1 count=256 | \
+tpm2_stirrandom -V < "${bigfile}" 2>&1 1>/dev/null | \
+grep -q "Submitting 128 bytes to TPM"
 
 # Read a complete file
-tpm2_stirrandom "${goodfile}" -V 2>&1 1>/dev/null | grep -q "Submitting 42 bytes to TPM"
+tpm2_stirrandom "${goodfile}" -V 2>&1 1>/dev/null | \
+grep -q "Submitting 42 bytes to TPM"
 
 # Try to read more than 128 bytes from file and get an error
 if tpm2_stirrandom "${bigfile}"; then

--- a/test/integration/tests/testparms.sh
+++ b/test/integration/tests/testparms.sh
@@ -54,7 +54,8 @@ for i in ${hashalgs}; do
 done
 
 # Test that null algorithm raise an error (error from software stack)
-if ! tpm2_testparms "null" 2>&1 1>/dev/null | grep -q "Invalid or unsupported by the tool : null"; then
+if ! tpm2_testparms "null" 2>&1 1>/dev/null | \
+    grep -q "Invalid or unsupported by the tool : null"; then
     echo "tpm2_testparms with 'null' algorithm didn't fail"
     exit 1
 else

--- a/test/integration/tests/toggle_options.sh
+++ b/test/integration/tests/toggle_options.sh
@@ -26,9 +26,10 @@ function check_toggle() {
         exit 254
     fi
 
-    for i in $(grep "'${toggle}'[[:space:]]*}" "${toolsdir}"/*.c | sed "s%[[:space:]]*%%g"); do
+    for i in $(grep "'${toggle}'[[:space:]]*}" "${toolsdir}"/*.c | \
+    sed "s%[[:space:]]*%%g"); do
         # An example:
-        # i:           tools/tpm2_nvdefine.c:{"hierarchy",required_argument,NULL,'a'},
+        # i:     tools/tpm2_nvdefine.c:{"hierarchy",required_argument,NULL,'a'},
         # filename:    tools/tpm2_nvdefine.c
         # match:       {"hierarchy",required_argument,NULL,'a'},
         # option:      a
@@ -40,8 +41,10 @@ function check_toggle() {
         match=${i##*:};
         option="$(sed -r "s%.*'([^'])'.*%\1%g" <<< "${match}")"
         option_long="$(grep -oP '(?<={").*(?=")' <<< "${match}")"
-        optionlist="$(grep -R "tpm2_options_new" "${filename}" | sed -r 's%.*("[^"]+").*%\1%g')"
-        getcase="$(grep "case '${option}'" "${filename}" | sed "s%[[:space:]]*%%g")"
+        optionlist="$(grep -R "tpm2_options_new" "${filename}" | \
+        sed -r 's%.*("[^"]+").*%\1%g')"
+        getcase="$(grep "case '${option}'" "${filename}" | \
+        sed "s%[[:space:]]*%%g")"
 
         echo "filename: $filename"
         echo "    match:        $match"
@@ -55,18 +58,20 @@ function check_toggle() {
         fi
 
         if ! grep -q "${option}" <<< "${optionlist}"; then
-            echo "$filename: option -$option (--$option_long) not found in option list $optionlist"
+            echo "$filename: option -$option (--$option_long) not found in \
+            option list $optionlist"
             exit 1
         fi
 
         if ! test -n "${getcase}"; then
-            echo "$filename: switch case '$option' not found for option -$option (--$option_long)"
+            echo "$filename: switch case '$option' not found for option \
+            -$option (--$option_long)"
             exit 1
         fi
 
         ####################### check man page #######################
-        man_filename="$(basename $filename)"                 # tpm2_nvdefine.c
-        man_filename="$mandir/${man_filename%.*}.1.md"       # man/tpm2_nvdefine.1.md
+        man_filename="$(basename $filename)"            # tpm2_nvdefine.c
+        man_filename="$mandir/${man_filename%.*}.1.md"  # man/tpm2_nvdefine.1.md
         man=$(cat "$man_filename")
 
         # resolve markdown includes
@@ -76,12 +81,14 @@ function check_toggle() {
         done
 
         # search markdown for option (short and long)
-        man_opt=$(grep -oe "\*\*-$option\*\*, \*\*\\\--$option_long\*\*" <<< "$man_resolved") || true
+        man_opt=$(grep -oe "\*\*-$option\*\*, \*\*\\\--$option_long\*\*" \
+        <<< "$man_resolved") || true
 
         if [ -n "$man_opt" ]; then
             echo "    man_opt:      $man_opt"
         else
-            echo "$filename: missing option -$option/--$option_long in $man_filename"
+            echo "$filename: missing option -$option/--$option_long in \
+            $man_filename"
             exit 1
         fi
     done
@@ -89,13 +96,17 @@ function check_toggle() {
 
 fail=0
 
-# For each detected option toggle, check if it is actually declared to be used and documented
-for i in $(grep -rn "case '.'" "${toolsdir}"/*.c | cut -d"'" -f2-2 | sort | uniq); do
+# For each detected option toggle, check if it is actually declared to be used
+# and documented
+for i in $(grep -rn "case '.'" "${toolsdir}"/*.c | \
+cut -d"'" -f2-2 | sort | uniq); do
     check_toggle "${i}"
 done
 
-# For each documented option toggle in the man pages, look if it is present in the code
-for j in $(grep -oe "\*\*-.\*\*, \*\*\\\--.*\*\*" "${mandir}"/*.1.md | sed -r 's/\s//g' ); do
+# For each documented option toggle in the man pages, look if it is present in
+# the code
+for j in $(grep -oe "\*\*-.\*\*, \*\*\\\--.*\*\*" "${mandir}"/*.1.md | \
+sed -r 's/\s//g' ); do
     filename=${j%%:*};
     option="$(grep -oP '(?<=\*\*-).(?=\*\*)' <<< "$j")"
     option_long="$(grep -oP '(?<=\*\*\\\--).*(?=\*\*)' <<< "$j")"
@@ -103,10 +114,12 @@ for j in $(grep -oe "\*\*-.\*\*, \*\*\\\--.*\*\*" "${mandir}"/*.1.md | sed -r 's
     c_filename=$(basename ${filename%.1.md}).c
 
     echo "$filename: looking for -$option (--$option_long) in $c_filename"
-    found=$(grep -r "case '${option}'" "$toolsdir" --include="$c_filename") || true
+    found=$(grep -r "case '${option}'" "$toolsdir" --include="$c_filename") \
+    || true
 
     if [ -z "$found" ]; then
-        echo "$filename: missing option -$option (--$option_long) in $c_filename"
+        echo "$filename: missing option -$option (--$option_long) in \
+        $c_filename"
         exit 1
     fi
 done

--- a/test/integration/tests/unseal.sh
+++ b/test/integration/tests/unseal.sh
@@ -12,8 +12,10 @@ file_policy=policy.data
 file_primary_key_ctx=context.p_"$alg_primary_obj"_"$alg_primary_key"
 file_unseal_key_pub=opu_"$alg_create_obj"
 file_unseal_key_priv=opr_"$alg_create_obj"
-file_unseal_key_ctx=ctx_load_out_"$alg_primary_obj"_"$alg_primary_key"-"$alg_create_obj"
-file_unseal_key_name=name.load_"$alg_primary_obj"_"$alg_primary_key"-"$alg_create_obj"
+file_unseal_key_ctx=ctx_load_out_"$alg_primary_obj"_"$alg_primary_key"-\
+"$alg_create_obj"
+file_unseal_key_name=name.load_"$alg_primary_obj"_"$alg_primary_key"-\
+"$alg_create_obj"
 file_unseal_output_data=usl_"$file_unseal_key_ctx"
 
 secret="12345678"
@@ -37,11 +39,14 @@ echo $secret > $file_input_data
 
 tpm2_clear
 
-tpm2_createprimary -Q -C e -g $alg_primary_obj -G $alg_primary_key -c $file_primary_key_ctx
+tpm2_createprimary -Q -C e -g $alg_primary_obj -G $alg_primary_key \
+-c $file_primary_key_ctx
 
-tpm2_create -Q -g $alg_create_obj -u $file_unseal_key_pub -r $file_unseal_key_priv -i $file_input_data -C $file_primary_key_ctx
+tpm2_create -Q -g $alg_create_obj -u $file_unseal_key_pub \
+-r $file_unseal_key_priv -i $file_input_data -C $file_primary_key_ctx
 
-tpm2_load -Q -C $file_primary_key_ctx  -u $file_unseal_key_pub  -r $file_unseal_key_priv -n $file_unseal_key_name -c $file_unseal_key_ctx
+tpm2_load -Q -C $file_primary_key_ctx -u $file_unseal_key_pub \
+-r $file_unseal_key_priv -n $file_unseal_key_name -c $file_unseal_key_ctx
 
 tpm2_unseal -Q -c $file_unseal_key_ctx -o $file_unseal_output_data
 
@@ -49,11 +54,14 @@ cmp -s $file_unseal_output_data $file_input_data
 
 # Test -i using stdin via pipe
 
-rm $file_unseal_key_pub $file_unseal_key_priv $file_unseal_key_name $file_unseal_key_ctx
+rm $file_unseal_key_pub $file_unseal_key_priv $file_unseal_key_name \
+$file_unseal_key_ctx
 
-cat $file_input_data | tpm2_create -Q -g $alg_create_obj -u $file_unseal_key_pub -r $file_unseal_key_priv -i- -C $file_primary_key_ctx
+cat $file_input_data | tpm2_create -Q -g $alg_create_obj \
+-u $file_unseal_key_pub -r $file_unseal_key_priv -i- -C $file_primary_key_ctx
 
-tpm2_load -Q -C $file_primary_key_ctx  -u $file_unseal_key_pub  -r $file_unseal_key_priv -n $file_unseal_key_name -c $file_unseal_key_ctx
+tpm2_load -Q -C $file_primary_key_ctx -u $file_unseal_key_pub \
+-r $file_unseal_key_priv -n $file_unseal_key_name -c $file_unseal_key_ctx
 
 tpm2_unseal -Q -c $file_unseal_key_ctx -o $file_unseal_output_data
 
@@ -61,18 +69,23 @@ cmp -s $file_unseal_output_data $file_input_data
 
 # Test using a PCR policy for auth and use file based stdin for -i
 
-rm $file_unseal_key_pub $file_unseal_key_priv $file_unseal_key_name $file_unseal_key_ctx
+rm $file_unseal_key_pub $file_unseal_key_priv $file_unseal_key_name \
+$file_unseal_key_ctx
 
 tpm2_pcrread -Q -o $file_pcr_value $pcr_specification
 
-tpm2_createpolicy -Q --policy-pcr -l $pcr_specification -f $file_pcr_value -L $file_policy
+tpm2_createpolicy -Q --policy-pcr -l $pcr_specification -f $file_pcr_value \
+-L $file_policy
 
-tpm2_create -Q -g $alg_create_obj -u $file_unseal_key_pub -r $file_unseal_key_priv -i- -C $file_primary_key_ctx -L $file_policy \
-  -a 'fixedtpm|fixedparent' <<< $secret
+tpm2_create -Q -g $alg_create_obj -u $file_unseal_key_pub \
+-r $file_unseal_key_priv -i- -C $file_primary_key_ctx -L $file_policy \
+-a 'fixedtpm|fixedparent' <<< $secret
 
-tpm2_load -Q -C $file_primary_key_ctx  -u $file_unseal_key_pub  -r $file_unseal_key_priv -n $file_unseal_key_name -c $file_unseal_key_ctx
+tpm2_load -Q -C $file_primary_key_ctx -u $file_unseal_key_pub \
+-r $file_unseal_key_priv -n $file_unseal_key_name -c $file_unseal_key_ctx
 
-unsealed=`tpm2_unseal -V --object-context $file_unseal_key_ctx -p pcr:$pcr_specification=$file_pcr_value`
+unsealed=`tpm2_unseal -V --object-context $file_unseal_key_ctx \
+-p pcr:$pcr_specification=$file_pcr_value`
 
 test "$unsealed" == "$secret"
 
@@ -100,15 +113,20 @@ fi
 
 trap onerror ERR
 
-rm $file_unseal_key_pub $file_unseal_key_priv $file_unseal_key_name $file_unseal_key_ctx
+rm $file_unseal_key_pub $file_unseal_key_priv $file_unseal_key_name \
+$file_unseal_key_ctx
 
 tpm2_pcrread -Q -o $file_pcr_value $pcr_specification
 
-tpm2_createpolicy -Q --policy-pcr -l $pcr_specification -f $file_pcr_value -L $file_policy
+tpm2_createpolicy -Q --policy-pcr -l $pcr_specification -f $file_pcr_value \
+-L $file_policy
 
-tpm2_create -Q -g $alg_create_obj -u $file_unseal_key_pub -r $file_unseal_key_priv -i- -C $file_primary_key_ctx -L $file_policy -p secretpass <<< $secret
+tpm2_create -Q -g $alg_create_obj -u $file_unseal_key_pub \
+-r $file_unseal_key_priv -i- -C $file_primary_key_ctx -L $file_policy \
+-p secretpass <<< $secret
 
-tpm2_load -Q -C $file_primary_key_ctx  -u $file_unseal_key_pub  -r $file_unseal_key_priv -n $file_unseal_key_name -c $file_unseal_key_ctx
+tpm2_load -Q -C $file_primary_key_ctx -u $file_unseal_key_pub \
+-r $file_unseal_key_priv -n $file_unseal_key_name -c $file_unseal_key_ctx
 
 unsealed=`tpm2_unseal -c $file_unseal_key_ctx -p secretpass`
 

--- a/test/integration/tests/verifysignature.sh
+++ b/test/integration/tests/verifysignature.sh
@@ -40,24 +40,32 @@ echo "12345678" > $file_input_data
 
 tpm2_clear
 
-tpm2_createprimary -Q -C e -g $alg_hash -G $alg_primary_key -c $file_primary_key_ctx
+tpm2_createprimary -Q -C e -g $alg_hash -G $alg_primary_key \
+-c $file_primary_key_ctx
 
-tpm2_create -Q -g $alg_hash -G $alg_signing_key -u $file_signing_key_pub -r $file_signing_key_priv -C $file_primary_key_ctx
+tpm2_create -Q -g $alg_hash -G $alg_signing_key -u $file_signing_key_pub \
+-r $file_signing_key_priv -C $file_primary_key_ctx
 
-tpm2_load -Q -C $file_primary_key_ctx -u $file_signing_key_pub -r $file_signing_key_priv -n $file_signing_key_name -c $file_signing_key_ctx
+tpm2_load -Q -C $file_primary_key_ctx -u $file_signing_key_pub \
+-r $file_signing_key_priv -n $file_signing_key_name -c $file_signing_key_ctx
 
-tpm2_sign -Q -c $file_signing_key_ctx -g $alg_hash -o $file_output_data $file_input_data
+tpm2_sign -Q -c $file_signing_key_ctx -g $alg_hash -o $file_output_data \
+$file_input_data
 
-tpm2_verifysignature -Q -c $file_signing_key_ctx -g $alg_hash -m $file_input_data -s $file_output_data -t $file_verify_tk_data
+tpm2_verifysignature -Q -c $file_signing_key_ctx -g $alg_hash \
+-m $file_input_data -s $file_output_data -t $file_verify_tk_data
 
-tpm2_hash -Q -C n -g $alg_hash -o $file_input_data_hash -t $file_input_data_hash_tk $file_input_data
+tpm2_hash -Q -C n -g $alg_hash -o $file_input_data_hash \
+-t $file_input_data_hash_tk $file_input_data
 
 rm -f $file_verify_tk_data
-tpm2_verifysignature -Q -c $file_signing_key_ctx -d $file_input_data_hash -s $file_output_data -t $file_verify_tk_data
+tpm2_verifysignature -Q -c $file_signing_key_ctx -d $file_input_data_hash \
+-s $file_output_data -t $file_verify_tk_data
 
 rm -f $file_verify_tk_data $file_signing_key_ctx -rf
 tpm2_loadexternal -Q -C n -u $file_signing_key_pub -c $file_signing_key_ctx
 
-tpm2_verifysignature -Q -c $file_signing_key_ctx -g $alg_hash -m $file_input_data -s $file_output_data -t $file_verify_tk_data
+tpm2_verifysignature -Q -c $file_signing_key_ctx -g $alg_hash \
+-m $file_input_data -s $file_output_data -t $file_verify_tk_data
 
 exit 0


### PR DESCRIPTION
1. Align text to appropriate width per coding guideline
2. Remove spurious double quotations
3. Replace single quotations in some instances as they were not safe for interpolating special characters like \
4. _ or underscore happens to be a valid variable name in bash, uninitialized if declared first time, and so every instance of concatenating variables for a new variable name have to be double quoted if the joining character is an underscore or _.