### PR TITLE
qualifying data as hex string or binary file and manpage fix

### DIFF
--- a/lib/files.c
+++ b/lib/files.c
@@ -76,7 +76,7 @@ bool files_get_file_size(FILE *fp, unsigned long *file_size, const char *path) {
     return true;
 }
 
-static bool read_bytes_from_file(FILE *f, UINT8 *buf, UINT16 *size,
+bool file_read_bytes_from_file(FILE *f, UINT8 *buf, UINT16 *size,
         const char *path) {
     unsigned long file_size;
     bool result = files_get_file_size(f, &file_size, path);
@@ -119,7 +119,7 @@ bool files_load_bytes_from_path(const char *path, UINT8 *buf, UINT16 *size) {
         return false;
     }
 
-    bool result = read_bytes_from_file(f, buf, size, path);
+    bool result = file_read_bytes_from_file(f, buf, size, path);
 
     fclose(f);
     return result;

--- a/lib/files.h
+++ b/lib/files.h
@@ -28,6 +28,22 @@
 bool files_load_bytes_from_path(const char *path, UINT8 *buf, UINT16 *size);
 
 /**
+ * Like files_load_bytes_from_path() but uses a FILE pointer.
+ * @param f
+ *  The FILE pointer to read from.
+ * @param buf
+ *  The buffer to store the data.
+ * @param size
+ *  On input the max size of the buffer, on success the actual count of bytes read.
+ * @param path
+ *  A possible path for error reporting, can be NULL to silence error reporting.
+ * @return
+ *  True on success, false otherwise.
+ */
+bool file_read_bytes_from_file(FILE *f, UINT8 *buf, UINT16 *size,
+        const char *path);
+
+/**
  * Loads data from an input buffer or file path or stdin enforcing an upper bound on size.
  * @param input_buffer
  *   The buffer to read the input data from, NULL means either specified by path or stdin

--- a/lib/tpm2_policy.h
+++ b/lib/tpm2_policy.h
@@ -38,8 +38,9 @@ tool_rc tpm2_policy_build_pcr(ESYS_CONTEXT *context,
  *   The policy session that has the policy digest to be authorized
  * @param policy_digest_path
  *   The policy digest file that needs to be authorized by signing authority
- * @param policy_qualifier_path
- *   The policy qualifier data that concatenates with approved policies
+ * @param policy_qualifier
+ *   The policy qualifier data that concatenates with approved policies. Can be
+ *   either a path to a file or a hex string.
  * @param verifying_pubkey_name_path
  *   The name of the public key that verifies the signature of the signer
  * @param ticket_path
@@ -49,7 +50,7 @@ tool_rc tpm2_policy_build_pcr(ESYS_CONTEXT *context,
  */
 tool_rc tpm2_policy_build_policyauthorize(ESYS_CONTEXT *ectx,
         tpm2_session *policy_session, const char *policy_digest_path,
-        const char *policy_qualifier_path,
+        const char *policy_qualifier,
         const char *verifying_pubkey_name_path, const char *ticket_path);
 
 /**

--- a/lib/tpm2_util.c
+++ b/lib/tpm2_util.c
@@ -182,6 +182,27 @@ int tpm2_util_hex_to_byte_structure(const char *input_string, UINT16 *byte_lengt
     return 0;
 }
 
+bool tpm2_util_bin_from_hex_or_file(const char *input, UINT16 *len, BYTE *buffer) {
+
+    bool result = false;
+
+    FILE *f = fopen(input, "rb");
+    if (!f) {
+        result = tpm2_util_hex_to_byte_structure(input, len, buffer) == 0;
+        goto out;
+    }
+
+    result = file_read_bytes_from_file(f, buffer, len, input);
+    fclose(f);
+out:
+    if (!result) {
+        LOG_ERR("Could not convert \"%s\". Neither a file path nor hex string.",
+        input);
+    }
+
+    return result;
+}
+
 void tpm2_util_hexdump2(FILE *f, const BYTE *data, size_t len) {
 
     size_t i;

--- a/lib/tpm2_util.h
+++ b/lib/tpm2_util.h
@@ -182,6 +182,20 @@ void tpm2_util_hexdump(const BYTE *data, size_t len);
 void tpm2_util_hexdump2(FILE *f, const BYTE *data, size_t len);
 
 /**
+ * Read a hex string converting it to binary or a binary file and
+ * store into a binary buffer.
+ * @param input
+ *  Either a hex string or a file path.
+ * @param len
+ *  The maximum length of the buffer.
+ * @param buffer
+ *  The buffer to read into.
+ * @return
+ *  True on success, False otherwise.
+ */
+bool tpm2_util_bin_from_hex_or_file(const char *input, UINT16 *len, BYTE *buffer);
+
+/**
  * Prints a file as a hex string to stdout if quiet mode
  * is not enabled.
  * ie no -Q option.

--- a/man/tpm2_certifycreation.1.md
+++ b/man/tpm2_certifycreation.1.md
@@ -58,10 +58,10 @@ created with either **TPM2_CreatePrimary** or **TPM2_Create** commands.
 
     The attestation data of the type TPM2_CREATION_INFO signed with signing key.
 
-  * **-q**, **\--qualification**=_FILE_:
+  * **-q**, **\--qualification**=_FILE\_OR\_HEX_:
 
-    The policy qualifier data that the signer can choose to include in the
-    signature.
+    Optional, the policy qualifier data that the signer can choose to include in the
+    signature. Can either be a path or hex string.
 
 ## References
 

--- a/man/tpm2_checkquote.1.md
+++ b/man/tpm2_checkquote.1.md
@@ -44,10 +44,10 @@ those in the quote.
     Optional PCR input file to save the list of PCR values that were included
     in the quote.
 
-  * **-q**, **\--qualification**=_HEX\_STRING_:
+  * **-q**, **\--qualification**=_HEX\_STRING\_OR\_PATH_:
 
-    Qualification data for the quote. This is typically used to add a nonce
-    against replay attacks.
+    Qualification data for the quote. Can either be a hex string or path.
+    This is typically used to add a nonce against replay attacks.
 
 ## References
 

--- a/man/tpm2_create.1.md
+++ b/man/tpm2_create.1.md
@@ -95,10 +95,10 @@ These options for creating the TPM entity:
 
     An optional file output that saves the creation hash for certification.
 
-  * **-q**, **\--outside-info**=_FILE_:
+  * **-q**, **\--outside-info**=_HEX\_STR\_OR\_FILE_:
 
-    An optional file to add unique data to the creation data. Note that it does
-    not contribute in creating statistically unique object.
+    An optional hex string or path to add unique data to the creation data.
+    Note that it does not contribute in creating statistically unique object.
 
   * **-l**, **\--pcr-list**=_PCR_:
 

--- a/man/tpm2_createprimary.1.md
+++ b/man/tpm2_createprimary.1.md
@@ -86,10 +86,10 @@ future interactions with the created primary.
 
     An optional file output that saves the creation hash for certification.
 
-  * **-q**, **\--outside-info**=_FILE_:
+  * **-q**, **\--outside-info**=_FILE\_OR\_HEX_:
 
-    An optional file to add unique data to the creation data. Note that it does
-    not contribute in creating statistically unique object.
+    An optional file or hex string to add unique data to the creation data.
+    Note that it does not contribute in creating statistically unique object.
 
   * **-l**, **\--pcr-list**=_PCR_:
 

--- a/man/tpm2_gettime.1.md
+++ b/man/tpm2_gettime.1.md
@@ -71,10 +71,10 @@ clock_info:
     If left unspecified, a default signature scheme for the key type will
      be used.
 
-  * **-q**, **\--qualification**=_FILE_:
+  * **-q**, **\--qualification**=_FILE\_OR\_HEX\_STR_:
 
-    The policy qualifier data that the signer can choose to include in the
-    signature.
+    Optional, the policy qualifier data that the signer can choose to include in the
+    signature. Can be either a hex string or path.
 
   * **-o**, **\--signature**=_FILE_:
 

--- a/man/tpm2_nvcertify.1.md
+++ b/man/tpm2_nvcertify.1.md
@@ -51,10 +51,10 @@ These options control the certification:
 
     Output file name for the signature data.
 
-  * **-q**, **\--qualification**=_FILE_:
+  * **-q**, **\--qualification**=_FILE\_OR\_HEX\_STR_:
 
-    The policy qualifier data that the signer can choose to include in the
-    signature.
+    Optional, the policy qualifier data that the signer can choose to include in the
+    signature. Can be either a hex string or path.
 
   * **\--size**=_NATURAL_NUMBER_:
 

--- a/man/tpm2_nvextend.1.md
+++ b/man/tpm2_nvextend.1.md
@@ -1,20 +1,20 @@
-% tpm2_nvsetbits(1) tpm2-tools | General Commands Manual
+% tpm2_nvextend(1) tpm2-tools | General Commands Manual
 
 # NAME
 
-**tpm2_nvsetbits**(1) - Bitwise OR bits into a Non-Volatile (NV).
+**tpm2_nvextend**(1) - Extend an Non-Volatile (NV) index like it was a PCR.
 
 # SYNOPSIS
 
-**tpm2_nvsetbits** [*OPTIONS*] [*ARGUMENT*]
+**tpm2_nvextend** [*OPTIONS*] [*ARGUMENT*]
 
 # DESCRIPTION
 
-**tpm2_nvsetbits**(1) - Bitwise OR bits into a Non-Volatile (NV). The
-NV index must be of type "bits" which is specified via the "nt" field
+**tpm2_nvextend**(1) - Extend an Non-Volatile (NV) index like it was a PCR.
+The NV index must be of type "extend" which is specified via the "nt" field
 when creating the NV space with tpm2_nvdefine(1). The index can be
 specified as raw handle or an offset value to the NV handle range
-"TPM2_HR_NV_INDEX".
+"TPM2_HR_NV_INDEX" as an argument.
 
 # OPTIONS
 
@@ -59,12 +59,12 @@ the various known TCTI modules.
 
 ## OR 0xbadc0de into an index of 0's
 ```bash
-tpm2_nvdefine -C o -a "nt=bits|ownerread|policywrite|ownerwrite|writedefine" 1
+tpm2_nvdefine -C o -a "nt=extend|ownerread|policywrite|ownerwrite|writedefine" 1
 
-tpm2_nvsetbits -C o -i 0xbadc0de 1
+echo 'my data' | tpm2_nvextend -C o -i- 1
 
-tpm2_nvread -C o 1 | xxd -p | sed s/'^0*'/0x/
-0xbadc0de
+tpm2_nvread -C o 1 | xxd -p -c32
+db7472e3fe3309b011ec11565bce4ea6668cc8ecdef7e6fdcda5206687af3f43
 ```
 
 [returns](common/returns.md)

--- a/man/tpm2_policyauthorize.1.md
+++ b/man/tpm2_policyauthorize.1.md
@@ -38,10 +38,11 @@ in the policy digest.
 
     The policy digest that has to be authorized.
 
-  * **-q**, **\--qualification**=_FILE_:
+  * **-q**, **\--qualification**=_FILE\_OR\_HEX_:
 
     The policy qualifier data signed in conjunction with the input policy digest.
-    This is a unique data that the signer can choose to include in the signature.
+    This is unique data that the signer can choose to include in the signature
+    and can either be a path or hex string.
 
   * **-n**, **\--name**=_FILE_:
 

--- a/man/tpm2_policysecret.1.md
+++ b/man/tpm2_policysecret.1.md
@@ -56,10 +56,10 @@ object use.
     limited to the current session. This can be specified as a file or can take
     a stdin input if the option argument value is a hyphen "-".
 
-  * **-q**, **\--qualification**=_FILE_:
+  * **-q**, **\--qualification**=_FILE\_OR\_HEX\_STR_:
 
-    The policy qualifier data that the signer can choose to include in the
-    signature.
+    Optional, the policy qualifier data that the signer can choose to include in the
+    signature. Can be either a hex string or path.
 
   * **ARGUMENT** the command line argument specifies the _AUTH_ to be set for
     the object specified with **-c**.

--- a/man/tpm2_policysigned.1.md
+++ b/man/tpm2_policysigned.1.md
@@ -61,10 +61,10 @@ The optional TPM2 parameters being cpHashA, nonceTPM, policyRef and expiration.
 
     The file path to record the timeout structure returned.
 
-  * **-q**, **\--qualification**=_FILE_:
+  * **-q**, **\--qualification**=_FILE\_OR\_HEX\_STR_:
 
-    The policy qualifier data that the signer can choose to include in the
-    signature.
+    Optional, the policy qualifier data that the signer can choose to include in the
+    signature. Can be either a hex string or path.
 
   * **-x**, **\--nonce-tpm**=_FILE_OR_STDIN_:
 

--- a/man/tpm2_policyticket.1.md
+++ b/man/tpm2_policyticket.1.md
@@ -39,10 +39,10 @@ it.
 
     The file path to record the timeout structure returned.
 
-  * **-q**, **\--qualification**=_FILE_:
+  * **-q**, **\--qualification**=_FILE\_OR\_HEX\_STR_:
 
-    The policy qualifier data that the signer can choose to include in the
-    signature.
+    Optional, the policy qualifier data that the signer can choose to include in the
+    signature. Can be either a hex string or path.
 
 ## References
 

--- a/man/tpm2_quote.1.md
+++ b/man/tpm2_quote.1.md
@@ -47,10 +47,10 @@ algorithm/banks.
     PCR output file, optional, records the list of PCR values as defined
     by **-l**.
 
-  * **-q**, **\--qualification**=_HEX\_STRING_:
+  * **-q**, **\--qualification**=_HEX\_STRING\_OR\_PATH_:
 
-    Data given as a Hex string to qualify the  quote, optional. This is
-    typically used to add a nonce against replay attacks.
+    Data given as a Hex string or binary file to qualify the quote, optional.
+    This is typically used to add a nonce against replay attacks.
 
   * **-g**, **\--hash-algorithm**:
 

--- a/tools/tpm2_gettime.c
+++ b/tools/tpm2_gettime.c
@@ -124,12 +124,8 @@ static bool on_option(char key, char *value) {
         break;
     case 'q':
         ctx.qualifying_data.size = sizeof(ctx.qualifying_data.buffer);
-        if (tpm2_util_hex_to_byte_structure(value, &ctx.qualifying_data.size,
-                ctx.qualifying_data.buffer) != 0) {
-            LOG_ERR("Could not convert \"%s\" from a hex string to byte array!",
-                    value);
-            return false;
-        }
+        return tpm2_util_bin_from_hex_or_file(value, &ctx.qualifying_data.size,
+                ctx.qualifying_data.buffer);
         break;
     case 2:
         ctx.certify_info_path = value;

--- a/tools/tpm2_policysecret.c
+++ b/tools/tpm2_policysecret.c
@@ -30,7 +30,7 @@ struct tpm2_policysecret_ctx {
 
     char *policy_timeout_path;
 
-    const char *qualifier_data_path;
+    const char *qualifier_data_arg;
 
     TPM2B_NONCE nonce_tpm;
 
@@ -87,7 +87,7 @@ static bool on_option(char key, char *value) {
         }
         break;
     case 'q':
-        ctx.qualifier_data_path = value;
+        ctx.qualifier_data_arg = value;
         break;
     }
 
@@ -178,7 +178,7 @@ tool_rc tpm2_tool_onrun(ESYS_CONTEXT *ectx, tpm2_option_flags flags) {
     TPM2B_TIMEOUT *timeout = NULL;
     rc = tpm2_policy_build_policysecret(ectx, ctx.extended_session,
             &ctx.auth_entity.object, ctx.expiration, &policy_ticket, &timeout,
-            &ctx.nonce_tpm, ctx.qualifier_data_path);
+            &ctx.nonce_tpm, ctx.qualifier_data_arg);
     tool_rc rc2 = tpm2_session_close(&ctx.auth_entity.object.session);
     if (rc != tool_rc_success) {
         goto tpm2_tool_onrun_out;

--- a/tools/tpm2_policysigned.c
+++ b/tools/tpm2_policysigned.c
@@ -33,7 +33,7 @@ struct tpm2_policysigned_ctx {
 
     char *policy_timeout_path;
 
-    const char *qualifier_data_path;
+    const char *policy_qualifier_data;
 
     union {
         struct {
@@ -84,7 +84,7 @@ static bool on_option(char key, char *value) {
         ctx.context_arg = value;
         break;
     case 'q':
-        ctx.qualifier_data_path = value;
+        ctx.policy_qualifier_data = value;
         break;
     case 0:
         ctx.policy_ticket_path = value;
@@ -196,7 +196,7 @@ tool_rc tpm2_tool_onrun(ESYS_CONTEXT *ectx, tpm2_option_flags flags) {
     TPMT_TK_AUTH *policy_ticket = NULL;
     rc = tpm2_policy_build_policysigned(ectx, ctx.session,
         &ctx.key_context_object, &ctx.signature, ctx.expiration, &timeout,
-        &policy_ticket, ctx.qualifier_data_path, &ctx.nonce_tpm);
+        &policy_ticket, ctx.policy_qualifier_data, &ctx.nonce_tpm);
     if (rc != tool_rc_success) {
         LOG_ERR("Could not build policysigned TPM");
         goto tpm2_tool_onrun_out;

--- a/tools/tpm2_policyticket.c
+++ b/tools/tpm2_policyticket.c
@@ -19,7 +19,7 @@ struct tpm2_policyticket_ctx {
 
     char *policy_timeout_path;
 
-    const char *qualifier_data_path;
+    const char *policy_qualifier_data;
 
     char *policy_ticket_path;
 
@@ -41,7 +41,7 @@ static bool on_option(char key, char *value) {
         ctx.auth_name_file = value;
         break;
     case 'q':
-        ctx.qualifier_data_path = value;
+        ctx.policy_qualifier_data = value;
         break;
     case 0:
         ctx.policy_ticket_path = value;
@@ -112,7 +112,7 @@ tool_rc tpm2_tool_onrun(ESYS_CONTEXT *ectx, tpm2_option_flags flags) {
     }
 
     rc = tpm2_policy_build_policyticket(ectx, ctx.session,
-        ctx.policy_timeout_path, ctx.qualifier_data_path,
+        ctx.policy_timeout_path, ctx.policy_qualifier_data,
         ctx.policy_ticket_path, ctx.auth_name_file);
     if (rc != tool_rc_success) {
         LOG_ERR("Could not build policyticket TPM");

--- a/tools/tpm2_quote.c
+++ b/tools/tpm2_quote.c
@@ -196,13 +196,9 @@ static bool on_option(char key, char *value) {
         }
         break;
     case 'q':
-        ctx.qualification_data.size = sizeof(ctx.qualification_data) - 2;
-        if (tpm2_util_hex_to_byte_structure(value, &ctx.qualification_data.size,
-                ctx.qualification_data.buffer) != 0) {
-            LOG_ERR("Could not convert \"%s\" from a hex string to byte array!",
-                    value);
-            return false;
-        }
+        ctx.qualification_data.size = sizeof(ctx.qualification_data.buffer);
+        return tpm2_util_bin_from_hex_or_file(value, &ctx.qualification_data.size,
+                ctx.qualification_data.buffer);
         break;
     case 's':
         ctx.signature_path = value;


### PR DESCRIPTION
- Unify qualifying data like options so the data argument can be a hex string or binary file.
- Fix the tpm2_nvextend manpage.

Fixes: #1631 
Fixes: #1820