### PR TITLE
Revert "tpm2_create.c: Fix an issue where userwithauth attr cleared if policy specified"

### DIFF
--- a/tools/tpm2_create.c
+++ b/tools/tpm2_create.c
@@ -405,6 +405,11 @@ tool_rc tpm2_tool_onrun(ESYS_CONTEXT *ectx, tpm2_option_flags flags) {
         return tool_rc_general_error;
     }
 
+    if (ctx.flags.L && !ctx.object.auth_str) {
+        ctx.object.public.publicArea.objectAttributes &=
+                ~TPMA_OBJECT_USERWITHAUTH;
+    }
+
     if (ctx.flags.i
             && ctx.object.public.publicArea.type != TPM2_ALG_KEYEDHASH) {
         LOG_ERR("Only TPM2_ALG_KEYEDHASH algorithm is allowed when sealing data");


### PR DESCRIPTION
HARD NACK. This was there so that if someone creates an object with a policy and no password, they wouldn't implicitly be getting a null password allowed on their object. What you need to do is check if they specified -a. If they specified -a, then we don't turn it down.

I think you want:

```diff
diff --git a/tools/tpm2_create.c b/tools/tpm2_create.c
index 17709a4aba92..36c2fbc2a8ac 100644
--- a/tools/tpm2_create.c
+++ b/tools/tpm2_create.c
@@ -405,7 +405,7 @@ tool_rc tpm2_tool_onrun(ESYS_CONTEXT *ectx, tpm2_option_flags flags) {
         return tool_rc_general_error;
     }
 
-    if (ctx.flags.L && !ctx.object.auth_str) {
+    if (!ctx.flags.b && ctx.flags.L && !ctx.object.auth_str) {
         ctx.object.public.publicArea.objectAttributes &=
                 ~TPMA_OBJECT_USERWITHAUTH;
     }
```
note that flags.b is actually the -a option, we should probably rename that to.