### PR TITLE
man: update private file output protection details

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -745,6 +745,8 @@ man/man1/%.1 : man/%.1.md $(MARKDOWN_COMMON_DEPS)
 	    -e '/\[returns\]/d' \
 	    -e '/\[footer\]/r $(top_srcdir)/man/common/footer.md' \
 	    -e '/\[footer\]/d' \
+	    -e '/\[protection details\]/r $(top_srcdir)/man/common/protection-details.md' \
+	    -e '/\[protection details\]/d' \
 	    < $< | pandoc -s -t man > $@
 
 CLEANFILES = $(dist_man1_MANS)

--- a/man/common/protection-details.md
+++ b/man/common/protection-details.md
@@ -1,0 +1,18 @@
+# Protection Details
+
+Objects that can move outside of TPM need to be protected (confidentiality and integrity).
+For instance, transient objects require that TPM protected data (key or seal material) be
+stored outside of the TPM. This is seen in tools like tpm2\_create(1), where the **-r** option
+outputs this protected data. This blob contains the sensitive portions of the object. The sensitive
+portions of the object are protected by the parent object, using the parent's symmetric encryption
+details to encrypt the sensitive data and HMAC it.
+
+In-depth details can be found in sections 23 of:
+
+  - https://trustedcomputinggroup.org/wp-content/uploads/TPM-Rev-2.0-Part-1-Architecture-01.38.pdf
+
+Notably Figure 20, is relevant, even though it's specifically referring to duplication blobs, the process
+is identical.
+
+If the output is from tpm2\_duplicate(1), the output will be slightly different, as described fully in
+section 23.

--- a/man/tpm2_changeauth.1.md
+++ b/man/tpm2_changeauth.1.md
@@ -38,6 +38,7 @@ see section "Authorization Formatting".
   * **-r**, **\--private**=_FILE_:
     The output file which contains the new sensitive portion of the object whose
     auth was being changed.
+    [protection details](common/protection-details.md)
 
   * **\--cphash**=_FILE_
 

--- a/man/tpm2_create.1.md
+++ b/man/tpm2_create.1.md
@@ -81,6 +81,8 @@ These options for creating the TPM entity:
 
     The output file which contains the sensitive portion of the object,
     optional.
+    [protection details](common/protection-details.md)
+
 
   * **-c**, **\--key-context**=_FILE_:
 

--- a/man/tpm2_createak.1.md
+++ b/man/tpm2_createak.1.md
@@ -66,6 +66,7 @@ loaded-key:
   * **-r**, **\--private**=_FILE_:
 
     The output file which contains the sensitive portion of the object, optional.
+    [protection details](common/protection-details.md)
 
   * **-f**, **\--format**=_FORMAT_:
 

--- a/man/tpm2_duplicate.1.md
+++ b/man/tpm2_duplicate.1.md
@@ -44,6 +44,7 @@ These options control the key importation process:
   * **-r**, **\--private**=_FILE_:
 
     Specifies the file path to save the private portion of the duplicated object.
+    [protection details](common/protection-details.md)
 
   * **-s**, **\--encrypted-seed**=_FILE_:
 

--- a/man/tpm2_import.1.md
+++ b/man/tpm2_import.1.md
@@ -63,6 +63,7 @@ These options control the key importation process:
 
     When importing a duplicated object this option specifies the file containing
     the private portion of the object to be imported.
+    [protection details](common/protection-details.md)
 
   * **-u**, **\--public**=_FILE_:
 

--- a/man/tpm2_loadexternal.1.md
+++ b/man/tpm2_loadexternal.1.md
@@ -64,7 +64,8 @@ It also saves a context file for future interactions with the object.
         is no need to specify -u for the public portion.
 
     *Note*: The private portion does not respect TSS formats as it's impossible
-    to get a **TPM2B_SENSITIVE** output from a previous command.
+    to get a **TPM2B_SENSITIVE** output from a previous command. They are always
+    protected by the TPM as **TPM2B_PRIVATE** blobs.
 
   * **-p**, **\--auth**=_AUTH_:
 


### PR DESCRIPTION
Detail how **-r** options are protected by the TPM at a high level and
link to the spec detailing the nitty gritty parts for those so inclined.

Fixes: #2056

Signed-off-by: William Roberts <william.c.roberts@intel.com>