### PR TITLE
configure.ac: be clearer whether man pages will be installed

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -212,5 +212,6 @@ AC_OUTPUT
 
 AC_MSG_RESULT([
     $PACKAGE_NAME    $VERSION
+    Man pages:    ${PANDOC:-no}
     Unit tests:   $enable_unit
 ])


### PR DESCRIPTION
Man pages are only built if pandoc is installed, but it's easy to miss

    checking for pandoc... no
    configure: WARNING: Required executable pandoc not found, man pages will not be built

in the middle of the 120 lines of configure output. This commit adds
an explicit "Man pages: yes/no" message to the end of configure
output.

Signed-off-by: Matthew Dempsky <matthew@dempsky.org>