### PR TITLE
TSS2 Tools Backport Fixes Part2

### DIFF
--- a/dist/bash-completion/tpm2-tools/tss2_setappdata
+++ b/dist/bash-completion/tpm2-tools/tss2_setappdata
@@ -8,7 +8,11 @@ _tss2_setappdata()
         -!(-*)h | --help)
             COMPREPLY=( $(compgen -W "man no-man" -- "$cur") )
             return;;
-        -!(-*)[pi] | --path | --appData)
+        -!(-*)[p] | --path )
+            return;;
+        -!(-*)i | --appData)
+            _filedir
+            if [ x"$cur" = x ]; then COMPREPLY+=( '-' ); fi
             return;;
     esac
 

--- a/doc/CHANGELOG.md
+++ b/doc/CHANGELOG.md
@@ -33,6 +33,8 @@
 
  * tss2_*: Add parameter types to all man pages
 
+ * tss2_*: tss2_setappdata now reads from file or stdin allowing to store also binary data
+
 ### 4.2 2020-04-08
 
  * Fix various issues reported by static analysis tools.

--- a/man/tss2_setappdata.1.md
+++ b/man/tss2_setappdata.1.md
@@ -22,7 +22,7 @@ These are the available options:
 
     Path of the object for which the appData will be stored.
 
-  * **-i**, **\--appData** _STRING_:
+  * **-i**, **\--appData** _FILENAME_ or _-_ (for stdin):
 
     The data to be stored. Optional parameter. If omitted, stored data is deleted.
 
@@ -31,7 +31,7 @@ These are the available options:
 # EXAMPLE
 
 ```
-tss2_setappdata --path HS/SRK/myRSACrypt --appData appData
+tss2_setappdata --path HS/SRK/myRSACrypt --appData appData.file
 ```
 
 # RETURNS

--- a/test/integration/fapi/fapi-set-get-app-data.sh
+++ b/test/integration/fapi/fapi-set-get-app-data.sh
@@ -29,8 +29,25 @@ tss2_setappdata --path $KEY_PATH --appData $APP_DATA_SET
 
 tss2_getappdata --path $KEY_PATH --appData $APP_DATA_FILE --force
 
-if [ `cat $APP_DATA_FILE` !=  "$APP_DATA_SET" ]; then
-  echo "Strings are not equal"
+if [ "$(< $APP_DATA_FILE)" !=  "$(< $APP_DATA_SET)" ]; then
+  echo "Files are not equal"
+  exit 99
+fi
+
+echo -n "" > $APP_DATA_FILE
+tss2_setappdata --path $KEY_PATH
+tss2_getappdata --path $KEY_PATH --appData $APP_DATA_FILE --force
+
+if [ "$(< $APP_DATA_FILE)" !=  "" ]; then
+  echo "File not empty"
+  exit 99
+fi
+
+echo -n "123" | tss2_setappdata --path $KEY_PATH --appData -
+tss2_getappdata --path $KEY_PATH --appData $APP_DATA_FILE --force
+
+if [ "$(< $APP_DATA_FILE)" !=  "123" ]; then
+  echo "Files are not equal"
   exit 99
 fi
 

--- a/tools/fapi/tss2_setappdata.c
+++ b/tools/fapi/tss2_setappdata.c
@@ -12,8 +12,7 @@ bool output_enabled = false;
 
 /* Context struct used to store passed commandline parameters */
 static struct cxt {
-    uint8_t const *data;
-    size_t  data_size;
+    char const *appData;
     char    const *path;
 } ctx;
 
@@ -21,8 +20,7 @@ static struct cxt {
 static bool on_option(char key, char *value) {
     switch (key) {
     case 'i':
-        ctx.data_size = strlen(value);
-        ctx.data = (uint8_t*) value;
+        ctx.appData = value;
         break;
     case 'p':
         ctx.path = value;
@@ -49,11 +47,25 @@ int tss2_tool_onrun (FAPI_CONTEXT *fctx) {
         return -1;
     }
 
+    /* Read appData from file */
+    TSS2_RC r;
+    uint8_t* appData = NULL;
+    size_t appDataSize = 0;
+    if (ctx.appData) {
+        r = open_read_and_close (ctx.appData, (void**)&appData,
+            &appDataSize);
+        if (r) {
+            return 1;
+        }
+    }
+
     /* Execute FAPI command with passed arguments */
-    TSS2_RC r = Fapi_SetAppData (fctx, ctx.path, ctx.data, ctx.data_size);
+    r = Fapi_SetAppData (fctx, ctx.path, appData, appDataSize);
     if (r != TSS2_RC_SUCCESS) {
         LOG_PERR ("Fapi_SetAppData", r);
+        free(appData);
         return 1;
     }
+    free(appData);
     return 0;
 }


### PR DESCRIPTION
Another fix for the tss2 tools which also should be back ported to 4.2.X: 
- tss2_setappdata now reads from file or stdin allowing to store also binary data

Signed-off-by: Christian Plappert <christian.plappert@sit.fraunhofer.de>