### PR TITLE
ci: set tpm2-tss version to 2.3.1

### DIFF
--- a/.ci/download-deps.sh
+++ b/.ci/download-deps.sh
@@ -8,7 +8,7 @@ function get_deps() {
 	echo "pwd clone tss: `pwd`"
 	if [ ! -d tpm2-tss ]; then
 		git clone --depth=1 \
-		--branch 2.3.1-rc0 https://github.com/tpm2-software/tpm2-tss.git
+		--branch 2.3.1 https://github.com/tpm2-software/tpm2-tss.git
 		pushd tpm2-tss
 		echo "pwd build tss: `pwd`"
 		./bootstrap


### PR DESCRIPTION
Set the test version to the stable TSS release for the upcoming
tpm2-tools 4.0 release.

Fixes: #1709

Signed-off-by: William Roberts <william.c.roberts@intel.com>