### PR TITLE
test: fix yaml.load warning

### DIFF
--- a/test/system/test_tpm2_activecredential.sh
+++ b/test/system/test_tpm2_activecredential.sh
@@ -61,7 +61,7 @@ from __future__ import print_function
 import yaml
 
 with open('ak.out', 'r') as f:
-    doc = yaml.load(f)
+    doc = yaml.load(f, Loader=yaml.BaseLoader)
     print(doc['loaded-key']['name'])
 pyscript`
 

--- a/test/system/test_tpm2_create.sh
+++ b/test/system/test_tpm2_create.sh
@@ -59,7 +59,7 @@ import yaml
 
 with open("$2") as f:
 	try:
-		y = yaml.load(f)
+		y = yaml.load(f, Loader=yaml.BaseLoader)
 		found = "$1" in y
 		if (not found):
 			sys.stderr.write('Could not find index 0x%X\n' % ("$1"))

--- a/test/system/test_tpm2_createprimary.sh
+++ b/test/system/test_tpm2_createprimary.sh
@@ -73,7 +73,7 @@ import yaml
 
 with open("$2") as f:
 	try:
-		y = yaml.load(f)
+		y = yaml.load(f, Loader=yaml.BaseLoader)
 		found = "$1" in y
 		if (not found):
 			sys.stderr.write('Could not find index 0x%X\n' % ("$1"))

--- a/test/system/test_tpm2_nv.sh
+++ b/test/system/test_tpm2_nv.sh
@@ -69,7 +69,7 @@ import yaml
 
 with open("$2") as f:
 	try:
-		y = yaml.load(f)
+		y = yaml.load(f, Loader=yaml.BaseLoader)
 		found = $1 in y
 		if (not found):
 			sys.stderr.write('Could not find index 0x%X\n' % ($1))

--- a/test/system/test_tpm2_pcrevent.sh
+++ b/test/system/test_tpm2_pcrevent.sh
@@ -59,7 +59,7 @@ import yaml
 with open("$1", 'r') as stream:
 
     try:
-        y = yaml.load(stream)
+        y = yaml.load(stream, Loader=yaml.BaseLoader)
         alg = y["$2"]
         value = alg[$3]
         print(value)


### PR DESCRIPTION
The yaml.load(f) is deprecated since pyyaml 5.1.
Use yaml.load(f, Loader=yaml.BaseLoader) instead of it.
See https://github.com/yaml/pyyaml/wiki/PyYAML-yaml.load(input)-Deprecation

Fixes warning:
YAMLLoadWarning: calling yaml.load() without Loader=... is deprecated,
as the default Loader is unsafe. Please read https://msg.pyyaml.org/load for full details.

Signed-off-by: Yi Zhao <yi.zhao@windriver.com>