### PR TITLE
tpm2_nvextend: implement tpm2_nvextend tool

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,8 @@
 * tpm2\_clockrateadjust: Add a new tool for modifying the period on the TPM
   clock.
 
+* tpm2\_nvextend: Add a new tool for extending an NV index similair to a PCR.
+
 * tpm2\_nvwritelock: Add a new tool for setting a write lock on an NV index
     or globally locking nv indices with TPMA\_NV\_GLOBALLOCK.
 

--- a/Makefile.am
+++ b/Makefile.am
@@ -66,6 +66,7 @@ bin_PROGRAMS = \
     tools/tpm2_loadexternal \
     tools/tpm2_makecredential \
     tools/tpm2_nvdefine \
+    tools/tpm2_nvextend \
     tools/tpm2_nvincrement \
     tools/tpm2_nvreadpublic \
     tools/tpm2_nvread \
@@ -203,6 +204,7 @@ tools_tpm2_shutdown_SOURCES = tools/tpm2_shutdown.c $(TOOL_SRC)
 tools_tpm2_clockrateadjust_SOURCES = tools/tpm2_clockrateadjust.c $(TOOL_SRC)
 tools_tpm2_nvwritelock_SOURCES = tools/tpm2_nvwritelock.c $(TOOL_SRC)
 tools_tpm2_nvsetbits_SOURCES = tools/tpm2_nvsetbits.c $(TOOL_SRC)
+tools_tpm2_nvextend_SOURCES = tools/tpm2_nvextend.c $(TOOL_SRC)
 
 if UNIT
 TESTS = $(check_PROGRAMS)
@@ -354,6 +356,7 @@ if HAVE_MAN_PAGES
     man/man1/tpm2_loadexternal.1 \
     man/man1/tpm2_makecredential.1 \
     man/man1/tpm2_nvdefine.1 \
+    man/man1/tpm2_nvextend.1 \
     man/man1/tpm2_nvincrement.1 \
     man/man1/tpm2_nvreadpublic.1 \
     man/man1/tpm2_nvread.1 \

--- a/lib/tpm2.c
+++ b/lib/tpm2.c
@@ -1418,6 +1418,38 @@ tool_rc tpm2_nvsetbits(ESYS_CONTEXT *esys_context,
     return tool_rc_success;
 }
 
