### PR TITLE
tools/misc/tpm2_eventlog: do not rely on reported file size

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -460,6 +460,7 @@ test_unit_test_tpm2_auth_util_LDFLAGS  = -Wl,--wrap=Esys_TR_SetAuth \
                                          -Wl,--wrap=fread \
                                          -Wl,--wrap=fseek \
                                          -Wl,--wrap=ftell \
+                                         -Wl,--wrap=feof, \
                                          -Wl,--wrap=fclose
 test_unit_test_tpm2_auth_util_LDADD    = $(CMOCKA_LIBS) $(LDADD)
 

--- a/test/unit/test_tpm2_auth_util.c
+++ b/test/unit/test_tpm2_auth_util.c
@@ -105,7 +105,7 @@ size_t __wrap_fread(void *ptr, size_t size, size_t nmemb, FILE *stream) {
     if (stream != &mocked_file_stream) {
         return __real_fread(ptr, size, nmemb, stream);
     }
-    memcpy(ptr, mocked_file_data, size * nmemb);
+    strncpy(ptr, mocked_file_data, size * nmemb);
     return mock_type(size_t);
 }
 
@@ -121,6 +121,14 @@ int __real_fseek(FILE *stream, long offset, int whence);
 int __wrap_fseek(FILE *stream, long offset, int whence) {
     if (stream != &mocked_file_stream) {
         return __real_fseek(stream, offset, whence);
+    }
+    return 0;
+}
+
+int __real_feof(FILE *stream);
+int __wrap_feof(FILE *stream) {
+    if (stream != &mocked_file_stream) {
+        return __real_feof(stream);
     }
     return 0;
 }

--- a/tools/misc/tpm2_eventlog.c
+++ b/tools/misc/tpm2_eventlog.c
@@ -53,7 +53,8 @@ tool_rc tpm2_tool_onrun(ESYS_CONTEXT *ectx, tpm2_option_flags flags) {
         return tool_rc_general_error;
     }
 
-    eventlog = calloc(1, size);
+    UINT16 size_tmp = UINT16_MAX;
+    eventlog = calloc(1, size_tmp);
     if (eventlog == NULL){
         LOG_ERR("failed to allocate %lu bytes: %s", size, strerror(errno));
         return tool_rc_general_error;
@@ -63,7 +64,6 @@ tool_rc tpm2_tool_onrun(ESYS_CONTEXT *ectx, tpm2_option_flags flags) {
         LOG_WARN("event log exceeds %" PRIu16 " and will be truncated",
                  UINT16_MAX);
     }
-    UINT16 size_tmp = size;
     ret = files_load_bytes_from_path(filename, eventlog, &size_tmp);
     if (!ret) {
         free(eventlog);


### PR DESCRIPTION
When using tpm2_eventlog directly on the sysfs file `/sys/kernel/security/tpm0/binary_bios_measurements`, an empty buffer is allocated because its file size is reported as 0. As we cannot know the correct buffer size in advance, allocate a buffer for the maximum amount of data and determine the correct buffer size from a full file read.

Fixes: #1975