### PR TITLE
tpm2_certify.1.md: Add a working example to show how to certify key objects

### DIFF
--- a/man/tpm2_certify.1.md
+++ b/man/tpm2_certify.1.md
@@ -77,14 +77,17 @@ the various known TCTI modules.
 
 # EXAMPLES
 
+Create a primary key and certify it with a signing key.
+
 ```bash
-tpm2_certify -H 0x81010002 -P 0x0011 -p 0x00FF -g 0x00B -a <fileName> \
--s <fileName>
+tpm2_createprimary -Q -C e -g sha256 -G rsa -c primary.ctx
 
-tpm2_certify -C obj.context -c key.context -P 0x0011 -p 0x00FF -g 0x00B \
--a <fileName> -s <fileName>
+tpm2_create -Q -g sha256 -G rsa -u certify.pub -r certify.priv -C primary.ctx
 
-tpm2_certify -H 0x81010002 -P 0011 -p 00FF  -g 0x00B -a <fileName> -s <fileName>
+tpm2_load -Q -C primary.ctx -u certify.pub -r certify.priv -n certify.name \
+-c certify.ctx
+
+tpm2_certify -Q -c primary.ctx -C certify.ctx -g sha256 -o attest.out -s sig.out
 ```
 
 [returns](common/returns.md)


### PR DESCRIPTION
Fixes #1892 

Signed-off-by: Imran Desai <imran.desai@intel.com>