### PR TITLE
Map TPMI_RH_HIERARCHY type to Esys_TR type

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -31,7 +31,15 @@ AM_CONDITIONAL([HAVE_PANDOC],[test "x${PANDOC}" = "xyes"])
 AM_CONDITIONAL(
     [HAVE_MAN_PAGES],
     [test -d "${srcdir}/man/man1" -o "x${PANDOC}" = "xyes"])
-PKG_CHECK_MODULES([TSS2_ESYS], [tss2-esys >= 2.3.0])
+
+PKG_CHECK_MODULES([TSS2_ESYS_3_0], [tss2-esys >= 3.0.0],
+                  [AC_DEFINE([ESYS_3_0], [1], [Esys3.0])]
+                  [AC_SUBST([TSS2_ESYS_CFLAGS], [$TSS2_ESYS_3_0_CFLAGS])
+                   AC_SUBST([TSS2_ESYS_LIBS], [$TSS2_ESYS_3_0_LIBS])],
+                  [PKG_CHECK_MODULES([TSS2_ESYS_2_3], [tss2-esys >= 2.3.0],
+                  [AC_DEFINE([ESYS_2_3], [1], [Esys2.3])]
+                  [AC_SUBST([TSS2_ESYS_CFLAGS], [$TSS2_ESYS_2_3_CFLAGS])
+                   AC_SUBST([TSS2_ESYS_LIBS], [$TSS2_ESYS_2_3_LIBS])])])
 PKG_CHECK_MODULES([TSS2_TCTILDR], [tss2-tctildr])
 PKG_CHECK_MODULES([TSS2_MU], [tss2-mu])
 PKG_CHECK_MODULES([TSS2_RC], [tss2-rc])

--- a/lib/tpm2.c
+++ b/lib/tpm2.c
@@ -8,6 +8,7 @@
 #include "tpm2.h"
 #include "tpm2_auth_util.h"
 #include "tpm2_tool.h"
+#include "config.h"
 
 #define TPM2_ERROR_TSS2_RC_ERROR_MASK 0xFFFF
 
@@ -591,13 +592,44 @@ tool_rc tpm2_evictcontrol(ESYS_CONTEXT *esys_context,
     return tool_rc_success;
 }
 
+/* This function addresses ESAPI change that changes parameter type from
+ * Esys_TR to TPMI_RH_HIERARCHY and breaks backwards compatibility.
+ * To keep the tools parameters consistent after v4.0 release we need to
+ * map the values to appropriate type based on the version of the ESYS API.
+ * Note: the mapping is based on the ESYS version recognized at compile time.
+ * The TSS change can be found here:
+ * https://github.com/tpm2-software/tpm2-tss/pull/1531
+ */
+uint32_t fix_esys_hierarchy(TPMI_RH_HIERARCHY hierarchy)
+{
+#if defined(ESYS_3_0)
+    switch (hierarchy) {
+        case TPM2_RH_NULL:
+            return ESYS_TR_RH_NULL;
+        case TPM2_RH_OWNER:
+            return ESYS_TR_RH_OWNER;
+        case TPM2_RH_ENDORSEMENT:
+            return ESYS_TR_RH_ENDORSEMENT;
+        case TPM2_RH_PLATFORM:
+            return ESYS_TR_RH_PLATFORM;
+        default:
+            return TSS2_ESYS_RC_BAD_VALUE;
+    }
+#elif defined(ESYS_2_3)
+    return hierarchy;
+#else
+    UNUSED(hierarchy);
+    return TSS2_ESYS_RC_BAD_VALUE;
+#endif
+}
+
 tool_rc tpm2_hash(ESYS_CONTEXT *esys_context, ESYS_TR shandle1, ESYS_TR shandle2,
         ESYS_TR shandle3, const TPM2B_MAX_BUFFER *data, TPMI_ALG_HASH hash_alg,
         TPMI_RH_HIERARCHY hierarchy, TPM2B_DIGEST **out_hash,
         TPMT_TK_HASHCHECK **validation) {
 
     TSS2_RC rval = Esys_Hash(esys_context, shandle1, shandle2, shandle3, data,
-            hash_alg, hierarchy, out_hash, validation);
+            hash_alg, fix_esys_hierarchy(hierarchy), out_hash, validation);
     if (rval != TSS2_RC_SUCCESS) {
         LOG_PERR(Esys_Hash, rval);
         return tool_rc_from_tpm(rval);
@@ -639,7 +671,7 @@ tool_rc tpm2_sequence_complete(ESYS_CONTEXT *esys_context,
 
     TSS2_RC rval = Esys_SequenceComplete(esys_context, sequence_handle,
             ESYS_TR_PASSWORD, ESYS_TR_NONE, ESYS_TR_NONE, buffer,
-            hierarchy, result, validation);
+            fix_esys_hierarchy(hierarchy), result, validation);
     if (rval != TSS2_RC_SUCCESS) {
         LOG_PERR(Esys_SequenceComplete, rval);
         return tool_rc_from_tpm(rval);

--- a/lib/tpm2.h
+++ b/lib/tpm2.h
@@ -340,4 +340,6 @@ tool_rc tpm2_policy_nv_written(ESYS_CONTEXT *esys_context,
         ESYS_TR policy_session, ESYS_TR shandle1, ESYS_TR shandle2,
         ESYS_TR shandle3, TPMI_YES_NO written_set);
 
+uint32_t fix_esys_hierarchy(TPMI_RH_HIERARCHY hierarchy);
+
 #endif /* LIB_TPM2_H_ */

--- a/tools/tpm2_loadexternal.c
+++ b/tools/tpm2_loadexternal.c
@@ -49,8 +49,8 @@ static tool_rc load_external(ESYS_CONTEXT *ectx, TPM2B_PUBLIC *pub,
         TPM2B_SENSITIVE *priv, bool has_priv, TPM2B_NAME **name) {
 
     tool_rc rc = tpm2_loadexternal(ectx,
-            has_priv ? priv : NULL, pub, ctx.hierarchy_value,
-            &ctx.handle);
+            has_priv ? priv : NULL, pub,
+            fix_esys_hierarchy(ctx.hierarchy_value), &ctx.handle);
     if (rc != tool_rc_success) {
         return rc;
     }


### PR DESCRIPTION
To continue discussion started in https://github.com/tpm2-software/tpm2-tss/pull/1531 the tools can handle the API change by some internal remapping like this.