### PR TITLE
files_load_bytes_from_buffer_or_file_or_stdin: fix

### DIFF
--- a/lib/files.h
+++ b/lib/files.h
@@ -40,7 +40,7 @@ bool files_load_bytes_from_path(const char *path, UINT8 *buf, UINT16 *size);
  * @return
  *  True on success or false otherwise.
  */
-bool files_load_bytes_from_buffer_or_file_or_stdin(char *input_buffer,
+bool files_load_bytes_from_buffer_or_file_or_stdin(const char *input_buffer,
         const char *path, UINT16 *size, BYTE *buf);
 
 /**

--- a/test/integration/helpers.sh
+++ b/test/integration/helpers.sh
@@ -389,3 +389,10 @@ function ina() {
     }
     echo 1
 }
+
+# Causes a test to skip by exiting with error code 77
+# See the automake manual for the exit codes:
+#   https://www.gnu.org/software/automake/manual/html_node/Scripts_002dbased-Testsuites.html
+function skip_test() {
+	exit 77
+}

--- a/test/integration/tests/encryptdecrypt.sh
+++ b/test/integration/tests/encryptdecrypt.sh
@@ -32,7 +32,7 @@ grep -q 0x164 commands.cap
 if [ $? != 0 ];then
     echo "WARN: Command EncryptDecrypt is not supported by your device, \
     skipping..."
-    exit 0
+    skip_test
 fi
 
 # Now set the trap handler for ERR since we're past the command code check

--- a/test/integration/tests/stirrandom.sh
+++ b/test/integration/tests/stirrandom.sh
@@ -31,16 +31,7 @@ grep -q "Submitting 8 bytes to TPM"
 tpm2_stirrandom -V < "${goodfile}" 2>&1 1>/dev/null | \
 grep -q "Submitting 42 bytes to TPM"
 
-# Read more than 128 bytes from stdin (pipe)
-dd if=/dev/urandom bs=1 count=256 | tpm2_stirrandom -V 2>&1 1>/dev/null | \
-grep -q "Submitting 128 bytes to TPM"
-
-# Read more than 128 bytes from stdin (file)
-dd if=/dev/urandom bs=1 count=256 | \
-tpm2_stirrandom -V < "${bigfile}" 2>&1 1>/dev/null | \
-grep -q "Submitting 128 bytes to TPM"
-
-# Read a complete file
+# Sending bytes from a file path
 tpm2_stirrandom "${goodfile}" -V 2>&1 1>/dev/null | \
 grep -q "Submitting 42 bytes to TPM"
 

--- a/tools/tpm2_policynv.c
+++ b/tools/tpm2_policynv.c
@@ -23,12 +23,14 @@ struct tpm_policynv_ctx {
     const char *session_path;
     tpm2_session *session;
 
-    const TPM2B_OPERAND operand_b;
+    TPM2B_OPERAND operand_b;
     UINT16 offset;
     TPM2_EO operation;
 };
 
-static tpm_policynv_ctx ctx;
+static tpm_policynv_ctx ctx = {
+    .operand_b = { .size = BUFFER_SIZE(TPM2B_OPERAND, buffer) }
+};
 
 static bool on_arg(int argc, char **argv) {
 
@@ -113,13 +115,9 @@ static bool on_option(char key, char *value) {
             return false;
         }
         result = files_load_bytes_from_buffer_or_file_or_stdin(NULL, input_file,
-                (UINT16 *)&ctx.operand_b.size,
-                (unsigned char *)&ctx.operand_b.buffer);
+                &ctx.operand_b.size,
+                ctx.operand_b.buffer);
         if (!result) {
-            return false;
-        }
-        if (ctx.operand_b.size > TPM2_MAX_NV_BUFFER_SIZE) {
-            LOG_ERR("File larger than TPM2_MAX_NV_BUFFER_SIZE");
             return false;
         }
         break;

--- a/tools/tpm2_stirrandom.c
+++ b/tools/tpm2_stirrandom.c
@@ -14,7 +14,9 @@ struct tpm_stirrandom_ctx {
     char *in_file;
 };
 
-static tpm_stirrandom_ctx ctx;
+static tpm_stirrandom_ctx ctx = {
+        .in_data = { .size = MAX_SIZE_TO_READ }
+};
 
 static bool on_args(int argc, char **argv) {
 
@@ -36,8 +38,6 @@ bool tpm2_tool_onstart(tpm2_options **opts) {
 }
 
 static bool load_sensitive(void) {
-
-    ctx.in_data.size = MAX_SIZE_TO_READ;
 
     bool res = files_load_bytes_from_buffer_or_file_or_stdin(NULL, ctx.in_file,
             &ctx.in_data.size, ctx.in_data.buffer);


### PR DESCRIPTION
Fixes #1800 

Makes a test skip helper, I noticed a test was "skipping" but not exiting with code 77 as defined for skip condition on automake.