### PR TITLE
tpm2_alg_util.c: fix a bug where the string rsa3072 wasnt being parsed

### DIFF
--- a/lib/tpm2_alg_util.c
+++ b/lib/tpm2_alg_util.c
@@ -301,6 +301,9 @@ static alg_parser_rc handle_rsa(const char *ext, TPM2B_PUBLIC *public) {
     } else if (!strncmp(ext, "4096", 4)) {
         r->keyBits = 4096;
         ext += 4;
+    } else if (!strncmp(ext, "3072", 4)) {
+        r->keyBits = 3072;
+        ext += 4;
     } else {
         r->keyBits = 2048;
     }


### PR DESCRIPTION
Fixes #1909 
Signed-off-by: Imran Desai <imran.desai@intel.com>