### PR TITLE
OpenSSL: Fix deprecated OpenSSL functions.

### DIFF
--- a/lib/tpm2_convert.c
+++ b/lib/tpm2_convert.c
@@ -193,7 +193,7 @@ static bool convert_pubkey_ECC(TPMT_PUBLIC *public,
         goto out;
     }
 
-    int rc = EC_POINT_set_affine_coordinates_GFp(group, point, x, y, NULL);
+    int rc = EC_POINT_set_affine_coordinates_tss(group, point, x, y, NULL);
     if (!rc) {
         print_ssl_error("Could not set affine coordinates");
         goto out;

--- a/lib/tpm2_kdfe.c
+++ b/lib/tpm2_kdfe.c
@@ -93,7 +93,7 @@ static EC_POINT * tpm2_get_EC_public_key(TPM2B_PUBLIC *public) {
         goto out;
     }
 
-    rval = EC_POINT_set_affine_coordinates_GFp(group, q, bn_qx, bn_qy, NULL);
+    rval = EC_POINT_set_affine_coordinates_tss(group, q, bn_qx, bn_qy, NULL);
     if (rval == false) {
         LOG_ERR("Could not set affine_coordinates");
         EC_POINT_free(q);
@@ -127,7 +127,7 @@ static bool get_public_key_from_ec_key(EC_KEY *key, TPMS_ECC_POINT *point) {
         goto out;
     }
 
-    EC_POINT_get_affine_coordinates_GFp(EC_KEY_get0_group(key),
+    EC_POINT_get_affine_coordinates_tss(EC_KEY_get0_group(key),
             pubkey, x, y, NULL);
     nbx = BN_num_bytes(x);
     nby = BN_num_bytes(y);

--- a/lib/tpm2_openssl.c
+++ b/lib/tpm2_openssl.c
@@ -745,7 +745,7 @@ static bool load_public_ECC_from_key(EC_KEY *k, TPM2B_PUBLIC *pub) {
      */
     const EC_POINT *point = EC_KEY_get0_public_key(k);
 
-    int ret = EC_POINT_get_affine_coordinates_GFp(group, point, x, y, NULL);
+    int ret = EC_POINT_get_affine_coordinates_tss(group, point, x, y, NULL);
     if (!ret) {
         LOG_ERR("Could not get X and Y affine coordinates");
         goto out;

--- a/lib/tpm2_openssl.h
+++ b/lib/tpm2_openssl.h
@@ -17,6 +17,21 @@
 #define LIB_TPM2_OPENSSL_OPENSSL_PRE11
 #endif
 
+#if OPENSSL_VERSION_NUMBER >= 0x10101000L
+#define EC_POINT_set_affine_coordinates_tss(group, tpm_pub_key, bn_x, bn_y, dmy) \
+        EC_POINT_set_affine_coordinates(group, tpm_pub_key, bn_x, bn_y, dmy)
+
+#define EC_POINT_get_affine_coordinates_tss(group, tpm_pub_key, bn_x, bn_y, dmy) \
+        EC_POINT_get_affine_coordinates(group, tpm_pub_key, bn_x, bn_y, dmy)
+
+#else
+#define EC_POINT_set_affine_coordinates_tss(group, tpm_pub_key, bn_x, bn_y, dmy) \
+        EC_POINT_set_affine_coordinates_GFp(group, tpm_pub_key, bn_x, bn_y, dmy)
+
+#define EC_POINT_get_affine_coordinates_tss(group, tpm_pub_key, bn_x, bn_y, dmy) \
+        EC_POINT_get_affine_coordinates_GFp(group, tpm_pub_key, bn_x, bn_y, dmy)
+#endif /* OPENSSL_VERSION_NUMBER >= 0x10101000L */
+
 #if defined(LIB_TPM2_OPENSSL_OPENSSL_PRE11)
 int RSA_set0_key(RSA *r, BIGNUM *n, BIGNUM *e, BIGNUM *d);
 void RSA_get0_factors(const RSA *r, const BIGNUM **p, const BIGNUM **q);


### PR DESCRIPTION
ECC Functions with suffix GFp will become deprecated (DEPRECATED_1_2_0).

Signed-off-by: Juergen Repp <juergen.repp@sit.fraunhofer.de>