### PR TITLE
ci: install curl and json-c for LGTM

### DIFF
--- a/.lgtm.yml
+++ b/.lgtm.yml
@@ -3,6 +3,8 @@ extraction:
     prepare:
       packages:
       - autoconf-archive
+      - libcurl4-openssl-dev
+      - libjson-c-dev
       - libssl-dev
     after_prepare:
     - cd "$LGTM_WORKSPACE"


### PR DESCRIPTION
Since upstream commit https://github.com/tpm2-software/tpm2-tss/commit/6da95b04b4f22284d5b40cc03fa19e6dc514339f, tpm2-tss needs curl and json-c to build. These are not picked up automatically by LGTM because we build tpm2-tss manually in `after_prepare`, so add them to the packages to install.

Log of the successful LGTM test build: https://lgtm.com/logs/36ed2f143fd448948a50d8ce278c47749c117303/lang:cpp