### PR TITLE
make: fix distcheck requiring root

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -547,6 +547,8 @@
     affects all tools.
   - Fix parsing bug in PCR mini-language.
   - Fix misspelling of TPM2_PT_HR constants which effects tpm2_getcap output.
+  - configure option --with-bashcompdir for specifying bash completion
+    directory.
 
 ### 3.2.1-rc0 - 2019-08-05
   * Correct PCR logic to prevent memory corruption bug.

--- a/Makefile.am
+++ b/Makefile.am
@@ -27,6 +27,8 @@ LDADD = \
     $(LIB_COMMON) $(TSS2_ESYS_LIBS) $(TSS2_MU_LIBS) $(CRYPTO_LIBS) $(TSS2_TCTILDR_LIBS) \
     $(TSS2_RC_LIBS)
 
+AM_DISTCHECK_CONFIGURE_FLAGS = --with-bashcompdir='$$(datarootdir)/bash-completion/completions'
+
 # keep me sorted
 bin_PROGRAMS = \
     tools/misc/tpm2_checkquote \

--- a/configure.ac
+++ b/configure.ac
@@ -55,9 +55,12 @@ AS_VAR_COPY([$1], [pkg_cv_][$1])
 AS_VAR_IF([$1], [""], [$5], [$4])dnl
 ])# PKG_CHECK_VAR
 ])
-PKG_CHECK_VAR(bashcompdir, [bash-completion], [completionsdir], ,
-  bashcompdir="${datarootdir}/bash-completion/completions")
-AC_SUBST(bashcompdir)
+
+AC_ARG_WITH([bashcompdir],
+            AS_HELP_STRING([--with-bashcompdir=DIR], [directory for bash completions]), ,
+            [PKG_CHECK_VAR([with_bashcompdir], [bash-completion], [completionsdir], ,
+                           [with_bashcompdir="${datarootdir}/bash-completion/completions"])])
+AC_SUBST(bashcompdir, [$with_bashcompdir])
 
 AC_CANONICAL_HOST
 


### PR DESCRIPTION
Because the bash completion installation didn't respect prefix,
The bash completion portion would requires root to install into
the /usr directory. This breaks make distcheck for non-root users.

The only options I found to fix this were too:
1. expand the prefix variable during pkgconfig
2. disable bash completion during make distcheck
3. ignore it

I chose option 1.

Fixes: #1706

Signed-off-by: William Roberts <william.c.roberts@intel.com>