### PR TITLE
tpm2_certify: fix key arguments

### DIFF
--- a/test/integration/tests/certify.sh
+++ b/test/integration/tests/certify.sh
@@ -25,6 +25,6 @@ tpm2_create -Q -g sha256 -G rsa -u certify.pub -r certify.priv -C primary.ctx
 tpm2_load -Q -C primary.ctx -u certify.pub -r certify.priv -n certify.name \
 -c certify.ctx
 
-tpm2_certify -Q -C primary.ctx -c certify.ctx -g sha256 -o attest.out -s sig.out
+tpm2_certify -Q -c primary.ctx -C certify.ctx -g sha256 -o attest.out -s sig.out
 
 exit 0

--- a/tools/tpm2_certify.c
+++ b/tools/tpm2_certify.c
@@ -140,10 +140,10 @@ out:
 static bool on_option(char key, char *value) {
 
     switch (key) {
-    case 'C':
+    case 'c':
         ctx.certified_key.ctx_path = value;
         break;
-    case 'c':
+    case 'C':
         ctx.signing_key.ctx_path = value;
         break;
     case 'P':


### PR DESCRIPTION
signing key is loaded as certified key and vice versa
 
Fixes https://github.com/tpm2-software/tpm2-tools/issues/1871