### PR TITLE
Add FAPI support to all tpm2_* tools

### DIFF
--- a/.ci/download-deps.sh
+++ b/.ci/download-deps.sh
@@ -3,7 +3,8 @@
 
 function get_deps() {
 
-	TSS_VERSION=2.4.0
+	TSS_VERSION=master
+#	TSS_VERSION=2.4.0
 	ABRMD_VERSION=2.3.1
 
 	echo "pwd starting: `pwd`"

--- a/Makefile.am
+++ b/Makefile.am
@@ -25,7 +25,7 @@ AM_LDFLAGS   := $(EXTRA_LDFLAGS) $(CODE_COVERAGE_LIBS)
 
 LDADD = \
     $(LIB_COMMON) $(TSS2_ESYS_LIBS) $(TSS2_MU_LIBS) $(CRYPTO_LIBS) $(TSS2_TCTILDR_LIBS) \
-    $(TSS2_RC_LIBS) $(TSS2_SYS_LIBS) $(UUID_LIBS)
+    $(TSS2_RC_LIBS) $(TSS2_SYS_LIBS) $(UUID_LIBS) $(TSS2_FAPI_LIBS)
 
 AM_DISTCHECK_CONFIGURE_FLAGS = --with-bashcompdir='$$(datarootdir)/bash-completion/completions'
 
@@ -172,7 +172,7 @@ bin_PROGRAMS += \
 
 noinst_LIBRARIES = $(LIB_COMMON)
 lib_libcommon_a_SOURCES = $(LIB_SRC)
-lib_libcommon_a_CFLAGS = -fPIC $(AM_CFLAGS)
+lib_libcommon_a_CFLAGS = -fPIC $(AM_CFLAGS) $(FAPI_CFLAGS)
 TOOL_SRC := tools/tpm2_tool.c tools/tpm2_tool.h
 
 tools_fapi_tss2_decrypt_CFLAGS = $(FAPI_CFLAGS)

--- a/lib/object.c
+++ b/lib/object.c
@@ -1,5 +1,7 @@
+#include "config.h"
 
 #include <stdio.h>
+#include <string.h>
 
 #include "files.h"
 #include "log.h"
@@ -9,6 +11,29 @@
 
 #define NULL_OBJECT "null"
 #define NULL_OBJECT_LEN (sizeof(NULL_OBJECT) - 1)
+
+
+#include <tss2/tss2_fapi.h>
+#include <tss2/tss2_mu.h>
+
+#define check(X) if (X != TSS2_RC_SUCCESS) { return TSS2_FAPI_RC_GENERAL_FAILURE; }
+
+#define FAPI_ESYSBLOB_CONTEXTLOAD 1
+#define FAPI_ESYSBLOB_DESERIALIZE 2
+TSS2_RC Fapi_GetEsysBlobs(FAPI_CONTEXT *fctx, const char *path, uint8_t *type, uint8_t **data, size_t *length) {
+    (void)(path);
+    TSS2_TCTI_CONTEXT *tcti;
+    ESYS_CONTEXT *esys;
+    ESYS_TR esystr;
+    check(Fapi_GetTcti(fctx, &tcti));
+    check(Esys_Initialize(&esys, tcti, NULL));
+    check(Esys_TR_FromTPMPublic(esys, 0x81000001, ESYS_TR_NONE, ESYS_TR_NONE, ESYS_TR_NONE, &esystr));
+    check(Esys_TR_Serialize(esys, esystr, data, length));
+    Esys_Finalize(&esys);
+    *type = FAPI_ESYSBLOB_DESERIALIZE;
+    return TSS2_RC_SUCCESS;
+}
+
 
 static tool_rc do_ctx_file(ESYS_CONTEXT *ctx, const char *objectstr, FILE *f,
         tpm2_loaded_object *outobject) {
@@ -40,6 +65,59 @@ static tool_rc tpm2_util_object_load2(ESYS_CONTEXT *ctx, const char *objectstr,
         LOG_ERR("object string is empty");
         return tool_rc_general_error;
     }
+
+//#ifdef FAPI_3_0
+    if (!strncmp(objectstr, "tss2:", strlen("tss2:"))) {
+        FAPI_CONTEXT *fapi;
+        TSS2_RC rval = Fapi_Initialize(&fapi, NULL);
+        if (rval != TSS2_RC_SUCCESS) {
+            LOG_PERR(Fapi_Initialize, rval);
+            return tool_rc_general_error;
+        }
+        uint8_t type;
+        uint8_t *data;
+        size_t length;
+
+        rval = Fapi_GetEsysBlobs(fapi, &objectstr[strlen("tss2:")], &type, &data, &length);
+        Fapi_Finalize(&fapi);
+        if (rval != TSS2_RC_SUCCESS) {
+            LOG_PERR(Fapi_GetEsysBlobs, rval);
+            return tool_rc_general_error;
+        }
+
+        /* assign a dummy transient handle */
+        outobject->handle = TPM2_TRANSIENT_FIRST;
+        outobject->path = NULL;
+
+        TPMS_CONTEXT blob;
+        switch(type) {
+        case FAPI_ESYSBLOB_CONTEXTLOAD:
+            rval = Tss2_MU_TPMS_CONTEXT_Unmarshal(data, length, NULL, &blob);
+            Fapi_Free(data);
+            if (rval != TSS2_RC_SUCCESS) {
+                LOG_PERR(Tss2_MU_TPMS_CONTEXT_Unmarshal, rval);
+                return tool_rc_general_error;
+            }
+            rval = Esys_ContextLoad(ctx, &blob, &outobject->tr_handle);
+            if (rval != TSS2_RC_SUCCESS) {
+                LOG_PERR(Esys_ContextLoad, rval);
+                return tool_rc_general_error;
+            }
+            return tool_rc_success;
+        case FAPI_ESYSBLOB_DESERIALIZE:
+            rval = Esys_TR_Deserialize(ctx, data, length, &outobject->tr_handle);
+            Fapi_Free(data);
+            if (!rval) {
+                LOG_PERR(Esys_TR_Deserialize, rval);
+                return tool_rc_general_error;
+            }
+            return tool_rc_success;
+        default:
+            Fapi_Free(data);
+            return tool_rc_general_error;
+        }
+    }
+//#endif /* FAPI_3_0 */
 
     // 1. Always attempt file
     FILE *f = fopen(objectstr, "rb");

--- a/man/common/ctxobj.md
+++ b/man/common/ctxobj.md
@@ -3,6 +3,9 @@
 The type of a context object, whether it is a handle or file name, is
 determined according to the following logic *in-order*:
 
+  * If the argument is prefixed *tss2:* then the FAPI keystore is queried for this object.
+    (Note: Only available for FAPI >= 3.0)
+
   * If the argument is a file path, then the file is loaded as a restored TPM transient object.
 
   * If the argument is a *prefix* match on one of:

--- a/test/integration/fapi/fapi-sign-verify.sh
+++ b/test/integration/fapi/fapi-sign-verify.sh
@@ -175,4 +175,7 @@ if {[lindex \$ret 2] || [lindex \$ret 3] != 1} {
 }
 EOF
 
+tpm2_sign -Q -c "tss2:${KEY_PATH}" -g sha1 \
+    -o "${DIGEST_FILE}.sig" "${DIGEST_FILE}"
+
 exit 0


### PR DESCRIPTION
By introducing a "tss2:" prefix to denote a FAPI object.

Open would be the Question
- Should the FAPI-calling be encapsulated in a different file than object.c ?
- Should we get the TCTI from the FAPI context or do we want to allow ppl to use FAPI-context objects in the regular tcti context ?