### PR TITLE
Fix detection of hardened c flags supported by the compiler

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -192,7 +192,8 @@ AS_IF([test x"$enable_hardening" != x"no"], [
   AC_DEFUN([add_hardened_c_flag], [
     AX_CHECK_COMPILE_FLAG([$1],
       [EXTRA_CFLAGS="$EXTRA_CFLAGS $1"],
-      [AC_MSG_ERROR([Cannot enable $1, consider configuring with --disable-hardening])]
+      [AC_MSG_ERROR([Cannot enable $1, consider configuring with --disable-hardening])],
+      [-Werror]
     )
   ])
 


### PR DESCRIPTION
For the clang compiler, adding an unsupported warning option generates
a warning (-Wunknown-warning-option), but not an error.  So all of the
add_hardened_c_flag checks will pass even for unsupported warnings.

However, when the code is actually being compiled, the -Werror flag is
used, which turns the -Wunknown-warning-option warnings into errors and
causes the build to fail.

In order to fix this, we need to be sure to pass -Werror to the
AX_CHECK_COMPILE_FLAG macro in order to correctly detect which
warnings are unsupported.