### PR TITLE
Qualified name and tpm2_print additions

### DIFF
--- a/doc/CHANGELOG.md
+++ b/doc/CHANGELOG.md
@@ -7,6 +7,7 @@
  * Fix missing handle maps for ESY3 handle breaks. See #1994.
 
  * tpm2\_createak: add qualified name output as -q.
+ * tpm2\_readpublic: add qualified name output as -q.
 
 ### 4.2 2020-04-08
 

--- a/doc/CHANGELOG.md
+++ b/doc/CHANGELOG.md
@@ -8,6 +8,9 @@
 
  * tpm2\_createak: add qualified name output as -q.
  * tpm2\_readpublic: add qualified name output as -q.
+ * tpm2\_print:
+   - Support printing TPM2B\_PUBLIC data structures.
+   - Support printing TPMT\_PUBLIC data structures.
 
 ### 4.2 2020-04-08
 

--- a/doc/CHANGELOG.md
+++ b/doc/CHANGELOG.md
@@ -6,6 +6,8 @@
 
  * Fix missing handle maps for ESY3 handle breaks. See #1994.
 
+ * tpm2\_createak: add qualified name output as -q.
+
 ### 4.2 2020-04-08
 
  * Fix various issues reported by static analysis tools.

--- a/doc/CHANGELOG.md
+++ b/doc/CHANGELOG.md
@@ -7,7 +7,9 @@
  * Fix missing handle maps for ESY3 handle breaks. See #1994.
 
  * tpm2\_createak: add qualified name output as -q.
+
  * tpm2\_readpublic: add qualified name output as -q.
+
  * tpm2\_print:
    - Support printing TPM2B\_PUBLIC data structures.
    - Support printing TPMT\_PUBLIC data structures.

--- a/lib/files.c
+++ b/lib/files.c
@@ -687,11 +687,34 @@ tool_rc files_save_ESYS_TR(ESYS_CONTEXT *ectx, ESYS_TR handle, const char *path)
         return rc == TPM2_RC_SUCCESS; \
     }
 
+#define LOAD_TYPE_FILE(type, name) \
+    bool files_load_##name##_file(FILE *f, const char *path, type *name) { \
+    \
+        UINT8 buffer[sizeof(*name)]; \
+        UINT16 size = sizeof(buffer); \
+        bool res = file_read_bytes_from_file(f, buffer, &size, path); \
+        if (!res) { \
+            return false; \
+        } \
+        \
+        size_t offset = 0; \
+        TSS2_RC rc = Tss2_MU_##type##_Unmarshal(buffer, size, &offset, name); \
+        if (rc != TSS2_RC_SUCCESS) { \
+            LOG_ERR("Error deserializing "str(name)" structure: 0x%x", rc); \
+            LOG_ERR("The input file needs to be a valid "xstr(type)" data structure"); \
+            return false; \
+        } \
+        \
+        return rc == TPM2_RC_SUCCESS; \
+    }
+
 SAVE_TYPE(TPM2B_PUBLIC, public)
 LOAD_TYPE(TPM2B_PUBLIC, public)
+LOAD_TYPE_FILE(TPM2B_PUBLIC, public)
 
 SAVE_TYPE(TPMT_PUBLIC, template)
 LOAD_TYPE(TPMT_PUBLIC, template)
+LOAD_TYPE_FILE(TPMT_PUBLIC, template)
 
 SAVE_TYPE(TPMT_SIGNATURE, signature)
 LOAD_TYPE(TPMT_SIGNATURE, signature)

--- a/lib/files.h
+++ b/lib/files.h
@@ -179,6 +179,13 @@ bool files_save_template(TPMT_PUBLIC *template, const char *path);
  */
 bool files_load_public(const char *path, TPM2B_PUBLIC *public);
 
