### PR TITLE
cirrus: switch TSS to master branch

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -25,7 +25,7 @@ task:
     - cd -
     - rm -rf $ibmtpm_name $ibmtpm_name.tar.gz
     - mkdir tss
-    - cd tss && git clone --branch 2.4.0 https://github.com/tpm2-software/tpm2-tss.git
+    - cd tss && git clone https://github.com/tpm2-software/tpm2-tss.git
     - cd tpm2-tss && ./bootstrap && ./configure --disable-doxygen-doc --disable-dependency-tracking && gmake install
     - cd ../../ && rm -rf tss
     - mkdir rm


### PR DESCRIPTION
After #1999 - Fix ESYS_TR hierarchy transition we can
switch cirrus to TSS master.