### PR TITLE
tpm2_nvwritelock & tpm2_nvsetbits: add tool

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,8 @@
 * tpm2\_clockrateadjust: Add a new tool for modifying the period on the TPM
   clock.
 
+* tpm2\_nvwritelock: Add a new tool for setting a write lock on an NV index.
+
 * tpm2_policysecret: Add tool options for specifying
   - \--expiration or -t
   - \--ticket

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,14 +2,14 @@
 
 ### next
 
-* tpm2_certifycreation: New tool enabling command TPM2_CertifyCreation.
+* tpm2\_certifycreation: New tool enabling command TPM2\_CertifyCreation.
 
-* tpm2_checkquote:
+* tpm2\_checkquote:
    - Fix YAML output bug.
    - \-g option for specifying hash algorithm is optional and defaults to
      sha256.
 
-* tpm2_createprimary: Add tool options for specifying output data for use
+* tpm2\_createprimary: Add tool options for specifying output data for use
   in certification
   - \--creation-data to save the creation data
   - \--creation-ticket or -t to save the creation ticket
@@ -20,18 +20,18 @@
 
 * tpm2\_nvwritelock: Add a new tool for setting a write lock on an NV index.
 
-* tpm2_policysecret: Add tool options for specifying
+* tpm2\_policysecret: Add tool options for specifying
   - \--expiration or -t
   - \--ticket
   - \--timeout
   - \--nonce-tpm or -x
   - \--qualification or -q
 
-* tpm2_policyticket: New tool enabling policy command TPM2_PolicyTicket.
+* tpm2\_policyticket: New tool enabling policy command TPM2\_PolicyTicket.
 
-* tpm2_startauthsession: Add option to retrieve the session nonceTPM.
+* tpm2\_startauthsession: Add option to retrieve the session nonceTPM.
 
-* tpm2_policysigned: New tool enabling policy command TPM2_PolicySigned.
+* tpm2\_policysigned: New tool enabling policy command TPM2\_PolicySigned.
 
 * misc:
   - support "tpmt" as a public key output format that only saves the TPMT structure.

--- a/Makefile.am
+++ b/Makefile.am
@@ -73,6 +73,7 @@ bin_PROGRAMS = \
     tools/tpm2_nvundefine \
     tools/tpm2_nvwrite \
     tools/tpm2_nvwritelock \
+    tools/tpm2_nvsetbits \
     tools/tpm2_pcrallocate \
     tools/tpm2_pcrevent \
     tools/tpm2_pcrextend \
@@ -201,6 +202,7 @@ tools_tpm2_setclock_SOURCES = tools/tpm2_setclock.c $(TOOL_SRC)
 tools_tpm2_shutdown_SOURCES = tools/tpm2_shutdown.c $(TOOL_SRC)
 tools_tpm2_clockrateadjust_SOURCES = tools/tpm2_clockrateadjust.c $(TOOL_SRC)
 tools_tpm2_nvwritelock_SOURCES = tools/tpm2_nvwritelock.c $(TOOL_SRC)
+tools_tpm2_nvsetbits_SOURCES = tools/tpm2_nvsetbits.c $(TOOL_SRC)
 
 if UNIT
 TESTS = $(check_PROGRAMS)
@@ -359,6 +361,7 @@ if HAVE_MAN_PAGES
     man/man1/tpm2_nvundefine.1 \
     man/man1/tpm2_nvwrite.1 \
     man/man1/tpm2_nvwritelock.1 \
+    man/man1/tpm2_nvsetbits.1 \
     man/man1/tpm2_pcrallocate.1 \
     man/man1/tpm2_pcrevent.1 \
     man/man1/tpm2_pcrextend.1 \

--- a/Makefile.am
+++ b/Makefile.am
@@ -72,6 +72,7 @@ bin_PROGRAMS = \
     tools/tpm2_nvreadlock \
     tools/tpm2_nvundefine \
     tools/tpm2_nvwrite \
+    tools/tpm2_nvwritelock \
     tools/tpm2_pcrallocate \
     tools/tpm2_pcrevent \
     tools/tpm2_pcrextend \
