### PR TITLE
tpm2_convert: fix ecdsa signature generation

### DIFF
--- a/lib/tpm2_convert.c
+++ b/lib/tpm2_convert.c
@@ -93,15 +93,10 @@ static bool convert_pubkey_RSA(TPMT_PUBLIC *public,
         goto error;
     }
 
-#if defined(LIB_TPM2_OPENSSL_OPENSSL_PRE11)
-    ssl_rsa_key->e = e;
-    ssl_rsa_key->n = n;
-#else
     if (!RSA_set0_key(ssl_rsa_key, n, e, NULL)) {
         print_ssl_error("Failed to set RSA modulus and exponent components");
         goto error;
     }
-#endif
 
     /* modulus and exponent components are now owned by the RSA struct */
     n = e = NULL;

--- a/lib/tpm2_openssl.c
+++ b/lib/tpm2_openssl.c
@@ -82,6 +82,21 @@ void RSA_get0_factors(const RSA *r, const BIGNUM **p, const BIGNUM **q) {
     }
 }
 
+int ECDSA_SIG_set0(ECDSA_SIG *sig, BIGNUM *r, BIGNUM *s) {
+
+    if (!r || !s) {
+        return 0;
+    }
+
+    BN_clear_free(sig->r);
+    BN_clear_free(sig->s);
+
+    sig->r = r;
+    sig->s = s;
+
+    return 1;
+}
+
 #endif
 
 static inline const char *get_openssl_err(void) {

--- a/lib/tpm2_openssl.c
+++ b/lib/tpm2_openssl.c
@@ -71,6 +71,17 @@ int RSA_set0_key(RSA *r, BIGNUM *n, BIGNUM *e, BIGNUM *d) {
 
     return 1;
 }
+
+void RSA_get0_factors(const RSA *r, const BIGNUM **p, const BIGNUM **q) {
+    if(p) {
+        *p = r->p;
+    }
+
+    if (q) {
+        *q = r->q;
+    }
+}
+
 #endif
 
 static inline const char *get_openssl_err(void) {

--- a/lib/tpm2_openssl.h
+++ b/lib/tpm2_openssl.h
@@ -18,6 +18,7 @@
 
 #if defined(LIB_TPM2_OPENSSL_OPENSSL_PRE11)
 int RSA_set0_key(RSA *r, BIGNUM *n, BIGNUM *e, BIGNUM *d);
+void RSA_get0_factors(const RSA *r, const BIGNUM **p, const BIGNUM **q);
 #endif
 
 /**

--- a/lib/tpm2_openssl.h
+++ b/lib/tpm2_openssl.h
@@ -6,6 +6,7 @@
 #include <tss2/tss2_sys.h>
 
 #include <openssl/ec.h>
+#include <openssl/ecdsa.h>
 #include <openssl/err.h>
 #include <openssl/hmac.h>
 #include <openssl/rsa.h>
@@ -19,6 +20,7 @@
 #if defined(LIB_TPM2_OPENSSL_OPENSSL_PRE11)
 int RSA_set0_key(RSA *r, BIGNUM *n, BIGNUM *e, BIGNUM *d);
 void RSA_get0_factors(const RSA *r, const BIGNUM **p, const BIGNUM **q);
+int ECDSA_SIG_set0(ECDSA_SIG *sig, BIGNUM *r, BIGNUM *s);
 #endif
 
 /**


### PR DESCRIPTION
No need to hand jam ASN1 structure if you just populate
an ECDSA_SIG object and work on that by setting the R
and S fields.

Fixes: #1649

Signed-off-by: William Roberts <william.c.roberts@intel.com>