### PR TITLE
man: add tpm2_shutdown.1

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -407,6 +407,7 @@ if HAVE_MAN_PAGES
     man/man1/tpm2_send.1 \
     man/man1/tpm2_selftest.1 \
     man/man1/tpm2_setclock.1 \
+    man/man1/tpm2_shutdown.1 \
     man/man1/tpm2_sign.1 \
     man/man1/tpm2_certifycreation.1 \
     man/man1/tpm2_nvcertify.1 \


### PR DESCRIPTION
tpm2_shutdown.1 manpage is missing. We need to add it in Makefile.am
for generation.

Signed-off-by: Ying-Chun Liu (PaulLiu) <paulliu@debian.org>