### PR TITLE
FAPI: Enable new style auth callback

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -40,6 +40,9 @@ AS_IF([test "$enable_fapi" = yes -o "$enable_fapi" = check],
          AS_IF([test "$enable_fapi" = yes], [AC_MSG_ERROR([Required module tss2-fapi not found])])
          enable_fapi=no
          ])
+       PKG_CHECK_MODULES([TSS2_FAPI_3_0], [tss2-fapi >= 3.0],
+                         [AC_DEFINE([FAPI_3_0], [1], [fapi3.0.0])],
+                         [true])
       ])
 AM_CONDITIONAL([HAVE_FAPI], [test "$enable_fapi" = yes])
 

--- a/test/integration/fapi/fapi-encrypt-decrypt.sh
+++ b/test/integration/fapi/fapi-encrypt-decrypt.sh
@@ -1,5 +1,4 @@
 #!/bin/bash
-
 set -e
 source helpers.sh
 
@@ -22,6 +21,8 @@ PCR_POLICY_DATA=$TEMP_DIR/pol_pcr16_0.json
 POLICY_PCR=policy/pcr-policy
 
 echo -n "Secret Text!" > $PLAIN_TEXT
+
+set -x
 
 tss2_provision
 

--- a/test/integration/fapi/fapi-key-change-auth.sh
+++ b/test/integration/fapi/fapi-key-change-auth.sh
@@ -22,6 +22,8 @@ SIGNATURE_FILE=$TEMP_DIR/signature.file
 PUBLIC_KEY_FILE=$TEMP_DIR/public_key.file
 IMPORTED_KEY_NAME=importedPubKey
 
+set -x
+
 tss2_provision
 echo 0123456789012345678 > $DIGEST_FILE
 tss2_createkey --path $KEY_PATH --type "noDa, sign" --authValue $PW1


### PR DESCRIPTION
Enable support for Auth-Callbacks of tpm2-tss FAPI >= 3.0 while retaining the ability to talk to FAPI < 3.0 style auth callbacks.

This is needed for https://github.com/tpm2-software/tpm2-tss/pull/1719

This can be merged right away, since it also works with FAPI 2.4.x which current CI depends upon.