### PR TITLE
tools: fix incompatible pointers in tpm2_eventlog

### DIFF
--- a/tools/misc/tpm2_eventlog.c
+++ b/tools/misc/tpm2_eventlog.c
@@ -42,7 +42,7 @@ tool_rc tpm2_tool_onrun(ESYS_CONTEXT *ectx, tpm2_option_flags flags) {
 
     bool ret = false;
     UINT8 *eventlog;
-    size_t size = 0;
+    unsigned long size = 0;
 
     if (filename == NULL) {
         LOG_ERR("Missing required positional parameter, try -h / --help");
@@ -55,7 +55,7 @@ tool_rc tpm2_tool_onrun(ESYS_CONTEXT *ectx, tpm2_option_flags flags) {
 
     eventlog = calloc(1, size);
     if (eventlog == NULL){
-        LOG_ERR("failed to allocate %zd bytes: %s", size, strerror(errno));
+        LOG_ERR("failed to allocate %lu bytes: %s", size, strerror(errno));
         return tool_rc_general_error;
     }
 


### PR DESCRIPTION
In `tpm2_eventlog`, a `size_t *` pointer is passed to a function which expects an `unsigned int long *`. That caused build failure on e.g. Raspberry Pi.