### PR TITLE
tpm2_policyor: Bug Fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ### next
 
+ * tpm2_policyor: List of policy files should be specified as an argument
+   instead of -l option. The -l option is still retained for backwards
+   compatibility. See issue#1894.
+
  * tpm2\_eventlog: add a tool for parsing and displaying the event log.
 
 ### 4.1.1 - 2020-01-21

--- a/lib/tpm2_policy.c
+++ b/lib/tpm2_policy.c
@@ -588,6 +588,7 @@ bool tpm2_policy_parse_policy_list(char *str, TPML_DIGEST *policy_list) {
                 hash = tpm2_alg_util_from_optarg(subtoken,
                         tpm2_alg_util_flags_hash);
                 if (hash == TPM2_ALG_ERROR) {
+                    LOG_ERR("Invalid/ Unspecified policy digest algorithm.");
                     return false;
                 }
             }

--- a/man/tpm2_policyor.1.md
+++ b/man/tpm2_policyor.1.md
@@ -24,16 +24,20 @@ if at least one of the policy events are true.
 
     File to save the compounded policy digest.
 
-  * **-l**, **\--policy-list**=_POLICY\_FILE_\_LIST:
-
-    The list of files for the policy digests that has to be compounded resulting
-    in individual policies being added to final policy digest that can
-    authenticate the object. The list begins with the policy digest hash alg.
-
   * **-S**, **\--session**=_FILE_:
 
     The policy session file generated via the **-S** option to
     **tpm2_startauthsession**(1).
+
+  * **ARGUMENT** the command line argument specifies the list of files for the
+    policy digests that has to be compounded resulting in individual policies
+    being added to final policy digest that can authenticate the object. The
+    list begins with the policy digest hash alg. Example sha256:policy1,policy2
+
+  * **-l**, **\--policy-list**=_POLICY\_FILE_\_LIST:
+
+    This option is retained for backwards compatibility. Use the argument method
+    instead.
 
 ## References
 
@@ -90,7 +94,7 @@ rm session.ctx
 tpm2_startauthsession -S session.ctx
 
 tpm2_policyor -S session.ctx -L policyOR \
--l sha256:set1.pcr0.policy,set2.pcr0.policy
+sha256:set1.pcr0.policy,set2.pcr0.policy
 
 tpm2_flushcontext session.ctx
 
@@ -114,7 +118,7 @@ tpm2_startauthsession -S session.ctx --policy-session
 tpm2_policypcr -S session.ctx -l sha1:23
 
 tpm2_policyor -S session.ctx -L policyOR \
--l sha256:set1.pcr0.policy,set2.pcr0.policy
+sha256:set1.pcr0.policy,set2.pcr0.policy
 
 unsealed=`tpm2_unseal -p session:session.ctx -c sealkey.ctx`
 
