### PR TITLE
Match types of counter variable and comparison bound

### DIFF
--- a/lib/pcr.c
+++ b/lib/pcr.c
@@ -191,8 +191,8 @@ bool pcr_print_pcr_struct(TPML_PCR_SELECTION *pcr_select, tpm2_pcrs *pcrs) {
         tpm2_tool_output("  %s:\n", alg_name);
 
         // Loop through all PCRs in this bank
-        UINT8 pcr_id;
-        for (pcr_id = 0; pcr_id < pcr_select->pcrSelections[i].sizeofSelect * 8;
+        unsigned int pcr_id;
+        for (pcr_id = 0; pcr_id < pcr_select->pcrSelections[i].sizeofSelect * 8u;
                 pcr_id++) {
             if (!tpm2_util_is_pcr_select_bit_set(&pcr_select->pcrSelections[i],
                     pcr_id)) {

--- a/lib/tpm2_openssl.c
+++ b/lib/tpm2_openssl.c
@@ -249,8 +249,8 @@ bool tpm2_openssl_hash_pcr_banks(TPMI_ALG_HASH hash_alg,
     for (i = 0; i < pcr_select->count; i++) {
 
         // Loop through all PCRs in this bank
-        UINT8 pcr_id;
-        for (pcr_id = 0; pcr_id < pcr_select->pcrSelections[i].sizeofSelect * 8;
+        unsigned int pcr_id;
+        for (pcr_id = 0; pcr_id < pcr_select->pcrSelections[i].sizeofSelect * 8u;
                 pcr_id++) {
             if (!tpm2_util_is_pcr_select_bit_set(&pcr_select->pcrSelections[i],
                     pcr_id)) {

--- a/lib/tpm2_policy.c
+++ b/lib/tpm2_policy.c
@@ -20,7 +20,7 @@ static bool evaluate_populate_pcr_digests(TPML_PCR_SELECTION *pcr_selections,
     unsigned dgst_cnt = 0;
 
     //Iterating the number of pcr banks selected
-    UINT8 i;
+    UINT32 i;
     for (i = 0; i < pcr_selections->count; i++) {
 
         UINT8 total_indices_for_this_alg = 0;

--- a/tools/tpm2_pcrread.c
+++ b/tools/tpm2_pcrread.c
@@ -33,9 +33,9 @@ static bool print_pcr_values(void) {
 
         tpm2_tool_output("%s:\n", alg_name);
 
-        UINT8 pcr_id;
+        unsigned int pcr_id;
         for (pcr_id = 0;
-                pcr_id < ctx.pcr_selections.pcrSelections[i].sizeofSelect * 8;
+                pcr_id < ctx.pcr_selections.pcrSelections[i].sizeofSelect * 8u;
                 pcr_id++) {
             if (!tpm2_util_is_pcr_select_bit_set(
                     &ctx.pcr_selections.pcrSelections[i], pcr_id)) {


### PR DESCRIPTION
Fix several small alerts found by LGTM:
- [`TPML_PCR_SELECTION.count`](https://github.com/tpm2-software/tpm2-tss/blob/1c99117f4d102fd465655ed86aca58909a13c10d/include/tss2/tss2_tpm2_types.h#L1046) is `UINT32`, so the counter variable needs to be `UINT32` as well.
- [`TPMS_PCR_SELECTION.sizeofSelect`](https://github.com/tpm2-software/tpm2-tss/blob/1c99117f4d102fd465655ed86aca58909a13c10d/include/tss2/tss2_tpm2_types.h#L951) is `UINT8`, but after multiplication with 8 it might only fit into an `int` (which is guaranteed to be at least 16 bits long) due to integer promotion.