### PR TITLE
cirrus: drop abrmd on the flight patching

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -29,8 +29,7 @@ task:
     - cd tpm2-tss && ./bootstrap && ./configure --disable-doxygen-doc --disable-dependency-tracking && gmake install
     - cd ../../ && rm -rf tss
     - mkdir rm
-    - cd rm && git clone https://github.com/tpm2-software/tpm2-abrmd.git
-    - cd tpm2-abrmd && wget https://patch-diff.githubusercontent.com/raw/tpm2-software/tpm2-abrmd/pull/711.patch -O - | git apply
+    - cd rm && git clone https://github.com/tpm2-software/tpm2-abrmd.git && cd tpm2-abrmd
     - ./bootstrap && ./configure --disable-dependency-tracking && gmake install
     - cd ../../ && rm -rf rm
   script:


### PR DESCRIPTION
After the PR has been merged to abrmd it doesn't need to
be patched anymore.

Fixes: #2001

Signed-off-by: Tadeusz Struk <tadeusz.struk@intel.com>