### PR TITLE
tpm2_identity_util: replace "encrypt_seed" with "share_secret"

### DIFF
--- a/lib/tpm2_identity_util.h
+++ b/lib/tpm2_identity_util.h
@@ -31,10 +31,11 @@ bool tpm2_identity_util_calc_outer_integrity_hmac_key_and_dupsensitive_enc_key(
         TPM2B_MAX_BUFFER *protection_enc_key);
 
 /**
- * Encrypts seed with parent public key for TPM2 credential protection process.
+ * Encrypts a randomly generated seed with parent public key for TPM2
+ * credential protection process.
  *
  * @param protection_seed
- *  The identity structure protection seed that is to be encrypted.
+ *  The identity structure protection seed to generate and populate.
  * @param parent_pub
  *  The public key used for encryption.
  * @param label
@@ -46,7 +47,7 @@ bool tpm2_identity_util_calc_outer_integrity_hmac_key_and_dupsensitive_enc_key(
  * @return
  *  True on success, false on failure.
  */
-bool tpm2_identity_util_encrypt_seed_with_public_key(
+bool tpm2_identity_util_share_secret_with_public_key(
         TPM2B_DIGEST *protection_seed, TPM2B_PUBLIC *parent_pub,
         unsigned char *label, int label_len,
         TPM2B_ENCRYPTED_SECRET *encrypted_protection_seed);

--- a/tools/tpm2_import.c
+++ b/tools/tpm2_import.c
@@ -446,19 +446,13 @@ static tool_rc openssl_import(ESYS_CONTEXT *ectx) {
     }
 
     /*
-     * When the parent is an RSA key, seed is randomly generated and encrypted
-     * with parents public key.
-     * When the parent is en ECC key, seed is derived using an ephemeral key
-     * and KDFe, and the encrypted_seed is the public key for the ephemeral key.
+     * Generate and encrypt seed
      */
     TPM2B_DIGEST *seed = &private.sensitiveArea.seedValue;
-    seed->size = tpm2_alg_util_get_hash_size(public.publicArea.nameAlg);
-    RAND_bytes(seed->buffer, seed->size);
-
     TPM2B_ENCRYPTED_SECRET encrypted_seed = TPM2B_EMPTY_INIT;
     unsigned char label[10] = { 'D', 'U', 'P', 'L', 'I', 'C', 'A', 'T', 'E', 0 };
     bool res;
-    res = tpm2_identity_util_encrypt_seed_with_public_key(seed, parent_pub,
+    res = tpm2_identity_util_share_secret_with_public_key(seed, parent_pub,
             label, 10, &encrypted_seed);
     if (!res) {
         LOG_ERR("Failed Seed Encryption\n");

--- a/tools/tpm2_makecredential.c
+++ b/tools/tpm2_makecredential.c
@@ -93,12 +93,9 @@ static tool_rc make_external_credential_and_save(void) {
      * Generate and encrypt seed
      */
     TPM2B_DIGEST seed = TPM2B_TYPE_INIT(TPM2B_DIGEST, buffer);
-    seed.size = tpm2_alg_util_get_hash_size(name_alg);
-    RAND_bytes(seed.buffer, seed.size);
-
     TPM2B_ENCRYPTED_SECRET encrypted_seed = TPM2B_EMPTY_INIT;
     unsigned char label[10] = { 'I', 'D', 'E', 'N', 'T', 'I', 'T', 'Y', 0 };
-    bool res = tpm2_identity_util_encrypt_seed_with_public_key(&seed,
+    bool res = tpm2_identity_util_share_secret_with_public_key(&seed,
             &ctx.public, label, 9, &encrypted_seed);
     if (!res) {
         LOG_ERR("Failed Seed Encryption\n");


### PR DESCRIPTION
This commit changes the
tpm2_identity_util_encrypt_seed_with_public_key in two ways:

1. It changes the callee to always be responsible for generating the
seed, independent of the public key algorithm. Previously, the caller
had to generate a random seed for RSA keys, which was unnecessary for
ECC keys.

2. It renames "encrypt_seed" to "share_secret" to be more consistent
with the name that the TPM 2.0 Library Specification uses for this
mechanism.

Fixes #1730.

Signed-off-by: Matthew Dempsky <matthew@dempsky.org>