### PR TITLE
lib/tpm2_nv_util.h: Set default NV buffer size if cap is missing info

### DIFF
--- a/lib/tpm2_nv_util.h
+++ b/lib/tpm2_nv_util.h
@@ -71,7 +71,12 @@ static inline tool_rc tpm2_util_nv_max_buffer_size(ESYS_CONTEXT *ectx,
         return rc;
     }
 
-    *size = cap_data->data.tpmProperties.tpmProperty[0].value;
+    if ( cap_data->data.tpmProperties.tpmProperty[0].property == TPM2_PT_NV_BUFFER_MAX ) {
+        *size = cap_data->data.tpmProperties.tpmProperty[0].value;
+    } else {
+        /* TPM2_PT_NV_BUFFER_MAX is not part of the module spec <= 0.98*/
+        *size = NV_DEFAULT_BUFFER_SIZE;
+    }
 
     free(cap_data);
 


### PR DESCRIPTION
Fixes #1958

tpm2_nvread and tpm2_nvwrite tools both rely on lib/tpm2_nv_util to
determine the adequate transmission size for a buffer
(TPM2_PT_NV_BUFFER_MAX).

The function used, tpm2_util_nv_max_buffer_size(), will silently fail
on modules conforming to the TPM2 Library Specification rev0.98 and
older. TPM2_PT_NV_BUFFER_MAX has been around since revision 0.99 [1],
and function TPM2_GetCapability is not specified to fail if the
requested property does not exist.

Signed-off-by: Imran Desai <imran.desai@intel.com>