+bool files_load_public_file(FILE *f, const char *path, TPM2B_PUBLIC *public);
+
+bool files_load_template(const char *path, TPMT_PUBLIC *public);
+
+bool files_load_template_file(FILE *f, const char *path, TPMT_PUBLIC *public);
+
+
 /**
  * Serializes a TPMT_SIGNATURE to the file path provided.
  * @param signature

--- a/lib/tpm2_openssl.c
+++ b/lib/tpm2_openssl.c
@@ -123,10 +123,6 @@ int ECDSA_SIG_set0(ECDSA_SIG *sig, BIGNUM *r, BIGNUM *s) {
 
 #endif
 
-static inline const char *get_openssl_err(void) {
-    return ERR_error_string(ERR_get_error(), NULL);
-}
-
 bool tpm2_openssl_hash_compute_data(TPMI_ALG_HASH halg, BYTE *buffer,
         UINT16 length, TPM2B_DIGEST *digest) {
 
@@ -139,26 +135,26 @@ bool tpm2_openssl_hash_compute_data(TPMI_ALG_HASH halg, BYTE *buffer,
 
     EVP_MD_CTX *mdctx = EVP_MD_CTX_create();
     if (!mdctx) {
-        LOG_ERR("%s", get_openssl_err());
+        LOG_ERR("%s", tpm2_openssl_get_err());
         return false;
     }
 
     int rc = EVP_DigestInit_ex(mdctx, md, NULL);
     if (!rc) {
-        LOG_ERR("%s", get_openssl_err());
+        LOG_ERR("%s", tpm2_openssl_get_err());
         goto out;
     }
 
     rc = EVP_DigestUpdate(mdctx, buffer, length);
     if (!rc) {
-        LOG_ERR("%s", get_openssl_err());
+        LOG_ERR("%s", tpm2_openssl_get_err());
         goto out;
     }
 
     unsigned size = EVP_MD_size(md);
     rc = EVP_DigestFinal_ex(mdctx, digest->buffer, &size);
     if (!rc) {
-        LOG_ERR("%s", get_openssl_err());
+        LOG_ERR("%s", tpm2_openssl_get_err());
         goto out;
     }
 
@@ -183,13 +179,13 @@ bool tpm2_openssl_hash_pcr_values(TPMI_ALG_HASH halg, TPML_DIGEST *digests,
 
     EVP_MD_CTX *mdctx = EVP_MD_CTX_create();
     if (!mdctx) {
-        LOG_ERR("%s", get_openssl_err());
+        LOG_ERR("%s", tpm2_openssl_get_err());
         return false;
     }
 
     int rc = EVP_DigestInit_ex(mdctx, md, NULL);
     if (!rc) {
-        LOG_ERR("%s", get_openssl_err());
+        LOG_ERR("%s", tpm2_openssl_get_err());
         goto out;
     }
 
@@ -199,7 +195,7 @@ bool tpm2_openssl_hash_pcr_values(TPMI_ALG_HASH halg, TPML_DIGEST *digests,
         TPM2B_DIGEST *b = &digests->digests[i];
         rc = EVP_DigestUpdate(mdctx, b->buffer, b->size);
         if (!rc) {
-            LOG_ERR("%s", get_openssl_err());
+            LOG_ERR("%s", tpm2_openssl_get_err());
             goto out;
         }
     }
@@ -208,7 +204,7 @@ bool tpm2_openssl_hash_pcr_values(TPMI_ALG_HASH halg, TPML_DIGEST *digests,
 
     rc = EVP_DigestFinal_ex(mdctx, digest->buffer, &size);
     if (!rc) {
-        LOG_ERR("%s", get_openssl_err());
+        LOG_ERR("%s", tpm2_openssl_get_err());
         goto out;
     }
 
@@ -235,13 +231,13 @@ bool tpm2_openssl_hash_pcr_banks(TPMI_ALG_HASH hash_alg,
 
     EVP_MD_CTX *mdctx = EVP_MD_CTX_create();
     if (!mdctx) {
-        LOG_ERR("%s", get_openssl_err());
+        LOG_ERR("%s", tpm2_openssl_get_err());
         return false;
     }
 
     int rc = EVP_DigestInit_ex(mdctx, md, NULL);
     if (!rc) {
-        LOG_ERR("%s", get_openssl_err());
+        LOG_ERR("%s", tpm2_openssl_get_err());
         goto out;
     }
 
@@ -266,7 +262,7 @@ bool tpm2_openssl_hash_pcr_banks(TPMI_ALG_HASH hash_alg,
             TPM2B_DIGEST *b = &pcrs->pcr_values[vi].digests[di];
             rc = EVP_DigestUpdate(mdctx, b->buffer, b->size);
             if (!rc) {
-                LOG_ERR("%s", get_openssl_err());
+                LOG_ERR("%s", tpm2_openssl_get_err());
                 goto out;
             }
 
@@ -285,7 +281,7 @@ bool tpm2_openssl_hash_pcr_banks(TPMI_ALG_HASH hash_alg,
     unsigned size = EVP_MD_size(md);
     rc = EVP_DigestFinal_ex(mdctx, digest->buffer, &size);
     if (!rc) {
-        LOG_ERR("%s", get_openssl_err());
+        LOG_ERR("%s", tpm2_openssl_get_err());
         goto out;
     }
 

--- a/lib/tpm2_openssl.h
+++ b/lib/tpm2_openssl.h
@@ -55,6 +55,10 @@ int ECDSA_SIG_set0(ECDSA_SIG *sig, BIGNUM *r, BIGNUM *s);
 typedef unsigned char *(*digester)(const unsigned char *d, size_t n,
         unsigned char *md);
 
+static inline const char *tpm2_openssl_get_err(void) {
+    return ERR_error_string(ERR_get_error(), NULL);
+}
+
 /**
  * Get an openssl hash algorithm ID from a tpm hashing algorithm ID.
  * @param algorithm

--- a/lib/tpm2_util.h
+++ b/lib/tpm2_util.h
@@ -463,4 +463,31 @@ bool tpm2_util_get_label(const char *value, TPM2B_DATA *label);
  */
 void tpm2_util_print_time(const TPMS_TIME_INFO *current_time);
 
