### PR TITLE
CHANGELOG.md: Update to version 4.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## Changelog
 
-### 4.1-rc1 2019-11-18
+### 4.1 2019-11-25
 
 * tpm2\_certifycreation: New tool enabling command TPM2\_CertifyCreation.
 
@@ -9,9 +9,9 @@
    - \-g option for specifying hash algorithm is optional and defaults to
      sha256.
 
-* tpm2_\changeeps: A new tool for changing the Endorsement hierarchy primary seed.
+* tpm2\_changeeps: A new tool for changing the Endorsement hierarchy primary seed.
 
-* tpm2_\changepps: A new tool for changing the Platform hierarchy primary seed.
+* tpm2\_changepps: A new tool for changing the Platform hierarchy primary seed.
 
 * tpm2\_clockrateadjust: Add a new tool for modifying the period on the TPM.
 
@@ -38,7 +38,7 @@ certification
       hierarchy is platform.
     - Fix bug in YAML key action where action was wrong when using ESYS\_TR.
 
-* tpm2_getcap: clean up remanenats of -c option in manpages and tool output.
+* tpm2\_getcap: clean up remanenats of -c option in manpages and tool output.
 
 * tpm2\_gettime: Add a new tool for retrieving a signed timestamp from a TPM.
 
@@ -112,115 +112,6 @@ certification
   - travis: bump abrmd version 2.3.0
   - tpm2_util.c: Fix an issue int variable size was checked against uint
   - pcr.c: Fix buffer length issue to support all defined hash algorithm
-
-### 4.1-rc0 2019-11-05
-
-* tpm2\_certifycreation: New tool enabling command TPM2\_CertifyCreation.
-
-* tpm2\_checkquote:
-   - Fix YAML output bug.
-   - \-g option for specifying hash algorithm is optional and defaults to
-     sha256.
-
-* tpm2_\changeeps: A new tool for changing the Endorsement hierarchy primary seed.
-
-* tpm2_\changepps: A new tool for changing the Platform hierarchy primary seed.
-
-* tpm2\_clockrateadjust: Add a new tool for modifying the period on the TPM.
-
-* tpm2\_create: Add tool options for specifying output data for use in
-certification
-  - \--creation-data to save the creation data
-  - \--creation-ticket or -t to save the creation ticket
-  - \--creation-hash or -d to save the creation hash
-  - \--template-data for saving the template data of the key
-  - \--outside-info or -q for specifying unique data to include in creation data.
-  - \--pcr-list or -l  Add option to specify pcr list to add to creation data.
-
-* tpm2\_createprimary: Add tool options for specifying output data for use
-  in certification
-  - \--creation-data to save the creation data
-  - \--creation-ticket or -t to save the creation ticket
-  - \--creation-hash or -d to save the creation hash
-  - \--template-data for saving the template data of the key
-  - \--outside-info or -q for specifying unique data to include in creation data.
-  - \--pcr-list or -l  Add option to specify pcr list to add to creation data.
-
-* tpm2\_evictcontrol:
-    - Fix bug in automatic persistent handle selection when
-      hierarchy is platform.
-    - Fix bug in YAML key action where action was wrong when using ESYS\_TR.
-
-* tpm2_getcap: clean up remanenats of -c option in manpages and tool output.
-
-* tpm2\_gettime: Add a new tool for retrieving a signed timestamp from a TPM.
-
-* tpm2\_nvcertify: Add a new tool for certifying the contents of an NV index.
-
-* tpm2\_nvdefine:
-  - Support default set of attributes so -a is not mandatory.
-  - Support searching for free index if an index isn't specified.
-
-* tpm2\_nvextend: Add a new tool for extending an NV index similair to a PCR.
-
-* tpm2\_nvreadpublic:
-  - Support specifying nv index to read public data from as argument.
-
-* tpm2\_nvsetbits: Add a new tool for setting the values of PCR with type
-    "bits".
-
-* tpm2\_nvundefine: Add support for deleting NV indices with attribute
-    `TPMA_NV_POLICY_DELETE` set using NV Undefine Special command.
-
-* tpm2\_nvwritelock: Add a new tool for setting a write lock on an NV index
-    or globally locking nv indices with TPMA\_NV\_GLOBALLOCK.
-
-* tpm2\_policyauthorizenv: New tool enabling signed, revocable policies.
-
-* tpm2\_policyauthvalue: New tool enabling authorization to be bound to the
-    authorization of another object.
-
-* tpm2\_policycountertimer: Add a new tool for enabling policy bound to TPM
-  clock or timer values.
-
-* tpm2\_policynamehash: Add a new tool for specifying policy based on object
-  name.
-
-* tpm2\_policynv: Add a new tool for specifying policy based on NV contents.
-
-* tpm2\_nvwritten: Add a new tool for specifying policy based on whether or not
-    an NV index was written to.
-
-* tpm2\_policysecret: Add tool options for specifying
-  - \--expiration or -t
-  - \--ticket
-  - \--timeout
-  - \--nonce-tpm or -x
-  - \--qualification or -q
-
-* tpm2\_policysigned: New tool enabling policy command TPM2\_PolicySigned.
-
-* tpm2\_policytemplate: New tool enabling policy command TPM2\_PolicyTemplate.
-
-* tpm2\_policyticket: New tool enabling policy command TPM2\_PolicyTicket.
-
-* tpm2\_readclock: Add a new tool for reading the TPM clock.
-
-* tpm2\_setclock: Add a new tool for setting the TPM clock.
-
-* tpm2\_setprimarypolicy: New tool setting policy on hierarchies.
-
-* tpm2\_shutdown: Add a new tool for issuing a TPM shutdown command.
-
-* misc:
-  - Support "tpmt" as a public key output format that only saves the TPMT
-  structure.
-  - Qualifying data or extra data in many tools can be hex array string or
-  binary file.
-  - Add support for specifying NV index type when specifying NV attributes.
-  - Support added for tools to run on FreeBSD.
-  - Skip and notify of action that man pages will not install if the package
-  pandoc is missing.
 
 ### 4.0.1 - 2019-10-28
 


