### PR TITLE
(4.2.X) lib/tpm2_eventlog: drop for loop declerations

### DIFF
--- a/lib/tpm2_eventlog.c
+++ b/lib/tpm2_eventlog.c
@@ -37,7 +37,8 @@ bool foreach_digest2(TCG_DIGEST2 const *digest, size_t count, size_t size,
 
     bool ret = true;
 
-    for (size_t i = 0; i < count; ++i) {
+    size_t i;
+    for (i = 0; i < count; ++i) {
         if (size < sizeof(*digest)) {
             LOG_ERR("insufficient size for digest header");
             return false;
@@ -240,7 +241,8 @@ bool specid_event(TCG_EVENT const *event, size_t size,
         return false;
     }
 
-    for (size_t i = 0; i < sizeof(event->digest); ++i) {
+    size_t i;
+    for (i = 0; i < sizeof(event->digest); ++i) {
         if (event->digest[i] != 0) {
             LOG_ERR("SpecID digest data malformed");
             return false;


### PR DESCRIPTION
Fixes:
CC lib/lib_libcommon_a-tpm2_eventlog.o
lib/tpm2_eventlog.c: In function ‘foreach_digest2’:
lib/tpm2_eventlog.c:40:5: error: ‘for’ loop initial declarations are only allowed in C99 mode
for (size_t i = 0; i < count; ++i) {
^
lib/tpm2_eventlog.c:40:5: note: use option -std=c99 or -std=gnu99 to compile your code
lib/tpm2_eventlog.c: In function ‘specid_event’:
lib/tpm2_eventlog.c:243:5: error: ‘for’ loop initial declarations are only allowed in C99 mode
for (size_t i = 0; i < sizeof(event->digest); ++i) {
^
make: *** [lib/lib_libcommon_a-tpm2_eventlog.o] Error 1

This fixes that bug without explicitly having to set the build -std
options, which would have to be gnu99. We may wish to specify that in
the future.

Fixes: #2011

Signed-off-by: William Roberts <william.c.roberts@intel.com>