### PR TITLE
Remove PCR Padding

### DIFF
--- a/man/tpm2_pcrread.1.md
+++ b/man/tpm2_pcrread.1.md
@@ -42,7 +42,6 @@ sha256 :
 
     The output file to write the PCR values in binary format, optional.
 
-
 [common options](common/options.md)
 
 [common tcti options](common/tcti.md)

--- a/tools/tpm2_pcrread.c
+++ b/tools/tpm2_pcrread.c
@@ -46,7 +46,7 @@ static bool print_pcr_values(void) {
                 return false;
             }
 
-            tpm2_tool_output("  %-2d: 0x", pcr_id);
+            tpm2_tool_output("  %-2d: ", pcr_id);
 
             int k;
             for (k = 0; k < ctx.pcrs.pcr_values[vi].digests[di].size; k++) {


### PR DESCRIPTION
Previously tpm2_pcrread used to display PCR values with no padding
(aka `0x`). This change reverts back to the original non padded
format.

Signed-off-by: Luke Hinds <lhinds@redhat.com>