### PR TITLE
tpm2_policyauthorize.c: Remove unused variable

### DIFF
--- a/tools/tpm2_policyauthorizenv.c
+++ b/tools/tpm2_policyauthorizenv.c
@@ -18,7 +18,6 @@ struct tpm_policyauthorizenv_ctx {
 
     TPM2_HANDLE nv_index;
 
-    char *policy_file;
     const char *out_policy_dgst_path;
 
     const char *session_path;


### PR DESCRIPTION
Signed-off-by: Imran Desai <imran.desai@intel.com>