### PR TITLE
tpm2_flushcontext.c: Fix segmentation fault

### DIFF
--- a/tools/tpm2_flushcontext.c
+++ b/tools/tpm2_flushcontext.c
@@ -140,6 +140,11 @@ tool_rc tpm2_tool_onrun(ESYS_CONTEXT *ectx, tpm2_option_flags flags) {
         return rc;
     }
 
+    if (!ctx.context_arg) {
+        LOG_ERR("Specify options to evict handles or a session context.");
+        return tool_rc_option_error;
+    }
+
     TPM2_HANDLE handle;
     bool result = tpm2_util_string_to_uint32(ctx.context_arg, &handle);
     if (!result) {


### PR DESCRIPTION
Fixes #1712 

When no arguments or options are specified the tools segfaults.
This commit fixes the issue.

Signed-off-by: Imran Desai <imran.desai@intel.com>