### PR TITLE
Portable tests

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -511,6 +511,14 @@ AM_TESTS_ENVIRONMENT =	\
 	SRCDIR=$(abs_srcdir); export SRCDIR; BUILDDIR=$(abs_builddir); export BUILDDIR; \
 	export TPM2_TOOLS_TEST_FIXTURES;
 
+if PERSISTENT
+    AM_TESTS_ENVIRONMENT +=	\
+        TPM2TOOLS_TEST_PERSISTENT=true; export TPM2TOOLS_TEST_PERSISTENT;
+else
+    AM_TESTS_ENVIRONMENT +=	\
+        TPM2TOOLS_TEST_PERSISTENT=false; export TPM2TOOLS_TEST_PERSISTENT;
+endif
+
 SH_LOG_COMPILER = dbus-run-session bash
 AM_SH_LOG_FLAGS = --
 endif

--- a/configure.ac
+++ b/configure.ac
@@ -102,6 +102,11 @@ AC_ARG_ENABLE([unit],
             [enable_unit=no])
 AM_CONDITIONAL([UNIT], [test "x$enable_unit" != xno])
 
+AC_ARG_ENABLE([persistent],
+            [AS_HELP_STRING([--disable-persistent],
+                            [disable tests that require resetting the TPM])],,)
+AM_CONDITIONAL([PERSISTENT], [test "x$enable_persistent" != xno])
+
 dnl macro that checks for specific modules in python
 AC_DEFUN([AC_PYTHON_MODULE],
 [AC_MSG_CHECKING([for module $1 in python])

--- a/test/integration/helpers.sh
+++ b/test/integration/helpers.sh
@@ -28,6 +28,22 @@ is_alg_supported() {
     fi
 }
 
+# Return 0 if command is supported, return 1 otherwise
+# Error if TPM is simulator and command is unsupported
+is_cmd_supported() {
+    if tpm2_getcap commands | grep -i "$1:" &> /dev/null; then
+        return 0
+    else
+        if is_simulator; then
+            echo "ERROR: $1 is not supported by the TPM simulator."
+            exit 1
+        else
+            echo "SKIP: Testing on a non-simulator TPM. Skipping unsupported command $1"
+            return 1
+        fi
+    fi
+}
+
 function filter_algs_by() {
 
 python << pyscript

--- a/test/integration/helpers.sh
+++ b/test/integration/helpers.sh
@@ -108,6 +108,64 @@ hash_alg_supported() {
     done
 }
 
+# Get nice names of supported algorithms lengths
+# Does not work with hashes!
+# e.g. calling "populate_alg_lengths rsa" will print:
+# rsa1024
+# rsa2048
+populate_alg_lengths() {
+    #set -x
+    alg="$1"
+    local lengths="1 128 192 224 256 384 512 1024 2048 4096"
+    local populated=""
+    for len in $lengths; do
+        if tpm2_testparms "$alg$len" 2> /dev/null; then
+            if [ -z "$populated" ]; then
+                populated="$alg$len"
+            else
+                populated="$populated\n$alg$len"
+            fi
+        fi
+    done;
+    printf "$populated"
+}
+
+# Get nice name of the algorithm with its weakest supported key size
+# Does not work with hashes!
+# e.g. calling "weakest_alg aes" will print "aes128"
+weakest_alg() {
+    populate_alg_lengths "$1" | head -n1
+}
+
+# Get nice name of the algorithm with its strongest supported key size
+# Does not work with hashes!
+# e.g. calling "strongest_alg aes" will print "aes256"
+strongest_alg() {
+    populate_alg_lengths "$1" | tail -n1
+}
+
+# Get nice names of supported algorithm modes
+# Does not work with hashes!
+# e.g. calling "populate_alg_modes aes128" will print:
+# aes128cfb
+# aes128cbc
+populate_alg_modes() {
+    #set -x
+    alg="$1"
+    local modes="ctr ofb cbc cfb ecb"
+    local populated=""
+    for mode in $modes; do
+        if tpm2_testparms "$alg$mode" 2> /dev/null; then
+            if [ -z "$populated" ]; then
+                populated="$alg$mode"
+            else
+                populated="$populated\n$alg$mode"
+            fi
+        fi
+    done;
+    printf "$populated"
+}
+
 #
 # Verifies that the contexts of a file path provided
 # as the first argument loads as a YAML file.

--- a/test/integration/helpers.sh
+++ b/test/integration/helpers.sh
@@ -223,6 +223,7 @@ function recreate_info() {
     a="$a""export TPM2ABRMD_TCTI=\"$TPM2ABRMD_TCTI\"\n"
     a="$a""export TPM2_SIMPORT=\"$TPM2_SIMPORT\"\n"
     a="$a""export TPM2TOOLS_TEST_TCTI=\"$TPM2TOOLS_TEST_TCTI\"\n"
+    a="$a""export TPM2TOOLS_TEST_PERSISTENT=\"$TPM2TOOLS_TEST_PERSISTENT\"\n"
     a="$a""export PATH=\"$PATH\"\n"
     a="$a""TPM2_SIM_NV_CHIP=\"$TPM2_SIM_NV_CHIP\"\n"
     a="$a""TPM2_TOOLS_TEST_FIXTURES=\"$TPM2_TOOLS_TEST_FIXTURES\"\n"

--- a/test/integration/tests/abrmd_nvundefinespecial.sh
+++ b/test/integration/tests/abrmd_nvundefinespecial.sh
@@ -5,6 +5,14 @@ source helpers.sh
 cleanup() {
 
     tpm2_flushcontext session.ctx 2>/dev/null || true
+
+    tpm2_startauthsession --policy-session -S session.ctx
+    tpm2_policyauthvalue -S session.ctx
+    tpm2_policycommandcode -S session.ctx TPM2_CC_NV_UndefineSpaceSpecial
+    tpm2_nvundefine -S session.ctx 1 2>/dev/null || true
+
+    tpm2_flushcontext session.ctx 2>/dev/null || true
+
     rm -f policy.dat session.ctx
 
     if [ "${1}" != "no-shutdown" ]; then

--- a/test/integration/tests/abrmd_policyauthvalue.sh
+++ b/test/integration/tests/abrmd_policyauthvalue.sh
@@ -10,13 +10,12 @@ key_ctx=key.ctx
 key_pub=key.pub
 key_priv=key.priv
 plain_txt=plain.txt
-encrypted_txt=enc.txt
-decrypted_txt=dec.txt
+signature_txt=signature.txt
 testpswd=testpswd
 
 cleanup() {
     rm -f $policyauthvalue $session_ctx $o_policy_digest $primary_key_ctx \
-    $key_ctx $key_pub $key_priv $plain_txt $encrypted_txt $decrypted_txt
+    $key_ctx $key_pub $key_priv $plain_txt $signature_txt
 
     tpm2_flushcontext $session_ctx 2>/dev/null || true
 
@@ -39,19 +38,18 @@ rm $session_ctx
 
 tpm2_createprimary -C o -c $primary_key_ctx
 
-tpm2_create -g sha256 -G aes -u $key_pub -r $key_priv -C $primary_key_ctx \
+tpm2_create -g sha256 -G ecc -u $key_pub -r $key_priv -C $primary_key_ctx \
 -L $policyauthvalue -p $testpswd
 
 tpm2_load -C $primary_key_ctx -u $key_pub -r $key_priv -c $key_ctx
-tpm2_encryptdecrypt -c $key_ctx -o $encrypted_txt -p $testpswd $plain_txt
+tpm2_sign -c $key_ctx -p $testpswd -o $signature_txt $plain_txt
+tpm2_verifysignature -c key.ctx -m $plain_txt -s $signature_txt
 
 tpm2_startauthsession --policy-session -S $session_ctx
 tpm2_policyauthvalue -S $session_ctx -L $policyauthvalue
-tpm2_encryptdecrypt -c $key_ctx -o $decrypted_txt -d \
--p session:$session_ctx+$testpswd $encrypted_txt
+tpm2_sign -c $key_ctx -p session:$session_ctx+$testpswd -o $signature_txt $plain_txt
+tpm2_verifysignature -c key.ctx -m $plain_txt -s $signature_txt
 tpm2_flushcontext $session_ctx
 rm $session_ctx
-
-diff $plain_txt $decrypted_txt
 
 exit 0

--- a/test/integration/tests/abrmd_policypassword.sh
+++ b/test/integration/tests/abrmd_policypassword.sh
@@ -10,13 +10,12 @@ key_ctx=key.ctx
 key_pub=key.pub
 key_priv=key.priv
 plain_txt=plain.txt
-encrypted_txt=enc.txt
-decrypted_txt=dec.txt
+signature_txt=signature.txt
 testpswd=testpswd
 
 cleanup() {
     rm -f $policypassword $session_ctx $o_policy_digest $primary_key_ctx \
-    $key_ctx $key_pub $key_priv $plain_txt $encrypted_txt $decrypted_txt
+    $key_ctx $key_pub $key_priv $plain_txt $signature_txt
 
     tpm2_flushcontext $session_ctx 2>/dev/null || true
 
@@ -39,19 +38,18 @@ rm $session_ctx
 
 tpm2_createprimary -C o -c $primary_key_ctx
 
-tpm2_create -g sha256 -G aes -u $key_pub -r $key_priv -C $primary_key_ctx \
+tpm2_create -g sha256 -G ecc -u $key_pub -r $key_priv -C $primary_key_ctx \
 -L $policypassword -p $testpswd
 
 tpm2_load -C $primary_key_ctx -u $key_pub -r $key_priv -c $key_ctx
-tpm2_encryptdecrypt -c $key_ctx -o $encrypted_txt -p $testpswd $plain_txt
+tpm2_sign -c $key_ctx -p $testpswd -o $signature_txt $plain_txt
+tpm2_verifysignature -c key.ctx -m $plain_txt -s $signature_txt
 
 tpm2_startauthsession --policy-session -S $session_ctx
 tpm2_policypassword -S $session_ctx -L $policypassword
-tpm2_encryptdecrypt -c $key_ctx -o $decrypted_txt -d \
--p session:$session_ctx+$testpswd $encrypted_txt
+tpm2_sign -c $key_ctx -p session:$session_ctx+$testpswd -o $signature_txt $plain_txt
+tpm2_verifysignature -c key.ctx -m $plain_txt -s $signature_txt
 tpm2_flushcontext $session_ctx
 rm $session_ctx
-
-diff $plain_txt $decrypted_txt
 
 exit 0

--- a/test/integration/tests/changeeps.sh
+++ b/test/integration/tests/changeeps.sh
@@ -3,6 +3,8 @@
 source helpers.sh
 
 cleanup() {
+  tpm2_changeauth -c p -p testpassword 2>/dev/null || true
+
   rm -f primary.ctx key.pub key.priv key.ctx key.name
 
   if [ "$1" != "no-shut-down" ]; then

--- a/test/integration/tests/changepps.sh
+++ b/test/integration/tests/changepps.sh
@@ -3,6 +3,8 @@
 source helpers.sh
 
 cleanup() {
+  tpm2_changeauth -c p -p testpassword 2>/dev/null || true
+
   rm -f primary.ctx key.pub key.priv key.ctx key.name
 
   if [ "$1" != "no-shut-down" ]; then

--- a/test/integration/tests/clockrateadjust.sh
+++ b/test/integration/tests/clockrateadjust.sh
@@ -3,7 +3,14 @@
 source helpers.sh
 
 cleanup() {
+	tpm2_changeauth -c o -p newowner 2>/dev/null || true
+	tpm2_changeauth -c p -p newplatform 2>/dev/null || true
+
 	rm -f clock.yaml
+
+	if [ "$1" != "no-shut-down" ]; then
+		shut_down
+	fi
 }
 trap cleanup EXIT
 

--- a/test/integration/tests/encryptdecrypt.sh
+++ b/test/integration/tests/encryptdecrypt.sh
@@ -4,7 +4,7 @@ source helpers.sh
 
 cleanup() {
   rm -f primary.ctx decrypt.ctx key.pub key.priv key.name decrypt.out \
-  decrypt2.out encrypt.out encrypt2.out secret.dat commands.cap secret2.dat \
+  decrypt2.out encrypt.out encrypt2.out secret.dat secret2.dat \
   iv.dat iv2.dat key128.ctx plain.dec128.tpm plain.dec256.tpm plain.enc128.tpm \
   plain.enc256.tpm sym128.key key256.ctx plain.dec128.ssl plain.dec256.ssl \
   plain.enc128.ssl plain.enc256.ssl plain.txt sym256.key
@@ -19,24 +19,10 @@ start_up
 
 cleanup "no-shut-down"
 
-# set the error handler for checking tpm2_getcap call
-trap onerror ERR
-
-# Check for encryptdecrypt command code 0x164
-tpm2_getcap commands > commands.cap
-
-# clear the handler for the grep check
-trap - ERR
-
-grep -q 0x164 commands.cap
-if [ $? != 0 ];then
-    echo "WARN: Command EncryptDecrypt is not supported by your device, \
-    skipping..."
+if ! is_cmd_supported "EncryptDecrypt"; then
+    echo "Command EncryptDecrypt is not supported by your device, skipping..."
     skip_test
 fi
-
-# Now set the trap handler for ERR since we're past the command code check
-trap onerror ERR
 
 echo "12345678" > secret.dat
 

--- a/test/integration/tests/hierarchycontrol.sh
+++ b/test/integration/tests/hierarchycontrol.sh
@@ -12,6 +12,13 @@ trap cleanup EXIT
 
 start_up
 
+if [ "$TPM2TOOLS_TEST_PERSISTENT" = false ]; then
+  echo "Skipping persistent test (requiring a TPM reset)."
+  echo "To execute this test, set TPM2TOOLS_TEST_PERSISTENT=true or configure " \
+       "with --enable-persistent"
+  skip_test
+fi
+
 cleanup "no-shut-down"
 
 # Storage hierarchy

--- a/test/integration/tests/import.sh
+++ b/test/integration/tests/import.sh
@@ -166,9 +166,13 @@ run_test() {
     tpm2_createprimary -Q -G "$parent_alg" -g "$name_alg" -C o -c parent.ctx
 
     # 128 bit AES is 16 bytes
-    run_aes_import_test parent.ctx aes-128-cfb 16
+    if is_alg_supported aes128; then
+        run_aes_import_test parent.ctx aes-128-cfb 16
+    fi
     # 256 bit AES is 32 bytes
-    run_aes_import_test parent.ctx aes-256-cfb 32
+    if is_alg_supported aes256; then
+        run_aes_import_test parent.ctx aes-256-cfb 32
+    fi
 
     run_rsa_import_test parent.ctx 1024
     run_rsa_import_test parent.ctx 2048
@@ -186,8 +190,10 @@ halgs=`populate_hash_algs 'and alg != "sha1"'`
 echo "halgs: $halgs"
 for pa in "${parent_algs[@]}"; do
   for name in $halgs; do
-    echo "$pa - $name"
-    run_test "$pa" "$name"
+    if is_alg_supported $pa; then
+        echo "$pa - $name"
+        run_test "$pa" "$name"
+    fi
   done;
 done;
 

--- a/test/integration/tests/loadexternal.sh
+++ b/test/integration/tests/loadexternal.sh
@@ -189,13 +189,21 @@ run_rsa_passin_test() {
 
 run_tss_test
 
-run_rsa_test 1024
-run_rsa_test 2048
+for len in "1024 2048"; do
+    if is_alg_supported "rsa$len"; then
+        run_rsa_test $len
+    fi
+done
 
-run_aes_test 128
-run_aes_test 256
+for len in "128 256"; do
+    if is_alg_supported "aes$len"; then
+        run_aes_test $len
+    fi
+done
 
-run_ecc_test prime256v1
+if is_alg_supported "ecc256"; then
+    run_ecc_test prime256v1
+fi
 
 #
 # Test loadexternal passin option

--- a/test/integration/tests/nv.sh
+++ b/test/integration/tests/nv.sh
@@ -236,34 +236,36 @@ if [ "$check" != "0xbadc0de" ]; then
 fi
 
 # Test global writelock
-tpm2_nvdefine -C o -P "owner" -s 32 -a "ownerread|ownerwrite|globallock" 42
-tpm2_nvdefine -C o -P "owner" -s 32 -a "ownerread|ownerwrite|globallock" 43
-tpm2_nvdefine -C o -P "owner" -s 32 -a "ownerread|ownerwrite|globallock" 44
+if is_cmd_supported "NV_GlobalWriteLock"; then
+  tpm2_nvdefine -C o -P "owner" -s 32 -a "ownerread|ownerwrite|globallock" 42
+  tpm2_nvdefine -C o -P "owner" -s 32 -a "ownerread|ownerwrite|globallock" 43
+  tpm2_nvdefine -C o -P "owner" -s 32 -a "ownerread|ownerwrite|globallock" 44
 
-echo foo | tpm2_nvwrite -C o -P "owner" -i- 42
-echo foo | tpm2_nvwrite -C o -P "owner" -i- 43
-echo foo | tpm2_nvwrite -C o -P "owner" -i- 44
+  echo foo | tpm2_nvwrite -C o -P "owner" -i- 42
+  echo foo | tpm2_nvwrite -C o -P "owner" -i- 43
+  echo foo | tpm2_nvwrite -C o -P "owner" -i- 44
 
-tpm2_nvwritelock -Co -P owner --global
+  tpm2_nvwritelock -Co -P owner --global
 
-# These writes should fail now that its in a writelocked state
-trap - ERR
-echo foo | tpm2_nvwrite -C o -P "owner" -i- 42
-if [ $? -eq 0 ]; then
-	echo "Expected tpm2_nvwrite to fail after globalwritelock of index 42"
-	exit 1
-fi
+  # These writes should fail now that its in a writelocked state
+  trap - ERR
+  echo foo | tpm2_nvwrite -C o -P "owner" -i- 42
+  if [ $? -eq 0 ]; then
+    echo "Expected tpm2_nvwrite to fail after globalwritelock of index 42"
+    exit 1
+  fi
 
-echo foo | tpm2_nvwrite -C o -P "owner" -i- 43
-if [ $? -eq 0 ]; then
-	echo "Expected tpm2_nvwrite to fail after globalwritelock of index 43"
-	exit 1
-fi
+  echo foo | tpm2_nvwrite -C o -P "owner" -i- 43
+  if [ $? -eq 0 ]; then
+    echo "Expected tpm2_nvwrite to fail after globalwritelock of index 43"
+    exit 1
+  fi
 
-echo foo | tpm2_nvwrite -C o -P "owner" -i- 44
-if [ $? -eq 0 ]; then
-	echo "Expected tpm2_nvwrite to fail after globalwritelock of index 44"
-	exit 1
+  echo foo | tpm2_nvwrite -C o -P "owner" -i- 44
+  if [ $? -eq 0 ]; then
+    echo "Expected tpm2_nvwrite to fail after globalwritelock of index 44"
+    exit 1
+  fi
 fi
 
 trap onerror ERR

--- a/test/integration/tests/setclock.sh
+++ b/test/integration/tests/setclock.sh
@@ -13,7 +13,14 @@ get_new_clock() {
 }
 
 cleanup() {
+	tpm2_changeauth -c o -p newowner 2>/dev/null || true
+	tpm2_changeauth -c p -p newplatform 2>/dev/null || true
+
 	rm -f clock.yaml
+
+	if [ "$1" != "no-shut-down" ]; then
+		shut_down
+	fi
 }
 trap cleanup EXIT
 


### PR DESCRIPTION
Some of the commands fail since certain requirements are not met, e.g. ECC curves or algorithms are not supported etc. In this case the tests in question should skip such algorithms or have the test return `77` (SKIP) altogether.

To make the tests more portable, I introduce following changes:

- Introduce  new tool `tpm2_getname` which returns the name of a TPM object. This tool is used in tests later. Any feedback is welcome!
- Use `tpm2_getname` in tests as an alternative to `tpm2_encryptdecrypt` if `tpm2_encryptdecrypt` is not supported
- Add `try` function to `helpers.sh` which is used to handle expected errors (e.g. algorithm not supported). In this case, sub-tests are skipped.
- Skip tests `toggle_options` if required files are not present (e.g. directory `man`)
- Replace `tpm2_encryptdecrypt` by `tpm2_sign` in test `abrmd_policyauthvalue`

Note:
I introduced a new tool `tpm_getname`. This tool might not be necessary to archieve what I wanted, but I did not find a way to determine an object's name using the tools. Please review this new tool in particular. Thanks!