### PR TITLE
changeauth.sh: Fix a typo

### DIFF
--- a/test/integration/tests/changeauth.sh
+++ b/test/integration/tests/changeauth.sh
@@ -47,7 +47,7 @@ tpm2_startauthsession -S session.ctx
 tpm2_policycommandcode -S session.ctx -L policy.nvchange TPM2_CC_NV_ChangeAuth
 tpm2_flushcontext session.ctx
 NVIndex=0x1500015
-tpm2_nvdefine   $NVIndex -a o -s 32 -a "authread|authwrite" -L policy.nvchange
+tpm2_nvdefine   $NVIndex -C o -s 32 -a "authread|authwrite" -L policy.nvchange
 tpm2_startauthsession --policy-session -S session.ctx
 tpm2_policycommandcode -S session.ctx -L policy.nvchange TPM2_CC_NV_ChangeAuth
 tpm2_changeauth -p session:session.ctx -c $NVIndex newindexauth


### PR DESCRIPTION
The short option for specifying hierarchy should be -C not -a

Signed-off-by: Imran Desai <imran.desai@intel.com>