### PR TITLE
Parse EV_POST_CODE as strings

### DIFF
--- a/lib/tpm2_eventlog.c
+++ b/lib/tpm2_eventlog.c
@@ -88,8 +88,11 @@ bool parse_event2body(TCG_EVENT2 const *event, UINT32 type) {
             }
         }
         break;
-    /* TCG PC Client FPF section 9.2.5 */
+    /* TCG PC Client FPF section 2.3.4.1 and 9.4.1 */
     case EV_POST_CODE:
+        // the event is a string, so there are no length requirements.
+        break;
+    /* TCG PC Client FPF section 9.2.5 */
     case EV_S_CRTM_CONTENTS:
     case EV_EFI_PLATFORM_FIRMWARE_BLOB:
         {

--- a/lib/tpm2_eventlog_yaml.c
+++ b/lib/tpm2_eventlog_yaml.c
@@ -182,10 +182,7 @@ static bool yaml_uefi_post_code(const TCG_EVENT2 * const event)
     const size_t len = event->EventSize;
 
     tpm2_tool_output(
-        "  Event:\n"
-        "    - Length: %zu\n"
-        "      String: '%.*s'\n",
-        len,
+        "  Event: '%.*s'\n",
         (int) len,
         data);
     return true;
@@ -225,11 +222,7 @@ bool yaml_uefi_platfwblob(UEFI_PLATFORM_FIRMWARE_BLOB *data) {
 /* TCG PC Client PFP section 9.4.4 */
 bool yaml_uefi_action(UINT8 const *action, size_t size) {
 
-    /* longest string permitted by spec is 47 chars */
-    char buf[50] = { '\0', };
-
-    memcpy (buf, action, size);
-    tpm2_tool_output("  Event: %s\n", buf);
+    tpm2_tool_output("  Event: '%.*s'\n", (int) size, action);
 
     return true;
 }

--- a/lib/tpm2_eventlog_yaml.c
+++ b/lib/tpm2_eventlog_yaml.c
@@ -171,13 +171,16 @@ static bool yaml_uefi_var_data(UEFI_VARIABLE_DATA *data) {
  * be the string "POST CODE" in all caps. ...
  * - Embedded SMM code and the code that sets it up SHOULD use
  * the string "SMM CODE" in all caps...
- * - BIS code (eclusing the BIS Certificate) should use event
+ * - BIS code (excluding the BIS Certificate) should use event
  * field string of "BIS CODE" in all caps. ...
  * - ACPI flash data prior to any modifications ... should use
  * event field string of "ACPI DATA" in all caps.
  */
-static bool yaml_uefi_post_code(const char * data, size_t len)
+static bool yaml_uefi_post_code(const TCG_EVENT2 * const event)
 {
+    const char * const data = (const char *) event->Event;
+    const size_t len = event->EventSize;
+
     tpm2_tool_output(
         "  Event:\n"
         "    - Length: %zu\n"
@@ -270,7 +273,7 @@ bool yaml_event2data(TCG_EVENT2 const *event, UINT32 type) {
     case EV_EFI_VARIABLE_AUTHORITY:
         return yaml_uefi_var((UEFI_VARIABLE_DATA*)event->Event);
     case EV_POST_CODE:
-        return yaml_uefi_post_code((const char*)event->Event, event->EventSize);
+        return yaml_uefi_post_code(event);
     case EV_S_CRTM_CONTENTS:
     case EV_EFI_PLATFORM_FIRMWARE_BLOB:
         return yaml_uefi_platfwblob((UEFI_PLATFORM_FIRMWARE_BLOB*)event->Event);

--- a/lib/tpm2_eventlog_yaml.c
+++ b/lib/tpm2_eventlog_yaml.c
@@ -329,7 +329,7 @@ void yaml_eventhdr(TCG_EVENT const *event, size_t *count) {
     bytes_to_str(event->digest, sizeof(event->digest), digest_hex, sizeof(digest_hex));
 
     tpm2_tool_output("- Event[%zu]:\n"
-                     "  pcrIndex: %" PRIu32 "\n"
+                     "  PCRIndex: %" PRIu32 "\n"
                      "  eventType: %s\n"
                      "  digest: %s\n"
                      "  eventDataSize: %" PRIu32 "\n", (*count)++, event->pcrIndex,

--- a/lib/tpm2_eventlog_yaml.c
+++ b/lib/tpm2_eventlog_yaml.c
@@ -330,9 +330,9 @@ void yaml_eventhdr(TCG_EVENT const *event, size_t *count) {
 
     tpm2_tool_output("- Event[%zu]:\n"
                      "  PCRIndex: %" PRIu32 "\n"
-                     "  eventType: %s\n"
-                     "  digest: %s\n"
-                     "  eventDataSize: %" PRIu32 "\n", (*count)++, event->pcrIndex,
+                     "  EventType: %s\n"
+                     "  Digest: %s\n"
+                     "  EventSize: %" PRIu32 "\n", (*count)++, event->pcrIndex,
                      eventtype_to_string(event->eventType), digest_hex,
                      event->eventDataSize);
 }

--- a/lib/tpm2_eventlog_yaml.c
+++ b/lib/tpm2_eventlog_yaml.c
@@ -165,6 +165,29 @@ static bool yaml_uefi_var_data(UEFI_VARIABLE_DATA *data) {
     return true;
 }
 /*
+ * TCG PC Client FPF section 2.3.4.1 and 9.4.1:
+ * Usage of the event type EV_POST_CODE:
+ * - If a combined event is measured, the event field SHOULD
+ * be the string "POST CODE" in all caps. ...
+ * - Embedded SMM code and the code that sets it up SHOULD use
+ * the string "SMM CODE" in all caps...
+ * - BIS code (eclusing the BIS Certificate) should use event
+ * field string of "BIS CODE" in all caps. ...
+ * - ACPI flash data prior to any modifications ... should use
+ * event field string of "ACPI DATA" in all caps.
+ */
+static bool yaml_uefi_post_code(const char * data, size_t len)
+{
+    tpm2_tool_output(
+        "  Event:\n"
+        "    - Length: %zu\n"
+        "      String: '%.*s'\n",
+        len,
+        (int) len,
+        data);
+    return true;
+}
+/*
  * TCG PC Client FPF section 9.2.6
  * The tpm2_eventlog module validates the event structure but nothing within
  * the event data buffer so we must do that here.
@@ -247,6 +270,7 @@ bool yaml_event2data(TCG_EVENT2 const *event, UINT32 type) {
     case EV_EFI_VARIABLE_AUTHORITY:
         return yaml_uefi_var((UEFI_VARIABLE_DATA*)event->Event);
     case EV_POST_CODE:
+        return yaml_uefi_post_code((const char*)event->Event, event->EventSize);
     case EV_S_CRTM_CONTENTS:
     case EV_EFI_PLATFORM_FIRMWARE_BLOB:
         return yaml_uefi_platfwblob((UEFI_PLATFORM_FIRMWARE_BLOB*)event->Event);

--- a/test/unit/test_tpm2_eventlog.c
+++ b/test/unit/test_tpm2_eventlog.c
@@ -266,7 +266,7 @@ static void test_parse_event2body_uefivar_badlength(void **state){
 
     assert_false(parse_event2body(event, EV_EFI_VARIABLE_DRIVER_CONFIG));
 }
-static void test_parse_event2body_postcode_badlength(void **state){
+static void test_parse_event2body_firmware_blob_badlength(void **state){
 
     (void)state;
 
@@ -465,7 +465,7 @@ int main(void) {
         cmocka_unit_test(test_foreach_event2_parse_event2body_fail),
         cmocka_unit_test(test_parse_event2body_uefivar_badsize),
         cmocka_unit_test(test_parse_event2body_uefivar_badlength),
-        cmocka_unit_test(test_parse_event2body_postcode_badlength),
+        cmocka_unit_test(test_parse_event2body_firmware_blob_badlength),
         cmocka_unit_test(test_specid_event_nohdr),
         cmocka_unit_test(test_specid_event_badeventtype),
         cmocka_unit_test(test_specid_event_badpcrindex),


### PR DESCRIPTION
According the TCG 2.3.4.1, `EV_POST_CODE` are byte strings, not firmware blobs. This patch adds string display to the event handling code and renames the firmware blob test function.