### PR TITLE
ci: skip whitespace checking if running CI for a specific tag

### DIFF
--- a/.ci/docker.run
+++ b/.ci/docker.run
@@ -83,7 +83,7 @@ popd
 # so people can verify the rest of their patch works in CI before dying.
 # git diff --check fails with a non-zero return code causing the shell to die
 # as it has a set -e executed.
-git diff --check origin/${TRAVIS_BRANCH:-master}
+[ -z "$TRAVIS_TAG" ] && git diff --check origin/${TRAVIS_BRANCH:-master}
 
 if [ "$ENABLE_COVERAGE" == "true" ]; then
     bash <(curl -s https://codecov.io/bash)


### PR DESCRIPTION
This fixes the failing whitespace check when running CI builds for a specific tag, see this [successful build of a custom tag for this PR](https://travis-ci.org/diabonas/tpm2-tools/builds/580333407).