### PR TITLE
Outside-info

### DIFF
--- a/man/tpm2_createprimary.1.md
+++ b/man/tpm2_createprimary.1.md
@@ -67,7 +67,12 @@ future interactions with the created primary.
   * **-u**, **\--unique-data**=_FILE_:
 
     An optional file input that contains the unique field of **TPMT_PUBLIC** in
-    little-endian format.
+    little-endian format. Primary key creator may place information that causes
+    the primary key generation scheme internal to the TPM to generate
+    statistically unique values. The TPM v2.0 specification calls this field
+    unique and overloads it so that it contains one value when the application
+    provides this structure as input and another value when the applications
+    receives this structure as output (like public portion of the rsa key).
 
   * **\--creation-data**=_FILE_:
 

--- a/man/tpm2_createprimary.1.md
+++ b/man/tpm2_createprimary.1.md
@@ -86,6 +86,11 @@ future interactions with the created primary.
 
     An optional file output that saves the creation hash for certification.
 
+  * **-q**, **\--outside-info**=_FILE_:
+
+    An optional file to add unique data to the creation data. Note that it does
+    not contribute in creating statistically unique object.
+
 ## References
 
 [context object format](common/ctxobj.md) details the methods for specifying

--- a/man/tpm2_createprimary.1.md
+++ b/man/tpm2_createprimary.1.md
@@ -91,6 +91,11 @@ future interactions with the created primary.
     An optional file to add unique data to the creation data. Note that it does
     not contribute in creating statistically unique object.
 
+  * **-l**, **\--pcr-list**=_PCR_:
+
+    The list of PCR banks and selected PCRs' ids for each bank to be included in
+    the creation data for certification.
+
 ## References
 
 [context object format](common/ctxobj.md) details the methods for specifying

--- a/test/integration/tests/createprimary.sh
+++ b/test/integration/tests/createprimary.sh
@@ -64,6 +64,14 @@ tpm2_createprimary -Q -c context.out
 # Test that -o does not need to be specified.
 tpm2_createprimary -Q
 
+# Test that creation data has the specified outside info
+dd if=/dev/urandom of=outside.info bs=1 count=32
+
+tpm2_createprimary -C o -c context.out --creation-data creation.data \
+-q outside.info
+
+xxd -p creation.data | tr -d '\n' | grep `xxd -p outside.info | tr -d '\n'`
+
 # Test for session leaks
 BEFORE=$(tpm2_getcap handles-loaded-session; tpm2_getcap handles-saved-session)
 tpm2_createprimary -Q

--- a/test/integration/tests/createprimary.sh
+++ b/test/integration/tests/createprimary.sh
@@ -72,6 +72,15 @@ tpm2_createprimary -C o -c context.out --creation-data creation.data \
 
 xxd -p creation.data | tr -d '\n' | grep `xxd -p outside.info | tr -d '\n'`
 
+# Test that selected pcrs digest is present in the creation data
+tpm2_pcrread sha256:0 -o pcr_data.bin
+
+tpm2_createprimary -C o -c context.out --creation-data creation.data \
+-l sha256:0
+
+xxd -p creation.data | tr -d '\n' | \
+grep `cat pcr_data.bin | openssl dgst -sha256 -binary | xxd -p | tr -d '\n'`
+
 # Test for session leaks
 BEFORE=$(tpm2_getcap handles-loaded-session; tpm2_getcap handles-saved-session)
 tpm2_createprimary -Q

--- a/tools/tpm2_createprimary.c
+++ b/tools/tpm2_createprimary.c
@@ -2,6 +2,7 @@
 
 #include "files.h"
 #include "log.h"
+#include "pcr.h"
 #include "tpm2_alg_util.h"
 #include "tpm2_auth_util.h"
 #include "tpm2_hierarchy.h"
@@ -99,6 +100,12 @@ static bool on_option(char key, char *value) {
     case 'q':
         ctx.outside_info_file = value;
         break;
+    case 'l':
+        if (!pcr_parse_selections(value, &ctx.objdata.in.creation_pcr)) {
+            LOG_ERR("Could not parse pcr selections, got: \"%s\"", value);
+            return false;
+        }
+        break;
         /* no default */
     }
 
@@ -121,9 +128,10 @@ bool tpm2_tool_onstart(tpm2_options **opts) {
         { "creation-ticket",required_argument, NULL, 't' },
         { "creation-hash",  required_argument, NULL, 'd' },
         { "outside-info",   required_argument, NULL, 'q' },
+        { "pcr-list",       required_argument, NULL, 'l' },
     };
 
-    *opts = tpm2_options_new("C:P:p:g:G:c:L:a:u:t:d:q:", ARRAY_LEN(topts), topts,
+    *opts = tpm2_options_new("C:P:p:g:G:c:L:a:u:t:d:q:l:", ARRAY_LEN(topts), topts,
             on_option, NULL, 0);
 
     return *opts != NULL;


### PR DESCRIPTION
Add option to tpm2_createprimary to specify outside info to be included in the creation data.