### PR TITLE
tpm2_evictcontrol: fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,8 +21,11 @@
   - \--creation-ticket or -t to save the creation ticket
   - \--creation-hash or -d to save the creation hash
 
-* tpm2\_evictcontrol: Fix bug in automatic persistent handle selection when
-    hierarchy is platform.
+* tpm2\_evictcontrol:
+    - Fix bug in automatic persistent handle selection when
+      hierarchy is platform.
+    - Fix bug in YAML key action where action was wrong when using ESYS\_TR.
+
 
 * tpm2\_gettime: Add a new tool for retrieving a signed timestamp from a TPM.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,9 @@
   - \--creation-ticket or -t to save the creation ticket
   - \--creation-hash or -d to save the creation hash
 
+* tpm2\_evictcontrol: Fix bug in automatic persistent handle selection when
+    hierarchy is platform.
+
 * tpm2\_gettime: Add a new tool for retrieving a signed timestamp from a TPM.
 
 * tpm2\_nvcertify: Add a new tool for certifying the contents of an NV index.

--- a/lib/tpm2_capability.h
+++ b/lib/tpm2_capability.h
@@ -28,12 +28,15 @@ tool_rc tpm2_capability_get(ESYS_CONTEXT *context, TPM2_CAP capability,
  * Attempts to find a vacant handle in the persistent handle namespace.
  * @param ctx
  *  Enhanced System API (ESAPI) context
+ *  @param is_platform
+ *   true if the persistent handle should be in the persistent range allocated for
+ *   platform hierarchy, false otherwise.
  * @param vacant
  *  the vacant handle found by the function if True returned
  * @return
  *  tool_rc indicating status.
  */
 tool_rc tpm2_capability_find_vacant_persistent_handle(ESYS_CONTEXT *ctx,
-        UINT32 *vacant);
+        bool is_platform, TPMI_DH_PERSISTENT *vacant);
 
 #endif /* LIB_TPM2_CAPABILITY_H_ */

--- a/test/integration/tests/evictcontrol.sh
+++ b/test/integration/tests/evictcontrol.sh
@@ -4,7 +4,7 @@ source helpers.sh
 
 cleanup() {
   rm -f primary.ctx decrypt.ctx key.pub key.priv key.name decrypt.out \
-        encrypt.out secret.dat key.dat evict.log
+        encrypt.out secret.dat key.dat evict.log primary.ctx key.ctx
 
   if [ "$1" != "no-shut-down" ]; then
       shut_down
@@ -40,5 +40,13 @@ phandle=$(yaml_get_kv evict.log "persistent-handle")
 tpm2_evictcontrol -Q -C o -c $phandle
 
 yaml_verify evict.log
+
+# verify that platform hierarchy auto selection for persistent handle works
+tpm2_createprimary -C p -c primary.ctx
+tpm2_create -C primary.ctx -c key.ctx
+tpm2_evictcontrol -C p -c key.ctx > evict.log
+
+phandle=$(yaml_get_kv evict.log persistent-handle)
+tpm2_evictcontrol -C p -c $phandle
 
 exit 0

--- a/tools/tpm2_createek.c
+++ b/tools/tpm2_createek.c
@@ -346,7 +346,7 @@ tool_rc tpm2_tool_onrun(ESYS_CONTEXT *ectx, tpm2_option_flags flags) {
          * to use and tell them what it is.
          */
         rc = tpm2_capability_find_vacant_persistent_handle(ectx,
-                &ctx.ctx_obj.handle);
+                false, &ctx.ctx_obj.handle);
         if (rc != tool_rc_success) {
             LOG_ERR("handle/-H passed with a value '-' but unable to find a"
                     " vacant persistent handle!");


### PR DESCRIPTION
1. Fix the platform flushing issue
2. While fixing one, noticed that the output was wrong when using an ESYS_TR handle. So fix the output for that. This is only a partial fix and #1816 has been filed to deal with the rest of it.