### PR TITLE
tpm2_tool_output: Move tool output variable and macros to new module.

### DIFF
--- a/lib/tpm2_eventlog_yaml.c
+++ b/lib/tpm2_eventlog_yaml.c
@@ -10,6 +10,7 @@
 #include "tpm2_eventlog.h"
 #include "tpm2_eventlog_yaml.h"
 #include "tpm2_tool.h"
+#include "tpm2_tool_output.h"
 
 char const *eventtype_to_string (UINT32 event_type) {
 

--- a/lib/tpm2_tool_output.c
+++ b/lib/tpm2_tool_output.c
@@ -1,0 +1,3 @@
+#include <stdbool.h>
+
+bool output_enabled = true;

--- a/lib/tpm2_tool_output.h
+++ b/lib/tpm2_tool_output.h
@@ -1,0 +1,30 @@
+#ifndef TPM2_TOOL_OUTPUT_H
+#define TPM2_TOOL_OUTPUT_H
+
+#include <stdio.h>
+
+extern bool output_enabled;
+
+/**
+ * Output is enabled by default. This wrapper prevents code that
+ * must disable output from accessing the global 'output_enabled'
+ * variable directly.
+ */
+#define tpm2_tool_output_disable() (output_enabled = false)
+
+/**
+ * prints output to stdout respecting the quiet option.
+ * Ie when quiet, don't print.
+ * @param fmt
+ *  The format specifier, ala printf.
+ * @param ...
+ *  The varargs, just like printf.
+ */
+#define tpm2_tool_output(fmt, ...)                   \
+    do {                                        \
+        if (output_enabled) {                   \
+            printf(fmt, ##__VA_ARGS__);         \
+        }                                       \
+    } while (0)
+
+#endif

--- a/test/unit/test_tpm2_eventlog_yaml.c
+++ b/test/unit/test_tpm2_eventlog_yaml.c
@@ -146,11 +146,6 @@ static void test_yaml_event2_callback(void **state){
     assert_true(yaml_event2_callback(eventhdr, sizeof(buf), &count));
 }
 
-/* link required symbol, but tpm2_tool.c declares it AND main, which
- * we have a main below for cmocka tests.
- */
-bool output_enabled = true;
-
 int main(void) {
 
     const struct CMUnitTest tests[] = {

--- a/tools/tpm2_tool.c
+++ b/tools/tpm2_tool.c
@@ -12,6 +12,7 @@
 #include "tpm2_errata.h"
 #include "tpm2_options.h"
 #include "tpm2_tool.h"
+#include "tpm2_tool_output.h"
 
 #define SUPPORTED_ABI_VERSION \
 { \
@@ -20,8 +21,6 @@
     .tssLevel = 1, \
     .tssVersion = 108, \
 }
-
-bool output_enabled = true;
 
 static void esys_teardown(ESYS_CONTEXT **esys_context) {
 
@@ -102,7 +101,7 @@ int main(int argc, char *argv[]) {
      * to respect quiet from here on out (onrun and onexit).
      */
     if (flags.quiet) {
-        output_enabled = false;
+        tpm2_tool_output_disable();
     }
 
     ESYS_CONTEXT *ectx = NULL;

--- a/tools/tpm2_tool.h
+++ b/tools/tpm2_tool.h
@@ -8,8 +8,7 @@
 
 #include "tool_rc.h"
 #include "tpm2_options.h"
-
-extern bool output_enabled;
+#include "tpm2_tool_output.h"
 
 /**
  * An optional interface for tools to specify what options they support.
@@ -49,20 +48,5 @@ tool_rc tpm2_tool_onstop(ESYS_CONTEXT *ectx) __attribute__((weak));
  * Called when the tool is exiting, useful for cleanup.
  */
 void tpm2_tool_onexit(void) __attribute__((weak));
-
-/**
- * prints output to stdout respecting the quiet option.
- * Ie when quiet, don't print.
- * @param fmt
- *  The format specifier, ala printf.
- * @param ...
- *  The varargs, just like printf.
- */
-#define tpm2_tool_output(fmt, ...)                   \
-    do {                                        \
-        if (output_enabled) {                   \
-            printf(fmt, ##__VA_ARGS__);         \
-        }                                       \
-    } while (0)
 
 #endif /* MAIN_H */


### PR DESCRIPTION
Defining the 'output_enabled' global variable in the tpm2_tool module
makes it unusable from any executable that defines it's own 'main'
function (mostly affecting unit tests). e2b7f1b1752f works around this
by defining the variable in the test. This works but requires all unit
tests using `tpm2_tool_output` to do the same. This may be a source of
mysteries for those working on unit tests in the future.

This commit removes this burden from unit test writers by moving
`output_enabled` out of the tpm2_tool module and into one of it's
own: tpm2_tool_output. This causes the symbol to be included in the
local utility library where any executable may link against it. This
commit also adds a new macro 'tpm2_tool_output_disable` to allow the
tpm2_tool module to disable output without having to access the
`output_enabled` variable directly.

Signed-off-by: Philip Tricca <philip.b.tricca@intel.com>