+/**
+ * Given the parent qualified name and the name of an object, computes
+ * that objects qualified name.
+ *
+ * The qualified name is defined as:
+ * QNB ≔ HB (QNA || NAMEB)
+ *
+ * Where:
+ *  - QNB is the qualified name of the object.
+ *  - HB is the name hash algorithm of the object.
+ *  - QNA is the qualified name of the parent object.
+ *  - NAMEB is the name of the object.
+ *
+ * @param pqname
+ *  The parent qualified name.
+ * @param halg
+ *  The name hash algorithm of the object.
+ * @param name
+ *  The name of the object.
+ * @param qname
+ *  The output qname, valid on success.
+ * @return
+ *  True on success, false otherwise.
+ */
+bool tpm2_calq_qname(TPM2B_NAME *pqname,
+        TPMI_ALG_HASH halg, TPM2B_NAME *name, TPM2B_NAME *qname);
+
 #endif /* STRING_BYTES_H */

--- a/lib/tpm2_util.h
+++ b/lib/tpm2_util.h
@@ -354,6 +354,8 @@ void print_yaml_indent(size_t indent_count);
  */
 void tpm2_util_public_to_yaml(TPM2B_PUBLIC *public, char *indent);
 
+void tpm2_util_tpmt_public_to_yaml(TPMT_PUBLIC *public, char *indent);
+
 /**
  * Convert a TPMA_OBJECT to a yaml format and output if not quiet.
  * @param obj

--- a/man/tpm2_createak.1.md
+++ b/man/tpm2_createak.1.md
@@ -71,6 +71,12 @@ loaded-key:
 
     Format selection for the signature output file.
 
+  * **-q**, **\--ak-qualified-name**=_FILE_:
+
+    The qualified name of the attestation key object. The qualified name is the qualified name
+    of the parent object (the EK in this instance) and the name of the object itself. Thus, the
+    qualified name of an object serves to bind it to its parents.
+
 ## References
 
 [context object format](common/ctxobj.md) details the methods for specifying

--- a/man/tpm2_print.1.md
+++ b/man/tpm2_print.1.md
@@ -18,9 +18,11 @@ path argument. Reads from stdin if unspecified.
 
   * **-t**, **\--type**:
 
-    Required. Type of data structure. Only **TPMS_ATTEST** and **TPMS_CONTEXT**
-    are presently supported.
-
+    Required. Type of data structure. The option supports the following arguments:
+      * **TPMS_ATTEST**
+      * **TPMS_CONTEXT**
+      * **TPM2B_PUBLIC**
+      * **TPMT_PUBLIC**
   * **ARGUMENT** the command line argument specifies the path of the TPM data.
 
 ## References
@@ -61,6 +63,18 @@ tpm2_quote -c key.ctx -l 0x0004:16,17,18+0x000b:16,17,18 -g sha256 -m msg.dat
 
 ```bash
 tpm2_print -t TPMS_ATTEST msg.dat
+```
+
+### Print a public file
+
+```bash
+tpm2_print -t TPM2B_PUBLIC key.pub
+```
+
+### Print a tpmt public file
+```bash
+tpm2_readpublic -c key.ctx -f tpmt -o key.tpmt
+tpm2_print -t TPMT_PUBLIC key.tpmt
 ```
 
 [returns](common/returns.md)

--- a/man/tpm2_readpublic.1.md
+++ b/man/tpm2_readpublic.1.md
@@ -36,6 +36,12 @@
     optionally save the serialized handle for use later. This routine does NOT verify the name of the object being read. Callers should ensure that the
     contents of name match the expected objects name.
 
+  * **-q**, **\--qualified-name**=_FILE_:
+
+    Saves the qualified name of the object to _FILE_. The qualified name of the object is the name algorithm hash of
+    the parents qualified and the objects name. Thus the qualified name of the object serves as proof of the objects
+    parents.
+
 ## References
 
 [context object format](common/ctxobj.md) details the methods for specifying

--- a/test/integration/tests/createak.sh
+++ b/test/integration/tests/createak.sh
@@ -28,6 +28,10 @@ tpm2_createek -Q -c 0x8101000b -G rsa -u ek.pub
 tpm2_createak -Q -C 0x8101000b -c ak.ctx -G rsa -g sha256 -s rsassa -u ak.pub \
 -n ak.name -q ak.qname
 
+# Validate the qname
+tpm2_readpublic -c ak.ctx -q ak.qname2
+diff ak.qname ak.qname2
+
 # Find a vacant persistent handle
 tpm2_createak -C 0x8101000b -c ak.ctx -G rsa -g sha256 -s rsassa -u ak.pub \
 -n ak.name

--- a/test/integration/tests/createak.sh
+++ b/test/integration/tests/createak.sh
@@ -26,7 +26,7 @@ cleanup "no-shut-down"
 tpm2_createek -Q -c 0x8101000b -G rsa -u ek.pub
 
 tpm2_createak -Q -C 0x8101000b -c ak.ctx -G rsa -g sha256 -s rsassa -u ak.pub \
--n ak.name
+-n ak.name -q ak.qname
 
 # Find a vacant persistent handle
 tpm2_createak -C 0x8101000b -c ak.ctx -G rsa -g sha256 -s rsassa -u ak.pub \

--- a/test/integration/tests/print.sh
+++ b/test/integration/tests/print.sh
@@ -13,7 +13,8 @@ print_file=quote.yaml
 
 cleanup() {
     rm -f $ak_name_file $ak_pubkey_file \
-          $quote_file $print_file $ak_ctx
+          $quote_file $print_file $ak_ctx \
+          tpmt_public.ak
 
     if [ "$1" != "no-shut-down" ]; then
        shut_down
@@ -31,6 +32,14 @@ tpm2_clear
 tpm2_createek -Q -G rsa -c $ek_handle
 tpm2_createak -Q -G rsa -g sha256 -s rsassa -C $ek_handle -c $ak_ctx\
   -u $ak_pubkey_file -n $ak_name_file
+
+tpm2_readpublic -c $ak_ctx -f tpmt -o tpmt_public.ak
+
+tpm2_print -t TPM2B_PUBLIC $ak_pubkey_file > $print_file
+yaml_verify $print_file
+
+tpm2_print -t TPMT_PUBLIC tpmt_public.ak > $print_file
+yaml_verify $print_file
 
 # Take PCR quote
 tpm2_quote -Q -c $ak_ctx -l "sha256:0,2,4,9,10,11,12,17" -q "0f8beb45ac" \

--- a/tools/tpm2_readpublic.c
+++ b/tools/tpm2_readpublic.c
@@ -16,6 +16,7 @@ struct tpm_readpub_ctx {
     } flags;
     char *output_path;
     char *out_name_file;
+    char *out_qname_file;
     tpm2_convert_pubkey_fmt format;
     tpm2_loaded_object context_object;
     const char *context_arg;
@@ -72,6 +73,14 @@ static tool_rc read_public_and_save(ESYS_CONTEXT *ectx) {
         goto out;
     }
 
+    if (ctx.out_qname_file) {
+        ret = files_save_bytes_to_file(ctx.out_qname_file, qualified_name->name,
+                qualified_name->size);
+        if (!ret) {
+            goto out;
+        }
+    }
+
     if (ctx.out_tr_file) {
         rc = files_save_ESYS_TR(ectx, ctx.context_object.tr_handle,
                 ctx.out_tr_file);
@@ -109,6 +118,9 @@ static bool on_option(char key, char *value) {
     case 't':
         ctx.out_tr_file = value;
         break;
+    case 'q':
+        ctx.out_qname_file = value;
+        break;
     }
 
     return true;
@@ -121,10 +133,11 @@ bool tpm2_tool_onstart(tpm2_options **opts) {
         { "object-context",    required_argument, NULL, 'c' },
         { "format",            required_argument, NULL, 'f' },
         { "name",              required_argument, NULL, 'n' },
-        { "serialized-handle", required_argument, NULL, 't' }
+        { "serialized-handle", required_argument, NULL, 't' },
+        { "qualified-name",    required_argument, NULL, 'q' }
     };
 
-    *opts = tpm2_options_new("o:c:f:n:t:", ARRAY_LEN(topts), topts, on_option,
+    *opts = tpm2_options_new("o:c:f:n:t:q:", ARRAY_LEN(topts), topts, on_option,
             NULL, 0);
 
     return *opts != NULL;


### PR DESCRIPTION
Add qualified name output to:
- tpm2_readublic: missing a file output
- tpm2_createak: missing qualified name

Add support for tpm2_print to print TPM2B_PUBLIC and TPMT_PUBLIC data structures.
