### PR TITLE
tpm2_cc_util: remove error message

### DIFF
--- a/lib/tpm2_cc_util.c
+++ b/lib/tpm2_cc_util.c
@@ -171,8 +171,10 @@ const char *tpm2_cc_util_to_str(TPM2_CC cc) {
      * an internal buffer state that could be clobbered. Thus keeping it
      * reentrant and thread safe even though the tools never need thread
      * safety.
+     *
+     * DO NOT LOG ERROR as tpm2_getcap can have unknown commands and knows
+     * how to deal with NULL returns.
      */
-    LOG_ERR("Could not convert command-code to got: \"%u\"", cc);
 
     return NULL;
 }


### PR DESCRIPTION
Sometime shwen converting a command to a name, the command isn't found.
That's ok, some manufacturers have custom commands or the TPM is on a
newer spec then the tools. The tpm2_cc_util routine for this conversion
already handled the not found case, and just returned NULL. The caller
in tpm2_getcap would then create a name for this tool. However, the
conversion routine was printing an error message that really wasn't on
a true error case, so remove it.

Fixes: #1704

Signed-off-by: William Roberts <william.c.roberts@intel.com>