### PR TITLE
Add YAML key for sigBuffer to fix checkquote

### DIFF
--- a/tools/misc/tpm2_checkquote.c
+++ b/tools/misc/tpm2_checkquote.c
@@ -12,6 +12,7 @@
 #include "tpm2_convert.h"
 #include "tpm2_openssl.h"
 #include "tpm2_options.h"
+#include "tpm2_tool.h"
 
 typedef struct tpm2_verifysig_ctx tpm2_verifysig_ctx;
 struct tpm2_verifysig_ctx {
@@ -77,7 +78,9 @@ static bool verify_signature() {
         goto err;
     }
     TPM2B_PUBLIC_KEY_RSA sig = ctx.signature.signature.rsassa.sig;
+    tpm2_tool_output("sigBuffer: ");
     tpm2_util_hexdump(sig.buffer, sig.size);
+    tpm2_tool_output("\n");
 
     // Verify the signature matches message digest
     int openssl_hash =


### PR DESCRIPTION
If PCRs provided then they will print with 'pcr' key
  Not having the 'sigBuffer' key here breaks YAML formatting

One potential way to address issue https://github.com/tpm2-software/tpm2-tools/issues/1782