### PR TITLE
tpm2.c layer updates

### DIFF
--- a/lib/tpm2.c
+++ b/lib/tpm2.c
@@ -510,13 +510,13 @@ tool_rc tpm2_sequence_update(ESYS_CONTEXT *esys_context, ESYS_TR sequence_handle
 }
 
 tool_rc tpm2_sequence_complete(ESYS_CONTEXT *esys_context,
-        ESYS_TR sequence_handle, ESYS_TR shandle1, ESYS_TR shandle2,
-        ESYS_TR shandle3, const TPM2B_MAX_BUFFER *buffer,
+        ESYS_TR sequence_handle, const TPM2B_MAX_BUFFER *buffer,
         TPMI_RH_HIERARCHY hierarchy, TPM2B_DIGEST **result,
         TPMT_TK_HASHCHECK **validation) {
 
-    TSS2_RC rval = Esys_SequenceComplete(esys_context, sequence_handle, shandle1,
-            shandle2, shandle3, buffer, hierarchy, result, validation);
+    TSS2_RC rval = Esys_SequenceComplete(esys_context, sequence_handle,
+            ESYS_TR_PASSWORD, ESYS_TR_NONE, ESYS_TR_NONE, buffer,
+            hierarchy, result, validation);
     if (rval != TSS2_RC_SUCCESS) {
         LOG_PERR(Esys_SequenceComplete, rval);
         return tool_rc_from_tpm(rval);

--- a/lib/tpm2.c
+++ b/lib/tpm2.c
@@ -1452,3 +1452,18 @@ tool_rc tpm2_pcr_reset(ESYS_CONTEXT *ectx, ESYS_TR pcr_handle) {
 
     return tool_rc_success;
 }
+
+tool_rc tpm2_makecredential(ESYS_CONTEXT *ectx, ESYS_TR handle,
+        const TPM2B_DIGEST *credential, const TPM2B_NAME *object_name,
+        TPM2B_ID_OBJECT **credential_blob, TPM2B_ENCRYPTED_SECRET **secret) {
+
+    TSS2_RC rval = Esys_MakeCredential(ectx, handle, ESYS_TR_NONE, ESYS_TR_NONE,
+            ESYS_TR_NONE, credential, object_name, credential_blob,
+            secret);
+    if (rval != TPM2_RC_SUCCESS) {
+        LOG_PERR(Esys_MakeCredential, rval);
+        return tool_rc_from_tpm(rval);
+    }
+
+    return tool_rc_success;
+}

--- a/lib/tpm2.c
+++ b/lib/tpm2.c
@@ -493,7 +493,7 @@ tool_rc tpm2_hash_sequence_start(ESYS_CONTEXT *esys_context, const TPM2B_AUTH *a
         return tool_rc_from_tpm(rval);
     }
 
-    return tool_rc_success;
+    return tpm2_tr_set_auth(esys_context, *sequence_handle, auth);
 }
 
 tool_rc tpm2_sequence_update(ESYS_CONTEXT *esys_context, ESYS_TR sequence_handle,

--- a/lib/tpm2.c
+++ b/lib/tpm2.c
@@ -483,12 +483,11 @@ tool_rc tpm2_hash(ESYS_CONTEXT *esys_context, ESYS_TR shandle1, ESYS_TR shandle2
     return tool_rc_success;
 }
 
-tool_rc tpm2_hash_sequence_start(ESYS_CONTEXT *esys_context, ESYS_TR shandle1,
-        ESYS_TR shandle2, ESYS_TR shandle3, const TPM2B_AUTH *auth,
+tool_rc tpm2_hash_sequence_start(ESYS_CONTEXT *esys_context, const TPM2B_AUTH *auth,
         TPMI_ALG_HASH hash_alg, ESYS_TR *sequence_handle) {
 
-    TSS2_RC rval = Esys_HashSequenceStart(esys_context, shandle1, shandle2,
-            shandle3, auth, hash_alg, sequence_handle);
+    TSS2_RC rval = Esys_HashSequenceStart(esys_context, ESYS_TR_NONE, ESYS_TR_NONE,
+            ESYS_TR_NONE, auth, hash_alg, sequence_handle);
     if (rval != TSS2_RC_SUCCESS) {
         LOG_PERR(Esys_HashSequenceStart, rval);
         return tool_rc_from_tpm(rval);

--- a/lib/tpm2.c
+++ b/lib/tpm2.c
@@ -1416,3 +1416,16 @@ tool_rc tpm2_pcr_event(ESYS_CONTEXT *ectx,
 
     return tool_rc_success;
 }
+
+tool_rc tpm2_getrandom(ESYS_CONTEXT *ectx, UINT16 count,
+        TPM2B_DIGEST **random) {
+
+    TSS2_RC rval = Esys_GetRandom(ectx, ESYS_TR_NONE, ESYS_TR_NONE,
+        ESYS_TR_NONE, count, random);
+    if (rval != TPM2_RC_SUCCESS) {
+        LOG_PERR(Esys_GetRandom, rval);
+        return tool_rc_from_tpm(rval);
+    }
+
+    return tool_rc_success;
+}

--- a/lib/tpm2.c
+++ b/lib/tpm2.c
@@ -759,6 +759,21 @@ tool_rc tpm2_rsa_decrypt(ESYS_CONTEXT *ectx, tpm2_loaded_object *keyobj,
     return tool_rc_success;
 }
 
+tool_rc tpm2_rsa_encrypt(ESYS_CONTEXT *ectx, tpm2_loaded_object *keyobj,
+        const TPM2B_PUBLIC_KEY_RSA *message, const TPMT_RSA_DECRYPT *scheme,
+        const TPM2B_DATA *label, TPM2B_PUBLIC_KEY_RSA **cipher_text) {
+
+    TSS2_RC rval = Esys_RSA_Encrypt(ectx, keyobj->tr_handle,
+            ESYS_TR_NONE, ESYS_TR_NONE, ESYS_TR_NONE, message, scheme,
+            label, cipher_text);
+    if (rval != TPM2_RC_SUCCESS) {
+        LOG_PERR(Esys_RSA_Encrypt, rval);
+        return tool_rc_from_tpm(rval);
+    }
+
+    return tool_rc_success;
+}
+
 tool_rc tpm2_load(ESYS_CONTEXT *esys_context, tpm2_loaded_object *parentobj,
         const TPM2B_PRIVATE *in_private, const TPM2B_PUBLIC *in_public,
         ESYS_TR *object_handle) {

--- a/lib/tpm2.c
+++ b/lib/tpm2.c
@@ -1346,3 +1346,16 @@ tool_rc tpm2_selftest(ESYS_CONTEXT *ectx, TPMI_YES_NO full_test) {
 
     return tool_rc_success;
 }
+
+tool_rc tpm2_gettestresult(ESYS_CONTEXT *ectx, TPM2B_MAX_BUFFER **out_data,
+        TPM2_RC *test_result) {
+
+    TSS2_RC rval = Esys_GetTestResult(ectx, ESYS_TR_NONE, ESYS_TR_NONE,
+            ESYS_TR_NONE, out_data, test_result);
+    if (rval != TSS2_RC_SUCCESS) {
+        LOG_PERR(Esys_GetTestResult, rval);
+        return tool_rc_from_tpm(rval);
+    }
+
+    return tool_rc_success;
+}

--- a/lib/tpm2.c
+++ b/lib/tpm2.c
@@ -1429,3 +1429,14 @@ tool_rc tpm2_getrandom(ESYS_CONTEXT *ectx, UINT16 count,
 
     return tool_rc_success;
 }
+
+tool_rc tpm2_startup(ESYS_CONTEXT *ectx, TPM2_SU startup_type) {
+
+    TSS2_RC rval = Esys_Startup(ectx, startup_type);
+    if (rval != TPM2_RC_SUCCESS && rval != TPM2_RC_INITIALIZE) {
+        LOG_PERR(Esys_Startup, rval);
+        return tool_rc_from_tpm(rval);
+    }
+
+    return tool_rc_success;
+}

--- a/lib/tpm2.c
+++ b/lib/tpm2.c
@@ -525,6 +525,27 @@ tool_rc tpm2_sequence_complete(ESYS_CONTEXT *esys_context,
     return tool_rc_success;
 }
 
+tool_rc tpm2_event_sequence_complete(ESYS_CONTEXT *ectx, ESYS_TR pcr,
+        ESYS_TR sequence_handle, tpm2_session *session,
+        const TPM2B_MAX_BUFFER *buffer, TPML_DIGEST_VALUES **results) {
+
+    ESYS_TR shandle1 = ESYS_TR_NONE;
+    tool_rc rc = tpm2_auth_util_get_shandle(ectx, pcr, session,
+            &shandle1);
+    if (rc != tool_rc_success) {
+        return rc;
+    }
+
+    TSS2_RC rval = Esys_EventSequenceComplete(ectx, pcr, sequence_handle, shandle1,
+            ESYS_TR_PASSWORD, ESYS_TR_NONE, buffer, results);
+    if (rval != TSS2_RC_SUCCESS) {
+        LOG_PERR(Esys_EventSequenceComplete, rval);
+        return tool_rc_from_tpm(rval);
+    }
+
+    return tool_rc_success;
+}
+
 tool_rc tpm2_tr_set_auth(ESYS_CONTEXT *esys_context, ESYS_TR handle,
         TPM2B_AUTH const *auth_value) {
 

--- a/lib/tpm2.c
+++ b/lib/tpm2.c
@@ -1334,3 +1334,15 @@ tool_rc tpm2_stirrandom(ESYS_CONTEXT *ectx,
 
     return tool_rc_success;
 }
+
+tool_rc tpm2_selftest(ESYS_CONTEXT *ectx, TPMI_YES_NO full_test) {
+
+    TSS2_RC rval = Esys_SelfTest(ectx, ESYS_TR_NONE, ESYS_TR_NONE, ESYS_TR_NONE,
+        full_test);
+    if (rval != TPM2_RC_SUCCESS) {
+        LOG_PERR(Esys_SelfTest, rval);
+        return tool_rc_from_tpm(rval);
+    }
+
+    return tool_rc_success;
+}

--- a/lib/tpm2.c
+++ b/lib/tpm2.c
@@ -1359,3 +1359,19 @@ tool_rc tpm2_gettestresult(ESYS_CONTEXT *ectx, TPM2B_MAX_BUFFER **out_data,
 
     return tool_rc_success;
 }
+
+tool_rc tpm2_loadexternal(ESYS_CONTEXT *ectx, const TPM2B_SENSITIVE *private,
+        const TPM2B_PUBLIC *public, TPMI_RH_HIERARCHY hierarchy,
+        ESYS_TR *objectHandle) {
+
+    TSS2_RC rval = Esys_LoadExternal(ectx,
+            ESYS_TR_NONE, ESYS_TR_NONE, ESYS_TR_NONE,
+            private, public, hierarchy,
+            objectHandle);
+    if (rval != TSS2_RC_SUCCESS) {
+        LOG_PERR(Esys_LoadExternal, rval);
+        return tool_rc_from_tpm(rval);
+    }
+
+    return tool_rc_success;
+}

--- a/lib/tpm2.c
+++ b/lib/tpm2.c
@@ -1467,3 +1467,18 @@ tool_rc tpm2_makecredential(ESYS_CONTEXT *ectx, ESYS_TR handle,
 
     return tool_rc_success;
 }
+
+tool_rc tpm2_verifysignature(ESYS_CONTEXT *ectx, ESYS_TR key_handle,
+        const TPM2B_DIGEST *digest, const TPMT_SIGNATURE *signature,
+        TPMT_TK_VERIFIED **validation) {
+
+    TSS2_RC rval = Esys_VerifySignature(ectx,
+            key_handle, ESYS_TR_NONE, ESYS_TR_NONE,
+            ESYS_TR_NONE, digest, signature, validation);
+    if (rval != TPM2_RC_SUCCESS) {
+        LOG_PERR(Esys_VerifySignature, rval);
+        return tool_rc_from_tpm(rval);
+    }
+
+    return tool_rc_success;
+}

--- a/lib/tpm2.c
+++ b/lib/tpm2.c
@@ -1375,3 +1375,25 @@ tool_rc tpm2_loadexternal(ESYS_CONTEXT *ectx, const TPM2B_SENSITIVE *private,
 
     return tool_rc_success;
 }
+
+tool_rc tpm2_pcr_event(ESYS_CONTEXT *ectx,
+        ESYS_TR pcr, tpm2_session *session,
+        const TPM2B_EVENT *eventData,
+        TPML_DIGEST_VALUES **digests) {
+
+    ESYS_TR shandle1 = ESYS_TR_NONE;
+    tool_rc rc = tpm2_auth_util_get_shandle(ectx, pcr, session,
+            &shandle1);
+    if (rc != tool_rc_success) {
+        return rc;
+    }
+
+    TSS2_RC rval = Esys_PCR_Event(ectx, pcr, shandle1, ESYS_TR_NONE,
+            ESYS_TR_NONE, eventData, digests);
+    if (rval != TSS2_RC_SUCCESS) {
+        LOG_PERR(Esys_PCR_Event, rval);
+        return tool_rc_from_tpm(rval);
+    }
+
+    return tool_rc_success;
+}

--- a/lib/tpm2.c
+++ b/lib/tpm2.c
@@ -1309,3 +1309,16 @@ tool_rc tpm2_unseal(ESYS_CONTEXT *esys_context, tpm2_loaded_object *sealkey_obj,
 
     return tool_rc_success;
 }
+
+tool_rc tpm2_incrementalselftest(ESYS_CONTEXT *ectx, const TPML_ALG *to_test,
+        TPML_ALG **to_do_list) {
+
+    TSS2_RC rval = Esys_IncrementalSelfTest(ectx, ESYS_TR_NONE, ESYS_TR_NONE,
+        ESYS_TR_NONE, to_test, to_do_list);
+    if (rval != TPM2_RC_SUCCESS) {
+        LOG_PERR(Esys_IncrementalSelfTest, rval);
+        return tool_rc_from_tpm(rval);
+    }
+
+    return tool_rc_success;
+}

--- a/lib/tpm2.c
+++ b/lib/tpm2.c
@@ -1322,3 +1322,16 @@ tool_rc tpm2_incrementalselftest(ESYS_CONTEXT *ectx, const TPML_ALG *to_test,
 
     return tool_rc_success;
 }
+
+tool_rc tpm2_stirrandom(ESYS_CONTEXT *ectx,
+        const TPM2B_SENSITIVE_DATA *data) {
+
+    TSS2_RC rval = Esys_StirRandom(ectx, ESYS_TR_NONE, ESYS_TR_NONE,
+        ESYS_TR_NONE, data);
+    if (rval != TPM2_RC_SUCCESS) {
+        LOG_PERR(Esys_StirRandom, rval);
+        return tool_rc_from_tpm(rval);
+    }
+
+    return tool_rc_success;
+}

--- a/lib/tpm2.c
+++ b/lib/tpm2.c
@@ -497,11 +497,10 @@ tool_rc tpm2_hash_sequence_start(ESYS_CONTEXT *esys_context, const TPM2B_AUTH *a
 }
 
 tool_rc tpm2_sequence_update(ESYS_CONTEXT *esys_context, ESYS_TR sequence_handle,
-        ESYS_TR shandle1, ESYS_TR shandle2, ESYS_TR shandle3,
         const TPM2B_MAX_BUFFER *buffer) {
 
-    TSS2_RC rval = Esys_SequenceUpdate(esys_context, sequence_handle, shandle1,
-            shandle2, shandle3, buffer);
+    TSS2_RC rval = Esys_SequenceUpdate(esys_context, sequence_handle, ESYS_TR_PASSWORD,
+            ESYS_TR_NONE, ESYS_TR_NONE, buffer);
     if (rval != TSS2_RC_SUCCESS) {
         LOG_PERR(Esys_SequenceUpdate, rval);
         return tool_rc_from_tpm(rval);

--- a/lib/tpm2.c
+++ b/lib/tpm2.c
@@ -1440,3 +1440,15 @@ tool_rc tpm2_startup(ESYS_CONTEXT *ectx, TPM2_SU startup_type) {
 
     return tool_rc_success;
 }
+
+tool_rc tpm2_pcr_reset(ESYS_CONTEXT *ectx, ESYS_TR pcr_handle) {
+
+    TSS2_RC rval = Esys_PCR_Reset(ectx, pcr_handle, ESYS_TR_PASSWORD,
+            ESYS_TR_NONE, ESYS_TR_NONE);
+    if (rval != TSS2_RC_SUCCESS) {
+        LOG_PERR(Esys_PCR_Reset, rval);
+        return tool_rc_from_tpm(rval);
+    }
+
+    return tool_rc_success;
+}

--- a/lib/tpm2.c
+++ b/lib/tpm2.c
@@ -106,12 +106,11 @@ tool_rc tpm2_nv_readpublic(ESYS_CONTEXT *esys_context, ESYS_TR nv_index,
     return tool_rc_success;
 }
 
-tool_rc tpm2_getcap(ESYS_CONTEXT *esys_context, ESYS_TR shandle1,
-        ESYS_TR shandle2, ESYS_TR shandle3, TPM2_CAP capability,
+tool_rc tpm2_getcap(ESYS_CONTEXT *esys_context, TPM2_CAP capability,
         UINT32 property, UINT32 property_count, TPMI_YES_NO *more_data,
         TPMS_CAPABILITY_DATA **capability_data) {
 
-    TSS2_RC rval = Esys_GetCapability(esys_context, shandle1, shandle2, shandle3,
+    TSS2_RC rval = Esys_GetCapability(esys_context, ESYS_TR_NONE, ESYS_TR_NONE, ESYS_TR_NONE,
             capability, property, property_count, more_data, capability_data);
     if (rval != TSS2_RC_SUCCESS) {
         LOG_PERR(Esys_NV_ReadPublic, rval);

--- a/lib/tpm2.h
+++ b/lib/tpm2.h
@@ -301,4 +301,8 @@ tool_rc tpm2_startup(ESYS_CONTEXT *ectx, TPM2_SU startup_type);
 
 tool_rc tpm2_pcr_reset(ESYS_CONTEXT *ectx, ESYS_TR pcr_handle);
 
+tool_rc tpm2_makecredential(ESYS_CONTEXT *ectx, ESYS_TR handle,
+        const TPM2B_DIGEST *credential, const TPM2B_NAME *object_name,
+        TPM2B_ID_OBJECT **credential_blob, TPM2B_ENCRYPTED_SECRET **secret);
+
 #endif /* LIB_TPM2_H_ */

--- a/lib/tpm2.h
+++ b/lib/tpm2.h
@@ -297,4 +297,6 @@ tool_rc tpm2_pcr_event(ESYS_CONTEXT *ectx, ESYS_TR pcr, tpm2_session *session,
 tool_rc tpm2_getrandom(ESYS_CONTEXT *ectx, UINT16 count,
         TPM2B_DIGEST **random);
 
+tool_rc tpm2_startup(ESYS_CONTEXT *ectx, TPM2_SU startup_type);
+
 #endif /* LIB_TPM2_H_ */

--- a/lib/tpm2.h
+++ b/lib/tpm2.h
@@ -144,6 +144,10 @@ tool_rc tpm2_sequence_complete(ESYS_CONTEXT *esys_context,
         TPMI_RH_HIERARCHY hierarchy, TPM2B_DIGEST **result,
         TPMT_TK_HASHCHECK **validation);
 
+tool_rc tpm2_event_sequence_complete(ESYS_CONTEXT *ectx, ESYS_TR pcr,
+        ESYS_TR sequence_handle, tpm2_session *session,
+        const TPM2B_MAX_BUFFER *buffer, TPML_DIGEST_VALUES **results);
+
 tool_rc tpm2_tr_set_auth(ESYS_CONTEXT *esys_context, ESYS_TR handle,
         TPM2B_AUTH const *auth_value);
 

--- a/lib/tpm2.h
+++ b/lib/tpm2.h
@@ -290,4 +290,7 @@ tool_rc tpm2_loadexternal(ESYS_CONTEXT *ectx, const TPM2B_SENSITIVE *private,
         const TPM2B_PUBLIC *public, TPMI_RH_HIERARCHY hierarchy,
         ESYS_TR *objectHandle);
 
+tool_rc tpm2_pcr_event(ESYS_CONTEXT *ectx, ESYS_TR pcr, tpm2_session *session,
+        const TPM2B_EVENT *event_data, TPML_DIGEST_VALUES **digests);
+
 #endif /* LIB_TPM2_H_ */

--- a/lib/tpm2.h
+++ b/lib/tpm2.h
@@ -281,4 +281,6 @@ tool_rc tpm2_incrementalselftest(ESYS_CONTEXT *ectx, const TPML_ALG *to_test,
 
 tool_rc tpm2_stirrandom(ESYS_CONTEXT *ectx, const TPM2B_SENSITIVE_DATA *data);
 
+tool_rc tpm2_selftest(ESYS_CONTEXT *ectx, TPMI_YES_NO full_test);
+
 #endif /* LIB_TPM2_H_ */

--- a/lib/tpm2.h
+++ b/lib/tpm2.h
@@ -277,4 +277,7 @@ tool_rc tpm2_quote(ESYS_CONTEXT *esys_context, tpm2_loaded_object *quote_obj,
 tool_rc tpm2_unseal(ESYS_CONTEXT *esys_context, tpm2_loaded_object *sealkey_obj,
         TPM2B_SENSITIVE_DATA **out_data);
 
+tool_rc tpm2_incrementalselftest(ESYS_CONTEXT *ectx, const TPML_ALG *to_test,
+        TPML_ALG **to_do_list);
+
 #endif /* LIB_TPM2_H_ */

--- a/lib/tpm2.h
+++ b/lib/tpm2.h
@@ -299,4 +299,6 @@ tool_rc tpm2_getrandom(ESYS_CONTEXT *ectx, UINT16 count,
 
 tool_rc tpm2_startup(ESYS_CONTEXT *ectx, TPM2_SU startup_type);
 
+tool_rc tpm2_pcr_reset(ESYS_CONTEXT *ectx, ESYS_TR pcr_handle);
+
 #endif /* LIB_TPM2_H_ */

--- a/lib/tpm2.h
+++ b/lib/tpm2.h
@@ -140,8 +140,7 @@ tool_rc tpm2_sequence_update(ESYS_CONTEXT *esys_context, ESYS_TR sequence_handle
         const TPM2B_MAX_BUFFER *buffer);
 
 tool_rc tpm2_sequence_complete(ESYS_CONTEXT *esys_context,
-        ESYS_TR sequence_handle, ESYS_TR shandle1, ESYS_TR shandle2,
-        ESYS_TR shandle3, const TPM2B_MAX_BUFFER *buffer,
+        ESYS_TR sequence_handle, const TPM2B_MAX_BUFFER *buffer,
         TPMI_RH_HIERARCHY hierarchy, TPM2B_DIGEST **result,
         TPMT_TK_HASHCHECK **validation);
 

--- a/lib/tpm2.h
+++ b/lib/tpm2.h
@@ -280,4 +280,6 @@ tool_rc tpm2_unseal(ESYS_CONTEXT *esys_context, tpm2_loaded_object *sealkey_obj,
 tool_rc tpm2_incrementalselftest(ESYS_CONTEXT *ectx, const TPML_ALG *to_test,
         TPML_ALG **to_do_list);
 
+tool_rc tpm2_stirrandom(ESYS_CONTEXT *ectx, const TPM2B_SENSITIVE_DATA *data);
+
 #endif /* LIB_TPM2_H_ */

--- a/lib/tpm2.h
+++ b/lib/tpm2.h
@@ -294,4 +294,7 @@ tool_rc tpm2_loadexternal(ESYS_CONTEXT *ectx, const TPM2B_SENSITIVE *private,
 tool_rc tpm2_pcr_event(ESYS_CONTEXT *ectx, ESYS_TR pcr, tpm2_session *session,
         const TPM2B_EVENT *event_data, TPML_DIGEST_VALUES **digests);
 
+tool_rc tpm2_getrandom(ESYS_CONTEXT *ectx, UINT16 count,
+        TPM2B_DIGEST **random);
+
 #endif /* LIB_TPM2_H_ */

--- a/lib/tpm2.h
+++ b/lib/tpm2.h
@@ -29,8 +29,7 @@ tool_rc tpm2_readpublic(ESYS_CONTEXT *esys_context, ESYS_TR object_handle,
         TPM2B_PUBLIC **out_public, TPM2B_NAME **name,
         TPM2B_NAME **qualified_name);
 
-tool_rc tpm2_getcap(ESYS_CONTEXT *esys_context, ESYS_TR shandle1,
-        ESYS_TR shandle2, ESYS_TR shandle3, TPM2_CAP capability,
+tool_rc tpm2_getcap(ESYS_CONTEXT *esys_context,TPM2_CAP capability,
         UINT32 property, UINT32 property_count, TPMI_YES_NO *more_data,
         TPMS_CAPABILITY_DATA **capability_data);
 

--- a/lib/tpm2.h
+++ b/lib/tpm2.h
@@ -190,6 +190,10 @@ tool_rc tpm2_rsa_decrypt(ESYS_CONTEXT *esys_context, tpm2_loaded_object *keyobj,
         const TPMT_RSA_DECRYPT *in_scheme, const TPM2B_DATA *label,
         TPM2B_PUBLIC_KEY_RSA **message);
 
+tool_rc tpm2_rsa_encrypt(ESYS_CONTEXT *ectx, tpm2_loaded_object *keyobj,
+        const TPM2B_PUBLIC_KEY_RSA *message, const TPMT_RSA_DECRYPT *scheme,
+        const TPM2B_DATA *label, TPM2B_PUBLIC_KEY_RSA **cipher_text);
+
 tool_rc tpm2_load(ESYS_CONTEXT *esys_context, tpm2_loaded_object *parentobj,
         const TPM2B_PRIVATE *in_private, const TPM2B_PUBLIC *in_public,
         ESYS_TR *object_handle);

--- a/lib/tpm2.h
+++ b/lib/tpm2.h
@@ -133,8 +133,7 @@ tool_rc tpm2_hash(ESYS_CONTEXT *esys_context, ESYS_TR shandle1, ESYS_TR shandle2
         TPMI_RH_HIERARCHY hierarchy, TPM2B_DIGEST **out_hash,
         TPMT_TK_HASHCHECK **validation);
 
-tool_rc tpm2_hash_sequence_start(ESYS_CONTEXT *esys_context, ESYS_TR shandle1,
-        ESYS_TR shandle2, ESYS_TR shandle3, const TPM2B_AUTH *auth,
+tool_rc tpm2_hash_sequence_start(ESYS_CONTEXT *esys_context, const TPM2B_AUTH *auth,
         TPMI_ALG_HASH hash_alg, ESYS_TR *sequence_handle);
 
 tool_rc tpm2_sequence_update(ESYS_CONTEXT *esys_context, ESYS_TR sequence_handle,

--- a/lib/tpm2.h
+++ b/lib/tpm2.h
@@ -305,4 +305,8 @@ tool_rc tpm2_makecredential(ESYS_CONTEXT *ectx, ESYS_TR handle,
         const TPM2B_DIGEST *credential, const TPM2B_NAME *object_name,
         TPM2B_ID_OBJECT **credential_blob, TPM2B_ENCRYPTED_SECRET **secret);
 
+tool_rc tpm2_verifysignature(ESYS_CONTEXT *ectx, ESYS_TR key_handle,
+        const TPM2B_DIGEST *digest, const TPMT_SIGNATURE *signature,
+        TPMT_TK_VERIFIED **validation);
+
 #endif /* LIB_TPM2_H_ */

--- a/lib/tpm2.h
+++ b/lib/tpm2.h
@@ -137,7 +137,6 @@ tool_rc tpm2_hash_sequence_start(ESYS_CONTEXT *esys_context, const TPM2B_AUTH *a
         TPMI_ALG_HASH hash_alg, ESYS_TR *sequence_handle);
 
 tool_rc tpm2_sequence_update(ESYS_CONTEXT *esys_context, ESYS_TR sequence_handle,
-        ESYS_TR shandle1, ESYS_TR shandle2, ESYS_TR shandle3,
         const TPM2B_MAX_BUFFER *buffer);
 
 tool_rc tpm2_sequence_complete(ESYS_CONTEXT *esys_context,

--- a/lib/tpm2.h
+++ b/lib/tpm2.h
@@ -283,4 +283,7 @@ tool_rc tpm2_stirrandom(ESYS_CONTEXT *ectx, const TPM2B_SENSITIVE_DATA *data);
 
 tool_rc tpm2_selftest(ESYS_CONTEXT *ectx, TPMI_YES_NO full_test);
 
+tool_rc tpm2_gettestresult(ESYS_CONTEXT *ectx, TPM2B_MAX_BUFFER **out_data,
+        TPM2_RC *test_result);
+
 #endif /* LIB_TPM2_H_ */

--- a/lib/tpm2.h
+++ b/lib/tpm2.h
@@ -286,4 +286,8 @@ tool_rc tpm2_selftest(ESYS_CONTEXT *ectx, TPMI_YES_NO full_test);
 tool_rc tpm2_gettestresult(ESYS_CONTEXT *ectx, TPM2B_MAX_BUFFER **out_data,
         TPM2_RC *test_result);
 
+tool_rc tpm2_loadexternal(ESYS_CONTEXT *ectx, const TPM2B_SENSITIVE *private,
+        const TPM2B_PUBLIC *public, TPMI_RH_HIERARCHY hierarchy,
+        ESYS_TR *objectHandle);
+
 #endif /* LIB_TPM2_H_ */

--- a/lib/tpm2_hash.c
+++ b/lib/tpm2_hash.c
@@ -111,8 +111,8 @@ static tool_rc tpm2_hash_common(ESYS_CONTEXT *ectx, TPMI_ALG_HASH halg,
         buffer.size = 0;
     }
 
-    return tpm2_sequence_complete(ectx, sequence_handle, ESYS_TR_PASSWORD,
-            ESYS_TR_NONE, ESYS_TR_NONE, &buffer, hierarchy, result, validation);
+    return tpm2_sequence_complete(ectx, sequence_handle,
+            &buffer, hierarchy, result, validation);
 }
 
 tool_rc tpm2_hash_compute_data(ESYS_CONTEXT *ectx, TPMI_ALG_HASH halg,

--- a/lib/tpm2_hash.c
+++ b/lib/tpm2_hash.c
@@ -52,8 +52,7 @@ static tool_rc tpm2_hash_common(ESYS_CONTEXT *ectx, TPMI_ALG_HASH halg,
      * chunks to loop over, if possible. This way we can call Complete with
      * data.
      */
-    tool_rc rc = tpm2_hash_sequence_start(ectx, ESYS_TR_NONE, ESYS_TR_NONE,
-            ESYS_TR_NONE, &null_auth, halg, &sequence_handle);
+    tool_rc rc = tpm2_hash_sequence_start(ectx, &null_auth, halg, &sequence_handle);
     if (rc != tool_rc_success) {
         return rc;
     }

--- a/lib/tpm2_hash.c
+++ b/lib/tpm2_hash.c
@@ -78,8 +78,7 @@ static tool_rc tpm2_hash_common(ESYS_CONTEXT *ectx, TPMI_ALG_HASH halg,
             inbuffer = inbuffer + buffer.size;
         }
 
-        rc = tpm2_sequence_update(ectx, sequence_handle, ESYS_TR_PASSWORD,
-                ESYS_TR_NONE, ESYS_TR_NONE, &buffer);
+        rc = tpm2_sequence_update(ectx, sequence_handle, &buffer);
         if (rc != tool_rc_success) {
             return rc;
         }

--- a/lib/tpm2_hash.c
+++ b/lib/tpm2_hash.c
@@ -57,11 +57,6 @@ static tool_rc tpm2_hash_common(ESYS_CONTEXT *ectx, TPMI_ALG_HASH halg,
         return rc;
     }
 
-    rc = tpm2_tr_set_auth(ectx, sequence_handle, &null_auth);
-    if (rc != tool_rc_success) {
-        return rc;
-    }
-
     /* If we know the file size, we decrement the amount read and terminate
      * the loop when 1 block is left, else we go till feof.
      */

--- a/lib/tpm2_nv_util.h
+++ b/lib/tpm2_nv_util.h
@@ -66,9 +66,8 @@ static inline tool_rc tpm2_util_nv_max_buffer_size(ESYS_CONTEXT *ectx,
     /* Get the maximum read block size */
     TPMS_CAPABILITY_DATA *cap_data;
     TPMI_YES_NO more_data;
-    tool_rc rc = tpm2_getcap(ectx, ESYS_TR_NONE, ESYS_TR_NONE, ESYS_TR_NONE,
-            TPM2_CAP_TPM_PROPERTIES, TPM2_PT_NV_BUFFER_MAX, 1, &more_data,
-            &cap_data);
+    tool_rc rc = tpm2_getcap(ectx, TPM2_CAP_TPM_PROPERTIES,
+            TPM2_PT_NV_BUFFER_MAX, 1, &more_data, &cap_data);
     if (rc != tool_rc_success) {
         return rc;
     }

--- a/tools/tpm2_createek.c
+++ b/tools/tpm2_createek.c
@@ -199,10 +199,9 @@ static tool_rc create_ek_handle(ESYS_CONTEXT *ectx) {
             return rc;
         }
 
-        TSS2_RC rval = Esys_FlushContext(ectx, ctx.objdata.out.handle);
-        if (rval != TSS2_RC_SUCCESS) {
-            LOG_PERR(Esys_FlushContext, rval);
-            return tool_rc_from_tpm(rval);
+        rc = tpm2_flush_context(ectx, ctx.objdata.out.handle);
+        if (rc != tool_rc_success) {
+            return rc;
         }
     } else {
         /* If it wasn't persistent, save a context for future tool interactions */

--- a/tools/tpm2_evictcontrol.c
+++ b/tools/tpm2_evictcontrol.c
@@ -159,11 +159,7 @@ tool_rc tpm2_tool_onrun(ESYS_CONTEXT *ectx, tpm2_option_flags flags) {
 
 out:
     if (!evicted) {
-        TSS2_RC rval = Esys_TR_Close(ectx, &out_tr);
-        if (rval != TPM2_RC_SUCCESS) {
-            LOG_PERR(Esys_TR_Close, rc);
-            rc = tool_rc_from_tpm(rval);
-        }
+        rc = tpm2_close(ectx, &out_tr);
     }
 
     return rc;

--- a/tools/tpm2_flushcontext.c
+++ b/tools/tpm2_flushcontext.c
@@ -4,6 +4,7 @@
 
 #include "log.h"
 #include "object.h"
+#include "tpm2.h"
 #include "tpm2_capability.h"
 #include "tpm2_options.h"
 
@@ -43,12 +44,11 @@ static tool_rc flush_contexts_tpm2(ESYS_CONTEXT *ectx, TPM2_HANDLE handles[],
             return rc;
         }
 
-        TPM2_RC rval = Esys_FlushContext(ectx, handle);
-        if (rval != TPM2_RC_SUCCESS) {
+        rc = tpm2_flush_context(ectx, handle);
+        if (rc != tool_rc_success) {
             LOG_ERR("Failed Flush Context for %s handle 0x%x",
                     get_property_name(handles[i]), handles[i]);
-            LOG_PERR(Esys_FlushContext, rval);
-            return tool_rc_from_tpm(rval);
+            return rc;
         }
     }
 
@@ -61,10 +61,9 @@ static bool flush_contexts_tr(ESYS_CONTEXT *ectx, ESYS_TR handles[],
     UINT32 i;
 
     for (i = 0; i < count; ++i) {
-        TPM2_RC rval = Esys_FlushContext(ectx, handles[i]);
-        if (rval != TPM2_RC_SUCCESS) {
-            LOG_PERR(Esys_FlushContext, rval);
-            return Tss2_RC_Decode(rval);
+        tool_rc rc = tpm2_flush_context(ectx, handles[i]);
+        if (rc != tool_rc_success) {
+            return rc;
         }
     }
 

--- a/tools/tpm2_getekcertificate.c
+++ b/tools/tpm2_getekcertificate.c
@@ -330,9 +330,8 @@ bool is_getekcertificate_feasible(ESYS_CONTEXT *ectx) {
     TPMI_YES_NO more_data;
     TPMS_CAPABILITY_DATA *capability_data;
 
-    tool_rc rc = tpm2_getcap(ectx, ESYS_TR_NONE, ESYS_TR_NONE, ESYS_TR_NONE,
-            TPM2_CAP_TPM_PROPERTIES, TPM2_PT_MANUFACTURER, 1, &more_data,
-            &capability_data);
+    tool_rc rc = tpm2_getcap(ectx, TPM2_CAP_TPM_PROPERTIES, TPM2_PT_MANUFACTURER,
+            1, &more_data, &capability_data);
     if (rc != tool_rc_success) {
         LOG_ERR("TPM property read failure.");
         return false;
@@ -347,9 +346,8 @@ bool is_getekcertificate_feasible(ESYS_CONTEXT *ectx) {
         return true;
     }
 
-    rc = tpm2_getcap(ectx, ESYS_TR_NONE, ESYS_TR_NONE, ESYS_TR_NONE,
-            TPM2_CAP_TPM_PROPERTIES, TPM2_PT_PERMANENT, 1, &more_data,
-            &capability_data);
+    rc = tpm2_getcap(ectx, TPM2_CAP_TPM_PROPERTIES, TPM2_PT_PERMANENT,
+            1, &more_data, &capability_data);
     if (rc != tool_rc_success) {
         LOG_ERR("TPM property read failure.");
         return false;

--- a/tools/tpm2_getrandom.c
+++ b/tools/tpm2_getrandom.c
@@ -9,6 +9,7 @@
 
 #include "files.h"
 #include "log.h"
+#include "tpm2.h"
 #include "tpm2_capability.h"
 #include "tpm2_tool.h"
 
@@ -26,11 +27,9 @@ static tool_rc get_random_and_save(ESYS_CONTEXT *ectx) {
 
     TPM2B_DIGEST *random_bytes;
 
-    TSS2_RC rval = Esys_GetRandom(ectx, ESYS_TR_NONE, ESYS_TR_NONE,
-            ESYS_TR_NONE, ctx.num_of_bytes, &random_bytes);
-    if (rval != TPM2_RC_SUCCESS) {
-        LOG_PERR(Esys_GetRandom, rval);
-        return tool_rc_from_tpm(rval);
+    tool_rc rc = tpm2_getrandom(ectx, ctx.num_of_bytes, &random_bytes);
+    if (rc != tool_rc_success) {
+        return rc;
     }
 
     /* ensure we got the expected number of bytes unless force is set */

--- a/tools/tpm2_gettestresult.c
+++ b/tools/tpm2_gettestresult.c
@@ -3,6 +3,7 @@
 #include <stdlib.h>
 
 #include "log.h"
+#include "tpm2.h"
 #include "tpm2_tool.h"
 
 bool tpm2_tool_onstart(tpm2_options **opts) {
@@ -26,11 +27,9 @@ tool_rc tpm2_tool_onrun(ESYS_CONTEXT *ectx, tpm2_option_flags flags) {
      * testResult will be TPM_RC_TESTING. If testing of all functions is complete without functional failures,
      * testResult will be TPM_RC_SUCCESS. If any test failed, testResult will be TPM_RC_FAILURE.
      */
-    TSS2_RC rval = Esys_GetTestResult(ectx, ESYS_TR_NONE, ESYS_TR_NONE,
-            ESYS_TR_NONE, &output, &status);
-    if (rval != TSS2_RC_SUCCESS) {
-        LOG_PERR(Esys_SelfTest, rval);
-        return tool_rc_from_tpm(rval);
+    tool_rc tmp_rc = tpm2_gettestresult(ectx, &output, &status);
+    if (tmp_rc != tool_rc_success) {
+        return tmp_rc;
     }
 
     tpm2_tool_output("status: ");

--- a/tools/tpm2_loadexternal.c
+++ b/tools/tpm2_loadexternal.c
@@ -8,6 +8,7 @@
 
 #include "files.h"
 #include "log.h"
+#include "tpm2.h"
 #include "tpm2_alg_util.h"
 #include "tpm2_attr_util.h"
 #include "tpm2_auth_util.h"
@@ -47,15 +48,14 @@ static tpm_loadexternal_ctx ctx = {
 static tool_rc load_external(ESYS_CONTEXT *ectx, TPM2B_PUBLIC *pub,
         TPM2B_SENSITIVE *priv, bool has_priv, TPM2B_NAME **name) {
 
-    TSS2_RC rval = Esys_LoadExternal(ectx, ESYS_TR_NONE, ESYS_TR_NONE,
-            ESYS_TR_NONE, has_priv ? priv : NULL, pub, ctx.hierarchy_value,
+    tool_rc rc = tpm2_loadexternal(ectx,
+            has_priv ? priv : NULL, pub, ctx.hierarchy_value,
             &ctx.handle);
-    if (rval != TPM2_RC_SUCCESS) {
-        LOG_PERR(Esys_LoadExternal, rval);
-        return tool_rc_from_tpm(rval);
+    if (rc != tool_rc_success) {
+        return rc;
     }
 
-    rval = Esys_TR_GetName(ectx, ctx.handle, name);
+    TSS2_RC rval = Esys_TR_GetName(ectx, ctx.handle, name);
     if (rval != TPM2_RC_SUCCESS) {
         LOG_PERR(Esys_TR_GetName, rval);
         return tool_rc_from_tpm(rval);

--- a/tools/tpm2_loadexternal.c
+++ b/tools/tpm2_loadexternal.c
@@ -55,13 +55,7 @@ static tool_rc load_external(ESYS_CONTEXT *ectx, TPM2B_PUBLIC *pub,
         return rc;
     }
 
-    TSS2_RC rval = Esys_TR_GetName(ectx, ctx.handle, name);
-    if (rval != TPM2_RC_SUCCESS) {
-        LOG_PERR(Esys_TR_GetName, rval);
-        return tool_rc_from_tpm(rval);
-    }
-
-    return tool_rc_success;
+    return tpm2_tr_get_name(ectx, ctx.handle, name);
 }
 
 static bool on_option(char key, char *value) {

--- a/tools/tpm2_makecredential.c
+++ b/tools/tpm2_makecredential.c
@@ -171,7 +171,6 @@ static tool_rc make_credential_and_save(ESYS_CONTEXT *ectx) {
     TPM2B_ID_OBJECT *cred_blob;
     TPM2B_ENCRYPTED_SECRET *secret;
     ESYS_TR tr_handle = ESYS_TR_NONE;
-    UINT32 rval;
 
     tool_rc rc = tpm2_loadexternal(ectx,
             NULL, &ctx.public, TPM2_RH_NULL, &tr_handle);
@@ -179,12 +178,11 @@ static tool_rc make_credential_and_save(ESYS_CONTEXT *ectx) {
         return rc;
     }
 
-    rval = Esys_MakeCredential(ectx, tr_handle, ESYS_TR_NONE, ESYS_TR_NONE,
-            ESYS_TR_NONE, &ctx.credential, &ctx.object_name, &cred_blob,
+    rc = tpm2_makecredential(ectx, tr_handle,
+            &ctx.credential, &ctx.object_name, &cred_blob,
             &secret);
-    if (rval != TPM2_RC_SUCCESS) {
-        LOG_PERR(Esys_MakeCredential, rval);
-        return tool_rc_from_tpm(rval);
+    if (rc != tool_rc_success) {
+        return rc;
     }
 
     rc = tpm2_flush_context(ectx, tr_handle);

--- a/tools/tpm2_makecredential.c
+++ b/tools/tpm2_makecredential.c
@@ -9,6 +9,7 @@
 
 #include "files.h"
 #include "log.h"
+#include "tpm2.h"
 #include "tpm2_alg_util.h"
 #include "tpm2_identity_util.h"
 #include "tpm2_options.h"
@@ -172,11 +173,10 @@ static tool_rc make_credential_and_save(ESYS_CONTEXT *ectx) {
     ESYS_TR tr_handle = ESYS_TR_NONE;
     UINT32 rval;
 
-    rval = Esys_LoadExternal(ectx, ESYS_TR_NONE, ESYS_TR_NONE, ESYS_TR_NONE,
+    tool_rc rc = tpm2_loadexternal(ectx,
             NULL, &ctx.public, TPM2_RH_NULL, &tr_handle);
-    if (rval != TPM2_RC_SUCCESS) {
-        LOG_PERR(Esys_LoadExternal, rval);
-        return tool_rc_from_tpm(rval);
+    if (rc != tool_rc_success) {
+        return rc;
     }
 
     rval = Esys_MakeCredential(ectx, tr_handle, ESYS_TR_NONE, ESYS_TR_NONE,

--- a/tools/tpm2_makecredential.c
+++ b/tools/tpm2_makecredential.c
@@ -187,10 +187,11 @@ static tool_rc make_credential_and_save(ESYS_CONTEXT *ectx) {
         return tool_rc_from_tpm(rval);
     }
 
-    rval = Esys_FlushContext(ectx, tr_handle);
-    if (rval != TPM2_RC_SUCCESS) {
-        LOG_PERR(Esys_FlushContext, rval);
-        return tool_rc_from_tpm(rval);
+    rc = tpm2_flush_context(ectx, tr_handle);
+    if (rc != tool_rc_success) {
+        free(cred_blob);
+        free(secret);
+        return rc;
     }
 
     bool ret = write_cred_and_secret(ctx.out_file_path, cred_blob, secret);

--- a/tools/tpm2_nvreadpublic.c
+++ b/tools/tpm2_nvreadpublic.c
@@ -47,13 +47,10 @@ static void print_nv_public(TPM2B_NV_PUBLIC *nv_public) {
 static tool_rc nv_readpublic(ESYS_CONTEXT *context) {
 
     TPMS_CAPABILITY_DATA *capability_data;
-    UINT32 property = tpm2_util_hton_32(TPM2_HT_NV_INDEX);
-    TSS2_RC rval = Esys_GetCapability(context, ESYS_TR_NONE, ESYS_TR_NONE,
-            ESYS_TR_NONE, TPM2_CAP_HANDLES, property, TPM2_PT_NV_INDEX_MAX,
-            NULL, &capability_data);
-    if (rval != TPM2_RC_SUCCESS) {
-        LOG_PERR(Esys_GetCapability, rval);
-        return tool_rc_from_tpm(rval);
+    tool_rc rc = tpm2_getcap(context, TPM2_CAP_HANDLES, tpm2_util_hton_32(TPM2_HT_NV_INDEX),
+            TPM2_PT_NV_INDEX_MAX, NULL, &capability_data);
+    if (rc != tool_rc_success) {
+        return rc;
     }
 
     UINT32 i;

--- a/tools/tpm2_pcrevent.c
+++ b/tools/tpm2_pcrevent.c
@@ -115,8 +115,21 @@ static tool_rc tpm_pcrevent_file(ESYS_CONTEXT *ectx,
         data.size = 0;
     }
 
-    return tpm2_event_sequence_complete(ectx, ctx.pcr, sequence_handle,
-            ctx.auth.session, &data, result);
+    ESYS_TR shandle1 = ESYS_TR_NONE;
+    rc = tpm2_auth_util_get_shandle(ectx, ctx.pcr, ctx.auth.session,
+            &shandle1);
+    if (rc != tool_rc_success) {
+        return rc;
+    }
+
+    rval = Esys_EventSequenceComplete(ectx, ctx.pcr, sequence_handle, shandle1,
+            ESYS_TR_PASSWORD, ESYS_TR_NONE, &data, result);
+    if (rval != TSS2_RC_SUCCESS) {
+        LOG_PERR(Esys_EventSequenceComplete, rval);
+        return tool_rc_from_tpm(rval);
+    }
+
+    return tool_rc_success;
 }
 
 static tool_rc do_pcrevent_and_output(ESYS_CONTEXT *ectx) {

--- a/tools/tpm2_pcrevent.c
+++ b/tools/tpm2_pcrevent.c
@@ -9,6 +9,7 @@
 
 #include "files.h"
 #include "log.h"
+#include "tpm2.h"
 #include "tpm2_alg_util.h"
 #include "tpm2_hierarchy.h"
 #include "tpm2_auth_util.h"
@@ -49,21 +50,7 @@ static tool_rc tpm_pcrevent_file(ESYS_CONTEXT *ectx,
             return tool_rc_general_error;
         }
 
-        ESYS_TR shandle1 = ESYS_TR_NONE;
-        tool_rc rc = tpm2_auth_util_get_shandle(ectx, ctx.pcr, ctx.auth.session,
-                &shandle1);
-        if (rc != tool_rc_success) {
-            return rc;
-        }
-
-        rval = Esys_PCR_Event(ectx, ctx.pcr, shandle1, ESYS_TR_NONE,
-                ESYS_TR_NONE, &buffer, result);
-        if (rval != TSS2_RC_SUCCESS) {
-            LOG_PERR(Esys_PCR_Event, rval);
-            return tool_rc_from_tpm(rval);
-        }
-
-        return tool_rc_success;
+        return tpm2_pcr_event(ectx, ctx.pcr, ctx.auth.session, &buffer, result);
     }
 
     ESYS_TR sequence_handle;

--- a/tools/tpm2_pcrevent.c
+++ b/tools/tpm2_pcrevent.c
@@ -32,7 +32,6 @@ static tpm_pcrevent_ctx ctx = {
 static tool_rc tpm_pcrevent_file(ESYS_CONTEXT *ectx,
         TPML_DIGEST_VALUES **result) {
 
-    TSS2_RC rval;
     unsigned long file_size = 0;
     FILE *input = ctx.input;
 
@@ -115,21 +114,8 @@ static tool_rc tpm_pcrevent_file(ESYS_CONTEXT *ectx,
         data.size = 0;
     }
 
-    ESYS_TR shandle1 = ESYS_TR_NONE;
-    rc = tpm2_auth_util_get_shandle(ectx, ctx.pcr, ctx.auth.session,
-            &shandle1);
-    if (rc != tool_rc_success) {
-        return rc;
-    }
-
-    rval = Esys_EventSequenceComplete(ectx, ctx.pcr, sequence_handle, shandle1,
-            ESYS_TR_PASSWORD, ESYS_TR_NONE, &data, result);
-    if (rval != TSS2_RC_SUCCESS) {
-        LOG_PERR(Esys_EventSequenceComplete, rval);
-        return tool_rc_from_tpm(rval);
-    }
-
-    return tool_rc_success;
+    return tpm2_event_sequence_complete(ectx, ctx.pcr, sequence_handle,
+            ctx.auth.session, &data, result);
 }
 
 static tool_rc do_pcrevent_and_output(ESYS_CONTEXT *ectx) {

--- a/tools/tpm2_pcrreset.c
+++ b/tools/tpm2_pcrreset.c
@@ -4,6 +4,7 @@
 
 #include "log.h"
 #include "pcr.h"
+#include "tpm2.h"
 #include "tpm2_options.h"
 
 typedef struct tpm_pcr_reset_ctx tpm_pcr_reset_ctx;
@@ -15,15 +16,12 @@ static tpm_pcr_reset_ctx ctx;
 
 static tool_rc pcr_reset_one(ESYS_CONTEXT *ectx, TPMI_DH_PCR pcr_index) {
 
-    TSS2_RC rval = Esys_PCR_Reset(ectx, pcr_index, ESYS_TR_PASSWORD,
-            ESYS_TR_NONE, ESYS_TR_NONE);
-    if (rval != TSS2_RC_SUCCESS) {
+    tool_rc rc = tpm2_pcr_reset(ectx, pcr_index);
+    if (rc != tool_rc_success) {
         LOG_ERR("Could not reset PCR index: %d", pcr_index);
-        LOG_PERR(Esys_PCR_Reset, rval);
-        return tool_rc_from_tpm(rval);
     }
 
-    return tool_rc_success;
+    return rc;
 }
 
 static tool_rc pcr_reset(ESYS_CONTEXT *ectx) {

--- a/tools/tpm2_rsaencrypt.c
+++ b/tools/tpm2_rsaencrypt.c
@@ -6,6 +6,7 @@
 #include "files.h"
 #include "log.h"
 #include "object.h"
+#include "tpm2.h"
 #include "tpm2_alg_util.h"
 #include "tpm2_options.h"
 
@@ -30,12 +31,10 @@ static tool_rc rsa_encrypt_and_save(ESYS_CONTEXT *context) {
     bool ret = false;
     TPM2B_PUBLIC_KEY_RSA *out_data = NULL;
 
-    TSS2_RC rval = Esys_RSA_Encrypt(context, ctx.key_context.tr_handle,
-            ESYS_TR_NONE, ESYS_TR_NONE, ESYS_TR_NONE, &ctx.message, &ctx.scheme,
-            &ctx.label, &out_data);
-    if (rval != TPM2_RC_SUCCESS) {
-        LOG_PERR(Esys_RSA_Encrypt, rval);
-        return tool_rc_from_tpm(rval);
+    tool_rc rc = tpm2_rsa_encrypt(context, &ctx.key_context,
+            &ctx.message, &ctx.scheme, &ctx.label, &out_data);
+    if (rc != tool_rc_success) {
+        return rc;
     }
 
     FILE *f = ctx.output_path ? fopen(ctx.output_path, "wb+") : stdout;

--- a/tools/tpm2_selftest.c
+++ b/tools/tpm2_selftest.c
@@ -1,6 +1,7 @@
 /* SPDX-License-Identifier: BSD-3-Clause */
 
 #include "log.h"
+#include "tpm2.h"
 #include "tpm2_options.h"
 
 typedef struct tpm_selftest_ctx tpm_selftest_ctx;
@@ -10,18 +11,6 @@ struct tpm_selftest_ctx {
 };
 
 static tpm_selftest_ctx ctx;
-
-static tool_rc tpm_selftest(ESYS_CONTEXT *ectx) {
-    TSS2_RC rval = Esys_SelfTest(ectx, ESYS_TR_NONE, ESYS_TR_NONE, ESYS_TR_NONE,
-            ctx.fulltest);
-    if (rval != TSS2_RC_SUCCESS) {
-        LOG_ERR("TPM SelfTest failed !");
-        LOG_PERR(Esys_SelfTest, rval);
-        return tool_rc_from_tpm(rval);
-    }
-
-    return tool_rc_success;
-}
 
 static bool on_option(char key, char *value) {
 
@@ -56,5 +45,5 @@ tool_rc tpm2_tool_onrun(ESYS_CONTEXT *ectx, tpm2_option_flags flags) {
 
     UNUSED(flags);
 
-    return tpm_selftest(ectx);
+    return tpm2_selftest(ectx, ctx.fulltest);
 }

--- a/tools/tpm2_startup.c
+++ b/tools/tpm2_startup.c
@@ -1,6 +1,7 @@
 /* SPDX-License-Identifier: BSD-3-Clause */
 
 #include "log.h"
+#include "tpm2.h"
 #include "tpm2_tool.h"
 
 /*
@@ -52,12 +53,5 @@ tool_rc tpm2_tool_onrun(ESYS_CONTEXT *context, tpm2_option_flags flags) {
     LOG_INFO("Sending TPM_Startup command with type: %s",
             ctx.clear ? "TPM2_SU_CLEAR" : "TPM2_SU_STATE");
 
-    TSS2_RC rval = Esys_Startup(context, startup_type);
-    if (rval != TPM2_RC_SUCCESS && rval != TPM2_RC_INITIALIZE) {
-        LOG_PERR(Esys_Startup, rval);
-        return tool_rc_from_tpm(rval);
-    }
-
-    LOG_INFO("Success. TSS2_RC: 0x%x", rval);
-    return tool_rc_success;
+    return tpm2_startup(context, startup_type);
 }

--- a/tools/tpm2_stirrandom.c
+++ b/tools/tpm2_stirrandom.c
@@ -2,6 +2,7 @@
 
 #include "files.h"
 #include "log.h"
+#include "tpm2.h"
 #include "tpm2_options.h"
 
 /* Spec enforce input data to be not longer than 128 bytes */
@@ -14,20 +15,6 @@ struct tpm_stirrandom_ctx {
 };
 
 static tpm_stirrandom_ctx ctx;
-
-static tool_rc do_stirrandom(ESYS_CONTEXT *ectx) {
-
-    TSS2_RC rval = Esys_StirRandom(ectx, ESYS_TR_NONE, ESYS_TR_NONE,
-            ESYS_TR_NONE, &ctx.in_data);
-    if (rval != TSS2_RC_SUCCESS) {
-        LOG_ERR("Error while injecting specified additionnal data into TPM "
-                "random pool");
-        LOG_PERR(Esys_StirRandom, rval);
-        return tool_rc_from_tpm(rval);
-    }
-
-    return tool_rc_success;
-}
 
 static bool on_args(int argc, char **argv) {
 
@@ -77,5 +64,5 @@ tool_rc tpm2_tool_onrun(ESYS_CONTEXT *ectx, tpm2_option_flags flags) {
         return tool_rc_general_error;
     }
 
-    return do_stirrandom(ectx);
+    return tpm2_stirrandom(ectx, &ctx.in_data);
 }

--- a/tools/tpm2_verifysignature.c
+++ b/tools/tpm2_verifysignature.c
@@ -5,6 +5,7 @@
 #include "files.h"
 #include "log.h"
 #include "object.h"
+#include "tpm2.h"
 #include "tpm2_alg_util.h"
 #include "tpm2_convert.h"
 #include "tpm2_hash.h"
@@ -43,15 +44,12 @@ static tpm2_verifysig_ctx ctx = {
 
 static tool_rc verify_signature(ESYS_CONTEXT *context) {
 
-    tool_rc rc = tool_rc_success;
-    TPMT_TK_VERIFIED *validation;
+    TPMT_TK_VERIFIED *validation = NULL;
 
-    TSS2_RC rval = Esys_VerifySignature(context,
-            ctx.key_context_object.tr_handle, ESYS_TR_NONE, ESYS_TR_NONE,
-            ESYS_TR_NONE, ctx.msg_hash, &ctx.signature, &validation);
-    if (rval != TPM2_RC_SUCCESS) {
-        LOG_PERR(Esys_VerifySignature, rval);
-        rc = tool_rc_from_tpm(rval);
+    tool_rc rc = tpm2_verifysignature(context,
+            ctx.key_context_object.tr_handle,
+            ctx.msg_hash, &ctx.signature, &validation);
+    if (rc != tool_rc_success) {
         goto out;
     }
 


### PR DESCRIPTION
Move all the ESys_ calls from tools into the lib/tpm2.c interface and use a slightly higher level interface. The igher interface should use tpm2_session *'s, remove unused session handles and tpm2_loaded_object *'s where appropriate.

Fixes: #1520
Fixes: #1539
