### PR TITLE
cirrus: fix install step

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -10,6 +10,7 @@ task:
     matrix:
       image_family: freebsd-12-1-snap
   install_script:
+    - pkg update -f
     - pkg upgrade -y
     - pkg install -y bash gmake coreutils libtool pkgconf autoconf autoconf-archive e2fsprogs-libuuid py37-yaml expect
     - pkg install -y automake glib dbus dbus-glib cmocka wget git libgcrypt openssl json-c vim


### PR DESCRIPTION
Something wrong happened with the cached FreeBSD-12 image.
The install step fails with:
[7/134] Fetching git-2.26.2.txz: .......... done
pkg: cached package git-2.26.2: size mismatch, fetching from remote
[8/134] Fetching git-2.26.2.txz: .......... done
pkg: cached package git-2.26.2: size mismatch, cannot continue
Consider running 'pkg update -f'
Exit status: 3

Added the recommended 'pkg update -f' step.