### PR TITLE
tpm2_import: support setting policy on imported key

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## Changelog
 
+### next
+
+* tpm2\_import: Support object policies when importing raw key material.
+
 ### 4.1 2019-11-25
 
 * tpm2\_certifycreation: New tool enabling command TPM2\_CertifyCreation.


### PR DESCRIPTION
When importing a raw key, specifying policy via -L would not
work. Correct this and allow -L to be used for raw keys.

Signed-off-by: William Roberts <william.c.roberts@intel.com>