### PR TITLE
travis: use cap sys_ptrace instead of unconfined

### DIFF
--- a/.ci/travis.run
+++ b/.ci/travis.run
@@ -15,8 +15,7 @@ if [ "$TRAVIS_BRANCH" != "coverity_scan" ]; then
   echo "Running non-coverity build"
   # Do normal CI script
   ci_env=$(bash <(curl -s https://codecov.io/env))
-  docker run $ci_env --env-file .ci/docker.env \
-    --security-opt seccomp=unconfined \
+  docker run --cap-add=SYS_PTRACE $ci_env --env-file .ci/docker.env \
     -v "$(pwd):/workspace/tpm2-tools" "tpm2software/tpm2-tss:$DOCKER_TAG" \
     /bin/bash -c '/workspace/tpm2-tools/.ci/docker.run'
 


### PR DESCRIPTION
Rather than disabling secomp, just use cap ptrace.

Signed-off-by: William Roberts <william.c.roberts@intel.com>