### PR TITLE
tpm2_nvundefine: support undefinespace special

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,9 @@
 * tpm2\_nvwritelock: Add a new tool for setting a write lock on an NV index
     or globally locking nv indices with TPMA\_NV\_GLOBALLOCK.
 
+* tpm2\_nvundefine: Add support for deleting NV indices with attribute
+    `TPMA_NV_POLICY_DELETE` set using NV Undefine Special command.
+
 * tpm2\_policysecret: Add tool options for specifying
   - \--expiration or -t
   - \--ticket

--- a/lib/tpm2.c
+++ b/lib/tpm2.c
@@ -1452,6 +1452,46 @@ tool_rc tpm2_nvundefine(ESYS_CONTEXT *esys_context,
     return tool_rc_success;
 }
 
+tool_rc tpm2_nvundefinespecial(ESYS_CONTEXT *esys_context,
+        tpm2_loaded_object *auth_hierarchy_obj, TPM2_HANDLE nv_index,
+        tpm2_session *policy_session) {
+
+    ESYS_TR esys_tr_nv_handle;
+    TSS2_RC rval = Esys_TR_FromTPMPublic(esys_context, nv_index, ESYS_TR_NONE,
+            ESYS_TR_NONE, ESYS_TR_NONE, &esys_tr_nv_handle);
+    if (rval != TPM2_RC_SUCCESS) {
+        LOG_PERR(Esys_TR_FromTPMPublic, rval);
+        return tool_rc_from_tpm(rval);
+    }
+
+    ESYS_TR auth_hierarchy_obj_session_handle = ESYS_TR_NONE;
+    tool_rc rc = tpm2_auth_util_get_shandle(esys_context,
+            auth_hierarchy_obj->tr_handle, auth_hierarchy_obj->session,
+            &auth_hierarchy_obj_session_handle);
+    if (rc != tool_rc_success) {
+        LOG_ERR("Couldn't get shandle");
+        return rc;
+    }
+
+    ESYS_TR policy_session_handle = tpm2_session_get_handle(policy_session);
+
+    rval = Esys_NV_UndefineSpaceSpecial(esys_context,
+            esys_tr_nv_handle,
+            auth_hierarchy_obj->tr_handle,
+            policy_session_handle, // policy session
+            auth_hierarchy_obj_session_handle, // auth session for hierarchy
+            ESYS_TR_NONE);
+    if (rval != TPM2_RC_SUCCESS) {
+        LOG_ERR("Failed to release NV area at index 0x%X", nv_index);
+        LOG_PERR(Esys_NV_UndefineSpace, rval);
+        return tool_rc_from_tpm(rval);
+    }
+
+    LOG_INFO("Success to release NV area at index 0x%x.", nv_index);
+
+    return tool_rc_success;
+}
+
 tool_rc tpm2_nvwrite(ESYS_CONTEXT *esys_context,
         tpm2_loaded_object *auth_hierarchy_obj, TPM2_HANDLE nvindex,
         const TPM2B_MAX_NV_BUFFER *data, UINT16 offset) {

--- a/lib/tpm2.h
+++ b/lib/tpm2.h
@@ -291,6 +291,10 @@ tool_rc tpm2_nvsetbits(ESYS_CONTEXT *esys_context,
 tool_rc tpm2_nvundefine(ESYS_CONTEXT *esys_context,
         tpm2_loaded_object *auth_hierarchy_obj, TPM2_HANDLE nv_index);
 
+tool_rc tpm2_nvundefinespecial(ESYS_CONTEXT *esys_context,
+        tpm2_loaded_object *auth_hierarchy_obj, TPM2_HANDLE nv_index,
+        tpm2_session *policy_session);
+
 tool_rc tpm2_nvwrite(ESYS_CONTEXT *esys_context,
         tpm2_loaded_object *auth_hierarchy_obj, TPM2_HANDLE nvindex,
         const TPM2B_MAX_NV_BUFFER *data, UINT16 offset);

--- a/test/integration/tests/abrmd_nvundefinespecial.sh
+++ b/test/integration/tests/abrmd_nvundefinespecial.sh
@@ -1,0 +1,38 @@
+# SPDX-License-Identifier: BSD-3-Clause
+
+source helpers.sh
+
+cleanup() {
+
+    tpm2_flushcontext session.ctx 2>/dev/null || true
+    rm -f policy.dat session.ctx
+
+    if [ "${1}" != "no-shutdown" ]; then
+        shut_down
+    fi
+}
+trap cleanup EXIT
+
+start_up
+
+cleanup "no-shutdown"
+
+tpm2_startauthsession -S session.ctx
+
+tpm2_policyauthvalue -S session.ctx
+
+tpm2_policycommandcode -S session.ctx TPM2_CC_NV_UndefineSpaceSpecial -L policy.dat
+
+tpm2_nvdefine -C p -s 32 -a "ppread|ppwrite|authread|authwrite|platformcreate|policydelete|write_stclear|read_stclear" -L policy.dat 1
+
+tpm2_flushcontext session.ctx
+
+tpm2_startauthsession --policy-session -S session.ctx
+
+tpm2_policyauthvalue -S session.ctx
+
+tpm2_policycommandcode -S session.ctx TPM2_CC_NV_UndefineSpaceSpecial
+
+tpm2_nvundefine -S session.ctx 1
+
+exit 0


### PR DESCRIPTION
Support CC TPM2_CC_NV_UndefineSpaceSpecial within tpm2_undefine.
Undefine special is used to delete NV indices witrh attribute
TPMA_NV_POLICY_DELETE. Internally the tool looks at the attribute
set of a given NV index and determines which undefine command
to use.

Because the command requires a policy session, the command now
supports option -S for specifying said policy session. This
option is only valid if the NV index attributes contain
TPMA_NV_POLICY_DELETE.

Fixes: #849

Signed-off-by: William Roberts <william.c.roberts@intel.com>