### PR TITLE
tpm2_verifysignature: Fixed a typo

### DIFF
--- a/tools/tpm2_verifysignature.c
+++ b/tools/tpm2_verifysignature.c
@@ -106,7 +106,7 @@ static tool_rc init(ESYS_CONTEXT *context) {
 
     /* check flags for mismatches */
     if (ctx.flags.digest && (ctx.flags.msg || ctx.flags.halg)) {
-        LOG_ERR("Cannot specify --digest (-D) and ( --msg (-m) or --halg (-g) )");
+        LOG_ERR("Cannot specify --digest (-d) and ( --msg (-m) or --halg (-g) )");
         return tool_rc_option_error;
     }
 


### PR DESCRIPTION
Fixes #1869

If you don't give the correct combination of "-d -m -g" to
verifysignature, then it gives an error and explains how to
use "--digest". The manual says that it's "-d", however the
error from the tools says that it's "-D".

Signed-off-by: Imran Desai <imran.desai@intel.com>