### PR TITLE
tpm2_getcap: Fix bitwise operator order for calculating cHandles

### DIFF
--- a/tools/tpm2_getcap.c
+++ b/tools/tpm2_getcap.c
@@ -645,7 +645,7 @@ static bool dump_command_attrs(TPMA_CC tpma_cc) {
             prop_str (tpma_cc & TPMA_CC_RHANDLE));
     tpm2_tool_output("  V:            %s\n", prop_str (tpma_cc & TPMA_CC_V));
     tpm2_tool_output("  Res:          0x%x\n",
-            tpma_cc & TPMA_CC_RES_MASK >> TPMA_CC_RES_SHIFT);
+            (tpma_cc & TPMA_CC_RES_MASK) >> TPMA_CC_RES_SHIFT);
     return true;
 }
 /*

--- a/tools/tpm2_getcap.c
+++ b/tools/tpm2_getcap.c
@@ -640,7 +640,7 @@ static bool dump_command_attrs(TPMA_CC tpma_cc) {
     tpm2_tool_output("  flushed:      %s\n",
             prop_str (tpma_cc & TPMA_CC_FLUSHED));
     tpm2_tool_output("  cHandles:     0x%x\n",
-            tpma_cc & TPMA_CC_CHANDLES_MASK >> TPMA_CC_CHANDLES_SHIFT);
+            (tpma_cc & TPMA_CC_CHANDLES_MASK) >> TPMA_CC_CHANDLES_SHIFT);
     tpm2_tool_output("  rHandle:      %s\n",
             prop_str (tpma_cc & TPMA_CC_RHANDLE));
     tpm2_tool_output("  V:            %s\n", prop_str (tpma_cc & TPMA_CC_V));


### PR DESCRIPTION
'>>' has a higher precedence than '&' which results in the value of cHandles
being computed as `tpma_cc & 0xE`. This just adds some parentheses to correct
the operator order so that cHandles is calculated and displayed correctly.