### PR TITLE
TSS2 Tools Backport Fixes (4.2.X)

### DIFF
--- a/dist/bash-completion/tpm2-tools/tss2_encrypt
+++ b/dist/bash-completion/tpm2-tools/tss2_encrypt
@@ -12,14 +12,14 @@ _tss2_encrypt()
             _filedir
             COMPREPLY+=( '-' )
             return;;
-        -!(-*)[pP] | --keyPath | --policyPath)
+        -!(-*)[p] | --keyPath )
             return;;
     esac
 
     $split && return
 
     COMPREPLY=( $(compgen -W "-h --help -v --version -f --force -o --cipherText
-    -p --keyPath  -P --policyPath -i --plainText" -- "$cur") )
+    -p --keyPath -i --plainText" -- "$cur") )
     [[ $COMPREPLY == *= ]] && compopt -o nospace
 } &&
 complete -F _tss2_encrypt tss2_encrypt

--- a/man/tss2_authorizepolicy.1.md
+++ b/man/tss2_authorizepolicy.1.md
@@ -19,19 +19,24 @@
 These are the available options:
 
   * **-P**, **\--policyPath**:
-    Path of the new policy. MUST NOT be NULL.
+    Path of the new policy.
+
+    A policyPath is composed of two elements, separated by "/". A policyPath
+    starts with "/policy". The second path element identifies the policy
+    or policy template using a meaningful name.
 
   * **-p**, **\--keyPath**:
-    Path of the signing key. MUST NOT be NULL.
+    Path of the signing key.
 
   * **-r**, **\--policyRef**:
-    A byte buffer to be included in the signature. MAY be NULL if policyRefSize is 0.
+    A byte buffer to be included in the signature. Optional parameter.
 
 [common tss2 options](common/tss2-options.md)
 
 # EXAMPLE
-
-tss2_authorizepolicy --keyPath HS/SRK/myPolicySignKey --policyPath policy/pcr-policy --policyRef policyRef.file
+```
+tss2_authorizepolicy --keyPath HS/SRK/myPolicySignKey --policyPath /policy/pcr-policy --policyRef policyRef.file
+```
 
 # RETURNS
 

--- a/man/tss2_authorizepolicy.1.md
+++ b/man/tss2_authorizepolicy.1.md
@@ -18,17 +18,17 @@
 
 These are the available options:
 
-  * **-P**, **\--policyPath**:
+  * **-P**, **\--policyPath** _STRING_:
     Path of the new policy.
 
     A policyPath is composed of two elements, separated by "/". A policyPath
     starts with "/policy". The second path element identifies the policy
     or policy template using a meaningful name.
 
-  * **-p**, **\--keyPath**:
+  * **-p**, **\--keyPath** _STRING_:
     Path of the signing key.
 
-  * **-r**, **\--policyRef**:
+  * **-r**, **\--policyRef** _FILENAME_ or _-_ (for stdin):
     A byte buffer to be included in the signature. Optional parameter.
 
 [common tss2 options](common/tss2-options.md)

--- a/man/tss2_changeauth.1.md
+++ b/man/tss2_changeauth.1.md
@@ -20,13 +20,13 @@ The authValue is a UTF-8 password.
 
 These are the available options:
 
-  * **-a**, **\--authValue**:
+  * **-a**, **\--authValue** _STRING_:
 
     The new UTF-8 password. Optional parameter. If it is neglected then the user
     is queried interactively for a password. To set no password, this option
     should be used with the empty string ("").
 
-  * **-p**, **\--entityPath**:
+  * **-p**, **\--entityPath** _STRING_:
 
     The path identifying the entity to modify.
 

--- a/man/tss2_changeauth.1.md
+++ b/man/tss2_changeauth.1.md
@@ -6,7 +6,7 @@
 
 **tss2_changeauth**(1) - This command changes the authorization data of an entity referred to by the path.
 
-The authValue is a UTF-8 password. If the length of the password is larger than the digest size of the entity's nameAlg (which is stored internally as part of its meta data) then the FAPI should hash the password, in accordance with the TPM specification, part 1 rev 138, section 19.6.4.3 "Authorization Size Convention."
+The authValue is a UTF-8 password.
 
 # SYNOPSIS
 
@@ -22,11 +22,13 @@ These are the available options:
 
   * **-a**, **\--authValue**:
 
-    The new 0-terminated password. MAY be NULL. If NULL then the password is set to the empty string.
+    The new UTF-8 password. Optional parameter. If it is neglected then the user
+    is queried interactively for a password. To set no password, this option
+    should be used with the empty string ("").
 
   * **-p**, **\--entityPath**:
 
-    The path identifying the entity to modify. MUST NOT be NULL.
+    The path identifying the entity to modify.
 
 [common tss2 options](common/tss2-options.md)
 
@@ -37,9 +39,9 @@ These are the available options:
 tss2_changeauth --entityPath HS/SRK/myRSACryptKey --authValue M1
 ```
 
-## Change a password for an entity HS/SRK/myRSACryptKey and ask the user to enter the password with disabled ecoh.
+## Change a password for an entity HS/SRK/myRSACryptKey and ask the user to enter the password.
 ```
-tss2_changeauth --entityPath HS/SRK/myRSACryptKey --authValue
+tss2_changeauth --entityPath HS/SRK/myRSACryptKey
 ```
 
 # RETURNS

--- a/man/tss2_createkey.1.md
+++ b/man/tss2_createkey.1.md
@@ -18,11 +18,11 @@
 
 These are the available options:
 
-  * **-p**, **\--path**:
+  * **-p**, **\--path** _STRING_:
 
     The path to the new key.
 
-  * **-t**, **\--type**:
+  * **-t**, **\--type** _STRING_:
 
     Identifies the intended usage. Optional parameter.
     Types may be any comma-separated combination of:
@@ -40,7 +40,7 @@ These are the available options:
         - A hexadecimal number (e.g. "0x81000001"): Marks a key object to be
           made persistent and sets the persistent object handle to this value.
 
-  * **-P**, **\--policyPath**:
+  * **-P**, **\--policyPath** _STRING_:
 
     The policy to be associated with the new key. Optional parameter. If omitted
     then no policy will be associated with the key.
@@ -49,7 +49,7 @@ These are the available options:
     starts with "/policy". The second path element identifies the policy
     or policy template using a meaningful name.
 
-  * **-a**, **\--authValue**:
+  * **-a**, **\--authValue** _STRING_:
 
     The new UTF-8 password. Optional parameter. If it is neglected then the user
     is queried interactively for a password. To set no password, this option

--- a/man/tss2_createkey.1.md
+++ b/man/tss2_createkey.1.md
@@ -20,19 +20,40 @@ These are the available options:
 
   * **-p**, **\--path**:
 
-    The path to the new key. MUST NOT be NULL.
+    The path to the new key.
 
   * **-t**, **\--type**:
 
-    Identifies the intended usage. For possible values see FAPI specification. MAY be NULL.
+    Identifies the intended usage. Optional parameter.
+    Types may be any comma-separated combination of:
+
+        - "sign": Sets the sign attribute of a key.
+        - "decrypt": Sets the decrypt attribute of a key.
+        - Hint: If neither sign nor decrypt are provided, both attributes are set.
+        - "restricted": Sets the restricted attribute of a key.
+        - Hint: If restricted is set, sign or decrypt (but not both) need to be set.
+        - "exportable": Clears the fixedTPM and fixedParent attributes of a key or
+          sealed object.
+        - "noda": Sets the noda attribute of a key or NV index.
+        - "system": Stores the data blobs and metadata for a created key or seal
+          in the system-wide directory instead of user's personal directory.
+        - A hexadecimal number (e.g. "0x81000001"): Marks a key object to be
+          made persistent and sets the persistent object handle to this value.
 
   * **-P**, **\--policyPath**:
 
-    The policy to be associated with the new key. policyPath MAY be NULL. If NULL then no policy will be associated with the key.
+    The policy to be associated with the new key. Optional parameter. If omitted
+    then no policy will be associated with the key.
+
+    A policyPath is composed of two elements, separated by "/". A policyPath
+    starts with "/policy". The second path element identifies the policy
+    or policy template using a meaningful name.
 
   * **-a**, **\--authValue**:
 
-    The new authorization value for the key. authValue MAY be NULL. If NULL then the authorization value will be the empty string.
+    The new UTF-8 password. Optional parameter. If it is neglected then the user
+    is queried interactively for a password. To set no password, this option
+    should be used with the empty string ("").
 
 [common tss2 options](common/tss2-options.md)
 
@@ -40,15 +61,15 @@ These are the available options:
 
 ## Create a key without password
 ```
-tss2_createkey --path HS/SRK/myRsaCryptKey --type "noDa, decrypt"
+tss2_createkey --path HS/SRK/myRsaCryptKey --type "noDa, decrypt" --authValue ""
 ```
 
 ## Create a key, ask for password on the command line
 ```
-tss2_createkey --path HS/SRK/myRsaCryptKey --type "noDa, decrypt" --authValue
+tss2_createkey --path HS/SRK/myRsaCryptKey --type "noDa, decrypt"
 ```
 
-## Create a key with password “abc”.
+## Create a key with password "abc".
 ```
 tss2_createkey --path HS/SRK/myRsaCryptKey --type "noDa, decrypt" --authValue abc
 ```

--- a/man/tss2_createnv.1.md
+++ b/man/tss2_createnv.1.md
@@ -12,7 +12,7 @@
 
 # DESCRIPTION
 
-**tss2_createnv**(1) - This command creates an NV index in the TPM. The path is constructed as described in section 1.7.2. The type field is described in section 1.8.
+**tss2_createnv**(1) - This command creates an NV index in the TPM.
 
 # OPTIONS
 
@@ -20,30 +20,56 @@ These are the available options:
 
   * **-p**, **\--path**:
 
-    Path of the new NV space. MUST NOT be NULL.
+    Path of the new NV space.
+
+    The path is composed of three elements, separated by "/". An nvPath starts
+    with "/nv". The second path element identifies the NV handle range
+    for the nv object. This includes the following values:
+    Owner, TPM, Platform, Endorsement_Certificate, Platform_Certificate,
+    Component_OEM, TPM_OEM, Platform_OEM, PC-Client, Server,
+    Virtualized_Platform, MPWG, Embedded. The third path element identifies
+    the actual NV-Index using a meaningful name.
 
   * **-t**, **\--type**:
 
-    Identifies the intended usage. For possible values see FAPI specification. MAY be NULL.
+    Identifies the intended usage. Optional parameter.
+    Types may be any comma-separated combination of:
+
+        - "noda": Sets the noda attribute of a key or NV index.
+        - "bitfield": Sets the NV type to bitfield.
+        - "counter": Sets the NV type to counter.
+        - "pcr": Sets the NV type to pcr-like behavior.
+        - Hint: If none of the previous three keywords is provided a regular NV
+          index is created.
+
 
   * **-s**, **\--size**:
 
-    The size in bytes of the NV index to be created. MAY be zero if the size is inferred from the type; e.g. an NV index of type counter has a size of 8 bytes.
+    The size in bytes of the NV index to be created. Can be omitted if size can
+    be inferred from the type; e.g. an NV index of type counter has a size of 8
+    bytes.
 
   * **-P**, **\--policyPath**:
 
-    Identifies the policy to be associated with the new NV space. MAY be NULL. If NULL then no policy will be associated with the NV space.
+    Identifies the policy to be associated with the new NV space. Optional parameter.
+    If omitted then no policy will be associated with the key.
+
+    A policyPath is composed of two elements, separated by "/". A policyPath
+    starts with "/policy". The second path element identifies the policy
+    or policy template using a meaningful name.
 
   * **-a**, **\--authValue**:
 
-    The new authorization value for the nv index. MAY be NULL. If NULL then the authorization value will be the empty string
-
+    The new UTF-8 password. Optional parameter. If it is neglected then the user
+    is queried interactively for a password. To set no password, this option
+    should be used with the empty string ("").
 
 [common tss2 options](common/tss2-options.md)
 
 # EXAMPLE
-
+```
 tss2_createnv --authValue abc --path /nv/Owner/myNV --size 20 --type "noDa"
+```
 
 # RETURNS
 

--- a/man/tss2_createnv.1.md
+++ b/man/tss2_createnv.1.md
@@ -18,7 +18,7 @@
 
 These are the available options:
 
-  * **-p**, **\--path**:
+  * **-p**, **\--path** _STRING_:
 
     Path of the new NV space.
 
@@ -30,7 +30,7 @@ These are the available options:
     Virtualized_Platform, MPWG, Embedded. The third path element identifies
     the actual NV-Index using a meaningful name.
 
-  * **-t**, **\--type**:
+  * **-t**, **\--type** _STRING_:
 
     Identifies the intended usage. Optional parameter.
     Types may be any comma-separated combination of:
@@ -43,13 +43,13 @@ These are the available options:
           index is created.
 
 
-  * **-s**, **\--size**:
+  * **-s**, **\--size** _INTEGER_:
 
     The size in bytes of the NV index to be created. Can be omitted if size can
     be inferred from the type; e.g. an NV index of type counter has a size of 8
     bytes.
 
-  * **-P**, **\--policyPath**:
+  * **-P**, **\--policyPath** _STRING_:
 
     Identifies the policy to be associated with the new NV space. Optional parameter.
     If omitted then no policy will be associated with the key.
@@ -58,7 +58,7 @@ These are the available options:
     starts with "/policy". The second path element identifies the policy
     or policy template using a meaningful name.
 
-  * **-a**, **\--authValue**:
+  * **-a**, **\--authValue** _STRING_:
 
     The new UTF-8 password. Optional parameter. If it is neglected then the user
     is queried interactively for a password. To set no password, this option

--- a/man/tss2_createseal.1.md
+++ b/man/tss2_createseal.1.md
@@ -20,29 +20,45 @@ These are the available options:
 
   * **-p**, **\--path**:
 
-    The path to the new key. MUST NOT be NULL.
+    The path to the new key.
 
   * **-t**, **\--type**:
 
-    Identifies the intended usage. For possible values see FAPI specification. MAY be NULL.
+    Identifies the intended usage. Optional parameter.
+    Types may be any comma-separated combination of:
+
+        - "exportable": Clears the fixedTPM and fixedParent attributes of a key or
+          sealed object.
+        - "noda": Sets the noda attribute of a key or NV index.
+        - "system": Stores the data blobs and metadata for a created key or seal
+          in the system-wide directory instead of user's personal directory.
+        - A hexadecimal number (e.g. "0x81000001"): Marks a key object to be
+          made persistent and sets the persistent object handle to this value.
 
   * **-P**, **\--policyPath**:
 
-    Identifies the policy to be associated with the new key. MAY be NULL. If NULL then no policy will be associated with the key.
+    Identifies the policy to be associated with the new key. Optional parameter.
+    If omitted then no policy will be associated with the key.
+
+    A policyPath is composed of two elements, separated by "/". A policyPath
+    starts with "/policy". The second path element identifies the policy
+    or policy template using a meaningful name.
 
   * **-a**, **\--authValue**:
 
-    The new authorization value for the key. MAY be NULL. If NULL then the authorization value will be the empty string.
+    The new UTF-8 password. Optional parameter. If it is neglected then the user
+    is queried interactively for a password. To set no password, this option
+    should be used with the empty string ("").
 
   * **-i**, **\--data**:
 
-    the data to be sealed by the TPM. MAY be NULL.
+    The data to be sealed by the TPM. Optional parameter.
 
 [common tss2 options](common/tss2-options.md)
 
 # EXAMPLE
 
-## Create a key without password and read data to be sealed from file.
+## Create a key with password "abc" and read sealing data from file.
 ```
 tss2_createseal --path HS/SRK/mySealKey --type "noDa" --authValue abc --data abc
 ```

--- a/man/tss2_createseal.1.md
+++ b/man/tss2_createseal.1.md
@@ -18,11 +18,11 @@
 
 These are the available options:
 
-  * **-p**, **\--path**:
+  * **-p**, **\--path** _STRING_:
 
     The path to the new key.
 
-  * **-t**, **\--type**:
+  * **-t**, **\--type** _STRING_:
 
     Identifies the intended usage. Optional parameter.
     Types may be any comma-separated combination of:
@@ -35,7 +35,7 @@ These are the available options:
         - A hexadecimal number (e.g. "0x81000001"): Marks a key object to be
           made persistent and sets the persistent object handle to this value.
 
-  * **-P**, **\--policyPath**:
+  * **-P**, **\--policyPath** _STRING_:
 
     Identifies the policy to be associated with the new key. Optional parameter.
     If omitted then no policy will be associated with the key.
@@ -44,13 +44,13 @@ These are the available options:
     starts with "/policy". The second path element identifies the policy
     or policy template using a meaningful name.
 
-  * **-a**, **\--authValue**:
+  * **-a**, **\--authValue** _STRING_:
 
     The new UTF-8 password. Optional parameter. If it is neglected then the user
     is queried interactively for a password. To set no password, this option
     should be used with the empty string ("").
 
-  * **-i**, **\--data**:
+  * **-i**, **\--data** _FILENAME_ or _-_ (for stdin):
 
     The data to be sealed by the TPM. Optional parameter.
 
@@ -60,7 +60,7 @@ These are the available options:
 
 ## Create a key with password "abc" and read sealing data from file.
 ```
-tss2_createseal --path HS/SRK/mySealKey --type "noDa" --authValue abc --data abc
+tss2_createseal --path HS/SRK/mySealKey --type "noDa" --authValue abc --data data.file
 ```
 
 # RETURNS

--- a/man/tss2_decrypt.1.md
+++ b/man/tss2_decrypt.1.md
@@ -12,7 +12,8 @@
 
 # DESCRIPTION
 
-**tss2_decrypt**(1) - Input pointer to data to be decrypted, and a place to put the decrypted data.
+**tss2_decrypt**(1) - This command decrypts data that was encrypted using tss2_encrypt.
+
 
 # OPTIONS
 
@@ -20,11 +21,11 @@ These are the available options:
 
   * **-p**, **\--keyPath**:
 
-    Identifies the decryption key. MUST NOT be NULL.
+    Identifies the decryption key.
 
   * **-i**, **\--cipherText**: \<filename\>
 
-    The JSON-encoded cipherText. MUST NOT be NULL.
+    The JSON-encoded cipherText.
 
   * **-f**, **\--force**:
 
@@ -32,13 +33,14 @@ These are the available options:
 
   * **-o**, **\--plainText**: \<filename\>
 
-    Returns the decrypted data. MAY be NULL.
+    Returns the decrypted data. Optional parameter.
 
 [common tss2 options](common/tss2-options.md)
 
 # EXAMPLE
-
+```
     tss2_decrypt --keyPath HS/SRK/myRSACrypt --cipherText encrypted.file --plainText abc
+```
 
 # RETURNS
 

--- a/man/tss2_decrypt.1.md
+++ b/man/tss2_decrypt.1.md
@@ -19,11 +19,11 @@
 
 These are the available options:
 
-  * **-p**, **\--keyPath**:
+  * **-p**, **\--keyPath** _STRING_:
 
     Identifies the decryption key.
 
-  * **-i**, **\--cipherText**: \<filename\>
+  * **-i**, **\--cipherText** _FILENAME_ or _-_ (for stdin):
 
     The JSON-encoded cipherText.
 
@@ -31,7 +31,7 @@ These are the available options:
 
     Force Overwriting the output file.
 
-  * **-o**, **\--plainText**: \<filename\>
+  * **-o**, **\--plainText** _FILENAME_ or _-_ (for stdout):
 
     Returns the decrypted data. Optional parameter.
 
@@ -39,7 +39,7 @@ These are the available options:
 
 # EXAMPLE
 ```
-    tss2_decrypt --keyPath HS/SRK/myRSACrypt --cipherText encrypted.file --plainText abc
+    tss2_decrypt --keyPath HS/SRK/myRSACrypt --cipherText cipherText.file --plainText plainText.file
 ```
 
 # RETURNS

--- a/man/tss2_delete.1.md
+++ b/man/tss2_delete.1.md
@@ -4,16 +4,17 @@
 
 # NAME
 
-**tss2_delete**(1) - This command deletes the given key, policy or NV from the system. Depending on the entity type, one of the following
-actions SHALL be taken:
-
-    * Non-persistent key: Flush from TPM (if loaded) and delete blobs public and private blobs from keystore.
-    * Persistent keys: Evict from TPM and delete public and private blobs from keystore
-    * Primary keys: Flush from TPM and delete public blobs from keystore
-    * NV index: Undefine NV index from TPM and delete public blob from metadata store
-    * Policies: Delete entry from policy store
-    * Hierarchy, PCR: Return TSS2_FAPI_RC_NOT_DELETABLE
-    * Special keys EK, SRK: Return TSS2_FAPI_RC_NOT_DELETABLE
+**tss2_delete**(1) - This command deletes the given key, policy or NV from the
+FAPI keystore and the TPM. Depending on the entity type, one of the following
+actions are taken:
+
+    - Non-persistent key: Flush from TPM (if loaded) and delete public and private blobs from keystore.
+    - Persistent keys: Evict from TPM and delete public and private blobs from keystore
+    - Primary keys: Flush from TPM and delete public blob from keystore
+    - NV index: Undefine NV index from TPM and delete public blob from metadata store
+    - Policies: Delete entry from policy store
+    - Hierarchy, PCR: These are not deletable
+    - Special keys ek, srk: These are not deletable
 
 # SYNOPSIS
 
@@ -29,7 +30,7 @@ These are the available options:
 
   * **-p**, **\--path**:
 
-    The path to the entity to delete. MUST NOT be NULL.
+    The path to the entity to delete.
 
 [common tss2 options](common/tss2-options.md)
 

--- a/man/tss2_delete.1.md
+++ b/man/tss2_delete.1.md
@@ -28,7 +28,7 @@ actions are taken:
 
 These are the available options:
 
-  * **-p**, **\--path**:
+  * **-p**, **\--path** _STRING_:
 
     The path to the entity to delete.
 

--- a/man/tss2_encrypt.1.md
+++ b/man/tss2_encrypt.1.md
@@ -21,7 +21,7 @@ These are the available options:
 
   * **-p**, **\--keyPath**:
 
-    Identifies the encryption key. MUST NOT be NULL.
+    Identifies the encryption key.
 
   * **-f**, **\--force**:
 
@@ -29,17 +29,18 @@ These are the available options:
 
   * **-i**, **\--plainText**:
 
-    The data to be encrypted. MUST NOT be NULL.
+    The data to be encrypted.
 
   * **-o**, **\--cipherText**:
 
-    Returns the JSON-encoded ciphertext. MUST NOT be NULL.
+    Returns the JSON-encoded ciphertext.
 
 [common tss2 options](common/tss2-options.md)
 
 # EXAMPLE
-
+```
   tss2_encrypt --keyPath HS/SRK/myRSACrypt --plainText plaintext.file --cipherText encrypted.file
+```
 
 # RETURNS
 

--- a/man/tss2_encrypt.1.md
+++ b/man/tss2_encrypt.1.md
@@ -12,16 +12,8 @@
 
 # DESCRIPTION
 
-**tss2_encrypt**(1) - This command encrypts the provided data for a target key.
-
-If keypath is an asymmetric key and a plaintext with size >= TPM2_MAX_SYM_SIZE is provided, Fapi_Encrypt() will bulk-encrypt the plaintext with an intermediate symmetric key and then “seal” this intermediate symmetric key with keyPath as a KEYEDHASH TPM object. This keyPath may refer to the local TPM or to a public key of a remote TPM where the KEYEDHASH can be imported. The decrypt operation performs a TPM2_Unseal. ciphertext output contains a reference to the decryption key, the sealed symmetric key (if any), the policy instance, and the encrypted plaintext.
-
-If plaintext has a size <= TPM2_MAX_SYM_SIZE the plaintext is sealed directly for keyPath.
-
-If encrypting for the local TPM (if keyPath is not from the external hierarchy), a storage key (symmetric or asymmetric) is required as keyPath (aka parent key) and the data intermediate symmetric key is created using TPM2_Create() as a KEYEDHASH object.
-
-If encrypting for a remote TPM, an asymmetric storage key is required as keyPath (aka parent key), and the data/intermediate symmetric key is encrypted such that it can be used in a TPM2_Import operation. The format of the cipherText is described in the FAPI specification.
-
+**tss2_encrypt**(1) - This command encrypts the provided data for a target key
+using the TPM encryption schemes as specified in the crypto profile.
 
 # OPTIONS
 
@@ -34,10 +26,6 @@ These are the available options:
   * **-f**, **\--force**:
 
     Force overwriting the output file.
-
-  * **-P**, **\--policyPath**:
-
-    Identifies the policy to be associated with the sealed data. MAY be NULL. If NULL then the sealed data will have no policy.
 
   * **-i**, **\--plainText**:
 

--- a/man/tss2_encrypt.1.md
+++ b/man/tss2_encrypt.1.md
@@ -19,7 +19,7 @@ using the TPM encryption schemes as specified in the crypto profile.
 
 These are the available options:
 
-  * **-p**, **\--keyPath**:
+  * **-p**, **\--keyPath** _STRING_:
 
     Identifies the encryption key.
 
@@ -27,11 +27,11 @@ These are the available options:
 
     Force overwriting the output file.
 
-  * **-i**, **\--plainText**:
+  * **-i**, **\--plainText** _FILENAME_ or _-_ (for stdin):
 
     The data to be encrypted.
 
-  * **-o**, **\--cipherText**:
+  * **-o**, **\--cipherText** _FILENAME_ or _-_ (for stdout):
 
     Returns the JSON-encoded ciphertext.
 
@@ -39,7 +39,7 @@ These are the available options:
 
 # EXAMPLE
 ```
-  tss2_encrypt --keyPath HS/SRK/myRSACrypt --plainText plaintext.file --cipherText encrypted.file
+  tss2_encrypt --keyPath HS/SRK/myRSACrypt --plainText plainText.file --cipherText cipherText.file
 ```
 
 # RETURNS

--- a/man/tss2_exportkey.1.md
+++ b/man/tss2_exportkey.1.md
@@ -19,7 +19,7 @@ exported data will contain the re-wrapped key pointed to by the pathOfKeyToDupli
 
 These are the available options:
 
-  * **-e** **\--pathToPublicKeyOfNewParent**:
+  * **-e** **\--pathToPublicKeyOfNewParent** _STRING_:
 
     The path to the public key of the new parent. This key MAY be in the public key hierarchy /ext.
     Optional parameter. If omitted only the public key will exported.
@@ -28,11 +28,11 @@ These are the available options:
 
     Force overwriting the output file.
 
-  * **-o**, **\--exportedData**:
+  * **-o**, **\--exportedData** _FILENAME_ or _-_ (for stdout):
 
     Returns the exported subtree.
 
-  * **-p**, **\--pathOfKeyToDuplicate**:
+  * **-p**, **\--pathOfKeyToDuplicate** _STRING_:
 
     The path to the root of the subtree to export.
 
@@ -40,7 +40,7 @@ These are the available options:
 
 # EXAMPLE
 ```
-tss2_exportkey --pathOfKeyToDuplicate HS/SRK/myRSADecrypt --exportedData exportedPublicKey
+tss2_exportkey --pathOfKeyToDuplicate HS/SRK/myRSADecrypt --exportedData exportedData.file
 ```
 
 # RETURNS

--- a/man/tss2_exportkey.1.md
+++ b/man/tss2_exportkey.1.md
@@ -12,7 +12,8 @@
 
 # DESCRIPTION
 
-**tss2_exportkey**(1) - This command will duplicate a key and encrypt it using the public key of a new parent. The exported data will contain the re-wrapped key pointed to by the pathOfKeyToDuplicate and then the JSON encoded policy. The exported data SHALL be encoded as described in the FAPI specification.
+**tss2_exportkey**(1) - This command will duplicate a key and encrypt it using the public key of a new parent. The
+exported data will contain the re-wrapped key pointed to by the pathOfKeyToDuplicate and then the JSON encoded policy.
 
 # OPTIONS
 
@@ -20,7 +21,8 @@ These are the available options:
 
   * **-e** **\--pathToPublicKeyOfNewParent**:
 
-    The path to the public key of the new parent. This key MAY be in the public key hierarchy /ext. If NULL only the public key will exported.
+    The path to the public key of the new parent. This key MAY be in the public key hierarchy /ext.
+    Optional parameter. If omitted only the public key will exported.
 
   * **-f**, **\--force**:
 
@@ -28,17 +30,18 @@ These are the available options:
 
   * **-o**, **\--exportedData**:
 
-    Returns the exported subtree. MUST NOT be NULL.
+    Returns the exported subtree.
 
   * **-p**, **\--pathOfKeyToDuplicate**:
 
-    The path to the root of the subtree to export. MUST NOT be NULL.
+    The path to the root of the subtree to export.
 
 [common tss2 options](common/tss2-options.md)
 
 # EXAMPLE
-
+```
 tss2_exportkey --pathOfKeyToDuplicate HS/SRK/myRSADecrypt --exportedData exportedPublicKey
+```
 
 # RETURNS
 

--- a/man/tss2_exportpolicy.1.md
+++ b/man/tss2_exportpolicy.1.md
@@ -13,7 +13,7 @@
 # DESCRIPTION
 
 **tss2_policyexport**(1) - This commands exports a policy associated with a key
-in JSON encoding. The exported policy SHALL be encoded according to TCG TSS 2.0 JSON Policy Language Specification.
+in JSON encoding.
 
 # OPTIONS
 
@@ -25,17 +25,18 @@ These are the available options:
 
   * **-o**, **\--jsonPolicy**:
 
-    Returns the JSON-encoded policy. MUST NOT be NULL.
+    Returns the JSON-encoded policy.
 
   * **-p**, **\--path**:
 
-    The path of the key. MUST NOT be NULL.
+    The path of the key.
 
 [common tss2 options](common/tss2-options.md)
 
 # EXAMPLE
-
+```
 tss2_exportpolicy --path HS/SRK/myRSASign --jsonPolicy pcr-policy.json
+```
 
 # RETURNS
 

--- a/man/tss2_exportpolicy.1.md
+++ b/man/tss2_exportpolicy.1.md
@@ -23,11 +23,11 @@ These are the available options:
 
     Force overwriting the output file.
 
-  * **-o**, **\--jsonPolicy**:
+  * **-o**, **\--jsonPolicy** _FILENAME_ or _-_ (for stdout):
 
     Returns the JSON-encoded policy.
 
-  * **-p**, **\--path**:
+  * **-p**, **\--path** _STRING_:
 
     The path of the key.
 
@@ -35,7 +35,7 @@ These are the available options:
 
 # EXAMPLE
 ```
-tss2_exportpolicy --path HS/SRK/myRSASign --jsonPolicy pcr-policy.json
+tss2_exportpolicy --path HS/SRK/myRSASign --jsonPolicy jsonPolicy.json
 ```
 
 # RETURNS

--- a/man/tss2_getappdata.1.md
+++ b/man/tss2_getappdata.1.md
@@ -12,7 +12,7 @@
 
 # DESCRIPTION
 
-**tss2_getappdata**(1) - This command returns the previously stored application data for an object. If no application data is present, then appDataSize SHALL be 0.
+**tss2_getappdata**(1) - This command returns the previously stored application data for an object.
 
 # OPTIONS
 
@@ -20,16 +20,15 @@ These are the available options:
 
   * **-p**, **\--path**:
 
-    Path of the object for which the appData will be loaded. MUST NOT be NULL.
+    Path of the object for which the appData will be loaded.
 
   * **-o**, **\--appData**:
 
-    Returns a copy of the stored data. MAY be NULL.
+    Returns a copy of the stored data. Optional parameter.
 
 [common tss2 options](common/tss2-options.md)
 
 # EXAMPLE
-
 ```
 tss2_getappdata --path HS/SRK/myRSACrypt --appData appData
 ```

--- a/man/tss2_getappdata.1.md
+++ b/man/tss2_getappdata.1.md
@@ -18,11 +18,11 @@
 
 These are the available options:
 
-  * **-p**, **\--path**:
+  * **-p**, **\--path** _STRING_:
 
     Path of the object for which the appData will be loaded.
 
-  * **-o**, **\--appData**:
+  * **-o**, **\--appData** _FILENAME_ or _-_ (for stdout):
 
     Returns a copy of the stored data. Optional parameter.
 
@@ -30,7 +30,7 @@ These are the available options:
 
 # EXAMPLE
 ```
-tss2_getappdata --path HS/SRK/myRSACrypt --appData appData
+tss2_getappdata --path HS/SRK/myRSACrypt --appData appData.file
 ```
 
 # RETURNS

--- a/man/tss2_getcertificate.1.md
+++ b/man/tss2_getcertificate.1.md
@@ -22,11 +22,11 @@ These are the available options:
 
     Force overwriting the output file.
 
-  * **-p**, **\--path**:
+  * **-p**, **\--path** _STRING_:
 
     The entity whose certificate is requested.
 
-  * **-o**, **\--x509certData**:
+  * **-o**, **\--x509certData** _FILENAME_ or _-_ (for stdout):
 
     Returns the PEM encoded certificate. If no certificate is stored, then an empty string is returned.
 
@@ -34,7 +34,7 @@ These are the available options:
 
 # EXAMPLE
 ```
-tss2_getcertificate --path HS/SRK/myRSACrypt --x509certData myRSACrypt.cert
+tss2_getcertificate --path HS/SRK/myRSACrypt --x509certData x509certData.file
 ```
 
 # RETURNS

--- a/man/tss2_getcertificate.1.md
+++ b/man/tss2_getcertificate.1.md
@@ -24,17 +24,18 @@ These are the available options:
 
   * **-p**, **\--path**:
 
-    The entity whose certificate is requested. MUST NOT be NULL.
+    The entity whose certificate is requested.
 
   * **-o**, **\--x509certData**:
 
-    Returns the PEM encoded certificate. MUST NOT be NULL. If no certificate is stored, then an empty string is returned.
+    Returns the PEM encoded certificate. If no certificate is stored, then an empty string is returned.
 
 [common tss2 options](common/tss2-options.md)
 
 # EXAMPLE
-
+```
 tss2_getcertificate --path HS/SRK/myRSACrypt --x509certData myRSACrypt.cert
+```
 
 # RETURNS
 

--- a/man/tss2_getdescription.1.md
+++ b/man/tss2_getdescription.1.md
@@ -23,11 +23,11 @@ These are the available options:
 
     Force overwriting the output file.
 
-  * **-p**, **\--path**:
+  * **-p**, **\--path** _STRING_:
 
     The path of the object for which the description will be loaded.
 
-  * **-o**, **\--description**:
+  * **-o**, **\--description** _FILENAME_ or _-_ (for stdout):
 
     Returns the stored description.
 

--- a/man/tss2_getdescription.1.md
+++ b/man/tss2_getdescription.1.md
@@ -12,7 +12,8 @@
 
 # DESCRIPTION
 
-**tss2_getdescription**(1) - This command returns the previously stored application data for an object. If no description is present, description SHALL be set to an empty string.
+**tss2_getdescription**(1) - This command returns the previously stored application data for an object. If no
+description is present, an empty string is returned.
 
 # OPTIONS
 
@@ -24,16 +25,15 @@ These are the available options:
 
   * **-p**, **\--path**:
 
-    The path of the object for which the appData will be loaded. MUST NOT be NULL.
+    The path of the object for which the description will be loaded.
 
   * **-o**, **\--description**:
 
-    Returns the stored description. MUST NOT be NULL.
+    Returns the stored description.
 
 [common tss2 options](common/tss2-options.md)
 
 # EXAMPLE
-
 ```
 tss2_getdescription --path HS/SRK --description description.file
 ```

--- a/man/tss2_getinfo.1.md
+++ b/man/tss2_getinfo.1.md
@@ -22,7 +22,7 @@ These are the available options:
 
     Force overwriting the output file.
 
-  * **-o**, **\--info**:
+  * **-o**, **\--info** _FILENAME_ or _-_ (for stdout):
 
     Returns the FAPI and TPM information.
 
@@ -31,7 +31,7 @@ These are the available options:
 
 # EXAMPLE
 ```
-tss2_getinfo --info data.info
+tss2_getinfo --info info.file
 ```
 
 # RETURNS

--- a/man/tss2_getinfo.1.md
+++ b/man/tss2_getinfo.1.md
@@ -12,7 +12,7 @@
 
 # DESCRIPTION
 
-**tss2_getinfo**(1) - This command returns a UTF-8 string identifying the version of the FAPI, the TPM, configurations and other relevant information in a human readable format. The concrete content of this string is implementation specific.
+**tss2_getinfo**(1) - This command returns a UTF-8 string identifying the version of the FAPI, the TPM, configurations and other relevant information in a human readable format.
 
 # OPTIONS
 
@@ -24,14 +24,15 @@ These are the available options:
 
   * **-o**, **\--info**:
 
-    Returns the FAPI and TPM information. MUST NOT be NULL.
+    Returns the FAPI and TPM information.
 
 
 [common tss2 options](common/tss2-options.md)
 
 # EXAMPLE
-
+```
 tss2_getinfo --info data.info
+```
 
 # RETURNS
 

--- a/man/tss2_getplatformcertificates.1.md
+++ b/man/tss2_getplatformcertificates.1.md
@@ -22,7 +22,7 @@ These are the available options:
 
     Force overwriting the output file.
 
-  * **-o**, **\--certificates**:
+  * **-o**, **\--certificates** _FILENAME_ or _-_ (for stdout):
 
     Returns a continuous buffer containing the concatenated platform certificates.
 
@@ -30,7 +30,7 @@ These are the available options:
 
 # EXAMPLE
 ```
-tss2_getplatformcertificates --certificates platform.certs
+tss2_getplatformcertificates --certificates certificates.file
 ```
 
 # RETURNS

--- a/man/tss2_getplatformcertificates.1.md
+++ b/man/tss2_getplatformcertificates.1.md
@@ -24,13 +24,14 @@ These are the available options:
 
   * **-o**, **\--certificates**:
 
-    Returns a continuous buffer containing the concatenated platform certificates. MUST NOT be NULL.
+    Returns a continuous buffer containing the concatenated platform certificates.
 
 [common tss2 options](common/tss2-options.md)
 
 # EXAMPLE
-
+```
 tss2_getplatformcertificates --certificates platform.certs
+```
 
 # RETURNS
 

--- a/man/tss2_getrandom.1.md
+++ b/man/tss2_getrandom.1.md
@@ -11,8 +11,7 @@
 
 # DESCRIPTION
 
-**tss2_getrandom**(1) - This command uses the TPM to create an array of random bytes. This function may perform multiple calls to the TPM if the number of bytes requested by the caller is larger than the maximum number of bytes that the TPM will return per call.
-
+**tss2_getrandom**(1) - This command uses the TPM to create an array of random bytes.
 
 # OPTIONS
 
@@ -20,7 +19,7 @@ These are the available options:
 
   * **-n**, **\--numBytes**: \<number\>
 
-    The number of bytes requested by the caller
+    The number of bytes requested by the caller.
 
   * **-f**, **\--force**:
 
@@ -28,13 +27,14 @@ These are the available options:
 
   * **-o**, **\--data**: \<filename\>
 
-    The returned random bytes. MUST NOT be NULL.
+    The returned random bytes.
 
 [common tss2 options](common/tss2-options.md)
 
 # EXAMPLE
-
+```
     tss2_getrandom --numBytes 20 -data - | hexdump -C
+```
 
 # RETURNS
 

--- a/man/tss2_getrandom.1.md
+++ b/man/tss2_getrandom.1.md
@@ -17,7 +17,7 @@
 
 These are the available options:
 
-  * **-n**, **\--numBytes**: \<number\>
+  * **-n**, **\--numBytes** _INTEGER_:
 
     The number of bytes requested by the caller.
 
@@ -25,7 +25,7 @@ These are the available options:
 
     Force overwriting the output file.
 
-  * **-o**, **\--data**: \<filename\>
+  * **-o**, **\--data** _FILENAME_ or _-_ (for stdout):
 
     The returned random bytes.
 

--- a/man/tss2_gettpmblobs.1.md
+++ b/man/tss2_gettpmblobs.1.md
@@ -22,19 +22,19 @@ These are the available options:
 
     Force overwriting the output file.
 
-  * **-p**, **\--path**:
+  * **-p**, **\--path** _STRING_:
 
     The path of the object for which the blobs will be returned.
 
-  * **-u**, **\--tpm2bPublic**:
+  * **-u**, **\--tpm2bPublic** _FILENAME_ or _-_ (for stdout):
 
     The returned public area of the object as a marshalled TPM2B_PUBLIC. Optional parameter.
 
-  * **-r**, **\--tpm2bPrivate**:
+  * **-r**, **\--tpm2bPrivate** _FILENAME_ or _-_ (for stdout):
 
     The returned private area of the object as a marshalled TPM2B_PRIVATE. Optional parameter.
 
-  * **-l**, **\--policy**:
+  * **-l**, **\--policy** _FILENAME_ or _-_ (for stdout):
 
     The returned policy associated with the object, encoded in JSON. Optional parameter.
 
@@ -42,7 +42,7 @@ These are the available options:
 
 # EXAMPLE
 ```
-tss2_gettpmblobs --path HS/SRK/myRSACrypt --tpm2bPublic public.file --tpm2bPrivate private.file --policy policy.file
+tss2_gettpmblobs --path HS/SRK/myRSACrypt --tpm2bPublic tpm2bPublic.file --tpm2bPrivate tpm2bPrivate.file --policy policy.file
 ```
 
 # RETURNS

--- a/man/tss2_gettpmblobs.1.md
+++ b/man/tss2_gettpmblobs.1.md
@@ -24,25 +24,26 @@ These are the available options:
 
   * **-p**, **\--path**:
 
-    The path of the object for which the blobs will be returned. MUST NOT be NULL.
+    The path of the object for which the blobs will be returned.
 
   * **-u**, **\--tpm2bPublic**:
 
-    The returned public area of the object as a marshalled TPM2B_PUBLIC. MAY be NULL.
+    The returned public area of the object as a marshalled TPM2B_PUBLIC. Optional parameter.
 
   * **-r**, **\--tpm2bPrivate**:
 
-    The returned private area of the object as a marshalled TPM2B_PRIVATE. MAY be NULL.
+    The returned private area of the object as a marshalled TPM2B_PRIVATE. Optional parameter.
 
   * **-l**, **\--policy**:
 
-    The returned policy associated with the object, encoded in JSON. policy MAY be NULL.
+    The returned policy associated with the object, encoded in JSON. Optional parameter.
 
 [common tss2 options](common/tss2-options.md)
 
 # EXAMPLE
-
+```
 tss2_gettpmblobs --path HS/SRK/myRSACrypt --tpm2bPublic public.file --tpm2bPrivate private.file --policy policy.file
+```
 
 # RETURNS
 

--- a/man/tss2_import.1.md
+++ b/man/tss2_import.1.md
@@ -12,7 +12,9 @@
 
 # DESCRIPTION
 
-**tss2_import**(1) - This command imports a JSON encoded policy or policy template encoded according to TCG TSS 2.0 JSON Policy Language Specification and stores it under the provided path or it imports a JSON encoded key under the provided path.
+**tss2_import**(1) - This command imports a JSON encoded policy or policy
+template and stores it under the provided path or it imports a JSON encoded key
+under the provided path.
 
 # OPTIONS
 
@@ -20,20 +22,21 @@ These are the available options:
 
   * **-p**, **\--path**:
 
-    The path of the new object. MUST NOT be NULL.
+    The path of the new object.
 
   * **-i**, **\--importData**:
 
-    The data to be imported. MUST NOT be NULL.
+    The data to be imported.
 
 [common tss2 options](common/tss2-options.md)
 
 # EXAMPLE
-
+```
 tss2_import --path duplicate_policy --importData pol_duplicate.json
-
+```
+```
 tss2_import --path importedPubKey --importData public_key.file
-
+```
 
 # RETURNS
 

--- a/man/tss2_import.1.md
+++ b/man/tss2_import.1.md
@@ -20,11 +20,11 @@ under the provided path.
 
 These are the available options:
 
-  * **-p**, **\--path**:
+  * **-p**, **\--path** _STRING_:
 
     The path of the new object.
 
-  * **-i**, **\--importData**:
+  * **-i**, **\--importData** _FILENAME_ or _-_ (for stdin):
 
     The data to be imported.
 
@@ -32,10 +32,10 @@ These are the available options:
 
 # EXAMPLE
 ```
-tss2_import --path duplicate_policy --importData pol_duplicate.json
+tss2_import --path /policy/duplicate-policy --importData importData.json
 ```
 ```
-tss2_import --path importedPubKey --importData public_key.file
+tss2_import --path /ext/key --importData importData.file
 ```
 
 # RETURNS

--- a/man/tss2_list.1.md
+++ b/man/tss2_list.1.md
@@ -12,7 +12,7 @@
 
 # DESCRIPTION
 
-**tss2_list**(1) - This command enumerates all objects in the metadata store in a given a path. The returned list SHALL consist of complete paths from the root (not relative paths from the search path), such that they can be directly used in another query. The values in this list SHALL be colon-separated.
+**tss2_list**(1) - This command enumerates all objects in the metadata store in a given a path.
 
 # OPTIONS
 
@@ -20,21 +20,23 @@ These are the available options:
 
   * **-p**, **\--searchPath**:
 
-    The path identifying the root of the search. MUST NOT be NULL.
+    The path identifying the root of the search. Optional parameter. If omitted,
+    all entities will be searched.
 
   * **-o**, **\--pathList**:
 
-    Returns the colon-separated list of paths. MUST NOT be NULL.
+    Returns the colon-separated list of paths. Optional parameter. If omitted,
+    results will be printed to _STDOUT_.
 
 [common tss2 options](common/tss2-options.md)
 
 # EXAMPLES
 
-## List all entities
+## List all entities and print results to stdout
 ```
 tss2_list
 ```
-## List all entities under the HS path
+## List all entities under the HS path and print results to file
 ```
 tss2_list --searchPath HS --pathList output.file
 ```

--- a/man/tss2_list.1.md
+++ b/man/tss2_list.1.md
@@ -18,12 +18,12 @@
 
 These are the available options:
 
-  * **-p**, **\--searchPath**:
+  * **-p**, **\--searchPath** _STRING_:
 
     The path identifying the root of the search. Optional parameter. If omitted,
     all entities will be searched.
 
-  * **-o**, **\--pathList**:
+  * **-o**, **\--pathList** _FILENAME_ or _-_ (for stdout):
 
     Returns the colon-separated list of paths. Optional parameter. If omitted,
     results will be printed to _STDOUT_.

--- a/man/tss2_nvextend.1.md
+++ b/man/tss2_nvextend.1.md
@@ -19,15 +19,15 @@
 
 These are the available options:
 
-  * **-i**, **\--data**:
+  * **-i**, **\--data** _FILENAME_ or _-_ (for stdin):
 
     The data to be extended into the NV space.
 
-  * **-p**, **\--nvPath**:
+  * **-p**, **\--nvPath** _STRING_:
 
     Identifies the NV space to write.
 
-  * **-l**, **\--logData**:
+  * **-l**, **\--logData** _FILENAME_ or _-_ (for stdin):
 
     A JSON representation of data to be written to the PCR's event log. Optional parameter.
 
@@ -35,7 +35,7 @@ These are the available options:
 
 # EXAMPLE
 ```
-tss2_nvextend --nvPath /nv/Owner/NvExtend --data nv_write_data.file --logData log.data
+tss2_nvextend --nvPath /nv/Owner/NvExtend --data data.file --logData logData.file
 ```
 
 # RETURNS

--- a/man/tss2_nvextend.1.md
+++ b/man/tss2_nvextend.1.md
@@ -12,7 +12,8 @@
 
 # DESCRIPTION
 
-**tss2_nvextend**(1) - This command performs an extend options on an NV index of type extend (i.e. an NV index that behaves similar to a PCR).
+**tss2_nvextend**(1) - This command performs an extend operation on an NV index
+(i.e. an NV index that behaves similar to a PCR).
 
 # OPTIONS
 
@@ -20,21 +21,22 @@ These are the available options:
 
   * **-i**, **\--data**:
 
-    The data to be extended into the NV space. MUST NOT be NULL.
+    The data to be extended into the NV space.
 
   * **-p**, **\--nvPath**:
 
-    Identifies the NV space to write. MUST NOT be NULL.
+    Identifies the NV space to write.
 
   * **-l**, **\--logData**:
 
-    A JSON representation of data to be written to the PCR’s event log. MAY be NULL.
+    A JSON representation of data to be written to the PCR's event log. Optional parameter.
 
 [common tss2 options](common/tss2-options.md)
 
 # EXAMPLE
-
+```
 tss2_nvextend --nvPath /nv/Owner/NvExtend --data nv_write_data.file --logData log.data
+```
 
 # RETURNS
 

--- a/man/tss2_nvincrement.1.md
+++ b/man/tss2_nvincrement.1.md
@@ -20,13 +20,14 @@ These are the availabe options:
 
   * **-p**, **\--nvPath**:
 
-    Identifies the NV space to increment. MUST NOT be NULL.
+    Identifies the NV space to increment.
 
 [common tss2 options](common/tss2-options.md)
 
 # EXAMPLE
-
+```
 tss2_nvincrement --nvPath /nv/Owner/myNVcounter
+```
 
 # RETURNS
 

--- a/man/tss2_nvincrement.1.md
+++ b/man/tss2_nvincrement.1.md
@@ -18,7 +18,7 @@
 
 These are the availabe options:
 
-  * **-p**, **\--nvPath**:
+  * **-p**, **\--nvPath** _STRING_:
 
     Identifies the NV space to increment.
 

--- a/man/tss2_nvread.1.md
+++ b/man/tss2_nvread.1.md
@@ -12,7 +12,7 @@
 
 # DESCRIPTION
 
-**tss2_nvread**(1) - This command reads the entire data from an NV index of the TPM. The FAPI will automatically perform multiple read operations with the TPM if the NV index is larger than the TPM's TPM2_MAX_NV_BUFFER_SIZE.
+**tss2_nvread**(1) - This command reads the entire data from an NV index of the TPM.
 
 # OPTIONS
 
@@ -24,22 +24,22 @@ These are the availabe options:
 
   * **-o**, **\--data**:
 
-    Returns the value read from the NV space. MUST NOT be NULL.
+    Returns the value read from the NV space.
 
   * **-p**, **\--nvPath**:
 
-    Identifies the NV space to read. MUST NOT be NULL.
+    Identifies the NV space to read.
 
   * **-l**, **\--logData**:
 
-    Returns the JSON encoded log, if the NV index is of type “extend” and an empty string otherwise. MAY be NULL.
+    Returns the JSON encoded log, if the NV index is of type "extend" and an empty string otherwise. Optional parameter.
 
 [common tss2 options](common/tss2-options.md)
 
 # EXAMPLE
-
+```
 tss2_nvread --nvPath /nv/Owner/myNVwrite --data nv_read_data.file
-
+```
 
 # RETURNS
 

--- a/man/tss2_nvread.1.md
+++ b/man/tss2_nvread.1.md
@@ -22,15 +22,15 @@ These are the availabe options:
 
     Force overwriting the output file.
 
-  * **-o**, **\--data**:
+  * **-o**, **\--data** _FILENAME_ or _-_ (for stdout):
 
     Returns the value read from the NV space.
 
-  * **-p**, **\--nvPath**:
+  * **-p**, **\--nvPath** _STRING_:
 
     Identifies the NV space to read.
 
-  * **-l**, **\--logData**:
+  * **-l**, **\--logData** _FILENAME_ or _-_ (for stdout):
 
     Returns the JSON encoded log, if the NV index is of type "extend" and an empty string otherwise. Optional parameter.
 
@@ -38,7 +38,7 @@ These are the availabe options:
 
 # EXAMPLE
 ```
-tss2_nvread --nvPath /nv/Owner/myNVwrite --data nv_read_data.file
+tss2_nvread --nvPath /nv/Owner/myNV --data data.file
 ```
 
 # RETURNS

--- a/man/tss2_nvsetbits.1.md
+++ b/man/tss2_nvsetbits.1.md
@@ -24,13 +24,14 @@ These are the availabe options:
 
   * **-p**, **\--nvPath**:
 
-    Identifies the NV space to write. MUST NOT be NULL.
+    Identifies the NV space to write.
 
 [common tss2 options](common/tss2-options.md)
 
 # EXAMPLE
-
+```
 tss2_nvsetbits --nvPath /nv/Owner/NvBitmap --bitmap 0x0102030405060608
+```
 
 # RETURNS
 

--- a/man/tss2_nvsetbits.1.md
+++ b/man/tss2_nvsetbits.1.md
@@ -18,11 +18,11 @@
 
 These are the availabe options:
 
-  * **-i**, **\--bitmap**:
+  * **-i**, **\--bitmap** _BITS_:
 
     A mask indicating which bits to set in the NV space.
 
-  * **-p**, **\--nvPath**:
+  * **-p**, **\--nvPath** _STRING_:
 
     Identifies the NV space to write.
 

--- a/man/tss2_nvwrite.1.md
+++ b/man/tss2_nvwrite.1.md
@@ -18,11 +18,11 @@
 
 These are the available options:
 
-  * **-i**, **\--data**:
+  * **-i**, **\--data** _FILENAME_ or _-_ (for stdin):
 
     The data to write to the NV space.
 
-  * **-p**, **\--nvPath**:
+  * **-p**, **\--nvPath** _STRING_:
 
     Identifies the NV space to write to.
 

--- a/man/tss2_nvwrite.1.md
+++ b/man/tss2_nvwrite.1.md
@@ -12,7 +12,7 @@
 
 # DESCRIPTION
 
-**tss2_nvwrite**(1) - This command writes data to a “regular” (not pin, extend or counter) NV index. Only the full index can be written, partial writes are not allowed. If the provided data is smaller than the NV index’s size, then it is padded up with zero bytes at the end. The FAPI will automatically perform multiple write operations with the TPM if the input buffer is larger than the TPM's TPM2_MAX_NV_BUFFER_SIZE.
+**tss2_nvwrite**(1) - This command writes data to a "regular" (not pin, extend or counter) NV index. Only the full index can be written, partial writes are not allowed. If the provided data is smaller than the NV index's size, then it is padded up with zero bytes at the end.
 
 # OPTIONS
 
@@ -20,17 +20,18 @@ These are the available options:
 
   * **-i**, **\--data**:
 
-    The data to write to the NV space. MUST NOT be NULL.
+    The data to write to the NV space.
 
   * **-p**, **\--nvPath**:
 
-    Identifies the NV space to write to. MUST NOT be NULL.
+    Identifies the NV space to write to.
 
 [common tss2 options](common/tss2-options.md)
 
 # EXAMPLE
-
+```
 tss2_nvwrite --nvPath /nv/Owner/myNV --data data.file
+```
 
 # RETURNS
 

--- a/man/tss2_pcrextend.1.md
+++ b/man/tss2_pcrextend.1.md
@@ -12,8 +12,7 @@
 
 # DESCRIPTION
 
-**tss2_pcrextend**(1) - This command extends the data into the PCR listed. The parameter logData is extended into the PCR log. If the logData is NULL, only the PCR extend takes place. All PCRs currently active in the TPM are extended, see
-TPM2_PCR_Event.
+**tss2_pcrextend**(1) - This command extends the data into the PCR listed. The parameter logData is extended into the PCR log. If the logData is NULL, only the PCR extend takes place. All PCRs currently active in the TPM are extended.
 
 # OPTIONS
 
@@ -25,18 +24,19 @@ These are the available options:
 
   * **-i**, **\--data**:
 
-    The event data. Note that this data will be hashed using the respective PCR’s hash algorithm. See the TPM2_PCR_Event function of the TPM specification. MUST NOT be NULL.
+    The event data to be extended.
 
   * **-l**, **\--logData**:
 
-    Contains a JSON representation of data to be written to the PCR’s event log. MAY be NULL.
+    Contains a JSON representation of data to be written to the PCR's event log. Optional parameter.
 
 
 [common tss2 options](common/tss2-options.md)
 
 # EXAMPLE
-
+```
 tss2_pcrextend --pcr 16 --data pcr_event_data.file --logData pcr_log_write.file
+```
 
 # RETURNS
 

--- a/man/tss2_pcrextend.1.md
+++ b/man/tss2_pcrextend.1.md
@@ -18,15 +18,15 @@
 
 These are the available options:
 
-  * **-x**, **\--pcr**:
+  * **-x**, **\--pcr** _INTEGER_:
 
    The PCR to extend.
 
-  * **-i**, **\--data**:
+  * **-i**, **\--data** _FILENAME_ or _-_ (for stdin):
 
     The event data to be extended.
 
-  * **-l**, **\--logData**:
+  * **-l**, **\--logData** _FILENAME_ or _-_ (for stdin):
 
     Contains a JSON representation of data to be written to the PCR's event log. Optional parameter.
 
@@ -35,7 +35,7 @@ These are the available options:
 
 # EXAMPLE
 ```
-tss2_pcrextend --pcr 16 --data pcr_event_data.file --logData pcr_log_write.file
+tss2_pcrextend --pcr 16 --data data.file --logData logData.file
 ```
 
 # RETURNS

--- a/man/tss2_pcrread.1.md
+++ b/man/tss2_pcrread.1.md
@@ -20,7 +20,7 @@ These are the available options:
 
   * **-o**, **\--pcrValue**:
 
-    Returns PCR digest. MAY be NULL.
+    Returns PCR digest. Optional parameter.
 
   * **-x**, **\--pcrIndex**:
 
@@ -32,13 +32,24 @@ These are the available options:
 
   * **-l**, **\--pcrLog**:
 
-    Returns the PCR log for that PCR in the format defined in the FAPI specification. MAY be NULL.
+    Returns the PCR log for that PCR. Optional parameter.
+
+    PCR event logs are a list (arbitrary length JSON array) of log entries with
+    the following content.
+
+        - recnum: Unique record number
+        - pcr: PCR index
+        - digest: The digests
+        - type: The type of event. At the moment the only possible value is: "LINUX_IMA" (legacy IMA)
+        - eventDigest: Digest of the event; e.g. the digest of the measured file
+        - eventName: Name of the event; e.g. the name of the measured file.
 
 [common tss2 options](common/tss2-options.md)
 
 # EXAMPLE
-
+```
 tss2_pcrread --pcrIndex 16 --pcrValue pcr_digest.file --pcrLog pcr_log_read.file
+```
 
 # RETURNS
 

--- a/man/tss2_pcrread.1.md
+++ b/man/tss2_pcrread.1.md
@@ -18,11 +18,11 @@
 
 These are the available options:
 
-  * **-o**, **\--pcrValue**:
+  * **-o**, **\--pcrValue** _FILENAME_ or _-_ (for stdout):
 
     Returns PCR digest. Optional parameter.
 
-  * **-x**, **\--pcrIndex**:
+  * **-x**, **\--pcrIndex** _INTEGER_:
 
     Identifies the PCR to read.
 
@@ -30,7 +30,7 @@ These are the available options:
 
     Force overwriting the output files.
 
-  * **-l**, **\--pcrLog**:
+  * **-l**, **\--pcrLog** _FILENAME_ or _-_ (for stdout):
 
     Returns the PCR log for that PCR. Optional parameter.
 
@@ -48,7 +48,7 @@ These are the available options:
 
 # EXAMPLE
 ```
-tss2_pcrread --pcrIndex 16 --pcrValue pcr_digest.file --pcrLog pcr_log_read.file
+tss2_pcrread --pcrIndex 16 --pcrValue pcrValue.file --pcrLog pcrLog.file
 ```
 
 # RETURNS

--- a/man/tss2_provision.1.md
+++ b/man/tss2_provision.1.md
@@ -12,11 +12,11 @@
 
 # DESCRIPTION
 
-**tss2_provision**(1) - This command provisions a FAPI instance and its associated TPM. The steps taken SHALL be:
+**tss2_provision**(1) - This command provisions a FAPI instance and its associated TPM. The steps taken are:
 
-  * Retrieve the EK template, nonce and certificate, verify that they match the TPM’s EK and store them in the key store.
+  * Retrieve the EK template, nonce and certificate, verify that they match the TPM's EK and store them in the key store.
   * Set the authValues and policies for the Owner (Storage Hierarchy), the Privacy Administrator (Endorsement Hierarchy) and the lockout authority.
-  * Scan the TPM’s nv indices and create entries in the metadata store. This operation MAY use a heuristic to guess the originating programs for nv indices found and name the entries accordingly.
+  * Scan the TPM's nv indices and create entries in the metadata store. This operation MAY use a heuristic to guess the originating programs for nv indices found and name the entries accordingly.
   * Create the SRK (storage primary key) inside the TPM and make it persistent if required by the FAPI configuration and stored its metadata in the system-wide metadata store. Note that the SRK will not have an authorization value associated.
 
 If an authorization value is associated with the storage hierarchy, it is highly RECOMMENDED that the SRK
@@ -27,13 +27,14 @@ without authorization value is made persistent.
 These are the available options:
 
   * **-E**, **\--authValueEh**:
-    The authorization value for the privacy admin, i.e. the endorsement hierarchy. MAY be NULL.
+    The authorization value for the privacy admin, i.e. the endorsement hierarchy.
+    Optional parameter.
 
   * **-S**, **\--authValueSh**:
-    The authorization value for the owner, i.e. the storage hierarchy. SHOULD be NULL.
+    The authorization value for the owner, i.e. the storage hierarchy. Optional parameter.
 
   * **-L**, **\--authValueLockout**:
-    The authorization value for the lockout authorization. SHOULD NOT be NULL.
+    The authorization value for the lockout authorization. Optional parameter.
 
 [common tss2 options](common/tss2-options.md)
 

--- a/man/tss2_provision.1.md
+++ b/man/tss2_provision.1.md
@@ -26,14 +26,14 @@ without authorization value is made persistent.
 
 These are the available options:
 
-  * **-E**, **\--authValueEh**:
+  * **-E**, **\--authValueEh** _STRING_:
     The authorization value for the privacy admin, i.e. the endorsement hierarchy.
     Optional parameter.
 
-  * **-S**, **\--authValueSh**:
+  * **-S**, **\--authValueSh** _STRING_:
     The authorization value for the owner, i.e. the storage hierarchy. Optional parameter.
 
-  * **-L**, **\--authValueLockout**:
+  * **-L**, **\--authValueLockout** _STRING_:
     The authorization value for the lockout authorization. Optional parameter.
 
 [common tss2 options](common/tss2-options.md)

--- a/man/tss2_quote.1.md
+++ b/man/tss2_quote.1.md
@@ -18,15 +18,15 @@
 
 These are the available options:
 
-  * **-x**, **\--pcrList**:
+  * **-x**, **\--pcrList** _STRING_:
 
     An array holding the PCR indices to quote against.
 
-  * **-Q**, **\--qualifyingData**:
+  * **-Q**, **\--qualifyingData** _FILENAME_ or _-_ (for stdin):
 
     A nonce provided by the caller to ensure freshness of the signature. Optional parameter.
 
-  * **-l**, **\--pcrLog**:
+  * **-l**, **\--pcrLog** _FILENAME_ or _-_ (for stdout):
 
     Returns the PCR log for the chosen PCR. Optional parameter.
 
@@ -44,19 +44,19 @@ These are the available options:
 
     Force overwriting the output file.
 
-  * **-p**, **\--keyPath**:
+  * **-p**, **\--keyPath** _STRING_:
 
     Identifies the signing key.
 
-  * **-q**, **\--quoteInfo**:
+  * **-q**, **\--quoteInfo** _FILENAME_ or _-_ (for stdout):
 
     Returns a JSON-encoded structure holding the inputs to the quote operation. This includes the digest value and PCR values.
 
-  * **-o**, **\--signature**:
+  * **-o**, **\--signature** _FILENAME_ or _-_ (for stdout):
 
     Returns the signature over the quoted material.
 
-  * **-c**, **\--certificate**:
+  * **-c**, **\--certificate** _FILENAME_ or _-_ (for stdout):
 
     The certificate associated with keyPath in PEM format. Optional parameter.
 
@@ -64,7 +64,7 @@ These are the available options:
 
 # EXAMPLE
 ```
-tss2_quote --keyPath HS/SRK/quotekey --pcrList "16" --qualifyingData nonce.file --signature signature.file --pcrLog pcr.log --certificate certificate.file --quoteInfo quote.info
+tss2_quote --keyPath HS/SRK/quotekey --pcrList "10,16" --qualifyingData qualifyingData.file --signature signature.file --pcrLog pcrLog.file --certificate certificate.file --quoteInfo quoteInfo.info
 ```
 
 # RETURNS

--- a/man/tss2_quote.1.md
+++ b/man/tss2_quote.1.md
@@ -20,16 +20,25 @@ These are the available options:
 
   * **-x**, **\--pcrList**:
 
-    An array holding the PCR indices to quote against. MUST NOT be NULL.
+    An array holding the PCR indices to quote against.
 
   * **-Q**, **\--qualifyingData**:
 
-    A nonce provided by the caller to ensure freshness of the signature. MAY be
-    NULL.
+    A nonce provided by the caller to ensure freshness of the signature. Optional parameter.
 
   * **-l**, **\--pcrLog**:
 
-    Returns the PCR log for the chosen PCR in the format defined in the FAPI specification. MAY be NULL.
+    Returns the PCR log for the chosen PCR. Optional parameter.
+
+    PCR event logs are a list (arbitrary length JSON array) of log entries with
+    the following content.
+
+        - recnum: Unique record number
+        - pcr: PCR index
+        - digest: The digests
+        - type: The type of event. At the moment the only possible value is: "LINUX_IMA" (legacy IMA)
+        - eventDigest: Digest of the event; e.g. the digest of the measured file
+        - eventName: Name of the event; e.g. the name of the measured file.
 
   * **-f**, **\--force**:
 
@@ -37,25 +46,26 @@ These are the available options:
 
   * **-p**, **\--keyPath**:
 
-    Identifies the signing key. MUST NOT be NULL.
+    Identifies the signing key.
 
   * **-q**, **\--quoteInfo**:
 
-    Returns a JSON-encoded structure holding the inputs to the quote operation. This includes the digest value and PCR values. MUST NOT be NULL.
+    Returns a JSON-encoded structure holding the inputs to the quote operation. This includes the digest value and PCR values.
 
   * **-o**, **\--signature**:
 
-    Returns the signature over the quoted material. MUST NOT be NULL.
+    Returns the signature over the quoted material.
 
   * **-c**, **\--certificate**:
 
-    The certificate associated with keyPath in PEM format. MAY be NULL.
+    The certificate associated with keyPath in PEM format. Optional parameter.
 
 [common tss2 options](common/tss2-options.md)
 
 # EXAMPLE
-
+```
 tss2_quote --keyPath HS/SRK/quotekey --pcrList "16" --qualifyingData nonce.file --signature signature.file --pcrLog pcr.log --certificate certificate.file --quoteInfo quote.info
+```
 
 # RETURNS
 

--- a/man/tss2_setappdata.1.md
+++ b/man/tss2_setappdata.1.md
@@ -12,7 +12,7 @@
 
 # DESCRIPTION
 
-**tss2_setappdata**(1) - allows an application to associate an arbitrary data blob with a given object. The data SHALL be stored and the same data SHALL be returned upon Fapi_GetAppData. Previously stored data SHALL be overwritten by this function. If NULL is passed in, stored data SHALL be deleted.
+**tss2_setappdata**(1) - This command allows an application to associate an arbitrary data blob with a given object. The data is stored and can be returned with tss2_getappdata. Previously stored data is overwritten by this function. If empty data is passed in, the stored data is deleted.
 
 # OPTIONS
 
@@ -20,11 +20,11 @@ These are the available options:
 
   * **-p**, **\--path**:
 
-    Path of the object for which the appData will be stored. MUST NOT be NULL.
+    Path of the object for which the appData will be stored.
 
   * **-i**, **\--appData**:
 
-    The data to be stored. MAY be NULL.
+    The data to be stored. Optional parameter. If omitted, stored data is deleted.
 
 [common tss2 options](common/tss2-options.md)
 

--- a/man/tss2_setappdata.1.md
+++ b/man/tss2_setappdata.1.md
@@ -18,11 +18,11 @@
 
 These are the available options:
 
-  * **-p**, **\--path**:
+  * **-p**, **\--path** _STRING_:
 
     Path of the object for which the appData will be stored.
 
-  * **-i**, **\--appData**:
+  * **-i**, **\--appData** _STRING_:
 
     The data to be stored. Optional parameter. If omitted, stored data is deleted.
 

--- a/man/tss2_setcertificate.1.md
+++ b/man/tss2_setcertificate.1.md
@@ -18,11 +18,11 @@
 
 These are the available options:
 
-  * **-p**, **\--path**:
+  * **-p**, **\--path** _STRING_:
 
     Identifies the entity to be associated with the certificate.
 
-  * **-i**, **\--x509certData**:
+  * **-i**, **\--x509certData** _FILENAME_ or _-_ (for stdin):
 
     The PEM encoded certificate. Optional parameter. If omitted, then the stored
     x509 certificate is removed.
@@ -32,7 +32,7 @@ These are the available options:
 # EXAMPLE
 
 ```
-tss2_setcertificate --path HS/SRK/myRSACrypt --x509certData certificate.file
+tss2_setcertificate --path HS/SRK/myRSACrypt --x509certData x509certData.file
 ```
 
 # RETURNS

--- a/man/tss2_setcertificate.1.md
+++ b/man/tss2_setcertificate.1.md
@@ -20,17 +20,20 @@ These are the available options:
 
   * **-p**, **\--path**:
 
-    Identifies the entity to be associated with the certificate. MUST NOT be NULL.
+    Identifies the entity to be associated with the certificate.
 
   * **-i**, **\--x509certData**:
 
-    The PEM encoded certificate. MAY be NULL. If x509certData is NULL then the stored x509 certificate SHALL be removed.
+    The PEM encoded certificate. Optional parameter. If omitted, then the stored
+    x509 certificate is removed.
 
 [common tss2 options](common/tss2-options.md)
 
 # EXAMPLE
 
+```
 tss2_setcertificate --path HS/SRK/myRSACrypt --x509certData certificate.file
+```
 
 # RETURNS
 

--- a/man/tss2_setdescription.1.md
+++ b/man/tss2_setdescription.1.md
@@ -12,7 +12,7 @@
 
 # DESCRIPTION
 
-**tss2_setdescription**(1) - This command allows an application to assign a human readable description to an object in the metadata store. Previously stored descriptions SHALL be overwritten by this function. If NULL is passed in, any stored description SHALL be deleted.
+**tss2_setdescription**(1) - This command allows an application to assign a human readable description to an object in the metadata store.  The data is stored and can be returned with tss2_getdescription. Previously stored data is overwritten by this function. If an empty description is passed in, the stored data is deleted.
 
 # OPTIONS
 
@@ -20,16 +20,19 @@ These are the available options:
 
   * **-i**, **\--description**:
 
-    The data to be stored as description for the object. MAY be NULL.
+    The data to be stored as description for the object. Optional parameter.
+    Previously stored descriptions are overwritten by this function. If omitted
+    any stored description is deleted.
 
   * **-p**, **\--path**:
 
-    The path of the object for which the description will be stored. MUST NOT be NULL.
+    The path of the object for which the description will be stored.
 
 
 [common tss2 options](common/tss2-options.md)
 
 # EXAMPLE
+
 ```
 tss2_setdescription --path HS/SRK --description object-description
 ```

--- a/man/tss2_setdescription.1.md
+++ b/man/tss2_setdescription.1.md
@@ -18,13 +18,13 @@
 
 These are the available options:
 
-  * **-i**, **\--description**:
+  * **-i**, **\--description** _STRING_:
 
     The data to be stored as description for the object. Optional parameter.
     Previously stored descriptions are overwritten by this function. If omitted
     any stored description is deleted.
 
-  * **-p**, **\--path**:
+  * **-p**, **\--path** _STRING_:
 
     The path of the object for which the description will be stored.
 
@@ -34,7 +34,7 @@ These are the available options:
 # EXAMPLE
 
 ```
-tss2_setdescription --path HS/SRK --description object-description
+tss2_setdescription --path HS/SRK --description description
 ```
 
 # RETURNS

--- a/man/tss2_sign.1.md
+++ b/man/tss2_sign.1.md
@@ -18,20 +18,20 @@
 
 These are the available options:
 
-  * **-p**, **\--keyPath**:
+  * **-p**, **\--keyPath** _STRING_:
 
     The path to the signing key.
 
-  * **-s**, **\--padding**:
+  * **-s**, **\--padding** _STRING_:
 
     The padding scheme used. Possible values are "RSA_SSA", "RSA_PSS" (case insensitive). Optional parameter.
     If omitted, the default padding specified in the crypto profile is used.
 
-  * **-c**, **\--certificate**:
+  * **-c**, **\--certificate** _FILENAME_ or _-_ (for stdout):
 
     The certificate associated with keyPath in PEM format. Optional parameter.
 
-  * **-d**, **\--digest**:
+  * **-d**, **\--digest** _FILENAME_ or _-_ (for stdin):
 
     The data to be signed, already hashed.
 
@@ -39,11 +39,11 @@ These are the available options:
 
     Force overwriting the output file.
 
-  * **-k**, **\--publicKey**:
+  * **-k**, **\--publicKey** _FILENAME_ or _-_ (for stdout):
 
     The public key associated with keyPath in PEM format. Optional parameter.
 
-  * **-o**, **\--signature**:
+  * **-o**, **\--signature** _FILENAME_ or _-_ (for stdout):
 
     Returns the signature in binary form.
 
@@ -52,7 +52,7 @@ These are the available options:
 # EXAMPLE
 
 ```
-tss2_sign --keyPath HS/SRK/myRSASign --padding "RSA_PSS" --digest digest.file --signature signature.file --publicKey public_key.file
+tss2_sign --keyPath HS/SRK/myRSASign --padding "RSA_PSS" --digest digest.file --signature signature.file --publicKey publicKey.file
 ```
 
 # RETURNS

--- a/man/tss2_sign.1.md
+++ b/man/tss2_sign.1.md
@@ -20,19 +20,20 @@ These are the available options:
 
   * **-p**, **\--keyPath**:
 
-    The path to the signing key. MUST NOT be NULL.
+    The path to the signing key.
 
   * **-s**, **\--padding**:
 
-    The padding scheme used. Possible values are “RSA_SSA”, “RSA_PSS” (case insensitive). MAY be NULL.
+    The padding scheme used. Possible values are "RSA_SSA", "RSA_PSS" (case insensitive). Optional parameter.
+    If omitted, the default padding specified in the crypto profile is used.
 
   * **-c**, **\--certificate**:
 
-    The certificate associated with keyPath in PEM format. MAY be NULL.
+    The certificate associated with keyPath in PEM format. Optional parameter.
 
   * **-d**, **\--digest**:
 
-    The data to be signed, already hashed. MUST NOT be NULL.
+    The data to be signed, already hashed.
 
   * **-f**, **\--force**:
 
@@ -40,17 +41,19 @@ These are the available options:
 
   * **-k**, **\--publicKey**:
 
-    The public key associated with keyPath in PEM format. MAY be NULL.
+    The public key associated with keyPath in PEM format. Optional parameter.
 
   * **-o**, **\--signature**:
 
-    Returns the signature in binary form. MUST NOT be NULL.
+    Returns the signature in binary form.
 
 [common tss2 options](common/tss2-options.md)
 
 # EXAMPLE
 
+```
 tss2_sign --keyPath HS/SRK/myRSASign --padding "RSA_PSS" --digest digest.file --signature signature.file --publicKey public_key.file
+```
 
 # RETURNS
 

--- a/man/tss2_unseal.1.md
+++ b/man/tss2_unseal.1.md
@@ -24,17 +24,19 @@ These are the available options:
 
   * **-p**, **\--path**:
 
-    Path of the object for which the blobs will be returned. MUST NOT be NULL.
+    Path of the object for which the blobs will be returned.
 
   * **-o**, **\--data**:
 
-    The decrypted data after unsealing. MAY be NULL.
+    The decrypted data after unsealing. Optional parameter.
 
 [common tss2 options](common/tss2-options.md)
 
 # EXAMPLE
 
+```
 tss2_unseal --path HS/SRK/myRSACrypt --data unsealed.data
+```
 
 # RETURNS
 

--- a/man/tss2_unseal.1.md
+++ b/man/tss2_unseal.1.md
@@ -22,11 +22,11 @@ These are the available options:
 
     Force overwriting the output file.
 
-  * **-p**, **\--path**:
+  * **-p**, **\--path** _STRING_:
 
     Path of the object for which the blobs will be returned.
 
-  * **-o**, **\--data**:
+  * **-o**, **\--data** _FILENAME_ or _-_ (for stdout):
 
     The decrypted data after unsealing. Optional parameter.
 
@@ -35,7 +35,7 @@ These are the available options:
 # EXAMPLE
 
 ```
-tss2_unseal --path HS/SRK/myRSACrypt --data unsealed.data
+tss2_unseal --path HS/SRK/myRSACrypt --data data.file
 ```
 
 # RETURNS

--- a/man/tss2_verifyquote.1.md
+++ b/man/tss2_verifyquote.1.md
@@ -26,11 +26,11 @@ An application using tss2_verifyquote() will further have to
 
 These are the available options:
 
-  * **-Q**, **\--qualifyingData**:
+  * **-Q**, **\--qualifyingData** _FILENAME_ or _-_ (for stdin):
 
     A nonce provided by the caller to ensure freshness of the signature. Optional parameter.
 
-  * **-l**, **\--pcrLog**:
+  * **-l**, **\--pcrLog** _FILENAME_ or _-_ (for stdin):
 
     Returns the PCR event log for the chosen PCR. Optional parameter.
 
@@ -44,15 +44,15 @@ These are the available options:
         - eventDigest: Digest of the event; e.g. the digest of the measured file
         - eventName: Name of the event; e.g. the name of the measured file.
 
-  * **-q**, **\--quoteInfo**:
+  * **-q**, **\--quoteInfo** _FILENAME_ or _-_ (for stdin):
 
     The JSON-encoded structure holding the inputs to the quote operation. This includes the digest value and PCR values.
 
-  * **-k**, **\--publicKeyPath**:
+  * **-k**, **\--publicKeyPath** _STRING_:
 
     Identifies the signing key. MAY be a path to the public key hierarchy /ext.
 
-  * **-i**, **\--signature**:
+  * **-i**, **\--signature** _FILENAME_ or _-_ (for stdin):
 
     The signature over the quoted material.
 
@@ -61,7 +61,7 @@ These are the available options:
 # EXAMPLE
 
 ```
-    tss2_verifyquote --publicKeyPath "ext/myNewParent" --qualifyingData nonce.file --quoteInfo quote.info --signature signature.file --pcrLog pcr.log
+    tss2_verifyquote --publicKeyPath "ext/myNewParent" --qualifyingData qualifyingData.file --quoteInfo quoteInfo.file --signature signature.file --pcrLog pcrLog.file
 ```
 
 # RETURNS

--- a/man/tss2_verifyquote.1.md
+++ b/man/tss2_verifyquote.1.md
@@ -14,13 +14,13 @@
 
 **tss2_verifyquote**(1) - This command verifies that the data returned by a quote is valid. This includes
 
-  * Reconstructing the quoteInfo’s PCR values from the eventLog (if an eventLog was provided)
+  * Reconstructing the quoteInfo's PCR values from the eventLog (if an eventLog was provided)
   * Verifying the quoteInfo using the signature and the publicKeyPath
 
-An application using Fapi_VerifyQuote() will further have to
+An application using tss2_verifyquote() will further have to
 
-* Assess the publicKey’s trustworthiness
-* Assess the eventLog entries’ trustworthiness
+  * Assess the publicKey's trustworthiness
+  * Assess the eventLog entries' trustworthiness
 
 # OPTIONS
 
@@ -28,29 +28,41 @@ These are the available options:
 
   * **-Q**, **\--qualifyingData**:
 
-    A nonce provided by the caller to ensure freshness of the signature. MAY be NULL.
+    A nonce provided by the caller to ensure freshness of the signature. Optional parameter.
 
   * **-l**, **\--pcrLog**:
 
-    Returns the PCR log for the chosen PCR in the format defined in the FAPI specification. MAY be NULL.
+    Returns the PCR event log for the chosen PCR. Optional parameter.
+
+    PCR event logs are a list (arbitrary length JSON array) of log entries with
+    the following content.
+
+        - recnum: Unique record number
+        - pcr: PCR index
+        - digest: The digests
+        - type: The type of event. At the moment the only possible value is: "LINUX_IMA" (legacy IMA)
+        - eventDigest: Digest of the event; e.g. the digest of the measured file
+        - eventName: Name of the event; e.g. the name of the measured file.
 
   * **-q**, **\--quoteInfo**:
 
-    The JSON-encoded structure holding the inputs to the quote operation. This includes the digest value and PCR values. MUST NOT be NULL.
+    The JSON-encoded structure holding the inputs to the quote operation. This includes the digest value and PCR values.
 
   * **-k**, **\--publicKeyPath**:
 
-    Identifies the signing key. MUST NOT be NULL. MAY be a path to the public key hierarchy /ext.
+    Identifies the signing key. MAY be a path to the public key hierarchy /ext.
 
   * **-i**, **\--signature**:
 
-    The signature over the quoted material. MUST NOT be NULL.
+    The signature over the quoted material.
 
 [common tss2 options](common/tss2-options.md)
 
 # EXAMPLE
 
+```
     tss2_verifyquote --publicKeyPath "ext/myNewParent" --qualifyingData nonce.file --quoteInfo quote.info --signature signature.file --pcrLog pcr.log
+```
 
 # RETURNS
 

--- a/man/tss2_verifysignature.1.md
+++ b/man/tss2_verifysignature.1.md
@@ -18,15 +18,15 @@
 
 These are the available options:
 
-  * **-d**, **\--digest**:
+  * **-d**, **\--digest** _FILENAME_ or _-_ (for stdin):
 
     The data that was signed, already hashed.
 
-  * **-p**, **\--keyPath**:
+  * **-p**, **\--keyPath** _STRING_:
 
     Path to the verification public key.
 
-  * **-i**, **\--signature**:
+  * **-i**, **\--signature** _FILENAME_ or _-_ (for stdin):
 
     The signature to be verified.
 

--- a/man/tss2_verifysignature.1.md
+++ b/man/tss2_verifysignature.1.md
@@ -12,7 +12,7 @@
 
 # DESCRIPTION
 
-**tss2_verifysignature**(1) - This command verifies a signature using a public key found in a keyPath. This function MAY or MAY NOT use the TPM for this operation.
+**tss2_verifysignature**(1) - This command verifies a signature using a public key found in the passed key path.
 
 # OPTIONS
 
@@ -20,22 +20,24 @@ These are the available options:
 
   * **-d**, **\--digest**:
 
-    The data that was signed, already hashed. MUST NOT be NULL
+    The data that was signed, already hashed.
 
   * **-p**, **\--keyPath**:
 
-    Path to the verification public key. MUST NOT be NULL.
+    Path to the verification public key.
 
   * **-i**, **\--signature**:
 
-    The signature to be verified. MUST NOT be NULL.
+    The signature to be verified.
 
 
 [common tss2 options](common/tss2-options.md)
 
 # EXAMPLE
 
+```
 tss2_verifysignature --keyPath ext/myRSASign --digest digest.file --signature signature.file
+```
 
 # RETURNS
 

--- a/man/tss2_writeauthorizenv.1.md
+++ b/man/tss2_writeauthorizenv.1.md
@@ -18,11 +18,11 @@
 
 These are the available options:
 
-  * **-p**, **\--nvPath**:
+  * **-p**, **\--nvPath** _STRING_:
 
     The path of the NV index.
 
-  * **-P**, **\--policyPath**:
+  * **-P**, **\--policyPath** _STRING_:
 
     The path of the new policy.
 
@@ -31,7 +31,7 @@ These are the available options:
 # EXAMPLE
 
 ```
-tss2_writeauthorizenv --nvPath /nv/Owner/myNV --policyPath pcr-policy
+tss2_writeauthorizenv --nvPath /nv/Owner/myNV --policyPath /policy/pcr-policy
 ```
 
 # RETURNS

--- a/man/tss2_writeauthorizenv.1.md
+++ b/man/tss2_writeauthorizenv.1.md
@@ -12,7 +12,7 @@
 
 # DESCRIPTION
 
-**tss2_writeauthorizenv**(1) - This command writes the digest value of a policy to an NV index such that this policy can be used in other policies containing a corresponding PolicyAuthorizeNv element. Note that the nameAlg property of the NV index defines the digest algorithm for the policy.
+**tss2_writeauthorizenv**(1) - This command writes the digest value of a policy to an NV index such that this policy can be used in other policies containing a corresponding PolicyAuthorizeNv element.
 
 # OPTIONS
 
@@ -20,17 +20,19 @@ These are the available options:
 
   * **-p**, **\--nvPath**:
 
-    The path of the NV index. MUST NOT be NULL.
+    The path of the NV index.
 
   * **-P**, **\--policyPath**:
 
-    The path of the new policy. MUST NOT be NULL.
+    The path of the new policy.
 
 [common tss2 options](common/tss2-options.md)
 
 # EXAMPLE
 
+```
 tss2_writeauthorizenv --nvPath /nv/Owner/myNV --policyPath pcr-policy
+```
 
 # RETURNS
 

--- a/test/integration/fapi/fapi-encrypt-decrypt.sh
+++ b/test/integration/fapi/fapi-encrypt-decrypt.sh
@@ -59,16 +59,6 @@ if {[lindex \$ret 2] || [lindex \$ret 3] != 1} {
 }
 EOF
 
-expect <<EOF
-# Try with missing type
-spawn tss2_createkey --path $KEY_PATH --authValue abc
-set ret [wait]
-if {[lindex \$ret 2] || [lindex \$ret 3] != 1} {
-    send_user "Command has not failed as expected\n"
-    exit 1
-}
-EOF
-
 tss2_import --path $POLICY_PCR --importData $PCR_POLICY_DATA
 
 expect <<EOF

--- a/test/integration/fapi/fapi-get-tpm-blobs.sh
+++ b/test/integration/fapi/fapi-get-tpm-blobs.sh
@@ -86,6 +86,48 @@ if {[lindex \$ret 2] || [lindex \$ret 3] != 1} {
 }
 EOF
 
+expect <<EOF
+# Try with multiple stdout (1)
+spawn tss2_gettpmblobs --path $KEY_PATH --tpm2bPublic - \
+    --tpm2bPrivate - --policy $POLICY_FILE --force
+set ret [wait]
+if {[lindex \$ret 2] || [lindex \$ret 3] != 1} {
+    Command has not failed as expected\n"
+    exit 1
+}
+EOF
 
+expect <<EOF
+# Try with multiple stdout (2)
+spawn tss2_gettpmblobs --path $KEY_PATH --tpm2bPublic $PUBLIC_KEY_FILE \
+    --tpm2bPrivate - --policy - --force
+set ret [wait]
+if {[lindex \$ret 2] || [lindex \$ret 3] != 1} {
+    Command has not failed as expected\n"
+    exit 1
+}
+EOF
+
+expect <<EOF
+# Try with multiple stdout (3)
+spawn tss2_gettpmblobs --path $KEY_PATH --tpm2bPublic - \
+    --tpm2bPrivate $PRIVATE_KEY_FILE --policy - --force
+set ret [wait]
+if {[lindex \$ret 2] || [lindex \$ret 3] != 1} {
+    Command has not failed as expected\n"
+    exit 1
+}
+EOF
+
+expect <<EOF
+# Try with multiple stdout (4)
+spawn tss2_gettpmblobs --path $KEY_PATH --tpm2bPublic - \
+    --tpm2bPrivate - --policy - --force
+set ret [wait]
+if {[lindex \$ret 2] || [lindex \$ret 3] != 1} {
+    Command has not failed as expected\n"
+    exit 1
+}
+EOF
 
 exit 0

--- a/test/integration/fapi/fapi-nv-extend.sh
+++ b/test/integration/fapi/fapi-nv-extend.sh
@@ -56,4 +56,14 @@ if {[lindex \$ret 2] || [lindex \$ret 3] != 1} {
 }
 EOF
 
+expect <<EOF
+# Try with multiple stdin
+spawn tss2_nvextend --nvPath $NV_PATH --data - --logData -
+set ret [wait]
+if {[lindex \$ret 2] || [lindex \$ret 3] != 1} {
+    Command has not failed as expected\n"
+    exit 1
+}
+EOF
+
 exit 0

--- a/test/integration/fapi/fapi-nv-write-read.sh
+++ b/test/integration/fapi/fapi-nv-write-read.sh
@@ -77,6 +77,16 @@ if {[lindex \$ret 2] || [lindex \$ret 3] != 1} {
 EOF
 
 expect <<EOF
+# Try with multiple stdout (1)
+spawn tss2_nvread --nvPath $NV_PATH --data - --logData - --force
+set ret [wait]
+if {[lindex \$ret 2] || [lindex \$ret 3] != 1} {
+    Command has not failed as expected\n"
+    exit 1
+}
+EOF
+
+expect <<EOF
 # Try with missing nvPath
 spawn tss2_nvwrite --data $DATA_WRITE_FILE
 set ret [wait]

--- a/test/integration/fapi/fapi-pcr-extend-read.sh
+++ b/test/integration/fapi/fapi-pcr-extend-read.sh
@@ -67,6 +67,16 @@ if {[lindex \$ret 2] || [lindex \$ret 3] != 1} {
 EOF
 
 expect <<EOF
+# Try with multiple stdins
+spawn tss2_pcrextend --pcr 16 --data - --logData -
+set ret [wait]
+if {[lindex \$ret 2] || [lindex \$ret 3] != 1} {
+    Command has not failed as expected\n"
+    exit 1
+}
+EOF
+
+expect <<EOF
 # Try with missing pcrIndex
 spawn tss2_pcrread --pcrValue $PCR_DIGEST_FILE --pcrLog $PCR_LOG_FILE_READ
 set ret [wait]
@@ -97,9 +107,9 @@ if {[lindex \$ret 2] || [lindex \$ret 3] != 1} {
 EOF
 
 expect <<EOF
-# Try with mutliple stdins
-spawn tss2_pcrread --pcrIndex 16 --pcrValue=- \
-    --pcrLog=-
+# Try with multiple stdins (1)
+spawn tss2_pcrread --pcrIndex 16 --pcrValue - \
+    --pcrLog -
 set ret [wait]
 if {[lindex \$ret 2] || [lindex \$ret 3] != 1} {
     Command has not failed as expected\n"

--- a/test/integration/fapi/fapi-pcr-extend-read.sh
+++ b/test/integration/fapi/fapi-pcr-extend-read.sh
@@ -56,16 +56,6 @@ if {[lindex \$ret 2] || [lindex \$ret 3] != 1} {
 EOF
 
 expect <<EOF
-# Try with missing logData
-spawn tss2_pcrextend --pcr 16 --data $PCR_EVENT_DATA
-set ret [wait]
-if {[lindex \$ret 2] || [lindex \$ret 3] != 1} {
-    Command has not failed as expected\n"
-    exit 1
-}
-EOF
-
-expect <<EOF
 # Try with wrong pcr
 spawn tss2_pcrextend --pcr abc --data $PCR_EVENT_DATA \
     --logData $PCR_LOG_FILE_WRITE

--- a/test/integration/fapi/fapi-quote-verify.sh
+++ b/test/integration/fapi/fapi-quote-verify.sh
@@ -67,49 +67,10 @@ if {[lindex \$ret 2] || [lindex \$ret 3] != 1} {
 EOF
 
 expect <<EOF
-# Try with missing qualifyingData
-spawn tss2_quote --keyPath $KEY_PATH --pcrList "16" \
-    --signature $SIGNATURE_FILE \
-    --pcrLog $PCR_LOG --certificate $CERTIFICATE_FILE \
-    --quoteInfo $QUOTE_INFO --force
-set ret [wait]
-if {[lindex \$ret 2] || [lindex \$ret 3] != 1} {
-    Command has not failed as expected\n"
-    exit 1
-}
-EOF
-
-expect <<EOF
 # Try with missing signature
 spawn tss2_quote --keyPath $KEY_PATH --pcrList "16" \
     --qualifyingData $NONCE_FILE \
     --pcrLog $PCR_LOG --certificate $CERTIFICATE_FILE \
-    --quoteInfo $QUOTE_INFO --force
-set ret [wait]
-if {[lindex \$ret 2] || [lindex \$ret 3] != 1} {
-    Command has not failed as expected\n"
-    exit 1
-}
-EOF
-
-expect <<EOF
-# Try with missing pcrLog
-spawn tss2_quote --keyPath $KEY_PATH --pcrList "16" \
-    --qualifyingData $NONCE_FILE --signature $SIGNATURE_FILE \
-    --certificate $CERTIFICATE_FILE \
-    --quoteInfo $QUOTE_INFO --force
-set ret [wait]
-if {[lindex \$ret 2] || [lindex \$ret 3] != 1} {
-    Command has not failed as expected\n"
-    exit 1
-}
-EOF
-
-expect <<EOF
-# Try with missing certificate
-spawn tss2_quote --keyPath $KEY_PATH --pcrList "16" \
-    --qualifyingData $NONCE_FILE --signature $SIGNATURE_FILE \
-    --pcrLog $PCR_LOG \
     --quoteInfo $QUOTE_INFO --force
 set ret [wait]
 if {[lindex \$ret 2] || [lindex \$ret 3] != 1} {
@@ -184,18 +145,6 @@ expect <<EOF
 # Try with missing publicKeyPath
 spawn tss2_verifyquote \
     --qualifyingData $NONCE_FILE --quoteInfo $QUOTE_INFO \
-    --signature $SIGNATURE_FILE
-set ret [wait]
-if {[lindex \$ret 2] || [lindex \$ret 3] != 1} {
-    Command has not failed as expected\n"
-    exit 1
-}
-EOF
-
-expect <<EOF
-# Try with missing qualifyingData
-spawn tss2_verifyquote --publicKeyPath "ext/myNewParent" \
-    --quoteInfo $QUOTE_INFO \
     --signature $SIGNATURE_FILE
 set ret [wait]
 if {[lindex \$ret 2] || [lindex \$ret 3] != 1} {

--- a/test/integration/fapi/fapi-quote-verify.sh
+++ b/test/integration/fapi/fapi-quote-verify.sh
@@ -38,7 +38,7 @@ tss2_import --path "ext/myNewParent" --importData $PUBLIC_QUOTE_KEY
 
 tss2_verifyquote --publicKeyPath "ext/myNewParent" \
     --qualifyingData $NONCE_FILE --quoteInfo $QUOTE_INFO \
-    --signature $SIGNATURE_FILE --pcrLog=$PCR_LOG
+    --signature $SIGNATURE_FILE --pcrLog $PCR_LOG
 
 expect <<EOF
 # Try with missing keyPath
@@ -93,11 +93,50 @@ if {[lindex \$ret 2] || [lindex \$ret 3] != 1} {
 EOF
 
 expect <<EOF
-# Try with multiple stdins
+# Try with multiple stdout (1)
+spawn tss2_quote --keyPath $KEY_PATH --pcrList "16" \
+    --qualifyingData $NONCE_FILE --signature - \
+    --pcrLog - --certificate $CERTIFICATE_FILE \
+    --quoteInfo $QUOTE_INFO --force
+set ret [wait]
+if {[lindex \$ret 2] || [lindex \$ret 3] != 1} {
+    Command has not failed as expected\n"
+    exit 1
+}
+EOF
+
+expect <<EOF
+# Try with multiple stdout (2)
 spawn tss2_quote --keyPath $KEY_PATH --pcrList "16" \
     --qualifyingData $NONCE_FILE --signature $SIGNATURE_FILE \
-    --pcrLog $PCR_LOG --certificate=- \
-    --quoteInfo=- --force
+    --pcrLog - --certificate - \
+    --quoteInfo $QUOTE_INFO --force
+set ret [wait]
+if {[lindex \$ret 2] || [lindex \$ret 3] != 1} {
+    Command has not failed as expected\n"
+    exit 1
+}
+EOF
+
+expect <<EOF
+# Try with multiple stdout (3)
+spawn tss2_quote --keyPath $KEY_PATH --pcrList "16" \
+    --qualifyingData $NONCE_FILE --signature $SIGNATURE_FILE \
+    --pcrLog $PCR_LOG --certificate - \
+    --quoteInfo - --force
+set ret [wait]
+if {[lindex \$ret 2] || [lindex \$ret 3] != 1} {
+    Command has not failed as expected\n"
+    exit 1
+}
+EOF
+
+expect <<EOF
+# Try with multiple stdout (4)
+spawn tss2_quote --keyPath $KEY_PATH --pcrList "16" \
+    --qualifyingData - --signature $SIGNATURE_FILE \
+    --pcrLog - --certificate $CERTIFICATE_FILE \
+    --quoteInfo - --force
 set ret [wait]
 if {[lindex \$ret 2] || [lindex \$ret 3] != 1} {
     Command has not failed as expected\n"
@@ -177,10 +216,70 @@ if {[lindex \$ret 2] || [lindex \$ret 3] != 1} {
 EOF
 
 expect <<EOF
-# Try with multiple stdins
+# Try with multiple stdins (1)
 spawn tss2_verifyquote --publicKeyPath "ext/myNewParent" \
-    --qualifyingData $NONCE_FILE --quoteInfo=- \
-    --signature=- --pcrLog=$PCR_LOG
+    --qualifyingData - --quoteInfo - \
+    --signature $SIGNATURE_FILE --pcrLog $PCR_LOG
+set ret [wait]
+if {[lindex \$ret 2] || [lindex \$ret 3] != 1} {
+    Command has not failed as expected\n"
+    exit 1
+}
+EOF
+
+expect <<EOF
+# Try with multiple stdins (2)
+spawn tss2_verifyquote --publicKeyPath "ext/myNewParent" \
+    --qualifyingData $NONCE_FILE --quoteInfo - \
+    --signature - --pcrLog $PCR_LOG
+set ret [wait]
+if {[lindex \$ret 2] || [lindex \$ret 3] != 1} {
+    Command has not failed as expected\n"
+    exit 1
+}
+EOF
+
+expect <<EOF
+# Try with multiple stdins (3)
+spawn tss2_verifyquote --publicKeyPath "ext/myNewParent" \
+    --qualifyingData $NONCE_FILE --quoteInfo $QUOTE_INFO \
+    --signature - --pcrLog -
+set ret [wait]
+if {[lindex \$ret 2] || [lindex \$ret 3] != 1} {
+    Command has not failed as expected\n"
+    exit 1
+}
+EOF
+
+expect <<EOF
+# Try with multiple stdins (4)
+spawn tss2_verifyquote --publicKeyPath "ext/myNewParent" \
+    --qualifyingData - --quoteInfo $QUOTE_INFO \
+    --signature $SIGNATURE_FILE --pcrLog -
+set ret [wait]
+if {[lindex \$ret 2] || [lindex \$ret 3] != 1} {
+    Command has not failed as expected\n"
+    exit 1
+}
+EOF
+
+expect <<EOF
+# Try with multiple stdins (5)
+spawn tss2_verifyquote --publicKeyPath "ext/myNewParent" \
+    --qualifyingData $NONCE_FILE --quoteInfo - \
+    --signature - --pcrLog $PCR_LOG
+set ret [wait]
+if {[lindex \$ret 2] || [lindex \$ret 3] != 1} {
+    Command has not failed as expected\n"
+    exit 1
+}
+EOF
+
+expect <<EOF
+# Try with multiple stdins (6)
+spawn tss2_verifyquote --publicKeyPath "ext/myNewParent" \
+    --qualifyingData - --quoteInfo - \
+    --signature - --pcrLog -
 set ret [wait]
 if {[lindex \$ret 2] || [lindex \$ret 3] != 1} {
     Command has not failed as expected\n"
@@ -192,7 +291,7 @@ expect <<EOF
 # Try with wrong qualifyingData file
 spawn tss2_verifyquote --publicKeyPath "ext/myNewParent" \
     --qualifyingData abc --quoteInfo $QUOTE_INFO \
-    --signature $SIGNATURE_FILE --pcrLog=$PCR_LOG
+    --signature $SIGNATURE_FILE --pcrLog $PCR_LOG
 set ret [wait]
 if {[lindex \$ret 2] || [lindex \$ret 3] != 1} {
     Command has not failed as expected\n"
@@ -204,7 +303,7 @@ expect <<EOF
 # Try with wrong signature file
 spawn tss2_verifyquote --publicKeyPath "ext/myNewParent" \
     --qualifyingData $NONCE_FILE --quoteInfo $QUOTE_INFO \
-    --signature abc --pcrLog=$PCR_LOG
+    --signature abc --pcrLog $PCR_LOG
 set ret [wait]
 if {[lindex \$ret 2] || [lindex \$ret 3] != 1} {
     Command has not failed as expected\n"
@@ -216,7 +315,7 @@ expect <<EOF
 # Try with wrong quoteInfo file
 spawn tss2_verifyquote --publicKeyPath "ext/myNewParent" \
     --qualifyingData $NONCE_FILE --quoteInfo abc \
-    --signature $SIGNATURE_FILE --pcrLog=$PCR_LOG
+    --signature $SIGNATURE_FILE --pcrLog $PCR_LOG
 set ret [wait]
 if {[lindex \$ret 2] || [lindex \$ret 3] != 1} {
     Command has not failed as expected\n"
@@ -228,7 +327,7 @@ expect <<EOF
 # Try failing tss2_verifyquote
 spawn tss2_verifyquote --publicKeyPath "ext/abc" \
     --qualifyingData $NONCE_FILE --quoteInfo abc \
-    --signature $SIGNATURE_FILE --pcrLog=$PCR_LOG
+    --signature $SIGNATURE_FILE --pcrLog $PCR_LOG
 set ret [wait]
 if {[lindex \$ret 2] || [lindex \$ret 3] != 1} {
     Command has not failed as expected\n"

--- a/test/integration/fapi/fapi-seal-unseal.sh
+++ b/test/integration/fapi/fapi-seal-unseal.sh
@@ -15,8 +15,9 @@ function cleanup {
 trap cleanup EXIT
 
 KEY_PATH=HS/SRK/sealKey
-SEALED_DATA=$TEMP_DIR/seal-data.file
-printf "data to seal" > $SEALED_DATA
+SEALED_DATA_FILE=$TEMP_DIR/seal-data.file
+SEAL_DATA="data to seal"
+printf "$SEAL_DATA" > $SEALED_DATA_FILE
 UNSEALED_DATA_FILE=$TEMP_DIR/unsealed-data.file
 PCR_POLICY_DATA=$TEMP_DIR/pol_pcr16_0.json
 POLICY_PCR=policy/pcr-policy
@@ -26,7 +27,7 @@ tss2_provision
 expect <<EOF
 # Try interactive prompt with different passwords
 spawn tss2_createseal --path $KEY_PATH --policyPath $POLICY_PCR --type "noDa" \
-    --data $SEALED_DATA
+    --data $SEALED_DATA_FILE
 expect "Authorize object Password: "
 send "1\r"
 expect "Authorize object Retype password: "
@@ -41,7 +42,7 @@ EOF
 
 expect <<EOF
 # Try with missing path
-spawn tss2_createseal --type "noDa" --data $SEALED_DATA --authValue ""
+spawn tss2_createseal --type "noDa" --data $SEALED_DATA_FILE --authValue ""
 set ret [wait]
 if {[lindex \$ret 2] || [lindex \$ret 3] != 1} {
     Command has not failed as expected\n"
@@ -51,7 +52,7 @@ EOF
 
 expect <<EOF
 # Try with missing type
-spawn tss2_createseal --path $KEY_PATH --data $SEALED_DATA --authValue ""
+spawn tss2_createseal --path $KEY_PATH --data $SEALED_DATA_FILE --authValue ""
 set ret [wait]
 if {[lindex \$ret 2] || [lindex \$ret 3] != 1} {
     Command has not failed as expected\n"
@@ -62,10 +63,23 @@ EOF
 tss2_import --path $POLICY_PCR --importData $PCR_POLICY_DATA
 
 tss2_createseal --path $KEY_PATH --policyPath $POLICY_PCR --type "noDa" \
-    --data $SEALED_DATA --authValue ""
+    --data $SEALED_DATA_FILE --authValue ""
 tss2_unseal --path $KEY_PATH --data $UNSEALED_DATA_FILE --force
 
-if [ "`cat $UNSEALED_DATA_FILE`" != "`cat $SEALED_DATA`" ]; then
+if [ "`xxd $UNSEALED_DATA_FILE`" != "`xxd $SEALED_DATA_FILE`" ]; then
+  echo "Seal/Unseal failed"
+  exit 1
+fi
+
+tss2_delete --path $KEY_PATH
+printf "$SEAL_DATA" | tss2_createseal --path $KEY_PATH --policyPath $POLICY_PCR --type "noDa" \
+    --data - --authValue ""
+UNSEALED_DATA=$(tss2_unseal --path $KEY_PATH --data - | xxd)
+
+V1=$(printf "$SEAL_DATA" | xxd)
+V2=$UNSEALED_DATA
+
+if [ "$V1" != "$V2" ]; then
   echo "Seal/Unseal failed"
   exit 1
 fi
@@ -89,7 +103,5 @@ if {[lindex \$ret 2] || [lindex \$ret 3] != 1} {
     exit 1
 }
 EOF
-
-
 
 exit 0

--- a/test/integration/fapi/fapi-seal-unseal.sh
+++ b/test/integration/fapi/fapi-seal-unseal.sh
@@ -50,16 +50,6 @@ if {[lindex \$ret 2] || [lindex \$ret 3] != 1} {
 }
 EOF
 
-expect <<EOF
-# Try with missing type
-spawn tss2_createseal --path $KEY_PATH --data $SEALED_DATA_FILE --authValue ""
-set ret [wait]
-if {[lindex \$ret 2] || [lindex \$ret 3] != 1} {
-    Command has not failed as expected\n"
-    exit 1
-}
-EOF
-
 tss2_import --path $POLICY_PCR --importData $PCR_POLICY_DATA
 
 tss2_createseal --path $KEY_PATH --policyPath $POLICY_PCR --type "noDa" \
@@ -87,16 +77,6 @@ fi
 expect <<EOF
 # Try with missing path
 spawn tss2_unseal --data $UNSEALED_DATA_FILE --force
-set ret [wait]
-if {[lindex \$ret 2] || [lindex \$ret 3] != 1} {
-    Command has not failed as expected\n"
-    exit 1
-}
-EOF
-
-expect <<EOF
-# Try with missing data
-spawn tss2_unseal --path $KEY_PATH --force
 set ret [wait]
 if {[lindex \$ret 2] || [lindex \$ret 3] != 1} {
     Command has not failed as expected\n"

--- a/test/integration/fapi/fapi-set-get-certificate.sh
+++ b/test/integration/fapi/fapi-set-get-certificate.sh
@@ -69,16 +69,6 @@ if {[lindex \$ret 2] || [lindex \$ret 3] != 1} {
 EOF
 
 expect <<EOF
-# Try with missing cert
-spawn tss2_setcertificate --path $KEY_PATH
-set ret [wait]
-if {[lindex \$ret 2] || [lindex \$ret 3] != 1} {
-    Command has not failed as expected\n"
-    exit 1
-}
-EOF
-
-expect <<EOF
 # Try with missing path
 spawn tss2_getcertificate --x509certData $READ_CERTIFICATE_FILE --force
 set ret [wait]

--- a/test/integration/fapi/fapi-set-get-description.sh
+++ b/test/integration/fapi/fapi-set-get-description.sh
@@ -45,16 +45,6 @@ if {[lindex \$ret 2] || [lindex \$ret 3] != 1} {
 EOF
 
 expect <<EOF
-# Try with missing description
-spawn tss2_setdescription --path $KEY_PATH
-set ret [wait]
-if {[lindex \$ret 2] || [lindex \$ret 3] != 1} {
-    Command has not failed as expected\n"
-    exit 1
-}
-EOF
-
-expect <<EOF
 # Try with missing path
 spawn tss2_getdescription --description $DESCRIPTION_FILE
 set ret [wait]

--- a/test/integration/fapi/fapi-sign-verify.sh
+++ b/test/integration/fapi/fapi-sign-verify.sh
@@ -24,7 +24,7 @@ PUB_KEY_DIR="ext"
 tss2_provision
 echo -n "01234567890123456789" > $DIGEST_FILE
 tss2_createkey --path $KEY_PATH --type "noDa, sign" --authValue ""
-echo -n `cat $DIGEST_FILE` | tss2_sign --digest=- --keyPath $KEY_PATH \
+echo -n `cat $DIGEST_FILE` | tss2_sign --digest - --keyPath $KEY_PATH \
     --padding "RSA_PSS" --signature $SIGNATURE_FILE --publicKey $PUBLIC_KEY_FILE
 
 tss2_import --path $IMPORTED_KEY_NAME --importData $PUBLIC_KEY_FILE
@@ -68,7 +68,7 @@ EOF
 expect <<EOF
 # Try with multiple stdins with publicKey and with certificate
 spawn tss2_sign --keyPath $KEY_PATH --padding "RSA_PSS" --digest $DIGEST_FILE \
-    --signature=- --publicKey=- --certificate=-
+    --signature - --publicKey - --certificate -
 set ret [wait]
 if {[lindex \$ret 2] || [lindex \$ret 3] != 1} {
     Command has not failed as expected\n"
@@ -79,7 +79,7 @@ EOF
 expect <<EOF
 # Try with multiple stdins without publicKey and with certificate
 spawn tss2_sign --keyPath $KEY_PATH --padding "RSA_PSS" --digest $DIGEST_FILE \
-    --signature=- --certificate=-
+    --signature - --certificate -
 set ret [wait]
 if {[lindex \$ret 2] || [lindex \$ret 3] != 1} {
     Command has not failed as expected\n"
@@ -134,7 +134,7 @@ EOF
 expect <<EOF
 # Try with multiple stdins
 spawn tss2_verifysignature --keyPath $PUB_KEY_DIR/$IMPORTED_KEY_NAME \
-    --digest=- --signature=-
+    --digest - --signature -
 set ret [wait]
 if {[lindex \$ret 2] || [lindex \$ret 3] != 1} {
     Command has not failed as expected\n"

--- a/test/integration/fapi/fapi-sign-verify.sh
+++ b/test/integration/fapi/fapi-sign-verify.sh
@@ -66,17 +66,6 @@ if {[lindex \$ret 2] || [lindex \$ret 3] != 1} {
 EOF
 
 expect <<EOF
-# Try with multiple stdins with publicKey and without certificate
-spawn tss2_sign --keyPath $KEY_PATH --padding "RSA_PSS" --digest $DIGEST_FILE \
-    --signature=- --publicKey=-
-set ret [wait]
-if {[lindex \$ret 2] || [lindex \$ret 3] != 1} {
-    Command has not failed as expected\n"
-    exit 1
-}
-EOF
-
-expect <<EOF
 # Try with multiple stdins with publicKey and with certificate
 spawn tss2_sign --keyPath $KEY_PATH --padding "RSA_PSS" --digest $DIGEST_FILE \
     --signature=- --publicKey=- --certificate=-
@@ -102,28 +91,6 @@ expect <<EOF
 # Try with missing digest file
 spawn tss2_sign --keyPath $KEY_PATH --padding "RSA_PSS" --digest abc \
     --signature $SIGNATURE_FILE --publicKey $PUBLIC_KEY_FILE
-set ret [wait]
-if {[lindex \$ret 2] || [lindex \$ret 3] != 1} {
-    Command has not failed as expected\n"
-    exit 1
-}
-EOF
-
-expect <<EOF
-# Try with missing signature file
-spawn tss2_sign --keyPath $KEY_PATH --padding "RSA_PSS" --digest $DIGEST_FILE \
-    --signature abc --publicKey $PUBLIC_KEY_FILE
-set ret [wait]
-if {[lindex \$ret 2] || [lindex \$ret 3] != 1} {
-    Command has not failed as expected\n"
-    exit 1
-}
-EOF
-
-expect <<EOF
-# Try with missing public key file
-spawn tss2_sign --keyPath $KEY_PATH --padding "RSA_PSS" --digest $DIGEST_FILE \
-    --signature $SIGNATURE_FILE --publicKey abc
 set ret [wait]
 if {[lindex \$ret 2] || [lindex \$ret 3] != 1} {
     Command has not failed as expected\n"

--- a/tools/fapi/tss2_changeauth.c
+++ b/tools/fapi/tss2_changeauth.c
@@ -54,7 +54,6 @@ int tss2_tool_onrun (FAPI_CONTEXT *fctx) {
         ctx.authValue = ask_for_password ();
         has_asked_for_password = true;
         if (!ctx.authValue){
-            free (ctx.authValue);
             return 1; /* User entered two different passwords */
         }
     }

--- a/tools/fapi/tss2_createkey.c
+++ b/tools/fapi/tss2_createkey.c
@@ -59,11 +59,6 @@ int tss2_tool_onrun (FAPI_CONTEXT *fctx) {
         return -1;
     }
 
-    if (!ctx.keyType) {
-        fprintf (stderr, "key type missing, use --type\n");
-        return -1;
-    }
-
     /* If no authValue was given, prompt the user interactively */
     if (!ctx.authValue) {
         ctx.authValue = ask_for_password ();

--- a/tools/fapi/tss2_createkey.c
+++ b/tools/fapi/tss2_createkey.c
@@ -69,7 +69,6 @@ int tss2_tool_onrun (FAPI_CONTEXT *fctx) {
         ctx.authValue = ask_for_password ();
         has_asked_for_password = true;
         if (!ctx.authValue){
-            free (ctx.authValue);
             return 1; /* User entered two different passwords */
         }
     }

--- a/tools/fapi/tss2_createnv.c
+++ b/tools/fapi/tss2_createnv.c
@@ -81,7 +81,6 @@ int tss2_tool_onrun (FAPI_CONTEXT *fctx) {
         ctx.authValue = ask_for_password ();
         has_asked_for_password = true;
         if (!ctx.authValue){
-            free (ctx.authValue);
             return 1; /* User entered two different passwords */
         }
     }
@@ -94,6 +93,7 @@ int tss2_tool_onrun (FAPI_CONTEXT *fctx) {
             free (ctx.authValue);
         }
         LOG_PERR ("Fapi_CreateNv", r);
+        return 1;
     }
 
     if(has_asked_for_password){

--- a/tools/fapi/tss2_createseal.c
+++ b/tools/fapi/tss2_createseal.c
@@ -63,10 +63,6 @@ int tss2_tool_onrun (FAPI_CONTEXT *fctx) {
         fprintf (stderr, "key path missing, use --path\n");
         return -1;
     }
-    if (!ctx.keyType) {
-        fprintf (stderr, "key type missing, use --type\n");
-        return -1;
-    }
     if (!ctx.data) {
         fprintf (stderr, "data to seal missing, use --data\n");
         return -1;

--- a/tools/fapi/tss2_createseal.c
+++ b/tools/fapi/tss2_createseal.c
@@ -77,7 +77,6 @@ int tss2_tool_onrun (FAPI_CONTEXT *fctx) {
         ctx.authValue = ask_for_password ();
         has_asked_for_password = true;
         if (!ctx.authValue){
-            free (ctx.authValue);
             return 1; /* User entered two different passwords */
         }
     }

--- a/tools/fapi/tss2_decrypt.c
+++ b/tools/fapi/tss2_decrypt.c
@@ -43,7 +43,7 @@ bool tss2_tool_onstart(tpm2_options **opts) {
         {"force"      , no_argument      , NULL, 'f'},
         {"plainText"     , required_argument, NULL, 'o'},
     };
-    return (*opts = tpm2_options_new ("i:f:o:p:", ARRAY_LEN(topts), topts,
+    return (*opts = tpm2_options_new ("i:fo:p:", ARRAY_LEN(topts), topts,
                                       on_option, NULL, 0)) != NULL;
 }
 

--- a/tools/fapi/tss2_encrypt.c
+++ b/tools/fapi/tss2_encrypt.c
@@ -48,7 +48,7 @@ bool tss2_tool_onstart(tpm2_options **opts) {
         {"cipherText",  required_argument, NULL, 'o'},
         {"force",       no_argument      , NULL, 'f'},
     };
-    return (*opts = tpm2_options_new ("f:P:o:p:i:", ARRAY_LEN(topts), topts,
+    return (*opts = tpm2_options_new ("fP:o:p:i:", ARRAY_LEN(topts), topts,
                                       on_option, NULL, 0)) != NULL;
 }
 

--- a/tools/fapi/tss2_encrypt.c
+++ b/tools/fapi/tss2_encrypt.c
@@ -11,7 +11,6 @@ bool output_enabled = false;
 /* Context struct used to store passed commandline parameters */
 static struct cxt {
     char const *keyPath;
-    char const *policyPath;
     char const *plainText;
     char const *cipherText;
     bool        overwrite;
@@ -22,9 +21,6 @@ static bool on_option(char key, char *value) {
     switch (key) {
     case 'f':
         ctx.overwrite = true;
-        break;
-    case 'P':
-        ctx.policyPath = value;
         break;
     case 'o':
         ctx.cipherText = value;
@@ -43,12 +39,11 @@ static bool on_option(char key, char *value) {
 bool tss2_tool_onstart(tpm2_options **opts) {
     struct option topts[] = {
         {"keyPath",     required_argument, NULL, 'p'},
-        {"policyPath",  required_argument, NULL, 'P'},
         {"plainText",   required_argument, NULL, 'i'},
         {"cipherText",  required_argument, NULL, 'o'},
         {"force",       no_argument      , NULL, 'f'},
     };
-    return (*opts = tpm2_options_new ("fP:o:p:i:", ARRAY_LEN(topts), topts,
+    return (*opts = tpm2_options_new ("fo:p:i:", ARRAY_LEN(topts), topts,
                                       on_option, NULL, 0)) != NULL;
 }
 

--- a/tools/fapi/tss2_exportkey.c
+++ b/tools/fapi/tss2_exportkey.c
@@ -44,7 +44,7 @@ bool tss2_tool_onstart(tpm2_options **opts) {
         {"exportedData",                required_argument, NULL, 'o'},
         {"pathOfKeyToDuplicate",        required_argument, NULL, 'p'}
     };
-    return (*opts = tpm2_options_new ("f:e:o:p:", ARRAY_LEN(topts), topts,
+    return (*opts = tpm2_options_new ("fe:o:p:", ARRAY_LEN(topts), topts,
                                       on_option, NULL, 0)) != NULL;
 }
 

--- a/tools/fapi/tss2_exportpolicy.c
+++ b/tools/fapi/tss2_exportpolicy.c
@@ -39,7 +39,7 @@ bool tss2_tool_onstart(tpm2_options **opts) {
         {"jsonPolicy",  required_argument, NULL, 'o'},
 
     };
-    return (*opts = tpm2_options_new ("f:o:p:", ARRAY_LEN(topts), topts,
+    return (*opts = tpm2_options_new ("fo:p:", ARRAY_LEN(topts), topts,
                                       on_option, NULL, 0)) != NULL;
 }
 

--- a/tools/fapi/tss2_getappdata.c
+++ b/tools/fapi/tss2_getappdata.c
@@ -65,10 +65,13 @@ int tss2_tool_onrun (FAPI_CONTEXT *fctx) {
     }
 
     /* Write returned data to file(s) */
-    r = open_write_and_close (ctx.data, ctx.overwrite, appData, appDataSize);
-    if (r != TSS2_RC_SUCCESS) {
-        LOG_PERR ("open_write_and_close appData", r);
-        return 1;
+    if (appData && ctx.data) {
+        r = open_write_and_close (ctx.data, ctx.overwrite, appData,
+            appDataSize);
+        if (r != TSS2_RC_SUCCESS) {
+            LOG_PERR ("open_write_and_close appData", r);
+            return 1;
+        }
     }
 
    /* Free allocated variables */

--- a/tools/fapi/tss2_getappdata.c
+++ b/tools/fapi/tss2_getappdata.c
@@ -41,7 +41,7 @@ bool tss2_tool_onstart(tpm2_options **opts) {
         {"force" , no_argument, NULL, 'f'},
 
     };
-    return (*opts = tpm2_options_new ("o:f:p:", ARRAY_LEN(topts), topts,
+    return (*opts = tpm2_options_new ("o:fp:", ARRAY_LEN(topts), topts,
                                       on_option, NULL, 0)) != NULL;
 }
 

--- a/tools/fapi/tss2_getcertificate.c
+++ b/tools/fapi/tss2_getcertificate.c
@@ -67,7 +67,7 @@ int tss2_tool_onrun (FAPI_CONTEXT *fctx) {
     r = open_write_and_close (ctx.x509cert, ctx.overwrite, x509certData,
         strlen(x509certData));
     if (r){
-        LOG_PERR ("open_read_and_close x509certData", r);
+        LOG_PERR ("open_write_and_close x509certData", r);
         Fapi_Free (x509certData);
         return 1;
     }

--- a/tools/fapi/tss2_getcertificate.c
+++ b/tools/fapi/tss2_getcertificate.c
@@ -39,7 +39,7 @@ bool tss2_tool_onstart(tpm2_options **opts) {
         {"path"    , required_argument, NULL, 'p'},
         {"x509certData", required_argument, NULL, 'o'}
     };
-    return (*opts = tpm2_options_new ("f:p:o:", ARRAY_LEN(topts), topts,
+    return (*opts = tpm2_options_new ("fp:o:", ARRAY_LEN(topts), topts,
                                       on_option, NULL, 0)) != NULL;
 }
 

--- a/tools/fapi/tss2_getdescription.c
+++ b/tools/fapi/tss2_getdescription.c
@@ -67,7 +67,7 @@ int tss2_tool_onrun (FAPI_CONTEXT *fctx) {
     r = open_write_and_close (ctx.description, ctx.overwrite, description,
         strlen(description));
     if (r){
-        LOG_PERR ("open_read_and_close description", r);
+        LOG_PERR ("open_write_and_close description", r);
         Fapi_Free (description);
         return 1;
     }

--- a/tools/fapi/tss2_getdescription.c
+++ b/tools/fapi/tss2_getdescription.c
@@ -39,7 +39,7 @@ bool tss2_tool_onstart(tpm2_options **opts) {
         {"description" , required_argument, NULL, 'o'},
         {"force"       , no_argument      , NULL, 'f'},
     };
-    return (*opts = tpm2_options_new ("o:f:p:", ARRAY_LEN(topts), topts,
+    return (*opts = tpm2_options_new ("o:fp:", ARRAY_LEN(topts), topts,
                                       on_option, NULL, 0)) != NULL;
 }
 

--- a/tools/fapi/tss2_getinfo.c
+++ b/tools/fapi/tss2_getinfo.c
@@ -34,7 +34,7 @@ bool tss2_tool_onstart(tpm2_options **opts) {
         /* output file */
         {"info"  , required_argument, NULL, 'o'}
     };
-    return (*opts = tpm2_options_new ("f:o:", ARRAY_LEN(topts), topts,
+    return (*opts = tpm2_options_new ("fo:", ARRAY_LEN(topts), topts,
                                       on_option, NULL, 0)) != NULL;
 }
 

--- a/tools/fapi/tss2_getinfo.c
+++ b/tools/fapi/tss2_getinfo.c
@@ -40,6 +40,12 @@ bool tss2_tool_onstart(tpm2_options **opts) {
 
 /* Execute specific tool */
 int tss2_tool_onrun (FAPI_CONTEXT *fctx) {
+    /* Check availability of required parameters */
+    if (!ctx.info) {
+        fprintf (stderr, "info parameter is missing, pass --info\n");
+        return -1;
+    }
+
     /* Execute FAPI command with passed arguments */
     char *info;
     TSS2_RC r = Fapi_GetInfo (fctx, &info);

--- a/tools/fapi/tss2_getplatformcertificates.c
+++ b/tools/fapi/tss2_getplatformcertificates.c
@@ -34,7 +34,7 @@ bool tss2_tool_onstart(tpm2_options **opts) {
         {"force",           no_argument      , NULL, 'f'},
         {"certificates",    required_argument, NULL, 'o'}
     };
-    return (*opts = tpm2_options_new ("f:o:", ARRAY_LEN(topts), topts,
+    return (*opts = tpm2_options_new ("fo:", ARRAY_LEN(topts), topts,
                                       on_option, NULL, 0)) != NULL;
 }
 

--- a/tools/fapi/tss2_getplatformcertificates.c
+++ b/tools/fapi/tss2_getplatformcertificates.c
@@ -53,23 +53,22 @@ int tss2_tool_onrun (FAPI_CONTEXT *fctx) {
         &certificatesSize);
     if (r != TSS2_RC_SUCCESS) {
         LOG_PERR ("Fapi_GetPlatformCertificates", r);
-        if (certificatesSize>0){
-            Fapi_Free (certificates);
-        }
+        Fapi_Free (certificates);
         return 1;
     }
 
     /* Write returned data to file(s) */
-    if (certificatesSize>0){
+    if (certificatesSize && certificatesSize > 0) {
         r = open_write_and_close (ctx.certificates, ctx.overwrite,
             certificates, certificatesSize);
-        if (r){
+        if (r) {
             LOG_PERR ("open_write_and_close certificates", r);
             Fapi_Free (certificates);
             return 1;
         }
-        Fapi_Free (certificates);
     }
+
+    Fapi_Free (certificates);
 
     return 0;
 }

--- a/tools/fapi/tss2_getrandom.c
+++ b/tools/fapi/tss2_getrandom.c
@@ -49,7 +49,7 @@ bool tss2_tool_onstart(tpm2_options **opts) {
         /* output file */
         {"data"   , required_argument, NULL, 'o'}
     };
-    return (*opts = tpm2_options_new ("f:n:o:", ARRAY_LEN(topts), topts,
+    return (*opts = tpm2_options_new ("fn:o:", ARRAY_LEN(topts), topts,
                                       on_option, NULL, 0)) != NULL;
 }
 

--- a/tools/fapi/tss2_gettpmblobs.c
+++ b/tools/fapi/tss2_gettpmblobs.c
@@ -61,6 +61,17 @@ int tss2_tool_onrun (FAPI_CONTEXT *fctx) {
         return -1;
     }
 
+    /* Check exclusive access to stdout */
+    int count_out = 0;
+    if (ctx.tpm2bPublic && !strcmp (ctx.tpm2bPublic, "-")) count_out +=1;
+    if (ctx.tpm2bPrivate && !strcmp (ctx.tpm2bPrivate, "-")) count_out +=1;
+    if (ctx.policy && !strcmp (ctx.policy, "-")) count_out +=1;
+    if (count_out > 1) {
+        fprintf (stderr, "Only one of --tpm2bPublic, --tpm2bPrivate and "\
+        "--policy can print to - (standard output)\n");
+        return -1;
+    }
+
     /* Execute FAPI command with passed arguments */
     uint8_t *tpm2bPublic;
     size_t  tpm2bPublicSize;

--- a/tools/fapi/tss2_gettpmblobs.c
+++ b/tools/fapi/tss2_gettpmblobs.c
@@ -49,7 +49,7 @@ bool tss2_tool_onstart(tpm2_options **opts) {
         {"tpm2bPrivate"    , required_argument, NULL, 'r'},
         {"policy"    , required_argument, NULL, 'l'},
     };
-    return (*opts = tpm2_options_new ("f:p:u:r:l", ARRAY_LEN(topts), topts,
+    return (*opts = tpm2_options_new ("fp:u:r:l", ARRAY_LEN(topts), topts,
                                       on_option, NULL, 0)) != NULL;
 }
 

--- a/tools/fapi/tss2_import.c
+++ b/tools/fapi/tss2_import.c
@@ -60,11 +60,11 @@ int tss2_tool_onrun (FAPI_CONTEXT *fctx) {
     r = Fapi_Import (fctx, ctx.path, importData);
     if (r != TSS2_RC_SUCCESS){
         LOG_PERR("Fapi_Import", r);
-        Fapi_Free (importData);
+        free (importData);
         return 1;
     }
 
-    Fapi_Free (importData);
+    free (importData);
 
     return 0;
 }

--- a/tools/fapi/tss2_nvextend.c
+++ b/tools/fapi/tss2_nvextend.c
@@ -3,6 +3,7 @@
 #include <stdbool.h>
 #include <stdio.h>
 #include <stdlib.h>
+#include <string.h>
 #include "tools/fapi/tss2_template.h"
 
 /* needed by tpm2_util and tpm2_option functions */
@@ -51,6 +52,16 @@ int tss2_tool_onrun (FAPI_CONTEXT *fctx) {
     }
     if (!ctx.data) {
         fprintf (stderr, "No file for input provided, use --data\n");
+        return -1;
+    }
+
+    /* Check exclusive access to stdin */
+    int count_in = 0;
+    if (ctx.data && !strcmp (ctx.data, "-")) count_in +=1;
+    if (ctx.logData && !strcmp (ctx.logData, "-")) count_in +=1;
+    if (count_in > 1) {
+        fprintf (stderr, "Only one of --data and --logData can read from - "\
+        "(standard input)\n");
         return -1;
     }
 

--- a/tools/fapi/tss2_nvextend.c
+++ b/tools/fapi/tss2_nvextend.c
@@ -68,11 +68,10 @@ int tss2_tool_onrun (FAPI_CONTEXT *fctx) {
         TSS2_RC r = open_read_and_close (ctx.logData, (void**)&logData, 0);
         if (r){
             LOG_PERR ("open_read_and_close logData", r);
-            Fapi_Free (data);
+            free (data);
             return 1;
         }
     }
-
 
     /* Execute FAPI command with passed arguments */
     r = Fapi_NvExtend(fctx, ctx.nvPath, data, data_len, logData);
@@ -80,10 +79,8 @@ int tss2_tool_onrun (FAPI_CONTEXT *fctx) {
         LOG_PERR("Fapi_NvExtend", r);
         return 1;
     }
-    Fapi_Free (data);
-    if (logData){
-        Fapi_Free (logData);
-    }
+    free (data);
+    free (logData);
 
     return 0;
 }

--- a/tools/fapi/tss2_nvread.c
+++ b/tools/fapi/tss2_nvread.c
@@ -61,6 +61,16 @@ int tss2_tool_onrun (FAPI_CONTEXT *fctx) {
         return -1;
     }
 
+    /* Check exclusive access to stdout */
+    int count_out = 0;
+    if (ctx.data && !strcmp (ctx.data, "-")) count_out +=1;
+    if (ctx.logData && !strcmp (ctx.logData, "-")) count_out +=1;
+    if (count_out > 1) {
+        fprintf (stderr, "Only one of --data and --logData can print to - "\
+        "(standard output)\n");
+        return -1;
+    }
+
     /* Execute FAPI command with passed arguments */
     uint8_t *data;
     size_t data_len;

--- a/tools/fapi/tss2_nvread.c
+++ b/tools/fapi/tss2_nvread.c
@@ -45,7 +45,7 @@ bool tss2_tool_onstart(tpm2_options **opts) {
         {"data", required_argument, NULL, 'o'},
         {"logData", required_argument, NULL, 'l'}
     };
-    return (*opts = tpm2_options_new ("f:o:p:l:", ARRAY_LEN(topts), topts,
+    return (*opts = tpm2_options_new ("fo:p:l:", ARRAY_LEN(topts), topts,
                                       on_option, NULL, 0)) != NULL;
 }
 

--- a/tools/fapi/tss2_nvread.c
+++ b/tools/fapi/tss2_nvread.c
@@ -70,23 +70,26 @@ int tss2_tool_onrun (FAPI_CONTEXT *fctx) {
         LOG_PERR ("Fapi_NvRead", r);
         return 1;
     }
-    else {
-        /* Write returned data to file(s) */
-        r = open_write_and_close (ctx.data, ctx.overwrite, data, data_len);
-        if (r){
-            LOG_PERR ("open_write_and_close data", r);
+
+    /* Write returned data to file(s) */
+    r = open_write_and_close (ctx.data, ctx.overwrite, data, data_len);
+    if (r) {
+        LOG_PERR ("open_write_and_close data", r);
+        return 1;
+    }
+
+    if (ctx.logData && logData) {
+        r = open_write_and_close (ctx.logData, ctx.overwrite, logData,
+            strlen(logData));
+        if (r) {
+            Fapi_Free (data);
+            LOG_PERR ("open_write_and_close logData", r);
             return 1;
         }
-        if (logData){
-            r = open_write_and_close (ctx.logData, ctx.overwrite, logData, strlen(logData));
-            if (r){
-                Fapi_Free (data);
-                LOG_PERR ("open_write_and_close logData", r);
-                return 1;
-            }
-            Fapi_Free (logData);
-        }
-        Fapi_Free (data);
     }
+
+    Fapi_Free (logData);
+    Fapi_Free (data);
+
     return 0;
 }

--- a/tools/fapi/tss2_nvwrite.c
+++ b/tools/fapi/tss2_nvwrite.c
@@ -65,6 +65,6 @@ int tss2_tool_onrun (FAPI_CONTEXT *fctx) {
         LOG_PERR ("Fapi_NvWrite", r);
         return 1;
     }
-    Fapi_Free (data);
+    free (data);
     return 0;
 }

--- a/tools/fapi/tss2_pcrextend.c
+++ b/tools/fapi/tss2_pcrextend.c
@@ -3,6 +3,7 @@
 #include <stdbool.h>
 #include <stdio.h>
 #include <stdlib.h>
+#include <string.h>
 #include "tools/fapi/tss2_template.h"
 
 /* needed by tpm2_util and tpm2_option functions */
@@ -55,6 +56,16 @@ int tss2_tool_onrun (FAPI_CONTEXT *fctx) {
     }
     if (!ctx.data) {
         fprintf (stderr, "No event data provided, use --data\n");
+        return -1;
+    }
+
+    /* Check exclusive access to stdin */
+    int count_in = 0;
+    if (ctx.data && !strcmp (ctx.data, "-")) count_in +=1;
+    if (ctx.logData && !strcmp (ctx.logData, "-")) count_in +=1;
+    if (count_in > 1) {
+        fprintf (stderr, "Only one of --data and --logData can read from - "\
+        "(standard input)\n");
         return -1;
     }
 

--- a/tools/fapi/tss2_pcrextend.c
+++ b/tools/fapi/tss2_pcrextend.c
@@ -57,13 +57,9 @@ int tss2_tool_onrun (FAPI_CONTEXT *fctx) {
         fprintf (stderr, "No event data provided, use --data\n");
         return -1;
     }
-    if (!ctx.logData) {
-        fprintf (stderr, "No log data provided, use --logData\n");
-        return -1;
-    }
 
     /* Read event data and log data from file */
-    uint8_t *data;
+    uint8_t *data = NULL;
     size_t eventDataSize;
     TSS2_RC r = open_read_and_close (ctx.data, (void**)&data,
         &eventDataSize);
@@ -71,12 +67,15 @@ int tss2_tool_onrun (FAPI_CONTEXT *fctx) {
         LOG_PERR ("open_read_and_close data", r);
         return -1;
     }
-    char *logData;
-    r = open_read_and_close (ctx.logData, (void**)&logData, 0);
-    if (r){
-        LOG_PERR ("open_read_and_close logData", r);
-        Fapi_Free (data);
-        return -1;
+
+    char *logData = NULL;
+    if (ctx.logData) {
+        r = open_read_and_close (ctx.logData, (void**)&logData, 0);
+        if (r) {
+            LOG_PERR ("open_read_and_close logData", r);
+            Fapi_Free (data);
+            return -1;
+        }
     }
 
     /* Execute FAPI command with passed arguments */
@@ -87,7 +86,7 @@ int tss2_tool_onrun (FAPI_CONTEXT *fctx) {
         return 1;
     }
 
-    Fapi_Free (data);
+    free (data);
     free (logData);
 
     return 0;

--- a/tools/fapi/tss2_pcrread.c
+++ b/tools/fapi/tss2_pcrread.c
@@ -60,12 +60,14 @@ int tss2_tool_onrun (FAPI_CONTEXT *fctx) {
         return -1;
     }
 
-    if (ctx.pcrLog && ctx.pcrValue) {
-        if (!strcmp (ctx.pcrLog, "-") && !strcmp (ctx.pcrValue, "-")) {
-            fprintf (stderr, "Only one of --pcrLog and --pcrValue "\
-                "can read from standard input");
-            return -1;
-        }
+    /* Check exclusive access to stdout */
+    int count_out = 0;
+    if (ctx.pcrValue && !strcmp (ctx.pcrValue, "-")) count_out +=1;
+    if (ctx.pcrLog && !strcmp (ctx.pcrLog, "-")) count_out +=1;
+    if (count_out > 1) {
+        fprintf (stderr, "Only one of --pcrValue and --pcrLog can print to - "\
+        "(standard output)\n");
+        return -1;
     }
 
     /* Execute FAPI command with passed arguments */

--- a/tools/fapi/tss2_pcrread.c
+++ b/tools/fapi/tss2_pcrread.c
@@ -48,7 +48,7 @@ bool tss2_tool_onstart(tpm2_options **opts) {
         {"force"         , no_argument      , NULL, 'f'},
         {"pcrLog"       , required_argument, NULL, 'l'}
     };
-    return (*opts = tpm2_options_new ("o:x:f:l:", ARRAY_LEN(topts), topts,
+    return (*opts = tpm2_options_new ("o:x:fl:", ARRAY_LEN(topts), topts,
                                       on_option, NULL, 0)) != NULL;
 }
 

--- a/tools/fapi/tss2_quote.c
+++ b/tools/fapi/tss2_quote.c
@@ -99,7 +99,7 @@ bool tss2_tool_onstart(tpm2_options **opts) {
         {"certificate"    , required_argument, NULL, 'c'},
         {"force"          , no_argument      , NULL, 'f'}
     };
-    return (*opts = tpm2_options_new ("x:Q:l:f:p:q:o:c:", ARRAY_LEN(topts),
+    return (*opts = tpm2_options_new ("x:Q:l:fp:q:o:c:", ARRAY_LEN(topts),
         topts, on_option, NULL, 0)) != NULL;
 }
 

--- a/tools/fapi/tss2_setcertificate.c
+++ b/tools/fapi/tss2_setcertificate.c
@@ -43,19 +43,18 @@ int tss2_tool_onrun (FAPI_CONTEXT *fctx) {
         fprintf (stderr, "path missing, use --path\n");
         return -1;
     }
-    if (!ctx.x509cert) {
-        fprintf (stderr, "x509certData missing, use --x509certData\n");
-        return -1;
-    }
 
     /* Read x509 certificate from file */
-    char* x509certData;
+    TSS2_RC r;
+    char* x509certData = NULL;
     size_t x509certSize;
-    TSS2_RC r = open_read_and_close (ctx.x509cert, (void**)&x509certData,
-        &x509certSize);
-    if (r){
-        LOG_PERR("open_read_and_close x509cert", r);
-        return 1;
+    if (ctx.x509cert) {
+        r = open_read_and_close (ctx.x509cert, (void**)&x509certData,
+            &x509certSize);
+        if (r) {
+            LOG_PERR("open_read_and_close x509cert", r);
+            return 1;
+        }
     }
 
     /* Execute FAPI command with passed arguments */

--- a/tools/fapi/tss2_setdescription.c
+++ b/tools/fapi/tss2_setdescription.c
@@ -47,10 +47,6 @@ int tss2_tool_onrun (FAPI_CONTEXT *fctx) {
         fprintf (stderr, "path is missing, use --path\n");
         return -1;
     }
-    if (!ctx.description) {
-        fprintf (stderr, "description is missing, use --description\n");
-        return -1;
-    }
 
     /* Execute FAPI command with passed arguments */
     TSS2_RC r = Fapi_SetDescription (fctx, ctx.path, ctx.description);

--- a/tools/fapi/tss2_sign.c
+++ b/tools/fapi/tss2_sign.c
@@ -61,7 +61,7 @@ bool tss2_tool_onstart(tpm2_options **opts) {
         {"certificate", required_argument, NULL, 'c'},
 
     };
-    return (*opts = tpm2_options_new ("c:d:f:p:k:o:s:", ARRAY_LEN(topts), topts,
+    return (*opts = tpm2_options_new ("c:d:fp:k:o:s:", ARRAY_LEN(topts), topts,
                                       on_option, NULL, 0)) != NULL;
 }
 

--- a/tools/fapi/tss2_sign.c
+++ b/tools/fapi/tss2_sign.c
@@ -81,27 +81,16 @@ int tss2_tool_onrun (FAPI_CONTEXT *fctx) {
         fprintf (stderr, "signature missing, use --signature\n");
         return -1;
     }
-    if (ctx.publicKey && ctx.certificate){
-        if (!strcmp ("-", ctx.signature) + !strcmp ("-", ctx.publicKey) +
-            !strcmp("-", ctx.certificate) > 1) {
-            fprintf (stderr, "At most one of --certificate, --publicKey and "\
-                "--signature can be '-' (standard output)\n");
-            return -1;
-        }
-    }
-    if (ctx.publicKey && !ctx.certificate){
-        if (!strcmp ("-", ctx.signature) + !strcmp ("-", ctx.publicKey) > 1) {
-            fprintf (stderr, "At most one of --publicKey and --signature can "\
-                "be '-' (standard output)\n");
-            return -1;
-        }
-    }
-    if (ctx.certificate && !ctx.publicKey){
-        if (!strcmp ("-", ctx.signature) + !strcmp("-", ctx.certificate) > 1) {
-            fprintf (stderr, "At most one of --certificate and --signature can"\
-            " be '-' (standard output)\n");
-            return -1;
-        }
+
+    /* Check exclusive access to stdout */
+    int count_out = 0;
+    if (ctx.certificate && !strcmp (ctx.certificate, "-")) count_out +=1;
+    if (ctx.signature && !strcmp (ctx.signature, "-")) count_out +=1;
+    if (ctx.publicKey && !strcmp (ctx.publicKey, "-")) count_out +=1;
+    if (count_out > 1) {
+        fprintf (stderr, "Only one of --certificate, --signature and "\
+        "--publicKey can print to - (standard output)\n");
+        return -1;
     }
 
     /* Read data needed to create signature */

--- a/tools/fapi/tss2_template.c
+++ b/tools/fapi/tss2_template.c
@@ -367,7 +367,6 @@ int open_write_and_close(const char* path, bool overwrite, const void *output,
             fprintf (stderr, "write(2) to stdout failed: %m\n");
             return 1;
         }
-        putchar ('\n');
         return 0;
     }
 

--- a/tools/fapi/tss2_template.c
+++ b/tools/fapi/tss2_template.c
@@ -123,25 +123,42 @@ static tpm2_option_code tss2_handle_options (
                 fprintf (stderr, "Not enough memory\n");
                 goto out;
             }
-            char *fapi_version;
-            TSS2_RC ret = Fapi_GetInfo(fctx, &fapi_version);
+            char *info;
+            TSS2_RC ret = Fapi_GetInfo(fctx, &info);
             if (ret != TSS2_RC_SUCCESS) {
                 fprintf (stderr, "Fapi_GetInfo returned %u\n", ret);
                 free(prog_name);
                 goto out;
             }
-            char* target = strndup(fapi_version, 50); // TODO: Extract correct version
-            /* N.B. the returned version is UTF-8 and printing it correct
-             * depends on the locale */
-            Fapi_Free(fapi_version);
-            printf ("%s from " PACKAGE " version " VERSION " using at run time "
-                    "FAPI library version %s.\nCopyright (C) 2019 Fraunhofer SI"
-                    "T.\nLicense BSD-3-Clause.\nMy homepage is https://github.com/tpm2"
-                    "-software/tpm2-tools .  The homepage of the FAPI library i"
-                    "s https://github.com/tpm2-software/tpm2-tss .\n",
-                    basename (prog_name), target /*fapi_version*/);
+
+            char *version = NULL;
+            char *t = strstr(info, "\"version\"");
+            if (t) {
+                t = t + strlen("\"version\"");
+                version = (char*) malloc(strlen(t) + 1);
+                if (!version) {
+                    fprintf (stderr, "malloc(2) failed: %m\n");
+                    return 1;
+                }
+                ret = sscanf(t, "%*[^\"]\"%[^\"]%*[*]", version);
+                /* Version string is not larger than 128 characters */
+                if (ret!=1 || strlen(version) > 128 ) {
+                    version = "not found";
+                    t = NULL;
+                }
+            }
+            else{
+                version = "not found";
+            }
+            Fapi_Free(info);
+
+            printf("tool=\"%s\" version=\"%s\" fapi-version=\"%s\"\n",
+                basename (prog_name), VERSION, version);
+
             free(prog_name);
-            free(target);
+            if (t) {
+                free(version);
+            }
             }
             rc = tpm2_option_code_stop;
             goto out;

--- a/tools/fapi/tss2_template.c
+++ b/tools/fapi/tss2_template.c
@@ -135,14 +135,10 @@ static tpm2_option_code tss2_handle_options (
             char *t = strstr(info, "\"version\"");
             if (t) {
                 t = t + strlen("\"version\"");
-                version = (char*) malloc(strlen(t) + 1);
-                if (!version) {
-                    fprintf (stderr, "malloc(2) failed: %m\n");
-                    return 1;
-                }
-                ret = sscanf(t, "%*[^\"]\"%[^\"]%*[*]", version);
+                ret = sscanf(t, "%*[^\"]\"%m[^\"]%*[*]", &version);
                 /* Version string is not larger than 128 characters */
                 if (ret!=1 || strlen(version) > 128 ) {
+                    free(version);
                     version = "not found";
                     t = NULL;
                 }

--- a/tools/fapi/tss2_unseal.c
+++ b/tools/fapi/tss2_unseal.c
@@ -49,10 +49,6 @@ int tss2_tool_onrun (FAPI_CONTEXT *fctx) {
         fprintf (stderr, "path to the sealed data missing, use --path\n");
         return -1;
     }
-    if (!ctx.data) {
-        fprintf (stderr, "path to decrypted data missing, use --data\n");
-        return -1;
-    }
 
     /* Execute FAPI command with passed arguments */
     uint8_t *data;
@@ -64,13 +60,15 @@ int tss2_tool_onrun (FAPI_CONTEXT *fctx) {
     }
 
     /* Write returned data to file(s) */
-    r = open_write_and_close (ctx.data, ctx.overwrite, data, size);
-    if (r){
-        LOG_PERR ("open_write_and_close data", r);
-        Fapi_Free (data);
-        return 1;
+    if (ctx.data && data) {
+        r = open_write_and_close (ctx.data, ctx.overwrite, data, size);
+        if (r) {
+            LOG_PERR ("open_write_and_close data", r);
+            Fapi_Free (data);
+            return 1;
+        }
     }
-
     Fapi_Free (data);
+
     return 0;
 }

--- a/tools/fapi/tss2_verifyquote.c
+++ b/tools/fapi/tss2_verifyquote.c
@@ -70,33 +70,17 @@ int tss2_tool_onrun (FAPI_CONTEXT *fctx) {
             " --signature\n");
         return -1;
     }
-    if (ctx.qualifyingData && ctx.pcrLog) {
-        if (!strcmp (ctx.signature, "-") + !strcmp(ctx.qualifyingData, "-") +
-            !strcmp(ctx.quoteInfo, "-") + !strcmp(ctx.pcrLog, "-") > 1) {
-                fprintf (stderr, "At most one of --signature, "\
-                    "--qualifyingData, --quoteInfo and --pcrLog can "\
-                    "be '-' (standard output)\n");
-                return -1;
-        }
-    }
 
-    if (!ctx.qualifyingData && ctx.pcrLog) {
-        if (!strcmp (ctx.signature, "-") + !strcmp(ctx.quoteInfo, "-") +
-            !strcmp(ctx.pcrLog, "-") > 1) {
-                fprintf (stderr, "At most one of --signature, "\
-                    " --quoteInfo and --pcrLog can be '-' (standard output)\n");
-                return -1;
-        }
-    }
-
-    if (ctx.qualifyingData && !ctx.pcrLog) {
-        if (!strcmp (ctx.signature, "-") + !strcmp(ctx.qualifyingData, "-") +
-            !strcmp(ctx.quoteInfo, "-") > 1) {
-                fprintf (stderr, "At most one of --signature, "\
-                    "--qualifyingData and --quoteInfo can "\
-                    "be '-' (standard output)\n");
-                return -1;
-        }
+    /* Check exclusive access to stdin */
+    int count_in = 0;
+    if (ctx.qualifyingData && !strcmp (ctx.qualifyingData, "-")) count_in +=1;
+    if (ctx.signature && !strcmp (ctx.signature, "-")) count_in +=1;
+    if (ctx.quoteInfo && !strcmp (ctx.quoteInfo, "-")) count_in +=1;
+    if (ctx.pcrLog && !strcmp (ctx.pcrLog, "-")) count_in +=1;
+    if (count_in > 1) {
+        fprintf (stderr, "Only one of --qualifyingData, --signature, "\
+        " --quoteInfo and --pcrLog can read from - (standard input)\n");
+        return -1;
     }
 
     /* Read qualifyingData, signature, quoteInfo and pcrLog from file */

--- a/tools/fapi/tss2_verifysignature.c
+++ b/tools/fapi/tss2_verifysignature.c
@@ -60,9 +60,14 @@ int tss2_tool_onrun (FAPI_CONTEXT *fctx) {
             "--signature\n");
         return -1;
     }
-    if (!strcmp ("-", ctx.signature)  && !strcmp("-", ctx.digest)) {
-        fprintf (stderr, "At most one of --signature and --digest can be '-'"\
-            " (standard input)\n");
+
+    /* Check exclusive access to stdin */
+    int count_in = 0;
+    if (ctx.digest && !strcmp (ctx.digest, "-")) count_in +=1;
+    if (ctx.signature && !strcmp (ctx.signature, "-")) count_in +=1;
+    if (count_in > 1) {
+        fprintf (stderr, "Only one of --digest and --signature can read from -"\
+        "(standard input)\n");
         return -1;
     }
 


### PR DESCRIPTION
- Several fixes for the tss2 tools to be back ported to 4.2.X branch:
  - Fix some double-free errors
  - Shorthand command -f does not need argument
  - Update tss2_encrypt to the new FAPI interface
  - An additional \n was appended when redirecting to stdout
  - Adapt optional and mandatory parameters for tools in code
  - Extract Fapi version from Fapi_GetInfo
  - Error handling in case of multiple inputs and/or outputs from/to stdin/stdout
  - Fix and update content of man pages 
  - Add parameter types to all man pages 

Signed-off-by: Christian Plappert christian.plappert@sit.fraunhofer.de