### PR TITLE
tests/abrmd_policycphash: provide plaintext for tpm2_encryptdecrypt

### DIFF
--- a/test/integration/tests/abrmd_policycphash.sh
+++ b/test/integration/tests/abrmd_policycphash.sh
@@ -660,7 +660,7 @@ cat secret.dat | tpm2_encryptdecrypt -c decrypt.ctx --iv iv.dat --cphash cp.hash
 generate_policycphash
 sign_and_verify_policycphash
 setup_authorized_policycphash
-tpm2_encryptdecrypt -c decrypt.ctx --iv iv.dat:iv2.dat \
+echo "plaintext" | tpm2_encryptdecrypt -c decrypt.ctx --iv iv.dat:iv2.dat \
 -p "session:session.ctx" > secret2.dat
 
 # Test tpm2_hmac


### PR DESCRIPTION
`tpm2_encryptdecrypt` expects some input to encrypt. The only reason the CI build works at the moment is because tests are run in parallel, which does special things to stdin. Running the single test however hangs indefinitely unless the user manually provides input on the terminal:
```
make check TESTS=test/integration/tests/abrmd_policycphash.sh
```