### PR TITLE
tpm2_util: fix public to yaml exponent handling

### DIFF
--- a/lib/tpm2_util.c
+++ b/lib/tpm2_util.c
@@ -546,7 +546,7 @@ void tpm2_util_public_to_yaml(TPM2B_PUBLIC *public, char *indent) {
         break;
     case TPM2_ALG_RSA: {
         TPMS_RSA_PARMS *r = &public->publicArea.parameters.rsaDetail;
-        tpm2_tool_output("%sexponent: 0x%x\n", indent, r->exponent);
+        tpm2_tool_output("%sexponent: %u\n", indent, r->exponent ? r->exponent : 65537);
         tpm2_tool_output("%sbits: %u\n", indent, r->keyBits);
 
         print_rsa_scheme(&r->scheme, indent);


### PR DESCRIPTION
The routine converting TPM2B_PUBLIC to YAML was just outputting the
exponent as is, and in hex. The TPM uses 0 to indicate the default
exponent which 65537. The YAML would just output 0x0. So add a condition
where if 0, output 65537, and update the output to unsigned singe that
is commonly how exponents are reported.

Before:
type:
  value: rsa
  raw: 0x1
exponent: 0x0
bits: 2048

After:
type:
  value: rsa
  raw: 0x1
exponent: 65537
bits: 2048

Fixes: #1919

Signed-off-by: William Roberts <william.c.roberts@intel.com>