@@ -199,6 +200,7 @@ tools_tpm2_readclock_SOURCES = tools/tpm2_readclock.c $(TOOL_SRC)
 tools_tpm2_setclock_SOURCES = tools/tpm2_setclock.c $(TOOL_SRC)
 tools_tpm2_shutdown_SOURCES = tools/tpm2_shutdown.c $(TOOL_SRC)
 tools_tpm2_clockrateadjust_SOURCES = tools/tpm2_clockrateadjust.c $(TOOL_SRC)
+tools_tpm2_nvwritelock_SOURCES = tools/tpm2_nvwritelock.c $(TOOL_SRC)
 
 if UNIT
 TESTS = $(check_PROGRAMS)
@@ -356,6 +358,7 @@ if HAVE_MAN_PAGES
     man/man1/tpm2_nvreadlock.1 \
     man/man1/tpm2_nvundefine.1 \
     man/man1/tpm2_nvwrite.1 \
+    man/man1/tpm2_nvwritelock.1 \
     man/man1/tpm2_pcrallocate.1 \
     man/man1/tpm2_pcrevent.1 \
     man/man1/tpm2_pcrextend.1 \

--- a/lib/tpm2.c
+++ b/lib/tpm2.c
@@ -1334,6 +1334,37 @@ tool_rc tpm2_nvreadlock(ESYS_CONTEXT *esys_context,
     return tool_rc_success;
 }
 