@@ -140,7 +144,7 @@ tpm2_policypcr -S session.ctx -l sha1:23
 ### This should fail
 ```bash
 tpm2_policyor -S session.ctx -L policyOR \
--l sha256:set1.pcr0.policy,set2.pcr0.policy
+sha256:set1.pcr0.policy,set2.pcr0.policy
 
 tpm2_flushcontext session.ctx
 
@@ -159,7 +163,7 @@ tpm2_startauthsession -S session.ctx --policy-session
 tpm2_policypcr -S session.ctx -l sha1:23
 
 tpm2_policyor -S session.ctx -L policyOR \
--l sha256:set1.pcr0.policy,set2.pcr0.policy
+sha256:set1.pcr0.policy,set2.pcr0.policy
 
 unsealed=`tpm2_unseal -p session:session.ctx -c sealkey.ctx`
 

--- a/man/tpm2_policyor.1.md
+++ b/man/tpm2_policyor.1.md
@@ -13,7 +13,7 @@
 **tpm2_policyor**(1) - Generates a policy_or event with the TPM. It expects a
 session to be already established via **tpm2_startauthsession**(1). If
 the input session is a trial session this tool generates a policy digest that
-compounds two or more input  policy digests such that the resulting policy digest
+compounds two or more input policy digests such that the resulting policy digest
 requires at least one of the policy events being true. If the input session is
 real policy session **tpm2_policyor**(1) authenticates the object successfully
 if at least one of the policy events are true.
@@ -49,129 +49,54 @@ the various known TCTI modules.
 
 # EXAMPLES
 
-Creates two sets of PCR data files, one of them being the existing PCR values
-and other being a set of PCR values that would result if the PCR were extended
-with a known value. Now create two separate policy digests, each with one set
-of the PCR values using **tpm2_policypcr**(1) tool in *trial* sessions. Now
-build a policy_or with the two PCR policy digests as inputs. Create a sealing
-object with an authentication policy compounding the 2 policies with
-**tpm2_policyor** and seal a secret. Unsealing with either of the PCR sets
-should be successful.
+Create an authorization policy for a sealing object that compounds a pcr policy
+and a policypassword in an OR fashion and show satisfying either policies could
+unseal the secret.
 
-## Create two unique pcr policies with corresponding unique sets of pcrs.
-
-### Start with pcr value 0
-```bash
-tpm2_pcrreset 23
-```
-
-### PCR1 policy
+## Create policypcr as first truth value for compounding the policies
 ```bash
 tpm2_startauthsession -S session.ctx
-
-tpm2_policypcr -S session.ctx -l sha1:23 -L set1.pcr0.policy
-
+tpm2_policypcr -S session.ctx -L policy.pcr -l sha256:0,1,2,3
 tpm2_flushcontext session.ctx
-
-rm session.ctx
 ```
 
-### PCR2 policy
-```bash
-tpm2_pcrextend 23:sha1=f1d2d2f924e986ac86fdf7b36c94bcdf32beec15
-
-tpm2_startauthsession -S session.ctx
-
-tpm2_policypcr -S session.ctx -l sha1:23 -L set2.pcr0.policy
-
-tpm2_flushcontext session.ctx
-
-rm session.ctx
-```
-
-## Create a policyOR resulting from compounding the two unique pcr policies in an OR fashion
+## Create policypassword as second truth value for compounding the policies
 ```bash
 tpm2_startauthsession -S session.ctx
-
-tpm2_policyor -S session.ctx -L policyOR \
-sha256:set1.pcr0.policy,set2.pcr0.policy
-
+tpm2_policypassword -S session.ctx -L policy.pass
 tpm2_flushcontext session.ctx
-
-rm session.ctx
 ```
 
-## Create a sealing object with auth policyOR created above.
+## Compound the two policies in an OR fashion with tpm2_policyor command
 ```bash
-tpm2_createprimary -C o -c prim.ctx
-
-tpm2_create -g sha256 -u sealkey.pub -r sealkey.priv -L policyOR -C prim.ctx \
--i- <<< "secretpass"
-
-tpm2_load -C prim.ctx -c sealkey.ctx -u sealkey.pub -r sealkey.priv
+tpm2_startauthsession -S session.ctx
+tpm2_policyor -S session.ctx -L policy.or sha256:policy.pass,policy.pcr
+tpm2_flushcontext session.ctx
 ```
 
-## Attempt unsealing by satisfying the policyOR by satisfying SECOND of the two policies.
+## Create a sealing object and attach the auth policy from tpm2_policyor command
+```bash
+tpm2_createprimary -c prim.ctx -Q
+echo "secret" | tpm2_create -C prim.ctx -c key.ctx -u key.pub -r key.priv \
+-L policy.or -i-
+```
+
+## Satisfy auth policy using password and unseal the secret
 ```bash
 tpm2_startauthsession -S session.ctx --policy-session
