### PR TITLE
Chinese SM2 SM4 algorithm support

### DIFF
--- a/lib/tpm2_identity_util.c
+++ b/lib/tpm2_identity_util.c
@@ -229,6 +229,7 @@ bool tpm2_identity_util_share_secret_with_public_key(
                 parent_pub, label, label_len, encrypted_protection_seed);
         break;
     case TPM2_ALG_ECC:
+    case TPM2_ALG_SM2:
         result = ecdh_derive_seed_and_encrypted_seed(parent_pub,
                 label, label_len,
                 protection_seed, encrypted_protection_seed);

--- a/lib/tpm2_openssl.c
+++ b/lib/tpm2_openssl.c
@@ -660,14 +660,14 @@ static const struct {
     { TPM2_ECC_NIST_P224, NID_secp224r1        },
     { TPM2_ECC_NIST_P256, NID_X9_62_prime256v1 },
     { TPM2_ECC_NIST_P384, NID_secp384r1        },
-    { TPM2_ECC_NIST_P521, NID_secp521r1        }
+    { TPM2_ECC_NIST_P521, NID_secp521r1        },
+    { TPM2_ECC_SM2_P256,  NID_sm2              },
     /*
      * XXX
      * See if it's possible to support the other curves, I didn't see the
      * mapping in OSSL:
      *  - TPM2_ECC_BN_P256
      *  - TPM2_ECC_BN_P638
-     *  - TPM2_ECC_SM2_P256
      */
 };
 
@@ -1117,6 +1117,7 @@ tpm2_openssl_load_rc tpm2_openssl_load_private(const char *path,
         rc = load_private_RSA_from_pem(f, path, pass, pub, priv);
         break;
     case TPM2_ALG_AES:
+    case TPM2_ALG_SM4:
         if (pass) {
             LOG_ERR("No password can be used for protecting AES key");
             rc = lprc_error;
@@ -1125,6 +1126,7 @@ tpm2_openssl_load_rc tpm2_openssl_load_private(const char *path,
         }
         break;
     case TPM2_ALG_ECC:
+    case TPM2_ALG_SM2:
         rc = load_private_ECC_from_pem(f, path, pass, pub, priv);
         break;
     default:

--- a/tools/tpm2_import.c
+++ b/tools/tpm2_import.c
@@ -537,6 +537,11 @@ static bool set_key_algorithm(TPMI_ALG_PUBLIC alg, TPMT_SYM_DEF_OBJECT * obj) {
     case TPM2_ALG_NULL:
         obj->algorithm = TPM2_ALG_NULL;
         break;
+    case TPM2_ALG_SM4:
+        obj->algorithm = TPM2_ALG_SM4;
+        obj->keyBits.sm4 = 128;
+        obj->mode.sm4 = TPM2_ALG_ECB;
+        break;
     default:
         LOG_ERR("The algorithm type input(0x%x) is not supported!", alg);
         result = false;


### PR DESCRIPTION
1. SM2 test case
```bash
openssl ecparam -name SM2 -genkey -noout -out private.ecc.pem
openssl ec -in private.ecc.pem -out public.ecc.pem -pubout
tpm2_loadexternal -Q -G sm2 -r private.ecc.pem -c key.ctx
echo "data to sign" > data.in.raw
sha256sum data.in.raw | awk '{ print "000000 " $1 }' | xxd -r -c 32 > data.in.digest

openssl dgst -sha256 -sign private.ecc.pem -out data.out.signed data.in.raw
tpm2_verifysignature -Q -c key.ctx -g sha256 -f ecdsa -m data.in.raw -s data.out.signed

tpm2_sign -Q -c key.ctx -g sha256 -d -f plain -o data.out.signed data.in.digest
openssl dgst -verify public.ecc.pem -keyform pem -sha256 -signature data.out.signed data.in.raw
```

2. SM4 test case
```
tpm2_createprimary -Q -C e -G rsa -c primary.ctx
tpm2_create -Q -G sm4ecb -u key.pub -r key.priv -C primary.ctx
tpm2_load -Q -C primary.ctx -u key.pub -r key.priv -n key.name -c decrypt.ctx

dd if=/dev/urandom of=secret.dat bs=1 count=16
tpm2_encryptdecrypt -Q -c decrypt.ctx -o encrypt.out secret.dat
tpm2_encryptdecrypt -Q -c decrypt.ctx -d -o decrypt.out encrypt.out
```

Signed-off-by: jeffery <scorchfly@sina.com>