### PR TITLE
tpm2_policynamehash, tpm2_policytemplate: fix bad buffer size specifi…

### DIFF
--- a/tools/tpm2_policynamehash.c
+++ b/tools/tpm2_policynamehash.c
@@ -23,7 +23,7 @@ static tpm2_policynamehash_ctx ctx;
 
 static bool process_input_name_hash(char *value) {
 
-    ctx.name_hash.size = UINT16_MAX;
+    ctx.name_hash.size = sizeof(ctx.name_hash.buffer);
     bool result = files_load_bytes_from_buffer_or_file_or_stdin(NULL, value,
             &ctx.name_hash.size, ctx.name_hash.buffer);
     if (!result) {

--- a/tools/tpm2_policytemplate.c
+++ b/tools/tpm2_policytemplate.c
@@ -23,7 +23,7 @@ static tpm2_policytemplate_ctx ctx;
 
 static bool process_input_template_hash(char *value) {
 
-    ctx.template_hash.size = UINT16_MAX;
+    ctx.template_hash.size = sizeof(ctx.template_hash.buffer);
     bool result = files_load_bytes_from_buffer_or_file_or_stdin(NULL, value,
             &ctx.template_hash.size, ctx.template_hash.buffer);
     if (!result) {


### PR DESCRIPTION
…cations

This fixes possible buffer overwrites as stated by the following linker
warnings:

```
In function 'fread',
    inlined from 'files_load_bytes_from_buffer_or_file_or_stdin' at lib/files.c:617:27,
    inlined from 'process_input_name_hash' at tools/tpm2_policynamehash.c:27:19,
    inlined from 'on_option' at tools/tpm2_policynamehash.c:49:18:
/usr/include/bits/stdio2.h:295:9: error: call to '__fread_chk_warn' declared with attribute warning: fread called with bigger size * nmemb than length of destination buffer [-Werror=attribute-warning]

In function 'fread',
    inlined from 'files_load_bytes_from_buffer_or_file_or_stdin' at lib/files.c:617:27,
    inlined from 'process_input_template_hash' at tools/tpm2_policytemplate.c:27:19,
    inlined from 'on_option' at tools/tpm2_policytemplate.c:49:18:
/usr/include/bits/stdio2.h:295:9: error: call to '__fread_chk_warn' declared with attribute warning: fread called with bigger size * nmemb than length of destination buffer [-Werror=attribute-warning]
```

Signed-off-by: Matthias Gerstner <matthias.gerstner@suse.de>