-
-tpm2_policypcr -S session.ctx -l sha1:23
-
-tpm2_policyor -S session.ctx -L policyOR \
-sha256:set1.pcr0.policy,set2.pcr0.policy
-
-unsealed=`tpm2_unseal -p session:session.ctx -c sealkey.ctx`
-
-echo $unsealed
-
+tpm2_policypassword -S session.ctx
+tpm2_policyor -S session.ctx sha256:policy.pass,policy.pcr
+tpm2_unseal -c key.ctx -p session:session.ctx
 tpm2_flushcontext session.ctx
-
-rm session.ctx
 ```
 
-## Extend the pcr to emulate tampering of the system software and hence the pcr value.
-```bash
-tpm2_pcrextend 23:sha1=f1d2d2f924e986ac86fdf7b36c94bcdf32beec15
-```
-
-## Attempt unsealing by trying to satisy the policOR by attempting to satisy one of the two policies.
+## Satisfy auth policy using pcr and unseal the secret
 ```bash
 tpm2_startauthsession -S session.ctx --policy-session
-
-tpm2_policypcr -S session.ctx -l sha1:23
-```
-
-### This should fail
-```bash
-tpm2_policyor -S session.ctx -L policyOR \
-sha256:set1.pcr0.policy,set2.pcr0.policy
-
+tpm2_policypcr -S session.ctx -l sha256:0,1,2,3
+tpm2_policyor -S session.ctx sha256:policy.pass,policy.pcr
+tpm2_unseal -c key.ctx -p session:session.ctx
 tpm2_flushcontext session.ctx
