### PR TITLE
scan-build: fix value is never read from variable issue

### DIFF
--- a/lib/tpm2_options.c
+++ b/lib/tpm2_options.c
@@ -138,7 +138,7 @@ static bool execute_man(char *prog_name, bool show_errors) {
         char *manpage = basename(prog_name);
         execlp("man", "man", manpage, NULL);
     } else {
-        if ((pid = waitpid(pid, &status, 0)) == -1) {
+        if (waitpid(pid, &status, 0) == -1) {
             LOG_ERR("Waiting for child process that executes man failed, error:"
                     " %s", strerror(errno));
             return false;

--- a/tools/fapi/tss2_template.c
+++ b/tools/fapi/tss2_template.c
@@ -54,7 +54,7 @@ static bool execute_man(char *prog_name, bool show_errors) {
         char *manpage = basename(prog_name);
         execlp("man", "man", manpage, NULL);
     } else {
-        if ((pid = waitpid(pid, &status, 0)) == -1) {
+        if (waitpid(pid, &status, 0) == -1) {
             LOG_ERR("Waiting for child process that executes man failed, error:"
                     " %s", strerror(errno));
             return false;


### PR DESCRIPTION
scan-build in llvm-10 complains about:
../tools/fapi/tss2_template.c:57:14: warning: Although the
value stored to 'pid' is used in the enclosing expression,
the value is never actually read from 'pid'
        if ((pid = waitpid(pid, &status, 0)) == -1) {
             ^     ~~~~~~~~~~~~~~~~~~~~~~~~

../lib/tpm2_options.c:141:14: warning: Although the value
stored to 'pid' is used in the enclosing expression, the
value is never actually read from 'pid'
        if ((pid = waitpid(pid, &status, 0)) == -1) {
             ^     ~~~~~~~~~~~~~~~~~~~~~~~~