### PR TITLE
 test/integration/helpers.sh: Add cert less option to FAPI test config.

### DIFF
--- a/test/integration/helpers.sh
+++ b/test/integration/helpers.sh
@@ -416,6 +416,7 @@ cat > $tempdir/fapi_config.json <<EOF
     "system_dir": "$tempdir/${KEYSTORE_SYSTEM}",
     "tcti": "${TPM2TOOLS_TCTI}",
     "system_pcrs" : [],
+    "ek_cert_less": "yes",
     "log_dir" : "$tempdir/${LOG_DIR}",
 }
 EOF


### PR DESCRIPTION
For FAPI there will be a PR which will change the provisioning behaviour. An error will be returned if no certificate for the generated EK exists.
To enable FAPI integration tests with the simulator and also with physical
TPMS the cert less option was added to the helper. So no error is signalled
in simulator tests without certificates and the certificate verification is
skipped in tests with physical TPMs.

Signed-off-by: Juergen Repp <juergen.repp@sit.fraunhofer.de>