### PR TITLE
tpm2_getekcertificate: add default web address

### DIFF
--- a/test/integration/tests/getekcertificate.sh
+++ b/test/integration/tests/getekcertificate.sh
@@ -38,12 +38,10 @@ else
     fi
 fi
 
-tpm2_getekcertificate -u test_ek.pub -x -X -o ECcert.bin \
-https://ekop.intel.com/ekcertservice/
+tpm2_getekcertificate -u test_ek.pub -x -X -o ECcert.bin
 
 # Test that stdoutput is the same
-tpm2_getekcertificate -u test_ek.pub -x https://ekop.intel.com/ekcertservice/ \
--X > ECcert2.bin
+tpm2_getekcertificate -u test_ek.pub -x -X > ECcert2.bin
 
 # stdout file should match -E file.
 cmp ECcert.bin ECcert2.bin

--- a/tools/tpm2_getekcertificate.c
+++ b/tools/tpm2_getekcertificate.c
@@ -32,6 +32,7 @@ struct tpm_getekcertificate_ctx {
 
 static tpm_getekcertificate_ctx ctx = {
     .is_tpm2_device_active = true,
+    .ek_server_addr = "https://ekop.intel.com/ekcertservice/",
 };
 
 static unsigned char *hash_ek_public(void) {


### PR DESCRIPTION
Currently only Intel (R) PTT certificates are hosted online.
A default web address pointing to the endorsement key certificate
hosting will help reduce user input.

Signed-off-by: Imran Desai <imran.desai@intel.com>