### PR TITLE
tpm2_certifycreation, tpm2_gettime, tpm2_nvcertify: normalize attesta…

### DIFF
--- a/test/integration/tests/certifycreation.sh
+++ b/test/integration/tests/certifycreation.sh
@@ -30,8 +30,8 @@ tpm2_certifycreation -C signing_key.ctx -c primary.ctx -d creation.digest \
 -t creation.ticket -g sha256 -o signature.bin --attestation attestation.bin \
 -f plain -s rsassa
 
-dd if=attestation.bin bs=1 skip=2 | \
-openssl dgst -verify sslpub.pem -keyform pem -sha256 -signature signature.bin
+openssl dgst -verify sslpub.pem -keyform pem -sha256 -signature signature.bin \
+attestation.bin
 
 #
 # Test with qualifier data
@@ -42,8 +42,8 @@ tpm2_certifycreation -C signing_key.ctx -c primary.ctx -d creation.digest \
 -t creation.ticket -g sha256 -o signature.bin --attestation attestation.bin \
 -f plain -s rsassa -q qual.dat
 
-dd if=attestation.bin bs=1 skip=2 | \
-openssl dgst -verify sslpub.pem -keyform pem -sha256 -signature signature.bin
+openssl dgst -verify sslpub.pem -keyform pem -sha256 -signature signature.bin \
+attestation.bin
 
 #
 # Test certification with non primary keys
@@ -57,7 +57,7 @@ tpm2_certifycreation -C signing_key.ctx -c sec_key.ctx -d creation.digest \
 -t creation.ticket -g sha256 -o signature.bin --attestation attestation.bin \
 -f plain -s rsassa
 
-dd if=attestation.bin bs=1 skip=2 | \
-openssl dgst -verify sslpub.pem -keyform pem -sha256 -signature signature.bin
+openssl dgst -verify sslpub.pem -keyform pem -sha256 -signature signature.bin \
+attestation.bin
 
 exit 0

--- a/test/integration/tests/nvcertify.sh
+++ b/test/integration/tests/nvcertify.sh
@@ -32,8 +32,8 @@ dd if=/dev/urandom bs=1 count=32 status=none| tpm2_nvwrite 1 -i-
 tpm2_nvcertify -C signing_key.ctx -g sha256 -f plain -s rsassa \
 -o signature.bin --attestation attestation.bin --size 32 1
 
-dd if=attestation.bin bs=1 skip=2 | \
-openssl dgst -verify sslpub.pem -keyform pem -sha256 -signature signature.bin
+openssl dgst -verify sslpub.pem -keyform pem -sha256 -signature signature.bin \
+attestation.bin
 
 #
 # Test with qualifier data
@@ -43,8 +43,8 @@ dd if=/dev/urandom of=qual.dat bs=1 count=32
 tpm2_nvcertify -C signing_key.ctx -g sha256 -f plain -s rsassa \
 -o signature.bin --attestation attestation.bin --size 32 -q qual.dat 1
 
-dd if=attestation.bin bs=1 skip=2 | \
-openssl dgst -verify sslpub.pem -keyform pem -sha256 -signature signature.bin
+openssl dgst -verify sslpub.pem -keyform pem -sha256 -signature signature.bin \
+attestation.bin
 
 #
 # Test if qualifier data was present in the attestation

--- a/tools/tpm2_certifycreation.c
+++ b/tools/tpm2_certifycreation.c
@@ -248,7 +248,8 @@ static tool_rc process_certifycreation_output(TPMT_SIGNATURE *signature,
         return tool_rc_general_error;
     }
 
-    result = files_save_attestation(certify_info, ctx.certify_info_path);
+    result = files_save_bytes_to_file(ctx.certify_info_path,
+        certify_info->attestationData, certify_info->size);
     if (!result) {
         LOG_ERR("Failed saving attestation data.");
         return tool_rc_general_error;

--- a/tools/tpm2_gettime.c
+++ b/tools/tpm2_gettime.c
@@ -190,7 +190,8 @@ tool_rc tpm2_tool_onrun(ESYS_CONTEXT *ectx, tpm2_option_flags flags) {
 
     if (ctx.certify_info_path) {
         /* save the attestation data */
-        bool result = files_save_attestation(time_info, ctx.certify_info_path);
+        bool result = files_save_bytes_to_file(ctx.certify_info_path,
+            time_info->attestationData, time_info->size);
         if (!result) {
             rc = tool_rc_general_error;
             goto out;

--- a/tools/tpm2_nvcertify.c
+++ b/tools/tpm2_nvcertify.c
@@ -266,7 +266,8 @@ static tool_rc process_nvcertify_output(TPMT_SIGNATURE *signature,
         return tool_rc_general_error;
     }
 
-    result = files_save_attestation(certify_info, ctx.certify_info_path);
+    result = files_save_bytes_to_file(ctx.certify_info_path,
+        certify_info->attestationData, certify_info->size);
     if (!result) {
         LOG_ERR("Failed saving attestation data.");
         return tool_rc_general_error;


### PR DESCRIPTION
…tion output

This normalizes the attestation output across the tools.
tpm2_quote etc only stores attestationData, not the whole TPM2B_ATTEST structure.

Fixes https://github.com/tpm2-software/tpm2-tools/issues/1872