-
-rm session.ctx
-```
-
-## Reset pcr to get back to the first set of pcr value
-```bash
-tpm2_pcrreset 23
-```
-
-## Attempt unsealing by satisfying the policyOR by satisfying FIRST of the two policies.
-```bash
-tpm2_startauthsession -S session.ctx --policy-session
-
-tpm2_policypcr -S session.ctx -l sha1:23
-
-tpm2_policyor -S session.ctx -L policyOR \
-sha256:set1.pcr0.policy,set2.pcr0.policy
-
-unsealed=`tpm2_unseal -p session:session.ctx -c sealkey.ctx`
-
-echo $unsealed
-
-tpm2_flushcontext session.ctx
-
-rm session.ctx
 ```
 
 [returns](common/returns.md)

--- a/test/integration/tests/abrmd_policyor.sh
+++ b/test/integration/tests/abrmd_policyor.sh
@@ -13,7 +13,9 @@ concatenated=con.cat
 
 cleanup() {
     rm -f $policy_1 $policy_2 $policy_init $test_vector $policyor_cc \
-    $session_ctx $policy_digest $concatenated
+    $session_ctx $policy_digest $concatenated \
+    set1.pcr0.policy set2.pcr0.policy prim.ctx sealkey.priv sealkey.pub \
+    sealkey.ctx policyOR
 
     tpm2_flushcontext $session_ctx 2>/dev/null || true
 
@@ -39,5 +41,54 @@ tpm2_policyor -L $o_policy_digest -S $session_ctx sha256:$policy_1,$policy_2
 tpm2_flushcontext $session_ctx
 
 diff $test_vector $o_policy_digest
+
+# Test case to compound two PCR policies
+
+tpm2_pcrreset 23
+tpm2_startauthsession -S session.ctx
+tpm2_policypcr -S session.ctx -l sha1:23 -L set1.pcr0.policy
+tpm2_flushcontext session.ctx
+rm session.ctx
+
+tpm2_pcrextend 23:sha1=f1d2d2f924e986ac86fdf7b36c94bcdf32beec15
+tpm2_startauthsession -S session.ctx
+tpm2_policypcr -S session.ctx -l sha1:23 -L set2.pcr0.policy
+tpm2_flushcontext session.ctx
+rm session.ctx
+
+tpm2_startauthsession -S session.ctx
+tpm2_policyor -S session.ctx -L policyOR \
+sha256:set1.pcr0.policy,set2.pcr0.policy
+tpm2_flushcontext session.ctx
+rm session.ctx
+
+tpm2_createprimary -C o -c prim.ctx
+tpm2_create -g sha256 -u sealkey.pub -r sealkey.priv -L policyOR -C prim.ctx \
+-i- <<< "secretpass"
+tpm2_load -C prim.ctx -c sealkey.ctx -u sealkey.pub -r sealkey.priv
+
+tpm2_startauthsession -S session.ctx --policy-session
+tpm2_policypcr -S session.ctx -l sha1:23
+tpm2_policyor -S session.ctx -L policyOR \
+sha256:set1.pcr0.policy,set2.pcr0.policy
+unsealed=`tpm2_unseal -p session:session.ctx -c sealkey.ctx`
+echo $unsealed
+tpm2_flushcontext session.ctx
+rm session.ctx
+
+tpm2_pcrextend 23:sha1=f1d2d2f924e986ac86fdf7b36c94bcdf32beec15
+tpm2_startauthsession -S session.ctx --policy-session
+tpm2_policypcr -S session.ctx -l sha1:23
+
+tpm2_pcrreset 23
+
+tpm2_startauthsession -S session.ctx --policy-session
+tpm2_policypcr -S session.ctx -l sha1:23
+tpm2_policyor -S session.ctx -L policyOR \
+sha256:set1.pcr0.policy,set2.pcr0.policy
+unsealed=`tpm2_unseal -p session:session.ctx -c sealkey.ctx`
+echo $unsealed
+tpm2_flushcontext session.ctx
+rm session.ctx
 
 exit 0

--- a/test/integration/tests/abrmd_policyor.sh
+++ b/test/integration/tests/abrmd_policyor.sh
@@ -35,7 +35,7 @@ cat $policy_init $policyor_cc $policy_1 $policy_2 > $concatenated
 openssl dgst -binary -sha256 $concatenated > $test_vector
 
 tpm2_startauthsession -S $session_ctx
-tpm2_policyor -L $o_policy_digest -l sha256:$policy_1,$policy_2 -S $session_ctx
+tpm2_policyor -L $o_policy_digest -S $session_ctx sha256:$policy_1,$policy_2
 tpm2_flushcontext $session_ctx
 
 diff $test_vector $o_policy_digest

--- a/tools/tpm2_policyor.c
+++ b/tools/tpm2_policyor.c
@@ -47,16 +47,32 @@ static bool on_option(char key, char *value) {
     return result;
 }
 
+static bool on_arg(int argc, char **argv) {
+
+    if (argc > 1) {
+        LOG_ERR("specify single argument for policy list.");
+        return false;
+    }
+
+    ctx.policy_list = calloc(1, sizeof(TPML_DIGEST));
+    bool result = tpm2_policy_parse_policy_list(argv[0], ctx.policy_list);
+    if (!result) {
+        return false;
+    }
+    return true;
+}
+
 bool tpm2_tool_onstart(tpm2_options **opts) {
 
     static struct option topts[] = {
         { "policy",                 required_argument, NULL, 'L' },
         { "session",                required_argument, NULL, 'S' },
+        //Option retained for backwards compatibility - See issue#1894
         { "policy-list",            required_argument, NULL, 'l' },
     };
 
     *opts = tpm2_options_new("L:S:l:", ARRAY_LEN(topts), topts, on_option,
-    NULL, 0);
+        on_arg, 0);
 
     return *opts != NULL;
 }


### PR DESCRIPTION
 Fixes #1893 
 Fixes #1894 
 Fixes #1896 
 Fixes #1895
- [x] Silent failure bug fix for invalid/unspecified policy digest alg
- [x] List of policy files can now be specified as argument
- [x] Add test case for compounding pcr policies
- [x] Change example in man page to show two separate policy events
 

Signed-off-by: Imran Desai <imran.desai@intel.com>