### PR TITLE
test: only support python3

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -121,24 +121,25 @@ AS_IF(
     [],
     [AC_MSG_WARN([Required executable bash not found, system tests require a bash shell!])])
 
-AC_CHECK_PROG([PYTHON],[python],[yes])
+AC_CHECK_PROG([PYTHON3],[python3],[yes])
 AS_IF(
-    [test "x${PYTHON}" = x"yes"],
+    [test "x${PYTHON3}" = x"yes"],
     [],
-    [AC_MSG_WARN([Required executable python not found, some system tests will fail!])])
+    [AC_MSG_WARN([Required executable python3 not found, some system tests will fail!])])
 
-dnl macro that checks for specific modules in python
-AC_DEFUN([AC_PYTHON_MODULE],
-[AC_MSG_CHECKING([for module $1 in python])
-  echo "import $1" | python -
+dnl macro that checks for specific modules in python3
+AC_DEFUN([AC_PYTHON3_MODULE],
+[AC_MSG_CHECKING([for module $1 in python3])
+  echo "import $1" | python3 -
   if test $? -ne 0 ; then
     AC_MSG_RESULT([not found])
     AC_MSG_WARN([System tests require pyyaml, some tests will fail!])
+  else
+    AC_MSG_RESULT(found)
   fi
-AC_MSG_RESULT(found)
 ])
 
-AC_PYTHON_MODULE([yaml])
+AC_PYTHON3_MODULE([yaml])
 
 AC_SUBST([EXTRA_CFLAGS])
 AC_SUBST([EXTRA_LDFLAGS])

--- a/test/system/test_tpm2_activecredential.sh
+++ b/test/system/test_tpm2_activecredential.sh
@@ -56,8 +56,7 @@ tpm2_getpubek -Q -H 0x81010009 -g rsa -f ek.pub
 tpm2_getpubak -E 0x81010009 -k 0x8101000a -g rsa -D sha256 -s rsassa -f ak.pub -n ak.name > ak.out
 
 # Capture the yaml output and verify that its the same as the name output
-loaded_key_name_yaml=`python << pyscript
-from __future__ import print_function
+loaded_key_name_yaml=`python3 << pyscript
 import yaml
 
 with open('ak.out', 'r') as f:

--- a/test/system/test_tpm2_create.sh
+++ b/test/system/test_tpm2_create.sh
@@ -51,9 +51,7 @@ trap cleanup EXIT
 
 function yaml_get() {
 
-python << pyscript
-from __future__ import print_function
-
+python3 << pyscript
 import sys
 import yaml
 

--- a/test/system/test_tpm2_createprimary.sh
+++ b/test/system/test_tpm2_createprimary.sh
@@ -65,9 +65,7 @@ done
 
 function yaml_get() {
 
-python << pyscript
-from __future__ import print_function
-
+python3 << pyscript
 import sys
 import yaml
 

--- a/test/system/test_tpm2_nv.sh
+++ b/test/system/test_tpm2_nv.sh
@@ -61,9 +61,7 @@ trap onerror ERR
 
 function yaml_get() {
 
-python << pyscript
-from __future__ import print_function
-
+python3 << pyscript
 import sys
 import yaml
 

--- a/test/system/test_tpm2_pcrevent.sh
+++ b/test/system/test_tpm2_pcrevent.sh
@@ -50,9 +50,7 @@ trap cleanup EXIT
 
 function yaml_get() {
 
-python << pyscript
-from __future__ import print_function
-
+python3 << pyscript
 import sys
 import yaml
 


### PR DESCRIPTION
The python2 is EOL and in some distributions (e.g. CentOS 8/RHEL 8),
there is no python symbolic link by default which will cause an error
when running the test scripts:
$ ./test_tpm2_activecredential.sh: line 66: python: command not found

See: https://developers.redhat.com/blog/2018/11/14/python-in-rhel-8/
So drop python2 support and only keep python3.

Signed-off-by: Yi Zhao <yi.zhao@windriver.com>