+tool_rc tpm2_nvwritelock(ESYS_CONTEXT *esys_context,
+        tpm2_loaded_object *auth_hierarchy_obj, TPM2_HANDLE nv_index) {
+
+    ESYS_TR esys_tr_nv_handle;
+    TSS2_RC rval = Esys_TR_FromTPMPublic(esys_context, nv_index, ESYS_TR_NONE,
+            ESYS_TR_NONE, ESYS_TR_NONE, &esys_tr_nv_handle);
+    if (rval != TPM2_RC_SUCCESS) {
+        LOG_PERR(Esys_TR_FromTPMPublic, rval);
+        return tool_rc_from_tpm(rval);
+    }
+
+    ESYS_TR auth_hierarchy_obj_session_handle = ESYS_TR_NONE;
+    tool_rc rc = tpm2_auth_util_get_shandle(esys_context,
+            auth_hierarchy_obj->tr_handle, auth_hierarchy_obj->session,
+            &auth_hierarchy_obj_session_handle);
+    if (rc != tool_rc_success) {
+        LOG_ERR("Failed to get shandle");
+        return rc;
+    }
+
+    rval = Esys_NV_WriteLock(esys_context, auth_hierarchy_obj->tr_handle,
+            esys_tr_nv_handle, auth_hierarchy_obj_session_handle, ESYS_TR_NONE,
+            ESYS_TR_NONE);
+    if (rval != TPM2_RC_SUCCESS) {
+        LOG_PERR(Esys_NV_WriteLock, rval);
+        return tool_rc_from_tpm(rval);
+    }
+
+    return tool_rc_success;
+}
+
 tool_rc tpm2_nvundefine(ESYS_CONTEXT *esys_context,
         tpm2_loaded_object *auth_hierarchy_obj, TPM2_HANDLE nv_index) {
 

--- a/lib/tpm2.c
+++ b/lib/tpm2.c
@@ -1364,6 +1364,38 @@ tool_rc tpm2_nvwritelock(ESYS_CONTEXT *esys_context,
     return tool_rc_success;
 }
 
+tool_rc tpm2_nvsetbits(ESYS_CONTEXT *esys_context,
+        tpm2_loaded_object *auth_hierarchy_obj, TPM2_HANDLE nv_index,
+        UINT64 bits) {
+
+    ESYS_TR esys_tr_nv_handle;
+    TSS2_RC rval = Esys_TR_FromTPMPublic(esys_context, nv_index, ESYS_TR_NONE,
+            ESYS_TR_NONE, ESYS_TR_NONE, &esys_tr_nv_handle);
+    if (rval != TPM2_RC_SUCCESS) {
+        LOG_PERR(Esys_TR_FromTPMPublic, rval);
+        return tool_rc_from_tpm(rval);
+    }
+
+    ESYS_TR auth_hierarchy_obj_session_handle = ESYS_TR_NONE;
+    tool_rc rc = tpm2_auth_util_get_shandle(esys_context,
+            auth_hierarchy_obj->tr_handle, auth_hierarchy_obj->session,
+            &auth_hierarchy_obj_session_handle);
+    if (rc != tool_rc_success) {
+        LOG_ERR("Failed to get shandle");
+        return rc;
+    }
+
+    rval = Esys_NV_SetBits(esys_context, auth_hierarchy_obj->tr_handle,
+            esys_tr_nv_handle, auth_hierarchy_obj_session_handle, ESYS_TR_NONE,
+            ESYS_TR_NONE, bits);
+    if (rval != TPM2_RC_SUCCESS) {
+        LOG_PERR(Esys_NV_SetBits, rval);
+        return tool_rc_from_tpm(rval);
+    }
+
+    return tool_rc_success;
+}
+
 tool_rc tpm2_nvundefine(ESYS_CONTEXT *esys_context,
         tpm2_loaded_object *auth_hierarchy_obj, TPM2_HANDLE nv_index) {
 

--- a/lib/tpm2.c
+++ b/lib/tpm2.c
@@ -1326,7 +1326,6 @@ tool_rc tpm2_nvreadlock(ESYS_CONTEXT *esys_context,
             esys_tr_nv_handle, auth_hierarchy_obj_session_handle, ESYS_TR_NONE,
             ESYS_TR_NONE);
     if (rval != TPM2_RC_SUCCESS) {
-        LOG_ERR("Failed to lock NVRAM area at index 0x%X", nv_index);
         LOG_PERR(Esys_NV_ReadLock, rval);
         return tool_rc_from_tpm(rval);
     }

--- a/lib/tpm2.h
+++ b/lib/tpm2.h
@@ -281,6 +281,10 @@ tool_rc tpm2_nvreadlock(ESYS_CONTEXT *esys_context,
 tool_rc tpm2_nvwritelock(ESYS_CONTEXT *esys_context,
         tpm2_loaded_object *auth_hierarchy_obj, TPM2_HANDLE nv_index);
 
+tool_rc tpm2_nvsetbits(ESYS_CONTEXT *esys_context,
+        tpm2_loaded_object *auth_hierarchy_obj, TPM2_HANDLE nv_index,
+        UINT64 bits);
+
 tool_rc tpm2_nvundefine(ESYS_CONTEXT *esys_context,
         tpm2_loaded_object *auth_hierarchy_obj, TPM2_HANDLE nv_index);
 

--- a/lib/tpm2.h
+++ b/lib/tpm2.h
@@ -278,6 +278,9 @@ tool_rc tpm2_nv_increment(ESYS_CONTEXT *esys_context,
 tool_rc tpm2_nvreadlock(ESYS_CONTEXT *esys_context,
         tpm2_loaded_object *auth_hierarchy_obj, TPM2_HANDLE nv_index);
 
+tool_rc tpm2_nvwritelock(ESYS_CONTEXT *esys_context,
+        tpm2_loaded_object *auth_hierarchy_obj, TPM2_HANDLE nv_index);
+
 tool_rc tpm2_nvundefine(ESYS_CONTEXT *esys_context,
         tpm2_loaded_object *auth_hierarchy_obj, TPM2_HANDLE nv_index);
 

--- a/lib/tpm2_attr_util.c
+++ b/lib/tpm2_attr_util.c
@@ -178,13 +178,39 @@ static bool written(TPMA_NV *nv, char *arg) {
     return true;
 }
 
+static bool lookup_nt_friendly_name(const char *arg, uint16_t *type) {
+
+    if (!strcmp(arg, "ordinary")) {
+        // Nothing to do
+    } else if (!strcmp(arg, "counter")) {
+        *type = TPM2_NT_COUNTER;
+    } else if (!strcmp(arg, "bits")) {
+        *type = TPM2_NT_BITS;
+    } else if (!strcmp(arg, "extend")) {
+        *type = TPM2_NT_EXTEND;
+    } else if (!strcmp(arg, "pinfail")) {
+        *type = TPM2_NT_PIN_FAIL;
+    } else if (!strcmp(arg, "pinpass")) {
+        *type = TPM2_NT_PIN_PASS;
+    } else {
+        LOG_ERR("Unknown NT type specifier, got: \"%s\"", arg);
+        return false;
+    }
+
+    return true;
+}
+
 static bool nt(TPMA_NV *nv, char *arg) {
 
     uint16_t value;
     bool result = tpm2_util_string_to_uint16(arg, &value);
     if (!result) {
-        LOG_ERR("Could not convert \"%s\", to a number", arg);
-        return false;
+        result = lookup_nt_friendly_name(arg, &value);
+        if (!result) {
+            LOG_ERR("Could not convert NT field, got \"%s\"."
+                    "Expected a number or friendly name", arg);
+            return false;
+        }
     }
 
     /* nt space is 4 bits, so max of 15 */

--- a/man/common/nv-attrs.md
+++ b/man/common/nv-attrs.md
@@ -13,7 +13,24 @@ ppwrite. Nice names can be joined using the bitwise or "|" symbol.
 
 Note that the **TPM_NT** field is 4 bits wide, and thus can be set via
 **nt=<num>** format. For instance, to set The fields **TPMA_NV_OWNERREAD**,
-**TPMA_NV_OWNERWRITE**, **TPMA_NV_POLICYWRITE**, and **TPMA_NT = 0x3**, the argument
+**TPMA_NV_OWNERWRITE**, **TPMA_NV_POLICYWRITE**, and **TPMA_NT = 0x2**, the argument
 would be:
 
-**ownerread|ownerwrite|policywrite|nt=0x3**
+**ownerread|ownerwrite|policywrite|nt=0x2**
+
+Additionally, the NT field, which denotes the type of the NV index, can also be specified
+via friendly names:
+  * ordinary - Ordinary contains data that is opaque to the TPM that can
+      only be modified using TPM2\_NV\_Write.
+  * counter - Counter contains an 8-octet value that is to be used as a
+      counter and can only be modified with TPM2\_NV\_Increment
+  * bits - Bit Field contains an 8-octet value to be used as a bit field
+      and can only be modified with TPM2\_NV\_SetBits.
+  * pinfail - PIN Fail contains an 8-octet pinCount that increments on a PIN authorization failure and a pinLimit.
+  * pinpass - PIN Pass contains an 8-octet pinCount that increments on a PIN authorization success and a pinLimit.
+
+For instance, to set The fields **TPMA_NV_OWNERREAD**,
+**TPMA_NV_OWNERWRITE**, **TPMA_NV_POLICYWRITE**, and **TPMA_NT = bits**, the argument
+would be:
+
+**ownerread|ownerwrite|policywrite|nt=bits**

--- a/man/tpm2_nvdefine.1.md
+++ b/man/tpm2_nvdefine.1.md
@@ -81,8 +81,8 @@ _OBJECT_.
 [authorization formatting](common/authorizations.md) details the methods for
 specifying _AUTH_.
 
-[object attribute specifiers](common/obj-attrs.md) details the options for
-specifying the object attributes _ATTRIBUTES_.
+[object attribute specifiers](common/nv-attrs.md) details the options for
+specifying the nv attributes _ATTRIBUTES_.
 
 [common options](common/options.md) collection of common options that provide
 information many users may expect.

--- a/man/tpm2_nvsetbits.1.md
+++ b/man/tpm2_nvsetbits.1.md
@@ -1,0 +1,73 @@
+% tpm2_nvsetbits(1) tpm2-tools | General Commands Manual
+
+# NAME
+
+**tpm2_nvsetbits**(1) - Bitwise OR bits into a Non-Volatile (NV).
+
+# SYNOPSIS
+
+**tpm2_nvsetbits** [*OPTIONS*] [*ARGUMENT*]
+
+# DESCRIPTION
+
+**tpm2_nvsetbits**(1) - Bitwise OR bits into a Non-Volatile (NV). The
+NV index must be of type "bits" which is specified via the "nt" field
+when creating the NV space with tpm2_nvdefine(1). The index can be
+specified as raw handle or an offset value to the NV handle range
+"TPM2_HR_NV_INDEX".
+
+# OPTIONS
+
+  * **-C**, **\--hierarchy**=_OBJECT_:
+
+    Specifies the hierarchy used to authorize.
+    Supported options are:
+      * **o** for **TPM_RH_OWNER**
+      * **p** for **TPM_RH_PLATFORM**
+      * **`<num>`** where a hierarchy handle or nv-index may be used.
+
+    When **-C** isn't explicitly passed the index handle will be used to
+    authorize against the index. The index auth value is set via the
+    **-p** option to **tpm2_nvdefine**(1).
+
+  * **-P**, **\--auth**=_AUTH_:
+
+    Specifies the authorization value for the hierarchy.
+
+  * **-i**, **\--bits**=_BITS_:
+
+    Specifies the bit value as a number to bitwise OR into the current value
+    of the NV index.
+
+  * **ARGUMENT** the command line argument specifies the NV index or offset
+    number.
+
+## References
+
+[context object format](common/ctxobj.md) details the methods for specifying
+_OBJECT_.
+
+[authorization formatting](common/authorizations.md) details the methods for
+specifying _AUTH_.
+
+[common options](common/options.md) collection of common options that provide
+information many users may expect.
+
+[common tcti options](common/tcti.md) collection of options used to configure
+the various known TCTI modules.
+
+# EXAMPLES
+
+## OR 0xbadc0de into an index of 0's
+```bash
+tpm2_nvdefine -C o -a "nt=bits|ownerread|policywrite|ownerwrite|writedefine" 1
+
+tpm2_nvsetbits -C o -i 0xbadc0de 1
+
+tpm2_nvread -C o 1 | xxd -p | sed s/'^0*'/0x/
+0xbadc0de
+```
+
+[returns](common/returns.md)
+
+[footer](common/footer.md)

--- a/man/tpm2_nvwritelock.1.md
+++ b/man/tpm2_nvwritelock.1.md
@@ -1,0 +1,72 @@
+% tpm2_nvwritelock(1) tpm2-tools | General Commands Manual
+
+# NAME
+
+**tpm2_nvwritelock**(1) - Lock the Non-Volatile (NV) index for further writes.
+
+# SYNOPSIS
+
+**tpm2_nvwritelock** [*OPTIONS*] [*ARGUMENT*]
+
+# DESCRIPTION
+
+**tpm2_nvwritelock**(1) - Lock the Non-Volatile (NV) index for further writes. The
+lock on the NV index is unlocked when the TPM is restarted and the NV index
+becomes writable again. The index can be specified as raw handle or an offset
+value to the nv handle range "TPM2_HR_NV_INDEX".
+
+# OPTIONS
+
+  * **-C**, **\--hierarchy**=_OBJECT_:
+
+    Specifies the hierarchy used to authorize.
+    Supported options are:
+      * **o** for **TPM_RH_OWNER**
+      * **p** for **TPM_RH_PLATFORM**
+      * **`<num>`** where a hierarchy handle or nv-index may be used.
+
+    When **-C** isn't explicitly passed the index handle will be used to
+    authorize against the index. The index auth value is set via the
+    **-p** option to **tpm2_nvdefine**(1).
+
+  * **-P**, **\--auth**=_AUTH_:
+
+    Specifies the authorization value for the hierarchy.
+
+  * **ARGUMENT** the command line argument specifies the NV index or offset
+    number.
+
+## References
+
+[context object format](common/ctxobj.md) details the methods for specifying
+_OBJECT_.
+
+[authorization formatting](common/authorizations.md) details the methods for
+specifying _AUTH_.
+
+[common options](common/options.md) collection of common options that provide
+information many users may expect.
+
+[common tcti options](common/tcti.md) collection of options used to configure
+the various known TCTI modules.
+
+# EXAMPLES
+
+## Lock an index
+```bash
+tpm2_nvdefine -C o -s 32 \
+  -a "ownerread|policywrite|ownerwrite|writedefine" 1
+
+echo "foobar" > nv.writelock
+
+tpm2_nvwrite -C o -i nv.writelock 1
+
+tpm2_nvwritelock -C o 1
+
+# fails with "NV access locked"
+tpm2_nvwrite -C o -i nv.writelock 1
+```
+
+[returns](common/returns.md)
+
+[footer](common/footer.md)

--- a/test/integration/tests/nv.sh
+++ b/test/integration/tests/nv.sh
@@ -144,7 +144,7 @@ tpm2_nvundefine -Q   $nv_test_index -C o
 # Test NV access locked
 #
 tpm2_nvdefine -Q   $nv_test_index -C o -s 32 \
--a "ownerread|policywrite|ownerwrite|read_stclear"
+-a "ownerread|policywrite|ownerwrite|read_stclear|writedefine"
 
 echo "foobar" > nv.readlock
 
@@ -163,6 +163,21 @@ if [ $? != 1 ];then
  exit 1
 fi
 
+trap onerror ERR
+
+# Test that write lock works
+tpm2_nvwritelock -C o $nv_test_index
+
+trap - ERR
+
+tpm2_nvwrite  $nv_test_index -C o -i nv.readlock
+if [ $? != 1 ];then
+ echo "nvwrite didn't fail!"
+ exit 1
+fi
+
+trap onerror ERR
+
 #
 # Test that owner and index passwords work by
 # 1. Setting up the owner password
@@ -172,7 +187,6 @@ fi
 # 3. Using index and owner based auth during write/read operations
 # 4. Testing that auth is needed or a failure occurs.
 #
-trap onerror ERR
 
 tpm2_changeauth -c o owner
 

--- a/tools/tpm2_nvsetbits.c
+++ b/tools/tpm2_nvsetbits.c
@@ -1,0 +1,96 @@
+/* SPDX-License-Identifier: BSD-3-Clause */
+#include <stdlib.h>
+
+#include "log.h"
+#include "tpm2.h"
+#include "tpm2_nv_util.h"
+#include "tpm2_options.h"
+
+typedef struct tpm_nvsetbits_ctx tpm_nvsetbits_ctx;
+struct tpm_nvsetbits_ctx {
+    struct {
+        const char *ctx_path;
+        const char *auth_str;
+        tpm2_loaded_object object;
+    } auth_hierarchy;
+
+    const char *bit_string;
+    TPM2_HANDLE nv_index;
+};
+
+static tpm_nvsetbits_ctx ctx;
+
+static bool on_arg(int argc, char **argv) {
+    /* If the user doesn't specify an authorization hierarchy use the index
+     * passed to -x/--index for the authorization index.
+     */
+    if (!ctx.auth_hierarchy.ctx_path) {
+        ctx.auth_hierarchy.ctx_path = argv[0];
+    }
+    return on_arg_nv_index(argc, argv, &ctx.nv_index);
+}
+
+static bool on_option(char key, char *value) {
+
+    switch (key) {
+
+    case 'C':
+        ctx.auth_hierarchy.ctx_path = value;
+        break;
+    case 'P':
+        ctx.auth_hierarchy.auth_str = value;
+        break;
+    case 'i':
+        ctx.bit_string = value;
+        break;
+    }
+
+    return true;
+}
+
+bool tpm2_tool_onstart(tpm2_options **opts) {
+
+    const struct option topts[] = {
+        { "hierarchy", required_argument, NULL, 'C' },
+        { "auth",      required_argument, NULL, 'P' },
+        { "bits",      required_argument, NULL, 'i' },
+    };
+
+    *opts = tpm2_options_new("C:P:i:", ARRAY_LEN(topts), topts, on_option,
+            on_arg, 0);
+
+    return *opts != NULL;
+}
+
+tool_rc tpm2_tool_onrun(ESYS_CONTEXT *ectx, tpm2_option_flags flags) {
+
+    UNUSED(flags);
+
+    if (!ctx.bit_string) {
+        LOG_ERR("Expected option --bits for specifying the bits to set");
+        return tool_rc_option_error;
+    }
+
+    UINT64 bits = 0;
+    bool result = tpm2_util_string_to_uint64(ctx.bit_string, &bits);
+    if (!result) {
+        LOG_ERR("Could not convert option argument to number, got: \"%s\"",
+                ctx.bit_string);
+        return tool_rc_general_error;
+    }
+
+    tool_rc rc = tpm2_util_object_load_auth(ectx, ctx.auth_hierarchy.ctx_path,
+            ctx.auth_hierarchy.auth_str, &ctx.auth_hierarchy.object, false,
+            TPM2_HANDLE_FLAGS_NV | TPM2_HANDLE_FLAGS_O | TPM2_HANDLE_FLAGS_P);
+    if (rc != tool_rc_success) {
+        LOG_ERR("Invalid handle authorization");
+        return rc;
+    }
+
+    return tpm2_nvsetbits(ectx, &ctx.auth_hierarchy.object, ctx.nv_index, bits);
+}
+
+tool_rc tpm2_tool_onstop(ESYS_CONTEXT *ectx) {
+    UNUSED(ectx);
+    return tpm2_session_close(&ctx.auth_hierarchy.object.session);
+}

--- a/tools/tpm2_nvwritelock.c
+++ b/tools/tpm2_nvwritelock.c
@@ -1,0 +1,78 @@
+/* SPDX-License-Identifier: BSD-3-Clause */
+#include <stdlib.h>
+
+#include "log.h"
+#include "tpm2.h"
+#include "tpm2_nv_util.h"
+#include "tpm2_options.h"
+
+typedef struct tpm_nvwritelock_ctx tpm_nvwritelock_ctx;
+struct tpm_nvwritelock_ctx {
+    struct {
+        const char *ctx_path;
+        const char *auth_str;
+        tpm2_loaded_object object;
+    } auth_hierarchy;
+
+    TPM2_HANDLE nv_index;
+};
+
+static tpm_nvwritelock_ctx ctx;
+
+static bool on_arg(int argc, char **argv) {
+    /* If the user doesn't specify an authorization hierarchy use the index
+     * passed to -x/--index for the authorization index.
+     */
+    if (!ctx.auth_hierarchy.ctx_path) {
+        ctx.auth_hierarchy.ctx_path = argv[0];
+    }
+    return on_arg_nv_index(argc, argv, &ctx.nv_index);
+}
+
+static bool on_option(char key, char *value) {
+
+    switch (key) {
+
+    case 'C':
+        ctx.auth_hierarchy.ctx_path = value;
+        break;
+    case 'P':
+        ctx.auth_hierarchy.auth_str = value;
+        break;
+    }
+
+    return true;
+}
+
+bool tpm2_tool_onstart(tpm2_options **opts) {
+
+    const struct option topts[] = {
+        { "hierarchy", required_argument, NULL, 'C' },
+        { "auth",      required_argument, NULL, 'P' },
+    };
+
+    *opts = tpm2_options_new("C:P:", ARRAY_LEN(topts), topts, on_option, on_arg,
+            0);
+
+    return *opts != NULL;
+}
+
+tool_rc tpm2_tool_onrun(ESYS_CONTEXT *ectx, tpm2_option_flags flags) {
+
+    UNUSED(flags);
+
+    tool_rc rc = tpm2_util_object_load_auth(ectx, ctx.auth_hierarchy.ctx_path,
+            ctx.auth_hierarchy.auth_str, &ctx.auth_hierarchy.object, false,
+            TPM2_HANDLE_FLAGS_NV | TPM2_HANDLE_FLAGS_O | TPM2_HANDLE_FLAGS_P);
+    if (rc != tool_rc_success) {
+        LOG_ERR("Invalid handle authorization");
+        return rc;
+    }
+
+    return tpm2_nvwritelock(ectx, &ctx.auth_hierarchy.object, ctx.nv_index);
+}
+
+tool_rc tpm2_tool_onstop(ESYS_CONTEXT *ectx) {
+    UNUSED(ectx);
+    return tpm2_session_close(&ctx.auth_hierarchy.object.session);
+}


### PR DESCRIPTION
add the nvwritelock and nvsetbits tool, enhance nt field specifiers with friendly names and a few clean up commits.

Fixes: #850
Fixes: #848