+tool_rc tpm2_nvextend(ESYS_CONTEXT *esys_context,
+        tpm2_loaded_object *auth_hierarchy_obj, TPM2_HANDLE nv_index,
+        TPM2B_MAX_NV_BUFFER *data) {
+
+    ESYS_TR esys_tr_nv_handle;
+    TSS2_RC rval = Esys_TR_FromTPMPublic(esys_context, nv_index, ESYS_TR_NONE,
+            ESYS_TR_NONE, ESYS_TR_NONE, &esys_tr_nv_handle);
+    if (rval != TPM2_RC_SUCCESS) {
+        LOG_PERR(Esys_TR_FromTPMPublic, rval);
+        return tool_rc_from_tpm(rval);
+    }
+
+    ESYS_TR auth_hierarchy_obj_session_handle = ESYS_TR_NONE;
+    tool_rc rc = tpm2_auth_util_get_shandle(esys_context,
+            auth_hierarchy_obj->tr_handle, auth_hierarchy_obj->session,
+            &auth_hierarchy_obj_session_handle);
+    if (rc != tool_rc_success) {
+        LOG_ERR("Failed to get shandle");
+        return rc;
+    }
+
+    rval = Esys_NV_Extend(esys_context, auth_hierarchy_obj->tr_handle,
+            esys_tr_nv_handle, auth_hierarchy_obj_session_handle, ESYS_TR_NONE,
+            ESYS_TR_NONE, data);
+    if (rval != TPM2_RC_SUCCESS) {
+        LOG_PERR(Esys_NV_Extend, rval);
+        return tool_rc_from_tpm(rval);
+    }
+
+    return tool_rc_success;
+}
+
 tool_rc tpm2_nvundefine(ESYS_CONTEXT *esys_context,
         tpm2_loaded_object *auth_hierarchy_obj, TPM2_HANDLE nv_index) {
 

--- a/lib/tpm2.h
+++ b/lib/tpm2.h
@@ -272,6 +272,10 @@ tool_rc tpm2_nv_definespace(ESYS_CONTEXT *esys_context,
         tpm2_loaded_object *auth_hierarchy_obj, const TPM2B_AUTH *auth,
         const TPM2B_NV_PUBLIC *public_info);
 
+tool_rc tpm2_nvextend(ESYS_CONTEXT *esys_context,
+        tpm2_loaded_object *auth_hierarchy_obj, TPM2_HANDLE nv_index,
+        TPM2B_MAX_NV_BUFFER *data);
+
 tool_rc tpm2_nv_increment(ESYS_CONTEXT *esys_context,
         tpm2_loaded_object *auth_hierarchy_obj, TPM2_HANDLE nv_index);
 

--- a/man/tpm2_nvextend.1.md
+++ b/man/tpm2_nvextend.1.md
@@ -1,0 +1,72 @@
+% tpm2_nvsetbits(1) tpm2-tools | General Commands Manual
+
+# NAME
+
+**tpm2_nvsetbits**(1) - Bitwise OR bits into a Non-Volatile (NV).
+
+# SYNOPSIS
+
+**tpm2_nvsetbits** [*OPTIONS*] [*ARGUMENT*]
+
+# DESCRIPTION
+
+**tpm2_nvsetbits**(1) - Bitwise OR bits into a Non-Volatile (NV). The
+NV index must be of type "bits" which is specified via the "nt" field
+when creating the NV space with tpm2_nvdefine(1). The index can be
+specified as raw handle or an offset value to the NV handle range
+"TPM2_HR_NV_INDEX".
+
+# OPTIONS
+
+  * **-C**, **\--hierarchy**=_OBJECT_:
+
+    Specifies the hierarchy used to authorize.
+    Supported options are:
+      * **o** for **TPM_RH_OWNER**
+      * **p** for **TPM_RH_PLATFORM**
+      * **`<num>`** where a hierarchy handle or nv-index may be used.
+
+    When **-C** isn't explicitly passed the index handle will be used to
+    authorize against the index. The index auth value is set via the
+    **-p** option to **tpm2_nvdefine**(1).
+
+  * **-P**, **\--auth**=_AUTH_:
+
+    Specifies the authorization value for the hierarchy.
+
+  * **-i**, **\--input**=_FILE_:
+
+    Specifies the input file with data to extend to the NV index.
+
+  * **ARGUMENT** the command line argument specifies the NV index or offset
+    number.
+
+## References
+
+[context object format](common/ctxobj.md) details the methods for specifying
+_OBJECT_.
+
+[authorization formatting](common/authorizations.md) details the methods for
+specifying _AUTH_.
+
+[common options](common/options.md) collection of common options that provide
+information many users may expect.
+
+[common tcti options](common/tcti.md) collection of options used to configure
+the various known TCTI modules.
+
+# EXAMPLES
+
+## OR 0xbadc0de into an index of 0's
+```bash
+tpm2_nvdefine -C o -a "nt=bits|ownerread|policywrite|ownerwrite|writedefine" 1
+
+tpm2_nvsetbits -C o -i 0xbadc0de 1
+
+tpm2_nvread -C o 1 | xxd -p | sed s/'^0*'/0x/
+0xbadc0de
+```
+
+[returns](common/returns.md)
+
+[footer](common/footer.md)

--- a/test/integration/tests/nv.sh
+++ b/test/integration/tests/nv.sh
@@ -267,4 +267,16 @@ fi
 
 trap onerror ERR
 
+tpm2_nvundefine -C o -P "owner" $nv_test_index
+
+# Test extend
+tpm2_nvdefine -C o -P "owner" -a "nt=extend|ownerread|policywrite|ownerwrite" $nv_test_index
+echo "foo" | tpm2_nvextend -C o -P "owner" -i- $nv_test_index
+check=$(tpm2_nvread -C o -P "owner" $nv_test_index | xxd -p -c 64 | sed s/'^0*'//)
+expected="1c8457de84bb43c18d5e1d75c43e393bdaa7bca8d25967eedd580c912db65e3e"
+if [ "$check" != "$expected" ]; then
+	echo "Expected setbits read value of \"$expected\", got \"$check\""
+	exit 1
+fi
+
 exit 0

--- a/tools/tpm2_nvextend.c
+++ b/tools/tpm2_nvextend.c
@@ -1,0 +1,94 @@
+/* SPDX-License-Identifier: BSD-3-Clause */
+#include <stdlib.h>
+
+#include "files.h"
+#include "log.h"
+#include "tpm2.h"
+#include "tpm2_nv_util.h"
+#include "tpm2_options.h"
+
+typedef struct tpm_nvextend_ctx tpm_nvextend_ctx;
+struct tpm_nvextend_ctx {
+    struct {
+        const char *ctx_path;
+        const char *auth_str;
+        tpm2_loaded_object object;
+    } auth_hierarchy;
+
+    const char *input_path;
+    TPM2_HANDLE nv_index;
+};
+
+static tpm_nvextend_ctx ctx;
+
+static bool on_arg(int argc, char **argv) {
+    /* If the user doesn't specify an authorization hierarchy use the index
+     * passed to -x/--index for the authorization index.
+     */
+    if (!ctx.auth_hierarchy.ctx_path) {
+        ctx.auth_hierarchy.ctx_path = argv[0];
+    }
+    return on_arg_nv_index(argc, argv, &ctx.nv_index);
+}
+
+static bool on_option(char key, char *value) {
+
+    switch (key) {
+
+    case 'C':
+        ctx.auth_hierarchy.ctx_path = value;
+        break;
+    case 'P':
+        ctx.auth_hierarchy.auth_str = value;
+        break;
+    case 'i':
+        ctx.input_path = value;
+        break;
+    }
+
+    return true;
+}
+
+bool tpm2_tool_onstart(tpm2_options **opts) {
+
+    const struct option topts[] = {
+        { "hierarchy", required_argument, NULL, 'C' },
+        { "auth",      required_argument, NULL, 'P' },
+        { "input",     required_argument, NULL, 'i' },
+    };
+
+    *opts = tpm2_options_new("C:P:i:", ARRAY_LEN(topts), topts, on_option,
+            on_arg, 0);
+
+    return *opts != NULL;
+}
+
+tool_rc tpm2_tool_onrun(ESYS_CONTEXT *ectx, tpm2_option_flags flags) {
+
+    UNUSED(flags);
+
+    ctx.input_path = strcmp(ctx.input_path, "-") ? ctx.input_path : NULL;
+
+    TPM2B_MAX_NV_BUFFER data = { .size = sizeof(data.buffer) };
+
+    bool result = files_load_bytes_from_buffer_or_file_or_stdin(NULL,
+            ctx.input_path, &data.size, data.buffer);
+    if (!result) {
+        return tool_rc_general_error;
+    }
+
+    tool_rc rc = tpm2_util_object_load_auth(ectx, ctx.auth_hierarchy.ctx_path,
+            ctx.auth_hierarchy.auth_str, &ctx.auth_hierarchy.object, false,
+            TPM2_HANDLE_FLAGS_NV | TPM2_HANDLE_FLAGS_O | TPM2_HANDLE_FLAGS_P);
+    if (rc != tool_rc_success) {
+        LOG_ERR("Invalid handle authorization");
+        return rc;
+    }
+
+    return tpm2_nvextend(ectx, &ctx.auth_hierarchy.object, ctx.nv_index, &data);
+}
+
+tool_rc tpm2_tool_onstop(ESYS_CONTEXT *ectx) {
+    UNUSED(ectx);
+    return tpm2_session_close(&ctx.auth_hierarchy.object.session);
+}


### PR DESCRIPTION
Implement the tpm2_nvextend which will extend, like a PCR, an NV index
with attribute nt=extend.

Fixes: #844

Signed-off-by: William Roberts <william.c.roberts@intel.com>