### PR DESCRIPTION
    * New tools added to support commands:
    TPM2_CertifyCreation, TPM2_ChangeEPS, TPM2_ChangePPS, TPM2_ClockRateAdjust,
    TPM2_GetTime, TPM2_NV_Certify, TPM2_NV_Extend, TPM2_NV_Setbits,
    TPM2_NV_UndefineSpaceSpecial, TPM2_NV_Writelock, TPM2_PolicyAuthorizeNV,
    TPM2_PolicyAuthValue, TPM2_PolicyCounterTimer, TPM2_PolicyNameHash,
    TPM2_PolicyNV, TPM2_NV_Written, TPM2_PolicySigned, TPM2_PolicyTemplate,
    TPM2_PolicyTicket, TPM2_ReadClock, TPM2_ClockSet, TPM2_SetPrimaryPolicy,
    TPM2_Shutdown.

    * travis: bump abrmd version 2.3.0

    * Bug fixes and additional options to existing tools.
    1. tpm2_checkquote: Fix YAML bug
    2. tpm2_policysecret: Add options to specify expiration, ticket, timeout,
    qualification data.
    3. tpm2_create/ tpm2_createprimary: Add options to specify creation-data,
    creation-ticket, creation-hash, outside-info, pcr-list
    4. Skip/notify of action that man pages will not install if pandoc is missing.
    5. Support "tpmt" as public key output format that saves the TPMT structure.
    6. Add support for specifying NV index type when specifying NV attributes.
    7. Fixed routine files_load_bytes_from_buffer_or_file_or_stdin where it can read
    one short of a UINT16 and overflow when buffer isn't a UINT16.
    8. Fix precedence issue with bitwise operator order int tpm2_getcap
    9. tpm2_util.c: Fix an issue int variable size was checked against uint
    10. pcr.c: Fix buffer length issue to support all defined hash algorithm

Signed-off-by: Imran Desai <imran.desai@intel.com>