### PR TITLE
travis: Disable seccomp for docker

### DIFF
--- a/.ci/travis.run
+++ b/.ci/travis.run
@@ -16,6 +16,7 @@ if [ "$TRAVIS_BRANCH" != "coverity_scan" ]; then
   # Do normal CI script
   ci_env=$(bash <(curl -s https://codecov.io/env))
   docker run $ci_env --env-file .ci/docker.env \
+    --security-opt seccomp=unconfined \
     -v "$(pwd):/workspace/tpm2-tools" "tpm2software/tpm2-tss:$DOCKER_TAG" \
     /bin/bash -c '/workspace/tpm2-tools/.ci/docker.run'
 


### PR DESCRIPTION
* LeakSanitizer is making a ptrace call which gets blocked by seccomp.
  This patch disables seccomp syscall allowlist which fixes the CI for
  clang builds.

Signed-off-by: John Andersen <john.s.andersen@intel.com>