### PR TITLE
Several bugfixes for the fapi tools

### DIFF
--- a/dist/bash-completion/tpm2-tools/tss2_authorizepolicy
+++ b/dist/bash-completion/tpm2-tools/tss2_authorizepolicy
@@ -18,8 +18,8 @@ _tss2_authorizepolicy()
 
     $split && return
 
-    COMPREPLY=( $(compgen -W "-h --help -v --version --policyPath -P
-      --keyPath -p --policyRef -r" -- "$cur") )
+    COMPREPLY=( $(compgen -W "-h --help -v --version --policyPath= -P
+      --keyPath= -p --policyRef= -r" -- "$cur") )
     [[ $COMPREPLY == *= ]] && compopt -o nospace
 } &&
 complete -F _tss2_authorizepolicy tss2_authorizepolicy

--- a/dist/bash-completion/tpm2-tools/tss2_authorizepolicy
+++ b/dist/bash-completion/tpm2-tools/tss2_authorizepolicy
@@ -10,7 +10,7 @@ _tss2_authorizepolicy()
             return;;
         -!(-*)[r] | --policyRef)
             _filedir
-            COMPREPLY+=( '-' )
+            if [ x"$cur" = x ]; then COMPREPLY+=( '-' ); fi
             return;;
         -!(-*)[Pp] | --policyPath | --keyPath )
             return;;

--- a/dist/bash-completion/tpm2-tools/tss2_changeauth
+++ b/dist/bash-completion/tpm2-tools/tss2_changeauth
@@ -14,8 +14,8 @@ _tss2_changeauth()
 
     $split && return
 
-    COMPREPLY=( $(compgen -W "-h --help -v --version -a --authValue
-    -p --entityPath" -- "$cur") )
+    COMPREPLY=( $(compgen -W "-h --help -v --version -a --authValue=
+    -p --entityPath=" -- "$cur") )
     [[ $COMPREPLY == *= ]] && compopt -o nospace
 } &&
 complete -F _tss2_changeauth tss2_changeauth

--- a/dist/bash-completion/tpm2-tools/tss2_changeauth
+++ b/dist/bash-completion/tpm2-tools/tss2_changeauth
@@ -14,7 +14,7 @@ _tss2_changeauth()
 
     $split && return
 
-    COMPREPLY=( $(compgen -W "-h --help -v --version -f --force -a --authValue
+    COMPREPLY=( $(compgen -W "-h --help -v --version -a --authValue
     -p --entityPath" -- "$cur") )
     [[ $COMPREPLY == *= ]] && compopt -o nospace
 } &&

--- a/dist/bash-completion/tpm2-tools/tss2_createkey
+++ b/dist/bash-completion/tpm2-tools/tss2_createkey
@@ -14,8 +14,8 @@ _tss2_createkey()
 
     $split && return
 
-    COMPREPLY=( $(compgen -W "-h --help -v --version -p --path  -t --type
-    -P --policyPath  -a --authValue" -- "$cur") )
+    COMPREPLY=( $(compgen -W "-h --help -v --version -p --path=  -t --type=
+    -P --policyPath=  -a --authValue=" -- "$cur") )
     [[ $COMPREPLY == *= ]] && compopt -o nospace
 } &&
 complete -F _tss2_createkey tss2_createkey

--- a/dist/bash-completion/tpm2-tools/tss2_createnv
+++ b/dist/bash-completion/tpm2-tools/tss2_createnv
@@ -14,8 +14,8 @@ _tss2_createnv()
 
     $split && return
 
-    COMPREPLY=( $(compgen -W "-h --help -v --version -P --policyPath
-    -p --path -s --size -t --type -a --authValue" -- "$cur") )
+    COMPREPLY=( $(compgen -W "-h --help -v --version -P --policyPath=
+    -p --path= -s --size= -t --type= -a --authValue=" -- "$cur") )
     [[ $COMPREPLY == *= ]] && compopt -o nospace
 } &&
 complete -F _tss2_createnv tss2_createnv

--- a/dist/bash-completion/tpm2-tools/tss2_createseal
+++ b/dist/bash-completion/tpm2-tools/tss2_createseal
@@ -12,13 +12,13 @@ _tss2_createseal()
             _filedir
             if [ x"$cur" = x ]; then COMPREPLY+=( '-' ); fi
             return;;
-        -!(-*)[ptPa] | --path | --type | --policyPath | --authValue)
+        -!(-*)[ptPas] | --path | --type | --policyPath | --authValue | --size)
             return;;
     esac
 
     $split && return
 
-    COMPREPLY=( $(compgen -W "-h --help -v --version --authValue= -a --path= -p --policyPath= -P --type= -t --data= -i" -- "$cur") )
+    COMPREPLY=( $(compgen -W "-h --help -v --version --authValue= -a --path= -p --policyPath= -P --type= -t --data= -i --size= -s" -- "$cur") )
     [[ $COMPREPLY == *= ]] && compopt -o nospace
 } &&
 complete -F _tss2_createseal tss2_createseal

--- a/dist/bash-completion/tpm2-tools/tss2_createseal
+++ b/dist/bash-completion/tpm2-tools/tss2_createseal
@@ -18,7 +18,7 @@ _tss2_createseal()
 
     $split && return
 
-    COMPREPLY=( $(compgen -W "-h --help -v --version --authValue -a --path -p --policyPath -P --type -t --data -i" -- "$cur") )
+    COMPREPLY=( $(compgen -W "-h --help -v --version --authValue= -a --path= -p --policyPath= -P --type= -t --data= -i" -- "$cur") )
     [[ $COMPREPLY == *= ]] && compopt -o nospace
 } &&
 complete -F _tss2_createseal tss2_createseal

--- a/dist/bash-completion/tpm2-tools/tss2_createseal
+++ b/dist/bash-completion/tpm2-tools/tss2_createseal
@@ -10,7 +10,7 @@ _tss2_createseal()
             return;;
         -!(-*)[i] | --data)
             _filedir
-            COMPREPLY+=( '-' )
+            if [ x"$cur" = x ]; then COMPREPLY+=( '-' ); fi
             return;;
         -!(-*)[ptPa] | --path | --type | --policyPath | --authValue)
             return;;

--- a/dist/bash-completion/tpm2-tools/tss2_decrypt
+++ b/dist/bash-completion/tpm2-tools/tss2_decrypt
@@ -18,7 +18,7 @@ _tss2_decrypt()
 
     $split && return
 
-    COMPREPLY=( $(compgen -W "-h --help -v --version --force -f -i --cipherText --plainText -o --keyPath -p" -- "$cur") )
+    COMPREPLY=( $(compgen -W "-h --help -v --version --force -f -i --cipherText= --plainText= -o --keyPath= -p" -- "$cur") )
     [[ $COMPREPLY == *= ]] && compopt -o nospace
 } &&
 complete -F _tss2_decrypt tss2_decrypt

--- a/dist/bash-completion/tpm2-tools/tss2_decrypt
+++ b/dist/bash-completion/tpm2-tools/tss2_decrypt
@@ -10,7 +10,7 @@ _tss2_decrypt()
             return;;
         -!(-*)[io] | --cipherText | --plainText)
             _filedir
-            COMPREPLY+=( '-' )
+            if [ x"$cur" = x ]; then COMPREPLY+=( '-' ); fi
             return;;
         -!(-*)p | --keyPath)
             return;;

--- a/dist/bash-completion/tpm2-tools/tss2_delete
+++ b/dist/bash-completion/tpm2-tools/tss2_delete
@@ -14,7 +14,7 @@ _tss2_delete()
 
     $split && return
 
-    COMPREPLY=( $(compgen -W "-h --help -v --version -p --path" -- "$cur") )
+    COMPREPLY=( $(compgen -W "-h --help -v --version -p --path=" -- "$cur") )
     [[ $COMPREPLY == *= ]] && compopt -o nospace
 } &&
 complete -F _tss2_delete tss2_delete

--- a/dist/bash-completion/tpm2-tools/tss2_encrypt
+++ b/dist/bash-completion/tpm2-tools/tss2_encrypt
@@ -18,8 +18,8 @@ _tss2_encrypt()
 
     $split && return
 
-    COMPREPLY=( $(compgen -W "-h --help -v --version -f --force -o --cipherText
-    -p --keyPath -i --plainText" -- "$cur") )
+    COMPREPLY=( $(compgen -W "-h --help -v --version -f --force -o --cipherText=
+    -p --keyPath= -i --plainText=" -- "$cur") )
     [[ $COMPREPLY == *= ]] && compopt -o nospace
 } &&
 complete -F _tss2_encrypt tss2_encrypt

--- a/dist/bash-completion/tpm2-tools/tss2_encrypt
+++ b/dist/bash-completion/tpm2-tools/tss2_encrypt
@@ -10,7 +10,7 @@ _tss2_encrypt()
             return;;
         -!(-*)[io] | --plainText | --cipherText)
             _filedir
-            COMPREPLY+=( '-' )
+            if [ x"$cur" = x ]; then COMPREPLY+=( '-' ); fi
             return;;
         -!(-*)[p] | --keyPath )
             return;;

--- a/dist/bash-completion/tpm2-tools/tss2_exportkey
+++ b/dist/bash-completion/tpm2-tools/tss2_exportkey
@@ -10,7 +10,7 @@ _tss2_exportkey()
             return;;
         -!(-*)[o] | --exportedData )
             _filedir
-            COMPREPLY+=( '-' )
+            if [ x"$cur" = x ]; then COMPREPLY+=( '-' ); fi
             return;;
         -!(-*)[pe] | --pathOfKeyToDuplicate | --pathToPublicKeyOfNewParent)
             return;;

--- a/dist/bash-completion/tpm2-tools/tss2_exportkey
+++ b/dist/bash-completion/tpm2-tools/tss2_exportkey
@@ -18,7 +18,7 @@ _tss2_exportkey()
 
     $split && return
 
-    COMPREPLY=( $(compgen -W "-h --help -v --version --exportedData -o --force -f --pathOfKeyToDuplicate -p --pathToPublicKeyOfNewParent -e" -- "$cur") )
+    COMPREPLY=( $(compgen -W "-h --help -v --version --exportedData= -o --force -f --pathOfKeyToDuplicate= -p --pathToPublicKeyOfNewParent= -e" -- "$cur") )
     [[ $COMPREPLY == *= ]] && compopt -o nospace
 } &&
 complete -F _tss2_exportkey tss2_exportkey

--- a/dist/bash-completion/tpm2-tools/tss2_exportpolicy
+++ b/dist/bash-completion/tpm2-tools/tss2_exportpolicy
@@ -10,7 +10,7 @@ _tss2_exportpolicy()
             return;;
         -!(-*)[o] | --jsonPolicy )
             _filedir
-            COMPREPLY+=( '-' )
+            if [ x"$cur" = x ]; then COMPREPLY+=( '-' ); fi
             return;;
         -!(-*)[p] | --path)
             return;;

--- a/dist/bash-completion/tpm2-tools/tss2_exportpolicy
+++ b/dist/bash-completion/tpm2-tools/tss2_exportpolicy
@@ -18,8 +18,8 @@ _tss2_exportpolicy()
 
     $split && return
 
-    COMPREPLY=( $(compgen -W "-h --help -v --version --jsonPolicy -o
-    --path -p --force -f" -- "$cur") )
+    COMPREPLY=( $(compgen -W "-h --help -v --version --jsonPolicy= -o
+    --path= -p --force -f" -- "$cur") )
     [[ $COMPREPLY == *= ]] && compopt -o nospace
 } &&
 complete -F _tss2_exportpolicy tss2_exportpolicy

--- a/dist/bash-completion/tpm2-tools/tss2_getappdata
+++ b/dist/bash-completion/tpm2-tools/tss2_getappdata
@@ -10,7 +10,7 @@ _tss2_getappdata()
             return;;
         -!(-*)[o] | --appData)
             _filedir
-            COMPREPLY+=( '-' )
+            if [ x"$cur" = x ]; then COMPREPLY+=( '-' ); fi
             return;;
         -!(-*)[p] | --path)
             return;;

--- a/dist/bash-completion/tpm2-tools/tss2_getappdata
+++ b/dist/bash-completion/tpm2-tools/tss2_getappdata
@@ -18,7 +18,7 @@ _tss2_getappdata()
 
     $split && return
 
-    COMPREPLY=( $(compgen -W "-h --help -v --version --force -f -p --path --appData -o" -- "$cur") )
+    COMPREPLY=( $(compgen -W "-h --help -v --version --force -f -p --path= --appData= -o" -- "$cur") )
     [[ $COMPREPLY == *= ]] && compopt -o nospace
 } &&
 complete -F _tss2_getappdata tss2_getappdata

--- a/dist/bash-completion/tpm2-tools/tss2_getcertificate
+++ b/dist/bash-completion/tpm2-tools/tss2_getcertificate
@@ -10,7 +10,7 @@ _tss2_getcertificate()
             return;;
         -!(-*)[o] | --x509certData)
             _filedir
-            COMPREPLY+=( '-' )
+            if [ x"$cur" = x ]; then COMPREPLY+=( '-' ); fi
             return;;
         -!(-*)[p] | --path)
             return;;

--- a/dist/bash-completion/tpm2-tools/tss2_getcertificate
+++ b/dist/bash-completion/tpm2-tools/tss2_getcertificate
@@ -18,7 +18,7 @@ _tss2_getcertificate()
 
     $split && return
 
-    COMPREPLY=( $(compgen -W "-h --help -v --version --force -f -p --path --x509certData -o" -- "$cur") )
+    COMPREPLY=( $(compgen -W "-h --help -v --version --force -f -p --path= --x509certData= -o" -- "$cur") )
     [[ $COMPREPLY == *= ]] && compopt -o nospace
 } &&
 complete -F _tss2_getcertificate tss2_getcertificate

--- a/dist/bash-completion/tpm2-tools/tss2_getdescription
+++ b/dist/bash-completion/tpm2-tools/tss2_getdescription
@@ -18,8 +18,8 @@ _tss2_getdescription()
 
     $split && return
 
-    COMPREPLY=( $(compgen -W "-h --help -v --version -f --force --path -p
-    --description -o " -- "$cur") )
+    COMPREPLY=( $(compgen -W "-h --help -v --version -f --force --path= -p
+    --description= -o " -- "$cur") )
     [[ $COMPREPLY == *= ]] && compopt -o nospace
 } &&
 complete -F _tss2_getdescription tss2_getdescription

--- a/dist/bash-completion/tpm2-tools/tss2_getdescription
+++ b/dist/bash-completion/tpm2-tools/tss2_getdescription
@@ -9,8 +9,8 @@ _tss2_getdescription()
             COMPREPLY=( $(compgen -W "man no-man" -- "$cur") )
             return;;
         -!(-*)[o] | --description)
-            COMPREPLY+=( '-' )
             _filedir
+            if [ x"$cur" = x ]; then COMPREPLY+=( '-' ); fi
             return;;
         -!(-*)[p] | --path)
             return;;

--- a/dist/bash-completion/tpm2-tools/tss2_getdescription
+++ b/dist/bash-completion/tpm2-tools/tss2_getdescription
@@ -18,7 +18,7 @@ _tss2_getdescription()
 
     $split && return
 
-    COMPREPLY=( $(compgen -W "-h --help -v --version --path -p
+    COMPREPLY=( $(compgen -W "-h --help -v --version -f --force --path -p
     --description -o " -- "$cur") )
     [[ $COMPREPLY == *= ]] && compopt -o nospace
 } &&

--- a/dist/bash-completion/tpm2-tools/tss2_getinfo
+++ b/dist/bash-completion/tpm2-tools/tss2_getinfo
@@ -16,7 +16,7 @@ _tss2_getinfo()
 
     $split && return
 
-    COMPREPLY=( $(compgen -W "-h --help -v --version --force -f --info -o" -- "$cur") )
+    COMPREPLY=( $(compgen -W "-h --help -v --version --force -f --info= -o" -- "$cur") )
     [[ $COMPREPLY == *= ]] && compopt -o nospace
 } &&
 complete -F _tss2_getinfo tss2_getinfo

--- a/dist/bash-completion/tpm2-tools/tss2_getinfo
+++ b/dist/bash-completion/tpm2-tools/tss2_getinfo
@@ -10,7 +10,7 @@ _tss2_getinfo()
             return;;
         -!(-*)o | --info)
             _filedir
-            COMPREPLY+=( '-' )
+            if [ x"$cur" = x ]; then COMPREPLY+=( '-' ); fi
             return;;
     esac
 

--- a/dist/bash-completion/tpm2-tools/tss2_getplatformcertificates
+++ b/dist/bash-completion/tpm2-tools/tss2_getplatformcertificates
@@ -10,7 +10,7 @@ _tss2_getplatformcertificates()
             return;;
         -!(-*)o | --certificates)
             _filedir
-            COMPREPLY+=( '-' )
+            if [ x"$cur" = x ]; then COMPREPLY+=( '-' ); fi
             return;;
     esac
 

--- a/dist/bash-completion/tpm2-tools/tss2_getplatformcertificates
+++ b/dist/bash-completion/tpm2-tools/tss2_getplatformcertificates
@@ -16,7 +16,7 @@ _tss2_getplatformcertificates()
 
     $split && return
 
-    COMPREPLY=( $(compgen -W "-h --help -v --version --force -f --certificates -o" -- "$cur") )
+    COMPREPLY=( $(compgen -W "-h --help -v --version --force -f --certificates= -o" -- "$cur") )
     [[ $COMPREPLY == *= ]] && compopt -o nospace
 } &&
 complete -F _tss2_getplatformcertificates tss2_getplatformcertificates

--- a/dist/bash-completion/tpm2-tools/tss2_getrandom
+++ b/dist/bash-completion/tpm2-tools/tss2_getrandom
@@ -10,7 +10,7 @@ _tss2_getrandom()
             return;;
         -!(-*)o | --data)
             _filedir
-            COMPREPLY+=( '-' )
+            if [ x"$cur" = x ]; then COMPREPLY+=( '-' ); fi
             return;;
         -!(-*)n | --numBytes)
             return;;

--- a/dist/bash-completion/tpm2-tools/tss2_getrandom
+++ b/dist/bash-completion/tpm2-tools/tss2_getrandom
@@ -18,7 +18,7 @@ _tss2_getrandom()
 
     $split && return
 
-    COMPREPLY=( $(compgen -W "-h --help -v --version --force -f --numBytes -n --data -o " -- "$cur") )
+    COMPREPLY=( $(compgen -W "-h --help -v --hex --version --force -f --numBytes -n --data -o " -- "$cur") )
     [[ $COMPREPLY == *= ]] && compopt -o nospace
 } &&
 complete -F _tss2_getrandom tss2_getrandom

--- a/dist/bash-completion/tpm2-tools/tss2_getrandom
+++ b/dist/bash-completion/tpm2-tools/tss2_getrandom
@@ -18,7 +18,7 @@ _tss2_getrandom()
 
     $split && return
 
-    COMPREPLY=( $(compgen -W "-h --help -v --hex --version --force -f --numBytes -n --data -o " -- "$cur") )
+    COMPREPLY=( $(compgen -W "-h --help -v --hex --version --force -f --numBytes= -n --data= -o " -- "$cur") )
     [[ $COMPREPLY == *= ]] && compopt -o nospace
 } &&
 complete -F _tss2_getrandom tss2_getrandom

--- a/dist/bash-completion/tpm2-tools/tss2_gettpmblobs
+++ b/dist/bash-completion/tpm2-tools/tss2_gettpmblobs
@@ -12,7 +12,7 @@ _tss2_gettpmblobs()
             return;;
         -!(-*)[url] | --tpm2bPublic | --tpm2bPrivate | --policy)
             _filedir
-            COMPREPLY+=( '-' )
+            if [ x"$cur" = x ]; then COMPREPLY+=( '-' ); fi
             return;;
     esac
 

--- a/dist/bash-completion/tpm2-tools/tss2_gettpmblobs
+++ b/dist/bash-completion/tpm2-tools/tss2_gettpmblobs
@@ -18,7 +18,7 @@ _tss2_gettpmblobs()
 
     $split && return
 
-    COMPREPLY=( $(compgen -W "-h --help -v --version --force -f --path -p --tpm2bPublic -u --tpm2bPrivate -r --policy -l" -- "$cur") )
+    COMPREPLY=( $(compgen -W "-h --help -v --version --force -f --path= -p --tpm2bPublic= -u --tpm2bPrivate= -r --policy= -l" -- "$cur") )
     [[ $COMPREPLY == *= ]] && compopt -o nospace
 } &&
 complete -F _tss2_gettpmblobs tss2_gettpmblobs

--- a/dist/bash-completion/tpm2-tools/tss2_import
+++ b/dist/bash-completion/tpm2-tools/tss2_import
@@ -12,7 +12,7 @@ _tss2_import()
             return;;
         -!(-*)[i] | --importData)
             _filedir
-            COMPREPLY+=( '-' )
+            if [ x"$cur" = x ]; then COMPREPLY+=( '-' ); fi
             return;;
     esac
 

--- a/dist/bash-completion/tpm2-tools/tss2_import
+++ b/dist/bash-completion/tpm2-tools/tss2_import
@@ -18,7 +18,7 @@ _tss2_import()
 
     $split && return
 
-    COMPREPLY=( $(compgen -W "-h --help -v --version --importData -i --path -p" -- "$cur") )
+    COMPREPLY=( $(compgen -W "-h --help -v --version --importData= -i --path= -p" -- "$cur") )
     [[ $COMPREPLY == *= ]] && compopt -o nospace
 } &&
 complete -F _tss2_import tss2_import

--- a/dist/bash-completion/tpm2-tools/tss2_list
+++ b/dist/bash-completion/tpm2-tools/tss2_list
@@ -18,7 +18,7 @@ _tss2_list()
 
     $split && return
 
-    COMPREPLY=( $(compgen -W "-h --help -v --version --pathList -o
+    COMPREPLY=( $(compgen -W "-h --help -v --version --force -f --pathList -o
     --searchPath -p" -- "$cur") )
     [[ $COMPREPLY == *= ]] && compopt -o nospace
 } &&

--- a/dist/bash-completion/tpm2-tools/tss2_list
+++ b/dist/bash-completion/tpm2-tools/tss2_list
@@ -18,8 +18,8 @@ _tss2_list()
 
     $split && return
 
-    COMPREPLY=( $(compgen -W "-h --help -v --version --force -f --pathList -o
-    --searchPath -p" -- "$cur") )
+    COMPREPLY=( $(compgen -W "-h --help -v --version --force -f --pathList= -o
+    --searchPath= -p" -- "$cur") )
     [[ $COMPREPLY == *= ]] && compopt -o nospace
 } &&
 complete -F _tss2_list tss2_list

--- a/dist/bash-completion/tpm2-tools/tss2_list
+++ b/dist/bash-completion/tpm2-tools/tss2_list
@@ -12,7 +12,7 @@ _tss2_list()
             return;;
         -!(-*)[o] | --pathList)
             _filedir
-            COMPREPLY+=( '-' )
+            if [ x"$cur" = x ]; then COMPREPLY+=( '-' ); fi
             return;;
     esac
 

--- a/dist/bash-completion/tpm2-tools/tss2_nvextend
+++ b/dist/bash-completion/tpm2-tools/tss2_nvextend
@@ -10,7 +10,7 @@ _tss2_nvextend()
             return;;
         -!(-*)[il] | --data |  --logData)
             _filedir
-            COMPREPLY+=( '-' )
+            if [ x"$cur" = x ]; then COMPREPLY+=( '-' ); fi
             return;;
         -!(-*)[p] | --nvPath )
             return;;

--- a/dist/bash-completion/tpm2-tools/tss2_nvextend
+++ b/dist/bash-completion/tpm2-tools/tss2_nvextend
@@ -18,7 +18,7 @@ _tss2_nvextend()
 
     $split && return
 
-    COMPREPLY=( $(compgen -W "-h --help -v --version --data -i --nvPath -p --logData -l" -- "$cur") )
+    COMPREPLY=( $(compgen -W "-h --help -v --version --data= -i --nvPath= -p --logData= -l" -- "$cur") )
     [[ $COMPREPLY == *= ]] && compopt -o nospace
 } &&
 complete -F _tss2_nvextend tss2_nvextend

--- a/dist/bash-completion/tpm2-tools/tss2_nvincrement
+++ b/dist/bash-completion/tpm2-tools/tss2_nvincrement
@@ -14,7 +14,7 @@ _tss2_nvincrement()
 
     $split && return
 
-    COMPREPLY=( $(compgen -W "-h --help -v --version --nvPath -p" -- "$cur") )
+    COMPREPLY=( $(compgen -W "-h --help -v --version --nvPath= -p" -- "$cur") )
     [[ $COMPREPLY == *= ]] && compopt -o nospace
 } &&
 complete -F _tss2_nvincrement tss2_nvincrement

--- a/dist/bash-completion/tpm2-tools/tss2_nvread
+++ b/dist/bash-completion/tpm2-tools/tss2_nvread
@@ -12,7 +12,7 @@ _tss2_nvread()
             return;;
         -!(-*)[ol] | --data | --logData)
             _filedir
-            COMPREPLY+=( '-' )
+            if [ x"$cur" = x ]; then COMPREPLY+=( '-' ); fi
             return;;
     esac
 

--- a/dist/bash-completion/tpm2-tools/tss2_nvread
+++ b/dist/bash-completion/tpm2-tools/tss2_nvread
@@ -18,7 +18,7 @@ _tss2_nvread()
 
     $split && return
 
-    COMPREPLY=( $(compgen -W "-h --help -v --version --force -f --nvPath -p --data -o --logData -l" -- "$cur") )
+    COMPREPLY=( $(compgen -W "-h --help -v --version --force -f --nvPath= -p --data= -o --logData= -l" -- "$cur") )
     [[ $COMPREPLY == *= ]] && compopt -o nospace
 } &&
 complete -F _tss2_nvread tss2_nvread

--- a/dist/bash-completion/tpm2-tools/tss2_nvsetbits
+++ b/dist/bash-completion/tpm2-tools/tss2_nvsetbits
@@ -14,7 +14,7 @@ _tss2_nvsetbits()
 
     $split && return
 
-    COMPREPLY=( $(compgen -W "-h --help -v --version -i --bitmap -p --nvPath" -- "$cur") )
+    COMPREPLY=( $(compgen -W "-h --help -v --version -i --bitmap= -p --nvPath=" -- "$cur") )
     [[ $COMPREPLY == *= ]] && compopt -o nospace
 } &&
 complete -F _tss2_nvsetbits tss2_nvsetbits

--- a/dist/bash-completion/tpm2-tools/tss2_nvwrite
+++ b/dist/bash-completion/tpm2-tools/tss2_nvwrite
@@ -12,7 +12,7 @@ _tss2_nvwrite()
             return;;
         -!(-*)[i] | --data)
             _filedir
-            COMPREPLY+=( '-' )
+            if [ x"$cur" = x ]; then COMPREPLY+=( '-' ); fi
             return;;
     esac
 

--- a/dist/bash-completion/tpm2-tools/tss2_nvwrite
+++ b/dist/bash-completion/tpm2-tools/tss2_nvwrite
@@ -18,7 +18,7 @@ _tss2_nvwrite()
 
     $split && return
 
-    COMPREPLY=( $(compgen -W "-h --help -v --version --nvPath -p --data  -i" -- "$cur") )
+    COMPREPLY=( $(compgen -W "-h --help -v --version --nvPath= -p --data= -i" -- "$cur") )
     [[ $COMPREPLY == *= ]] && compopt -o nospace
 } &&
 complete -F _tss2_nvwrite tss2_nvwrite

--- a/dist/bash-completion/tpm2-tools/tss2_pcrextend
+++ b/dist/bash-completion/tpm2-tools/tss2_pcrextend
@@ -18,7 +18,7 @@ _tss2_pcrextend()
 
     $split && return
 
-    COMPREPLY=( $(compgen -W "-h --help -v --version -x --pcr -i --data -l --logData -- "$cur") )
+    COMPREPLY=( $(compgen -W "-h --help -v --version -x --pcr -i --data -l --logData" -- "$cur") )
     [[ $COMPREPLY == *= ]] && compopt -o nospace
 } &&
 complete -F _tss2_pcrextend tss2_pcrextend

--- a/dist/bash-completion/tpm2-tools/tss2_pcrextend
+++ b/dist/bash-completion/tpm2-tools/tss2_pcrextend
@@ -18,7 +18,7 @@ _tss2_pcrextend()
 
     $split && return
 
-    COMPREPLY=( $(compgen -W "-h --help -v --version -x --pcr -i --data -l --logData" -- "$cur") )
+    COMPREPLY=( $(compgen -W "-h --help -v --version -x --pcr= -i --data= -l --logData=" -- "$cur") )
     [[ $COMPREPLY == *= ]] && compopt -o nospace
 } &&
 complete -F _tss2_pcrextend tss2_pcrextend

--- a/dist/bash-completion/tpm2-tools/tss2_pcrextend
+++ b/dist/bash-completion/tpm2-tools/tss2_pcrextend
@@ -12,7 +12,7 @@ _tss2_pcrextend()
             return;;
         -!(-*)[il] | --data | --logData)
             _filedir
-            COMPREPLY+=( '-' )
+            if [ x"$cur" = x ]; then COMPREPLY+=( '-' ); fi
             return;;
     esac
 

--- a/dist/bash-completion/tpm2-tools/tss2_pcrread
+++ b/dist/bash-completion/tpm2-tools/tss2_pcrread
@@ -18,7 +18,7 @@ _tss2_pcrread()
 
     $split && return
 
-    COMPREPLY=( $(compgen -W "-h --help -v --version -o --pcrValue -x --pcrIndex --force -f -l --pcrLog" -- "$cur") )
+    COMPREPLY=( $(compgen -W "-h --help -v --version -o --pcrValue= -x --pcrIndex= --force -f -l --pcrLog=" -- "$cur") )
     [[ $COMPREPLY == *= ]] && compopt -o nospace
 } &&
 complete -F _tss2_pcrread tss2_pcrread

--- a/dist/bash-completion/tpm2-tools/tss2_pcrread
+++ b/dist/bash-completion/tpm2-tools/tss2_pcrread
@@ -12,7 +12,7 @@ _tss2_pcrread()
             return;;
         -!(-*)[ol] | --pcrValue | --pcrLog)
             _filedir
-            COMPREPLY+=( '-' )
+            if [ x"$cur" = x ]; then COMPREPLY+=( '-' ); fi
             return;;
     esac
 

--- a/dist/bash-completion/tpm2-tools/tss2_provision
+++ b/dist/bash-completion/tpm2-tools/tss2_provision
@@ -14,7 +14,7 @@ _tss2_provision()
 
     $split && return
 
-    COMPREPLY=( $(compgen -W "-h --help -v --version -E -S -L --authValueEh --authValueSh --authValueLockout" -- "$cur") )
+    COMPREPLY=( $(compgen -W "-h --help -v --version -E -S -L --authValueEh= --authValueSh= --authValueLockout=" -- "$cur") )
     [[ $COMPREPLY == *= ]] && compopt -o nospace
 } &&
 complete -F _tss2_provision tss2_provision

--- a/dist/bash-completion/tpm2-tools/tss2_quote
+++ b/dist/bash-completion/tpm2-tools/tss2_quote
@@ -12,7 +12,7 @@ _tss2_quote()
             return;;
         -!(-*)[olqQc] | --signature | --pcrLog | --quoteInfo | --qualifyingData | --certificate)
             _filedir
-            COMPREPLY+=( '-' )
+            if [ x"$cur" = x ]; then COMPREPLY+=( '-' ); fi
             return;;
     esac
 

--- a/dist/bash-completion/tpm2-tools/tss2_quote
+++ b/dist/bash-completion/tpm2-tools/tss2_quote
@@ -18,7 +18,7 @@ _tss2_quote()
 
     $split && return
 
-    COMPREPLY=( $(compgen -W "-h --help -v --version --pcrList -x --qualifyingData -Q --pcrLog -l --force -f --keyPath -p --quoteInfo -q --signature -o --certificate -c " -- "$cur") )
+    COMPREPLY=( $(compgen -W "-h --help -v --version --pcrList= -x --qualifyingData= -Q --pcrLog= -l --force -f --keyPath= -p --quoteInfo= -q --signature= -o --certificate= -c " -- "$cur") )
     [[ $COMPREPLY == *= ]] && compopt -o nospace
 } &&
 complete -F _tss2_quote tss2_quote

--- a/dist/bash-completion/tpm2-tools/tss2_setappdata
+++ b/dist/bash-completion/tpm2-tools/tss2_setappdata
@@ -18,7 +18,7 @@ _tss2_setappdata()
 
     $split && return
 
-    COMPREPLY=( $(compgen -W "-h --help -v --version --force -f -p --path --appData -i" -- "$cur") )
+    COMPREPLY=( $(compgen -W "-h --help -v --version -p --path --appData -i" -- "$cur") )
 
     [[ $COMPREPLY == *= ]] && compopt -o nospace
 } &&

--- a/dist/bash-completion/tpm2-tools/tss2_setappdata
+++ b/dist/bash-completion/tpm2-tools/tss2_setappdata
@@ -18,7 +18,7 @@ _tss2_setappdata()
 
     $split && return
 
-    COMPREPLY=( $(compgen -W "-h --help -v --version -p --path --appData -i" -- "$cur") )
+    COMPREPLY=( $(compgen -W "-h --help -v --version -p --path= --appData= -i" -- "$cur") )
 
     [[ $COMPREPLY == *= ]] && compopt -o nospace
 } &&

--- a/dist/bash-completion/tpm2-tools/tss2_setcertificate
+++ b/dist/bash-completion/tpm2-tools/tss2_setcertificate
@@ -10,7 +10,7 @@ _tss2_setcertificate()
             return;;
         -!(-*)i | --x509certData)
             _filedir
-            COMPREPLY+=( '-' )
+            if [ x"$cur" = x ]; then COMPREPLY+=( '-' ); fi
             return;;
         -!(-*)p | --path)
             return;;

--- a/dist/bash-completion/tpm2-tools/tss2_setcertificate
+++ b/dist/bash-completion/tpm2-tools/tss2_setcertificate
@@ -18,7 +18,7 @@ _tss2_setcertificate()
 
     $split && return
 
-    COMPREPLY=( $(compgen -W "-h --help -v --version -p --path --x509certData -i" -- "$cur") )
+    COMPREPLY=( $(compgen -W "-h --help -v --version -p --path= --x509certData= -i" -- "$cur") )
     [[ $COMPREPLY == *= ]] && compopt -o nospace
 } &&
 complete -F _tss2_setcertificate tss2_setcertificate

--- a/dist/bash-completion/tpm2-tools/tss2_setdescription
+++ b/dist/bash-completion/tpm2-tools/tss2_setdescription
@@ -14,7 +14,7 @@ _tss2_setdescription()
 
     $split && return
 
-    COMPREPLY=( $(compgen -W "-h --help -v --version --path -p --description -i " -- "$cur") )
+    COMPREPLY=( $(compgen -W "-h --help -v --version --path= -p --description= -i " -- "$cur") )
     [[ $COMPREPLY == *= ]] && compopt -o nospace
 } &&
 complete -F _tss2_setdescription tss2_setdescription

--- a/dist/bash-completion/tpm2-tools/tss2_sign
+++ b/dist/bash-completion/tpm2-tools/tss2_sign
@@ -10,7 +10,7 @@ _tss2_sign()
             return;;
         -!(-*)[dokc] | --digest | --signature | --publicKey | --certificate)
             _filedir
-            COMPREPLY+=( '-' )
+            if [ x"$cur" = x ]; then COMPREPLY+=( '-' ); fi
             return;;
         -!(-*)[ps] | --keyPath | --padding)
             return;;

--- a/dist/bash-completion/tpm2-tools/tss2_sign
+++ b/dist/bash-completion/tpm2-tools/tss2_sign
@@ -18,7 +18,7 @@ _tss2_sign()
 
     $split && return
 
-    COMPREPLY=( $(compgen -W "-h --help -v --version --force -f --certificate -c --digest -d --keyPath -p --publicKey -k --signature -o --padding -s" -- "$cur") )
+    COMPREPLY=( $(compgen -W "-h --help -v --version --force -f --certificate= -c --digest= -d --keyPath= -p --publicKey= -k --signature= -o --padding= -s" -- "$cur") )
     [[ $COMPREPLY == *= ]] && compopt -o nospace
 } &&
 complete -F _tss2_sign tss2_sign

--- a/dist/bash-completion/tpm2-tools/tss2_unseal
+++ b/dist/bash-completion/tpm2-tools/tss2_unseal
@@ -18,7 +18,7 @@ _tss2_unseal()
 
     $split && return
 
-    COMPREPLY=( $(compgen -W "-h --help -v --version --data -o --path -p" -- "$cur") )
+    COMPREPLY=( $(compgen -W "-h --help -v --version --data -o -f --force --path -p" -- "$cur") )
     [[ $COMPREPLY == *= ]] && compopt -o nospace
 } &&
 complete -F _tss2_unseal tss2_unseal

--- a/dist/bash-completion/tpm2-tools/tss2_unseal
+++ b/dist/bash-completion/tpm2-tools/tss2_unseal
@@ -18,7 +18,7 @@ _tss2_unseal()
 
     $split && return
 
-    COMPREPLY=( $(compgen -W "-h --help -v --version --data -o -f --force --path -p" -- "$cur") )
+    COMPREPLY=( $(compgen -W "-h --help -v --version --data= -o -f --force --path= -p" -- "$cur") )
     [[ $COMPREPLY == *= ]] && compopt -o nospace
 } &&
 complete -F _tss2_unseal tss2_unseal

--- a/dist/bash-completion/tpm2-tools/tss2_unseal
+++ b/dist/bash-completion/tpm2-tools/tss2_unseal
@@ -10,7 +10,7 @@ _tss2_unseal()
             return;;
         -!(-*)o | --data)
             _filedir
-            COMPREPLY+=( '-' )
+            if [ x"$cur" = x ]; then COMPREPLY+=( '-' ); fi
             return;;
         -!(-*)p | --path )
             return;;

--- a/dist/bash-completion/tpm2-tools/tss2_verifyquote
+++ b/dist/bash-completion/tpm2-tools/tss2_verifyquote
@@ -18,7 +18,7 @@ _tss2_verifyquote()
 
     $split && return
 
-    COMPREPLY=( $(compgen -W "-h --help -v --version --qualifyingData -Q --pcrLog -l --quoteInfo -q --publicKeyPath -k --signature -i" -- "$cur") )
+    COMPREPLY=( $(compgen -W "-h --help -v --version --qualifyingData= -Q --pcrLog= -l --quoteInfo= -q --publicKeyPath= -k --signature= -i" -- "$cur") )
     [[ $COMPREPLY == *= ]] && compopt -o nospace
 } &&
 complete -F _tss2_verifyquote tss2_verifyquote

--- a/dist/bash-completion/tpm2-tools/tss2_verifyquote
+++ b/dist/bash-completion/tpm2-tools/tss2_verifyquote
@@ -10,7 +10,7 @@ _tss2_verifyquote()
             return;;
         -!(-*)[Qilq] | --qualifyingData | --signature | --pcrLog | --quoteInfo)
             _filedir
-            COMPREPLY+=( '-' )
+            if [ x"$cur" = x ]; then COMPREPLY+=( '-' ); fi
             return;;
         -!(-*)[k] | --publicKeyPath)
             return;;

--- a/dist/bash-completion/tpm2-tools/tss2_verifysignature
+++ b/dist/bash-completion/tpm2-tools/tss2_verifysignature
@@ -18,7 +18,7 @@ _tss2_verifysignature()
 
     $split && return
 
-    COMPREPLY=( $(compgen -W "-h --help -v --version --digest -d --keyPath -p --signature -i" -- "$cur") )
+    COMPREPLY=( $(compgen -W "-h --help -v --version --digest= -d --keyPath= -p --signature= -i" -- "$cur") )
     [[ $COMPREPLY == *= ]] && compopt -o nospace
 } &&
 complete -F _tss2_verifysignature tss2_verifysignature

--- a/dist/bash-completion/tpm2-tools/tss2_verifysignature
+++ b/dist/bash-completion/tpm2-tools/tss2_verifysignature
@@ -21,6 +21,6 @@ _tss2_verifysignature()
     COMPREPLY=( $(compgen -W "-h --help -v --version --digest -d --keyPath -p --signature -i" -- "$cur") )
     [[ $COMPREPLY == *= ]] && compopt -o nospace
 } &&
-complete -F _tss2verify_signature tss2verify_signature
+complete -F _tss2_verifysignature tss2_verifysignature
 
 # ex: filetype=sh

--- a/dist/bash-completion/tpm2-tools/tss2_verifysignature
+++ b/dist/bash-completion/tpm2-tools/tss2_verifysignature
@@ -10,7 +10,7 @@ _tss2_verifysignature()
             return;;
         -!(-*)[di] | --digest | --signature)
             _filedir
-            COMPREPLY+=( '-' )
+            if [ x"$cur" = x ]; then COMPREPLY+=( '-' ); fi
             return;;
         -!(-*)p | --keyPath)
             return;;

--- a/dist/bash-completion/tpm2-tools/tss2_writeauthorizenv
+++ b/dist/bash-completion/tpm2-tools/tss2_writeauthorizenv
@@ -14,7 +14,7 @@ _tss2_writeauthorizenv()
 
     $split && return
 
-    COMPREPLY=( $(compgen -W "-h --help -v --version --nvPath -p -policyPath -P" -- "$cur") )
+    COMPREPLY=( $(compgen -W "-h --help -v --version --nvPath= -p -policyPath= -P" -- "$cur") )
     [[ $COMPREPLY == *= ]] && compopt -o nospace
 } &&
 complete -F _tss2_writeauthorizenv tss2_writeauthorizenv

--- a/doc/CHANGELOG.md
+++ b/doc/CHANGELOG.md
@@ -35,6 +35,24 @@
 
  * tss2_*: tss2_setappdata now reads from file or stdin allowing to store also binary data
 
+ * tss2_*: Fix bash-completion for tss2_pcrextend and tss2_verifysignature
+
+ * tss2_*: Add force option to tss2_list
+
+ * tss2_*: Make force option consistent in all fapi tools
+
+ * tss2_*: Do not decode non-TPM errors
+
+ * tss2_*: Enhance integration tests to test changes of optional/mandatory parameters
+
+ * tss2_*: Add --hex parameter to tss2_getrandom
+
+ * tss2_*: Fix autocompletion issue
+
+ * tss2_*: Switch tss2_* to with-"="-style
+
+ * tss2_*: Add size parameter to tss2_createseal
+
 ### 4.2 2020-04-08
 
  * Fix various issues reported by static analysis tools.

--- a/man/tss2_authorizepolicy.1.md
+++ b/man/tss2_authorizepolicy.1.md
@@ -18,24 +18,24 @@
 
 These are the available options:
 
-  * **-P**, **\--policyPath** _STRING_:
+  * **-P**, **\--policyPath**=_STRING_:
     Path of the new policy.
 
     A policyPath is composed of two elements, separated by "/". A policyPath
     starts with "/policy". The second path element identifies the policy
     or policy template using a meaningful name.
 
-  * **-p**, **\--keyPath** _STRING_:
+  * **-p**, **\--keyPath**=_STRING_:
     Path of the signing key.
 
-  * **-r**, **\--policyRef** _FILENAME_ or _-_ (for stdin):
+  * **-r**, **\--policyRef**=_FILENAME_ or _-_ (for stdin):
     A byte buffer to be included in the signature. Optional parameter.
 
 [common tss2 options](common/tss2-options.md)
 
 # EXAMPLE
 ```
-tss2_authorizepolicy --keyPath HS/SRK/myPolicySignKey --policyPath /policy/pcr-policy --policyRef policyRef.file
+tss2_authorizepolicy --keyPath=HS/SRK/myPolicySignKey --policyPath=/policy/pcr-policy --policyRef=policyRef.file
 ```
 
 # RETURNS

--- a/man/tss2_changeauth.1.md
+++ b/man/tss2_changeauth.1.md
@@ -20,13 +20,13 @@ The authValue is a UTF-8 password.
 
 These are the available options:
 
-  * **-a**, **\--authValue** _STRING_:
+  * **-a**, **\--authValue**=_STRING_:
 
     The new UTF-8 password. Optional parameter. If it is neglected then the user
     is queried interactively for a password. To set no password, this option
     should be used with the empty string ("").
 
-  * **-p**, **\--entityPath** _STRING_:
+  * **-p**, **\--entityPath**=_STRING_:
 
     The path identifying the entity to modify.
 
@@ -36,12 +36,12 @@ These are the available options:
 
 ## Change a password for an entity HS/SRK/myRSACryptKey to M1
 ```
-tss2_changeauth --entityPath HS/SRK/myRSACryptKey --authValue M1
+tss2_changeauth --entityPath=HS/SRK/myRSACryptKey --authValue=M1
 ```
 
 ## Change a password for an entity HS/SRK/myRSACryptKey and ask the user to enter the password.
 ```
-tss2_changeauth --entityPath HS/SRK/myRSACryptKey
+tss2_changeauth --entityPath=HS/SRK/myRSACryptKey
 ```
 
 # RETURNS

--- a/man/tss2_createkey.1.md
+++ b/man/tss2_createkey.1.md
@@ -18,11 +18,11 @@
 
 These are the available options:
 
-  * **-p**, **\--path** _STRING_:
+  * **-p**, **\--path**=_STRING_:
 
     The path to the new key.
 
-  * **-t**, **\--type** _STRING_:
+  * **-t**, **\--type**=_STRING_:
 
     Identifies the intended usage. Optional parameter.
     Types may be any comma-separated combination of:
@@ -40,7 +40,7 @@ These are the available options:
         - A hexadecimal number (e.g. "0x81000001"): Marks a key object to be
           made persistent and sets the persistent object handle to this value.
 
-  * **-P**, **\--policyPath** _STRING_:
+  * **-P**, **\--policyPath**=_STRING_:
 
     The policy to be associated with the new key. Optional parameter. If omitted
     then no policy will be associated with the key.
@@ -49,7 +49,7 @@ These are the available options:
     starts with "/policy". The second path element identifies the policy
     or policy template using a meaningful name.
 
-  * **-a**, **\--authValue** _STRING_:
+  * **-a**, **\--authValue**=_STRING_:
 
     The new UTF-8 password. Optional parameter. If it is neglected then the user
     is queried interactively for a password. To set no password, this option
@@ -61,17 +61,17 @@ These are the available options:
 
 ## Create a key without password
 ```
-tss2_createkey --path HS/SRK/myRsaCryptKey --type "noDa, decrypt" --authValue ""
+tss2_createkey --path=HS/SRK/myRsaCryptKey --type="noDa, decrypt" --authValue=""
 ```
 
 ## Create a key, ask for password on the command line
 ```
-tss2_createkey --path HS/SRK/myRsaCryptKey --type "noDa, decrypt"
+tss2_createkey --path=HS/SRK/myRsaCryptKey --type="noDa, decrypt"
 ```
 
 ## Create a key with password "abc".
 ```
-tss2_createkey --path HS/SRK/myRsaCryptKey --type "noDa, decrypt" --authValue abc
+tss2_createkey --path=HS/SRK/myRsaCryptKey --type="noDa, decrypt" --authValue=abc
 ```
 
 # RETURNS

--- a/man/tss2_createnv.1.md
+++ b/man/tss2_createnv.1.md
@@ -18,7 +18,7 @@
 
 These are the available options:
 
-  * **-p**, **\--path** _STRING_:
+  * **-p**, **\--path**=_STRING_:
 
     Path of the new NV space.
 
@@ -30,7 +30,7 @@ These are the available options:
     Virtualized_Platform, MPWG, Embedded. The third path element identifies
     the actual NV-Index using a meaningful name.
 
-  * **-t**, **\--type** _STRING_:
+  * **-t**, **\--type**=_STRING_:
 
     Identifies the intended usage. Optional parameter.
     Types may be any comma-separated combination of:
@@ -43,13 +43,13 @@ These are the available options:
           index is created.
 
 
-  * **-s**, **\--size** _INTEGER_:
+  * **-s**, **\--size**=_INTEGER_:
 
     The size in bytes of the NV index to be created. Can be omitted if size can
     be inferred from the type; e.g. an NV index of type counter has a size of 8
     bytes.
 
-  * **-P**, **\--policyPath** _STRING_:
+  * **-P**, **\--policyPath**=_STRING_:
 
     Identifies the policy to be associated with the new NV space. Optional parameter.
     If omitted then no policy will be associated with the key.
@@ -58,7 +58,7 @@ These are the available options:
     starts with "/policy". The second path element identifies the policy
     or policy template using a meaningful name.
 
-  * **-a**, **\--authValue** _STRING_:
+  * **-a**, **\--authValue**=_STRING_:
 
     The new UTF-8 password. Optional parameter. If it is neglected then the user
     is queried interactively for a password. To set no password, this option
@@ -68,7 +68,7 @@ These are the available options:
 
 # EXAMPLE
 ```
-tss2_createnv --authValue abc --path /nv/Owner/myNV --size 20 --type "noDa"
+tss2_createnv --authValue=abc --path=/nv/Owner/myNV --size=20 --type="noDa"
 ```
 
 # RETURNS

--- a/man/tss2_createseal.1.md
+++ b/man/tss2_createseal.1.md
@@ -52,7 +52,13 @@ These are the available options:
 
   * **-i**, **\--data**=_FILENAME_ or _-_ (for stdin):
 
-    The data to be sealed by the TPM. Optional parameter.
+    The data to be sealed by the TPM. Optional parameter. Must not be used
+    together with \--size.
+
+  * **-s**, **\--size**=_INTEGER_:
+
+    Determines the number of random bytes the TPM should generate and seal.
+    Optional parameter. Must not be "0". Must no be used together with \--data.
 
 [common tss2 options](common/tss2-options.md)
 

--- a/man/tss2_createseal.1.md
+++ b/man/tss2_createseal.1.md
@@ -18,11 +18,11 @@
 
 These are the available options:
 
-  * **-p**, **\--path** _STRING_:
+  * **-p**, **\--path**=_STRING_:
 
     The path to the new key.
 
-  * **-t**, **\--type** _STRING_:
+  * **-t**, **\--type**=_STRING_:
 
     Identifies the intended usage. Optional parameter.
     Types may be any comma-separated combination of:
@@ -35,7 +35,7 @@ These are the available options:
         - A hexadecimal number (e.g. "0x81000001"): Marks a key object to be
           made persistent and sets the persistent object handle to this value.
 
-  * **-P**, **\--policyPath** _STRING_:
+  * **-P**, **\--policyPath**=_STRING_:
 
     Identifies the policy to be associated with the new key. Optional parameter.
     If omitted then no policy will be associated with the key.
@@ -44,13 +44,13 @@ These are the available options:
     starts with "/policy". The second path element identifies the policy
     or policy template using a meaningful name.
 
-  * **-a**, **\--authValue** _STRING_:
+  * **-a**, **\--authValue**=_STRING_:
 
     The new UTF-8 password. Optional parameter. If it is neglected then the user
     is queried interactively for a password. To set no password, this option
     should be used with the empty string ("").
 
-  * **-i**, **\--data** _FILENAME_ or _-_ (for stdin):
+  * **-i**, **\--data**=_FILENAME_ or _-_ (for stdin):
 
     The data to be sealed by the TPM. Optional parameter.
 
@@ -60,7 +60,7 @@ These are the available options:
 
 ## Create a key with password "abc" and read sealing data from file.
 ```
-tss2_createseal --path HS/SRK/mySealKey --type "noDa" --authValue abc --data data.file
+tss2_createseal --path=HS/SRK/mySealKey --type="noDa" --authValue=abc --data=data.file
 ```
 
 # RETURNS

--- a/man/tss2_decrypt.1.md
+++ b/man/tss2_decrypt.1.md
@@ -19,11 +19,11 @@
 
 These are the available options:
 
-  * **-p**, **\--keyPath** _STRING_:
+  * **-p**, **\--keyPath**=_STRING_:
 
     Identifies the decryption key.
 
-  * **-i**, **\--cipherText** _FILENAME_ or _-_ (for stdin):
+  * **-i**, **\--cipherText**=_FILENAME_ or _-_ (for stdin):
 
     The JSON-encoded cipherText.
 
@@ -31,7 +31,7 @@ These are the available options:
 
     Force Overwriting the output file.
 
-  * **-o**, **\--plainText** _FILENAME_ or _-_ (for stdout):
+  * **-o**, **\--plainText**=_FILENAME_ or _-_ (for stdout):
 
     Returns the decrypted data. Optional parameter.
 
@@ -39,7 +39,7 @@ These are the available options:
 
 # EXAMPLE
 ```
-    tss2_decrypt --keyPath HS/SRK/myRSACrypt --cipherText cipherText.file --plainText plainText.file
+    tss2_decrypt --keyPath=HS/SRK/myRSACrypt --cipherText=cipherText.file --plainText=plainText.file
 ```
 
 # RETURNS

--- a/man/tss2_delete.1.md
+++ b/man/tss2_delete.1.md
@@ -28,7 +28,7 @@ actions are taken:
 
 These are the available options:
 
-  * **-p**, **\--path** _STRING_:
+  * **-p**, **\--path**=_STRING_:
 
     The path to the entity to delete.
 
@@ -38,7 +38,7 @@ These are the available options:
 
 # Deletes storage hierarchy (HS) and everything below it:
 ```
-tss2_delete --path /HS
+tss2_delete --path=/HS
 ```
 
 # RETURNS

--- a/man/tss2_encrypt.1.md
+++ b/man/tss2_encrypt.1.md
@@ -19,7 +19,7 @@ using the TPM encryption schemes as specified in the crypto profile.
 
 These are the available options:
 
-  * **-p**, **\--keyPath** _STRING_:
+  * **-p**, **\--keyPath**=_STRING_:
 
     Identifies the encryption key.
 
@@ -27,11 +27,11 @@ These are the available options:
 
     Force overwriting the output file.
 
-  * **-i**, **\--plainText** _FILENAME_ or _-_ (for stdin):
+  * **-i**, **\--plainText**=_FILENAME_ or _-_ (for stdin):
 
     The data to be encrypted.
 
-  * **-o**, **\--cipherText** _FILENAME_ or _-_ (for stdout):
+  * **-o**, **\--cipherText**=_FILENAME_ or _-_ (for stdout):
 
     Returns the JSON-encoded ciphertext.
 
@@ -39,7 +39,7 @@ These are the available options:
 
 # EXAMPLE
 ```
-  tss2_encrypt --keyPath HS/SRK/myRSACrypt --plainText plainText.file --cipherText cipherText.file
+  tss2_encrypt --keyPath=HS/SRK/myRSACrypt --plainText=plainText.file --cipherText=cipherText.file
 ```
 
 # RETURNS

--- a/man/tss2_exportkey.1.md
+++ b/man/tss2_exportkey.1.md
@@ -19,7 +19,7 @@ exported data will contain the re-wrapped key pointed to by the pathOfKeyToDupli
 
 These are the available options:
 
-  * **-e** **\--pathToPublicKeyOfNewParent** _STRING_:
+  * **-e** **\--pathToPublicKeyOfNewParent**=_STRING_:
 
     The path to the public key of the new parent. This key MAY be in the public key hierarchy /ext.
     Optional parameter. If omitted only the public key will exported.
@@ -28,11 +28,11 @@ These are the available options:
 
     Force overwriting the output file.
 
-  * **-o**, **\--exportedData** _FILENAME_ or _-_ (for stdout):
+  * **-o**, **\--exportedData**=_FILENAME_ or _-_ (for stdout):
 
     Returns the exported subtree.
 
-  * **-p**, **\--pathOfKeyToDuplicate** _STRING_:
+  * **-p**, **\--pathOfKeyToDuplicate**=_STRING_:
 
     The path to the root of the subtree to export.
 
@@ -40,7 +40,7 @@ These are the available options:
 
 # EXAMPLE
 ```
-tss2_exportkey --pathOfKeyToDuplicate HS/SRK/myRSADecrypt --exportedData exportedData.file
+tss2_exportkey --pathOfKeyToDuplicate=HS/SRK/myRSADecrypt --exportedData=exportedData.file
 ```
 
 # RETURNS

--- a/man/tss2_exportpolicy.1.md
+++ b/man/tss2_exportpolicy.1.md
@@ -23,11 +23,11 @@ These are the available options:
 
     Force overwriting the output file.
 
-  * **-o**, **\--jsonPolicy** _FILENAME_ or _-_ (for stdout):
+  * **-o**, **\--jsonPolicy**=_FILENAME_ or _-_ (for stdout):
 
     Returns the JSON-encoded policy.
 
-  * **-p**, **\--path** _STRING_:
+  * **-p**, **\--path**=_STRING_:
 
     The path of the key.
 
@@ -35,7 +35,7 @@ These are the available options:
 
 # EXAMPLE
 ```
-tss2_exportpolicy --path HS/SRK/myRSASign --jsonPolicy jsonPolicy.json
+tss2_exportpolicy --path=HS/SRK/myRSASign --jsonPolicy=jsonPolicy.json
 ```
 
 # RETURNS

--- a/man/tss2_getappdata.1.md
+++ b/man/tss2_getappdata.1.md
@@ -18,6 +18,10 @@
 
 These are the available options:
 
+  * **-f**, **\--force**:
+
+    Force overwriting the output file.
+
   * **-p**, **\--path** _STRING_:
 
     Path of the object for which the appData will be loaded.

--- a/man/tss2_getappdata.1.md
+++ b/man/tss2_getappdata.1.md
@@ -22,11 +22,11 @@ These are the available options:
 
     Force overwriting the output file.
 
-  * **-p**, **\--path** _STRING_:
+  * **-p**, **\--path**=_STRING_:
 
     Path of the object for which the appData will be loaded.
 
-  * **-o**, **\--appData** _FILENAME_ or _-_ (for stdout):
+  * **-o**, **\--appData**=_FILENAME_ or _-_ (for stdout):
 
     Returns a copy of the stored data. Optional parameter.
 
@@ -34,7 +34,7 @@ These are the available options:
 
 # EXAMPLE
 ```
-tss2_getappdata --path HS/SRK/myRSACrypt --appData appData.file
+tss2_getappdata --path=HS/SRK/myRSACrypt --appData=appData.file
 ```
 
 # RETURNS

--- a/man/tss2_getcertificate.1.md
+++ b/man/tss2_getcertificate.1.md
@@ -22,11 +22,11 @@ These are the available options:
 
     Force overwriting the output file.
 
-  * **-p**, **\--path** _STRING_:
+  * **-p**, **\--path**=_STRING_:
 
     The entity whose certificate is requested.
 
-  * **-o**, **\--x509certData** _FILENAME_ or _-_ (for stdout):
+  * **-o**, **\--x509certData**=_FILENAME_ or _-_ (for stdout):
 
     Returns the PEM encoded certificate. If no certificate is stored, then an empty string is returned.
 
@@ -34,7 +34,7 @@ These are the available options:
 
 # EXAMPLE
 ```
-tss2_getcertificate --path HS/SRK/myRSACrypt --x509certData x509certData.file
+tss2_getcertificate --path=HS/SRK/myRSACrypt --x509certData=x509certData.file
 ```
 
 # RETURNS

--- a/man/tss2_getdescription.1.md
+++ b/man/tss2_getdescription.1.md
@@ -23,11 +23,11 @@ These are the available options:
 
     Force overwriting the output file.
 
-  * **-p**, **\--path** _STRING_:
+  * **-p**, **\--path**=_STRING_:
 
     The path of the object for which the description will be loaded.
 
-  * **-o**, **\--description** _FILENAME_ or _-_ (for stdout):
+  * **-o**, **\--description**=_FILENAME_ or _-_ (for stdout):
 
     Returns the stored description.
 
@@ -35,7 +35,7 @@ These are the available options:
 
 # EXAMPLE
 ```
-tss2_getdescription --path HS/SRK --description description.file
+tss2_getdescription --path=HS/SRK --description=description.file
 ```
 
 # RETURNS

--- a/man/tss2_getinfo.1.md
+++ b/man/tss2_getinfo.1.md
@@ -22,7 +22,7 @@ These are the available options:
 
     Force overwriting the output file.
 
-  * **-o**, **\--info** _FILENAME_ or _-_ (for stdout):
+  * **-o**, **\--info**=_FILENAME_ or _-_ (for stdout):
 
     Returns the FAPI and TPM information.
 
@@ -31,7 +31,7 @@ These are the available options:
 
 # EXAMPLE
 ```
-tss2_getinfo --info info.file
+tss2_getinfo --info=info.file
 ```
 
 # RETURNS

--- a/man/tss2_getplatformcertificates.1.md
+++ b/man/tss2_getplatformcertificates.1.md
@@ -22,7 +22,7 @@ These are the available options:
 
     Force overwriting the output file.
 
-  * **-o**, **\--certificates** _FILENAME_ or _-_ (for stdout):
+  * **-o**, **\--certificates**=_FILENAME_ or _-_ (for stdout):
 
     Returns a continuous buffer containing the concatenated platform certificates.
 
@@ -30,7 +30,7 @@ These are the available options:
 
 # EXAMPLE
 ```
-tss2_getplatformcertificates --certificates certificates.file
+tss2_getplatformcertificates --certificates=certificates.file
 ```
 
 # RETURNS

--- a/man/tss2_getrandom.1.md
+++ b/man/tss2_getrandom.1.md
@@ -17,7 +17,7 @@
 
 These are the available options:
 
-  * **-n**, **\--numBytes** _INTEGER_:
+  * **-n**, **\--numBytes**=_INTEGER_:
 
     The number of bytes requested by the caller.
 
@@ -25,7 +25,7 @@ These are the available options:
 
     Force overwriting the output file.
 
-  * **-o**, **\--data** _FILENAME_ or _-_ (for stdout):
+  * **-o**, **\--data**=_FILENAME_ or _-_ (for stdout):
 
     The returned random bytes.
 
@@ -37,7 +37,7 @@ These are the available options:
 
 # EXAMPLE
 ```
-    tss2_getrandom --numBytes 20 -data - | hexdump -C
+    tss2_getrandom --numBytes=20 -data=- | hexdump -C
 ```
 
 # RETURNS

--- a/man/tss2_getrandom.1.md
+++ b/man/tss2_getrandom.1.md
@@ -29,6 +29,10 @@ These are the available options:
 
     The returned random bytes.
 
+  * **\--hex**
+
+    Convert the output data to hex format without a leading "0x".
+
 [common tss2 options](common/tss2-options.md)
 
 # EXAMPLE

--- a/man/tss2_gettpmblobs.1.md
+++ b/man/tss2_gettpmblobs.1.md
@@ -22,19 +22,19 @@ These are the available options:
 
     Force overwriting the output file.
 
-  * **-p**, **\--path** _STRING_:
+  * **-p**, **\--path**=_STRING_:
 
     The path of the object for which the blobs will be returned.
 
-  * **-u**, **\--tpm2bPublic** _FILENAME_ or _-_ (for stdout):
+  * **-u**, **\--tpm2bPublic**=_FILENAME_ or _-_ (for stdout):
 
     The returned public area of the object as a marshalled TPM2B_PUBLIC. Optional parameter.
 
-  * **-r**, **\--tpm2bPrivate** _FILENAME_ or _-_ (for stdout):
+  * **-r**, **\--tpm2bPrivate**=_FILENAME_ or _-_ (for stdout):
 
     The returned private area of the object as a marshalled TPM2B_PRIVATE. Optional parameter.
 
-  * **-l**, **\--policy** _FILENAME_ or _-_ (for stdout):
+  * **-l**, **\--policy**=_FILENAME_ or _-_ (for stdout):
 
     The returned policy associated with the object, encoded in JSON. Optional parameter.
 
@@ -42,7 +42,7 @@ These are the available options:
 
 # EXAMPLE
 ```
-tss2_gettpmblobs --path HS/SRK/myRSACrypt --tpm2bPublic tpm2bPublic.file --tpm2bPrivate tpm2bPrivate.file --policy policy.file
+tss2_gettpmblobs --path=HS/SRK/myRSACrypt --tpm2bPublic=tpm2bPublic.file --tpm2bPrivate=tpm2bPrivate.file --policy=policy.file
 ```
 
 # RETURNS

--- a/man/tss2_import.1.md
+++ b/man/tss2_import.1.md
@@ -20,11 +20,11 @@ under the provided path.
 
 These are the available options:
 
-  * **-p**, **\--path** _STRING_:
+  * **-p**, **\--path**=_STRING_:
 
     The path of the new object.
 
-  * **-i**, **\--importData** _FILENAME_ or _-_ (for stdin):
+  * **-i**, **\--importData**=_FILENAME_ or _-_ (for stdin):
 
     The data to be imported.
 
@@ -32,10 +32,10 @@ These are the available options:
 
 # EXAMPLE
 ```
-tss2_import --path /policy/duplicate-policy --importData importData.json
+tss2_import --path=/policy/duplicate-policy --importData=importData.json
 ```
 ```
-tss2_import --path /ext/key --importData importData.file
+tss2_import --path=/ext/key --importData=importData.file
 ```
 
 # RETURNS

--- a/man/tss2_list.1.md
+++ b/man/tss2_list.1.md
@@ -18,6 +18,10 @@
 
 These are the available options:
 
+  * **-f**, **\--force**:
+
+    Force overwriting the output file.
+
   * **-p**, **\--searchPath** _STRING_:
 
     The path identifying the root of the search. Optional parameter. If omitted,

--- a/man/tss2_list.1.md
+++ b/man/tss2_list.1.md
@@ -22,12 +22,12 @@ These are the available options:
 
     Force overwriting the output file.
 
-  * **-p**, **\--searchPath** _STRING_:
+  * **-p**, **\--searchPath**=_STRING_:
 
     The path identifying the root of the search. Optional parameter. If omitted,
     all entities will be searched.
 
-  * **-o**, **\--pathList** _FILENAME_ or _-_ (for stdout):
+  * **-o**, **\--pathList**=_FILENAME_ or _-_ (for stdout):
 
     Returns the colon-separated list of paths. Optional parameter. If omitted,
     results will be printed to _STDOUT_.
@@ -42,7 +42,7 @@ tss2_list
 ```
 ## List all entities under the HS path and print results to file
 ```
-tss2_list --searchPath HS --pathList output.file
+tss2_list --searchPath=HS --pathList=output.file
 ```
 
 # RETURNS

--- a/man/tss2_nvextend.1.md
+++ b/man/tss2_nvextend.1.md
@@ -19,15 +19,15 @@
 
 These are the available options:
 
-  * **-i**, **\--data** _FILENAME_ or _-_ (for stdin):
+  * **-i**, **\--data**=_FILENAME_ or _-_ (for stdin):
 
     The data to be extended into the NV space.
 
-  * **-p**, **\--nvPath** _STRING_:
+  * **-p**, **\--nvPath**=_STRING_:
 
     Identifies the NV space to write.
 
-  * **-l**, **\--logData** _FILENAME_ or _-_ (for stdin):
+  * **-l**, **\--logData**=_FILENAME_ or _-_ (for stdin):
 
     A JSON representation of data to be written to the PCR's event log. Optional parameter.
 
@@ -35,7 +35,7 @@ These are the available options:
 
 # EXAMPLE
 ```
-tss2_nvextend --nvPath /nv/Owner/NvExtend --data data.file --logData logData.file
+tss2_nvextend --nvPath=/nv/Owner/NvExtend --data=data.file --logData=logData.file
 ```
 
 # RETURNS

--- a/man/tss2_nvincrement.1.md
+++ b/man/tss2_nvincrement.1.md
@@ -18,7 +18,7 @@
 
 These are the availabe options:
 
-  * **-p**, **\--nvPath** _STRING_:
+  * **-p**, **\--nvPath**=_STRING_:
 
     Identifies the NV space to increment.
 
@@ -26,7 +26,7 @@ These are the availabe options:
 
 # EXAMPLE
 ```
-tss2_nvincrement --nvPath /nv/Owner/myNVcounter
+tss2_nvincrement --nvPath=/nv/Owner/myNVcounter
 ```
 
 # RETURNS

--- a/man/tss2_nvread.1.md
+++ b/man/tss2_nvread.1.md
@@ -22,15 +22,15 @@ These are the availabe options:
 
     Force overwriting the output file.
 
-  * **-o**, **\--data** _FILENAME_ or _-_ (for stdout):
+  * **-o**, **\--data**=_FILENAME_ or _-_ (for stdout):
 
     Returns the value read from the NV space.
 
-  * **-p**, **\--nvPath** _STRING_:
+  * **-p**, **\--nvPath**=_STRING_:
 
     Identifies the NV space to read.
 
-  * **-l**, **\--logData** _FILENAME_ or _-_ (for stdout):
+  * **-l**, **\--logData**=_FILENAME_ or _-_ (for stdout):
 
     Returns the JSON encoded log, if the NV index is of type "extend" and an empty string otherwise. Optional parameter.
 
@@ -38,7 +38,7 @@ These are the availabe options:
 
 # EXAMPLE
 ```
-tss2_nvread --nvPath /nv/Owner/myNV --data data.file
+tss2_nvread --nvPath=/nv/Owner/myNV --data=data.file
 ```
 
 # RETURNS

--- a/man/tss2_nvsetbits.1.md
+++ b/man/tss2_nvsetbits.1.md
@@ -18,11 +18,11 @@
 
 These are the availabe options:
 
-  * **-i**, **\--bitmap** _BITS_:
+  * **-i**, **\--bitmap**=_BITS_:
 
     A mask indicating which bits to set in the NV space.
 
-  * **-p**, **\--nvPath** _STRING_:
+  * **-p**, **\--nvPath**=_STRING_:
 
     Identifies the NV space to write.
 
@@ -30,7 +30,7 @@ These are the availabe options:
 
 # EXAMPLE
 ```
-tss2_nvsetbits --nvPath /nv/Owner/NvBitmap --bitmap 0x0102030405060608
+tss2_nvsetbits --nvPath=/nv/Owner/NvBitmap --bitmap=0x0102030405060608
 ```
 
 # RETURNS

--- a/man/tss2_nvwrite.1.md
+++ b/man/tss2_nvwrite.1.md
@@ -18,11 +18,11 @@
 
 These are the available options:
 
-  * **-i**, **\--data** _FILENAME_ or _-_ (for stdin):
+  * **-i**, **\--data**=_FILENAME_ or _-_ (for stdin):
 
     The data to write to the NV space.
 
-  * **-p**, **\--nvPath** _STRING_:
+  * **-p**, **\--nvPath**=_STRING_:
 
     Identifies the NV space to write to.
 
@@ -30,7 +30,7 @@ These are the available options:
 
 # EXAMPLE
 ```
-tss2_nvwrite --nvPath /nv/Owner/myNV --data data.file
+tss2_nvwrite --nvPath=/nv/Owner/myNV --data=data.file
 ```
 
 # RETURNS

--- a/man/tss2_pcrextend.1.md
+++ b/man/tss2_pcrextend.1.md
@@ -18,15 +18,15 @@
 
 These are the available options:
 
-  * **-x**, **\--pcr** _INTEGER_:
+  * **-x**, **\--pcr**=_INTEGER_:
 
    The PCR to extend.
 
-  * **-i**, **\--data** _FILENAME_ or _-_ (for stdin):
+  * **-i**, **\--data**=_FILENAME_ or _-_ (for stdin):
 
     The event data to be extended.
 
-  * **-l**, **\--logData** _FILENAME_ or _-_ (for stdin):
+  * **-l**, **\--logData**=_FILENAME_ or _-_ (for stdin):
 
     Contains a JSON representation of data to be written to the PCR's event log. Optional parameter.
 
@@ -35,7 +35,7 @@ These are the available options:
 
 # EXAMPLE
 ```
-tss2_pcrextend --pcr 16 --data data.file --logData logData.file
+tss2_pcrextend --pcr=16 --data=data.file --logData=logData.file
 ```
 
 # RETURNS

--- a/man/tss2_pcrread.1.md
+++ b/man/tss2_pcrread.1.md
@@ -18,11 +18,11 @@
 
 These are the available options:
 
-  * **-o**, **\--pcrValue** _FILENAME_ or _-_ (for stdout):
+  * **-o**, **\--pcrValue**=_FILENAME_ or _-_ (for stdout):
 
     Returns PCR digest. Optional parameter.
 
-  * **-x**, **\--pcrIndex** _INTEGER_:
+  * **-x**, **\--pcrIndex**=_INTEGER_:
 
     Identifies the PCR to read.
 
@@ -30,7 +30,7 @@ These are the available options:
 
     Force overwriting the output files.
 
-  * **-l**, **\--pcrLog** _FILENAME_ or _-_ (for stdout):
+  * **-l**, **\--pcrLog**=_FILENAME_ or _-_ (for stdout):
 
     Returns the PCR log for that PCR. Optional parameter.
 
@@ -48,7 +48,7 @@ These are the available options:
 
 # EXAMPLE
 ```
-tss2_pcrread --pcrIndex 16 --pcrValue pcrValue.file --pcrLog pcrLog.file
+tss2_pcrread --pcrIndex=16 --pcrValue=pcrValue.file --pcrLog=pcrLog.file
 ```
 
 # RETURNS

--- a/man/tss2_provision.1.md
+++ b/man/tss2_provision.1.md
@@ -26,14 +26,14 @@ without authorization value is made persistent.
 
 These are the available options:
 
-  * **-E**, **\--authValueEh** _STRING_:
+  * **-E**, **\--authValueEh**=_STRING_:
     The authorization value for the privacy admin, i.e. the endorsement hierarchy.
     Optional parameter.
 
-  * **-S**, **\--authValueSh** _STRING_:
+  * **-S**, **\--authValueSh**=_STRING_:
     The authorization value for the owner, i.e. the storage hierarchy. Optional parameter.
 
-  * **-L**, **\--authValueLockout** _STRING_:
+  * **-L**, **\--authValueLockout**=_STRING_:
     The authorization value for the lockout authorization. Optional parameter.
 
 [common tss2 options](common/tss2-options.md)

--- a/man/tss2_quote.1.md
+++ b/man/tss2_quote.1.md
@@ -18,15 +18,15 @@
 
 These are the available options:
 
-  * **-x**, **\--pcrList** _STRING_:
+  * **-x**, **\--pcrList**=_STRING_:
 
     An array holding the PCR indices to quote against.
 
-  * **-Q**, **\--qualifyingData** _FILENAME_ or _-_ (for stdin):
+  * **-Q**, **\--qualifyingData**=_FILENAME_ or _-_ (for stdin):
 
     A nonce provided by the caller to ensure freshness of the signature. Optional parameter.
 
-  * **-l**, **\--pcrLog** _FILENAME_ or _-_ (for stdout):
+  * **-l**, **\--pcrLog**=_FILENAME_ or _-_ (for stdout):
 
     Returns the PCR log for the chosen PCR. Optional parameter.
 
@@ -44,19 +44,19 @@ These are the available options:
 
     Force overwriting the output file.
 
-  * **-p**, **\--keyPath** _STRING_:
+  * **-p**, **\--keyPath**=_STRING_:
 
     Identifies the signing key.
 
-  * **-q**, **\--quoteInfo** _FILENAME_ or _-_ (for stdout):
+  * **-q**, **\--quoteInfo**=_FILENAME_ or _-_ (for stdout):
 
     Returns a JSON-encoded structure holding the inputs to the quote operation. This includes the digest value and PCR values.
 
-  * **-o**, **\--signature** _FILENAME_ or _-_ (for stdout):
+  * **-o**, **\--signature**=_FILENAME_ or _-_ (for stdout):
 
     Returns the signature over the quoted material.
 
-  * **-c**, **\--certificate** _FILENAME_ or _-_ (for stdout):
+  * **-c**, **\--certificate**=_FILENAME_ or _-_ (for stdout):
 
     The certificate associated with keyPath in PEM format. Optional parameter.
 
@@ -64,7 +64,7 @@ These are the available options:
 
 # EXAMPLE
 ```
-tss2_quote --keyPath HS/SRK/quotekey --pcrList "10,16" --qualifyingData qualifyingData.file --signature signature.file --pcrLog pcrLog.file --certificate certificate.file --quoteInfo quoteInfo.info
+tss2_quote --keyPath=HS/SRK/quotekey --pcrList="10,16" --qualifyingData=qualifyingData.file --signature=signature.file --pcrLog=pcrLog.file --certificate=certificate.file --quoteInfo=quoteInfo.info
 ```
 
 # RETURNS

--- a/man/tss2_setappdata.1.md
+++ b/man/tss2_setappdata.1.md
@@ -18,11 +18,11 @@
 
 These are the available options:
 
-  * **-p**, **\--path** _STRING_:
+  * **-p**, **\--path**=_STRING_:
 
     Path of the object for which the appData will be stored.
 
-  * **-i**, **\--appData** _FILENAME_ or _-_ (for stdin):
+  * **-i**, **\--appData**=_FILENAME_ or _-_ (for stdin):
 
     The data to be stored. Optional parameter. If omitted, stored data is deleted.
 
@@ -31,7 +31,7 @@ These are the available options:
 # EXAMPLE
 
 ```
-tss2_setappdata --path HS/SRK/myRSACrypt --appData appData.file
+tss2_setappdata --path=HS/SRK/myRSACrypt --appData=appData.file
 ```
 
 # RETURNS

--- a/man/tss2_setcertificate.1.md
+++ b/man/tss2_setcertificate.1.md
@@ -18,11 +18,11 @@
 
 These are the available options:
 
-  * **-p**, **\--path** _STRING_:
+  * **-p**, **\--path**=_STRING_:
 
     Identifies the entity to be associated with the certificate.
 
-  * **-i**, **\--x509certData** _FILENAME_ or _-_ (for stdin):
+  * **-i**, **\--x509certData**=_FILENAME_ or _-_ (for stdin):
 
     The PEM encoded certificate. Optional parameter. If omitted, then the stored
     x509 certificate is removed.
@@ -32,7 +32,7 @@ These are the available options:
 # EXAMPLE
 
 ```
-tss2_setcertificate --path HS/SRK/myRSACrypt --x509certData x509certData.file
+tss2_setcertificate --path=HS/SRK/myRSACrypt --x509certData=x509certData.file
 ```
 
 # RETURNS

--- a/man/tss2_setdescription.1.md
+++ b/man/tss2_setdescription.1.md
@@ -18,13 +18,13 @@
 
 These are the available options:
 
-  * **-i**, **\--description** _STRING_:
+  * **-i**, **\--description**=_STRING_:
 
     The data to be stored as description for the object. Optional parameter.
     Previously stored descriptions are overwritten by this function. If omitted
     any stored description is deleted.
 
-  * **-p**, **\--path** _STRING_:
+  * **-p**, **\--path**=_STRING_:
 
     The path of the object for which the description will be stored.
 
@@ -34,7 +34,7 @@ These are the available options:
 # EXAMPLE
 
 ```
-tss2_setdescription --path HS/SRK --description description
+tss2_setdescription --path=HS/SRK --description=description
 ```
 
 # RETURNS

--- a/man/tss2_sign.1.md
+++ b/man/tss2_sign.1.md
@@ -18,20 +18,20 @@
 
 These are the available options:
 
-  * **-p**, **\--keyPath** _STRING_:
+  * **-p**, **\--keyPath**=_STRING_:
 
     The path to the signing key.
 
-  * **-s**, **\--padding** _STRING_:
+  * **-s**, **\--padding**=_STRING_:
 
     The padding scheme used. Possible values are "RSA_SSA", "RSA_PSS" (case insensitive). Optional parameter.
     If omitted, the default padding specified in the crypto profile is used.
 
-  * **-c**, **\--certificate** _FILENAME_ or _-_ (for stdout):
+  * **-c**, **\--certificate**=_FILENAME_ or _-_ (for stdout):
 
     The certificate associated with keyPath in PEM format. Optional parameter.
 
-  * **-d**, **\--digest** _FILENAME_ or _-_ (for stdin):
+  * **-d**, **\--digest**=_FILENAME_ or _-_ (for stdin):
 
     The data to be signed, already hashed.
 
@@ -39,11 +39,11 @@ These are the available options:
 
     Force overwriting the output file.
 
-  * **-k**, **\--publicKey** _FILENAME_ or _-_ (for stdout):
+  * **-k**, **\--publicKey**=_FILENAME_ or _-_ (for stdout):
 
     The public key associated with keyPath in PEM format. Optional parameter.
 
-  * **-o**, **\--signature** _FILENAME_ or _-_ (for stdout):
+  * **-o**, **\--signature**=_FILENAME_ or _-_ (for stdout):
 
     Returns the signature in binary form.
 
@@ -52,7 +52,7 @@ These are the available options:
 # EXAMPLE
 
 ```
-tss2_sign --keyPath HS/SRK/myRSASign --padding "RSA_PSS" --digest digest.file --signature signature.file --publicKey publicKey.file
+tss2_sign --keyPath=HS/SRK/myRSASign --padding="RSA_PSS" --digest=digest.file --signature=signature.file --publicKey=publicKey.file
 ```
 
 # RETURNS

--- a/man/tss2_unseal.1.md
+++ b/man/tss2_unseal.1.md
@@ -22,11 +22,11 @@ These are the available options:
 
     Force overwriting the output file.
 
-  * **-p**, **\--path** _STRING_:
+  * **-p**, **\--path**=_STRING_:
 
     Path of the object for which the blobs will be returned.
 
-  * **-o**, **\--data** _FILENAME_ or _-_ (for stdout):
+  * **-o**, **\--data**=_FILENAME_ or _-_ (for stdout):
 
     The decrypted data after unsealing. Optional parameter.
 
@@ -35,7 +35,7 @@ These are the available options:
 # EXAMPLE
 
 ```
-tss2_unseal --path HS/SRK/myRSACrypt --data data.file
+tss2_unseal --path=HS/SRK/myRSACrypt --data=data.file
 ```
 
 # RETURNS

--- a/man/tss2_verifyquote.1.md
+++ b/man/tss2_verifyquote.1.md
@@ -26,11 +26,11 @@ An application using tss2_verifyquote() will further have to
 
 These are the available options:
 
-  * **-Q**, **\--qualifyingData** _FILENAME_ or _-_ (for stdin):
+  * **-Q**, **\--qualifyingData**=_FILENAME_ or _-_ (for stdin):
 
     A nonce provided by the caller to ensure freshness of the signature. Optional parameter.
 
-  * **-l**, **\--pcrLog** _FILENAME_ or _-_ (for stdin):
+  * **-l**, **\--pcrLog**=_FILENAME_ or _-_ (for stdin):
 
     Returns the PCR event log for the chosen PCR. Optional parameter.
 
@@ -44,15 +44,15 @@ These are the available options:
         - eventDigest: Digest of the event; e.g. the digest of the measured file
         - eventName: Name of the event; e.g. the name of the measured file.
 
-  * **-q**, **\--quoteInfo** _FILENAME_ or _-_ (for stdin):
+  * **-q**, **\--quoteInfo**=_FILENAME_ or _-_ (for stdin):
 
     The JSON-encoded structure holding the inputs to the quote operation. This includes the digest value and PCR values.
 
-  * **-k**, **\--publicKeyPath** _STRING_:
+  * **-k**, **\--publicKeyPath**=_STRING_:
 
     Identifies the signing key. MAY be a path to the public key hierarchy /ext.
 
-  * **-i**, **\--signature** _FILENAME_ or _-_ (for stdin):
+  * **-i**, **\--signature**=_FILENAME_ or _-_ (for stdin):
 
     The signature over the quoted material.
 
@@ -61,7 +61,7 @@ These are the available options:
 # EXAMPLE
 
 ```
-    tss2_verifyquote --publicKeyPath "ext/myNewParent" --qualifyingData qualifyingData.file --quoteInfo quoteInfo.file --signature signature.file --pcrLog pcrLog.file
+    tss2_verifyquote --publicKeyPath="ext/myNewParent" --qualifyingData=qualifyingData.file --quoteInfo=quoteInfo.file --signature=signature.file --pcrLog=pcrLog.file
 ```
 
 # RETURNS

--- a/man/tss2_verifysignature.1.md
+++ b/man/tss2_verifysignature.1.md
@@ -18,15 +18,15 @@
 
 These are the available options:
 
-  * **-d**, **\--digest** _FILENAME_ or _-_ (for stdin):
+  * **-d**, **\--digest**=_FILENAME_ or _-_ (for stdin):
 
     The data that was signed, already hashed.
 
-  * **-p**, **\--keyPath** _STRING_:
+  * **-p**, **\--keyPath**=_STRING_:
 
     Path to the verification public key.
 
-  * **-i**, **\--signature** _FILENAME_ or _-_ (for stdin):
+  * **-i**, **\--signature**=_FILENAME_ or _-_ (for stdin):
 
     The signature to be verified.
 
@@ -36,7 +36,7 @@ These are the available options:
 # EXAMPLE
 
 ```
-tss2_verifysignature --keyPath ext/myRSASign --digest digest.file --signature signature.file
+tss2_verifysignature --keyPath=ext/myRSASign --digest=digest.file --signature=signature.file
 ```
 
 # RETURNS

--- a/man/tss2_writeauthorizenv.1.md
+++ b/man/tss2_writeauthorizenv.1.md
@@ -18,11 +18,11 @@
 
 These are the available options:
 
-  * **-p**, **\--nvPath** _STRING_:
+  * **-p**, **\--nvPath**=_STRING_:
 
     The path of the NV index.
 
-  * **-P**, **\--policyPath** _STRING_:
+  * **-P**, **\--policyPath**=_STRING_:
 
     The path of the new policy.
 
@@ -31,7 +31,7 @@ These are the available options:
 # EXAMPLE
 
 ```
-tss2_writeauthorizenv --nvPath /nv/Owner/myNV --policyPath /policy/pcr-policy
+tss2_writeauthorizenv --nvPath=/nv/Owner/myNV --policyPath=/policy/pcr-policy
 ```
 
 # RETURNS

--- a/test/integration/fapi/fapi-authorize-policy.sh
+++ b/test/integration/fapi/fapi-authorize-policy.sh
@@ -8,7 +8,7 @@ start_up
 setup_fapi
 
 function cleanup {
-    tss2_delete --path /
+    tss2_delete --path=/
     shut_down
 }
 
@@ -30,26 +30,26 @@ echo 'f0f1f2f3f4f5f6f7f8f9' | xxd -r -p > $POLICY_REF
 
 tss2_provision
 
-tss2_import --path $POLICY_PCR --importData $PCR_POLICY_DATA
+tss2_import --path=$POLICY_PCR --importData=$PCR_POLICY_DATA
 
-tss2_import --path $POLICY_AUTHORIZE --importData $AUTHORIZE_POLICY_DATA
+tss2_import --path=$POLICY_AUTHORIZE --importData=$AUTHORIZE_POLICY_DATA
 
-tss2_createkey --path $POLICY_SIGN_KEY_PATH --type "noDa, sign" --authValue ""
+tss2_createkey --path=$POLICY_SIGN_KEY_PATH --type="noDa, sign" --authValue=""
 
-tss2_authorizepolicy --keyPath $POLICY_SIGN_KEY_PATH --policyPath $POLICY_PCR \
-    --policyRef $POLICY_REF
+tss2_authorizepolicy --keyPath=$POLICY_SIGN_KEY_PATH --policyPath=$POLICY_PCR \
+    --policyRef=$POLICY_REF
 
-tss2_createkey --path $KEY_PATH --type "noDa, sign" \
-    --policyPath $POLICY_AUTHORIZE --authValue ""
+tss2_createkey --path=$KEY_PATH --type="noDa, sign" \
+    --policyPath=$POLICY_AUTHORIZE --authValue=""
 
-tss2_sign --keyPath $KEY_PATH --padding "RSA_PSS" --digest $DIGEST_FILE \
-    --signature $SIGNATURE_FILE --publicKey $PUBLIC_KEY_FILE
+tss2_sign --keyPath=$KEY_PATH --padding="RSA_PSS" --digest=$DIGEST_FILE \
+    --signature=$SIGNATURE_FILE --publicKey=$PUBLIC_KEY_FILE
 
 
 expect <<EOF
 # Try with missing policyPath
-spawn tss2_authorizepolicy --keyPath $POLICY_SIGN_KEY_PATH \
-    --policyRef $POLICY_REF
+spawn tss2_authorizepolicy --keyPath=$POLICY_SIGN_KEY_PATH \
+    --policyRef=$POLICY_REF
 set ret [wait]
 if {[lindex \$ret 2] || [lindex \$ret 3] != 1} {
     Command has not failed as expected\n"
@@ -60,7 +60,7 @@ EOF
 expect <<EOF
 # Try with missing keyPath
 spawn tss2_authorizepolicy \
-    --policyPath $POLICY_PCR --policyRef $POLICY_REF
+    --policyPath=$POLICY_PCR --policyRef=$POLICY_REF
 set ret [wait]
 if {[lindex \$ret 2] || [lindex \$ret 3] != 1} {
     Command has not failed as expected\n"

--- a/test/integration/fapi/fapi-branch-select.sh
+++ b/test/integration/fapi/fapi-branch-select.sh
@@ -8,7 +8,7 @@ start_up
 setup_fapi
 
 function cleanup {
-    tss2_delete --path /
+    tss2_delete --path=/
     shut_down
 }
 
@@ -29,29 +29,31 @@ echo -n 01234567890123456789012345678901 > $DIGEST_FILE
 POLICY_REF=$TEMP_DIR/policy_ref.file
 echo 'f0f1f2f3f4f5f6f7f8f9' | xxd -r -p > $POLICY_REF
 
+PADDINGS="RSA_PSS"
+
 tss2_provision
 
-tss2_import --path $POLICY_PCR --importData $PCR_POLICY_DATA
+tss2_import --path=$POLICY_PCR --importData=$PCR_POLICY_DATA
 
-tss2_import --path $POLICY_PCR2 --importData $PCR_POLICY_DATA
+tss2_import --path=$POLICY_PCR2 --importData=$PCR_POLICY_DATA
 
-tss2_import --path $POLICY_AUTHORIZE --importData $AUTHORIZE_POLICY_DATA
+tss2_import --path=$POLICY_AUTHORIZE --importData=$AUTHORIZE_POLICY_DATA
 
-tss2_createkey --path $POLICY_SIGN_KEY_PATH --type "noDa, sign" --authValue ""
+tss2_createkey --path=$POLICY_SIGN_KEY_PATH --type="noDa, sign" --authValue=""
 
-tss2_authorizepolicy --keyPath $POLICY_SIGN_KEY_PATH --policyPath $POLICY_PCR \
-    --policyRef $POLICY_REF
+tss2_authorizepolicy --keyPath=$POLICY_SIGN_KEY_PATH --policyPath=$POLICY_PCR \
+    --policyRef=$POLICY_REF
 
-tss2_authorizepolicy --keyPath $POLICY_SIGN_KEY_PATH --policyPath $POLICY_PCR2 \
-    --policyRef $POLICY_REF
+tss2_authorizepolicy --keyPath=$POLICY_SIGN_KEY_PATH --policyPath=$POLICY_PCR2 \
+    --policyRef=$POLICY_REF
 
-tss2_createkey --path $KEY_PATH --type "noDa, sign" \
-    --policyPath $POLICY_AUTHORIZE --authValue ""
+tss2_createkey --path=$KEY_PATH --type="noDa, sign" \
+    --policyPath=$POLICY_AUTHORIZE --authValue=""
 
 expect <<EOF
 # Check if system asks for branch selection
-spawn tss2_sign --keyPath $KEY_PATH --padding "RSA_PSS" --digest $DIGEST_FILE \
-    --signature $SIGNATURE_FILE --publicKey $PUBLIC_KEY_FILE
+spawn tss2_sign --keyPath=$KEY_PATH --padding=$PADDINGS --digest=$DIGEST_FILE \
+    --signature=$SIGNATURE_FILE --publicKey=$PUBLIC_KEY_FILE
 expect {
     "Your choice: " {
     } eof {
@@ -69,8 +71,8 @@ EOF
 
 expect <<EOF
 # Selecting wrong branch
-spawn tss2_sign --keyPath $KEY_PATH --padding "RSA_PSS" --digest $DIGEST_FILE \
-    --signature $SIGNATURE_FILE --publicKey $PUBLIC_KEY_FILE
+spawn tss2_sign --keyPath=$KEY_PATH --padding=$PADDINGS --digest=$DIGEST_FILE \
+    --signature=$SIGNATURE_FILE --publicKey=$PUBLIC_KEY_FILE
 expect {
     "Your choice: " {
     } eof {

--- a/test/integration/fapi/fapi-encrypt-decrypt.sh
+++ b/test/integration/fapi/fapi-encrypt-decrypt.sh
@@ -7,7 +7,7 @@ start_up
 setup_fapi
 
 function cleanup {
-    tss2_delete --path /
+    tss2_delete --path=/
     shut_down
 }
 
@@ -19,6 +19,7 @@ ENCRYPTED_FILE=$TEMP_DIR/encrypted.file
 DECRYPTED_FILE=$TEMP_DIR/decrypted.file
 PCR_POLICY_DATA=$TEMP_DIR/pol_pcr16_0.json
 POLICY_PCR=policy/pcr-policy
+TYPES="noDa,decrypt"
 
 echo -n "Secret Text!" > $PLAIN_TEXT
 
@@ -28,7 +29,7 @@ tss2_provision
 
 expect <<EOF
 # Try interactive prompt with 2 different passwords
-spawn tss2_createkey --path $KEY_PATH --type "noDa, decrypt"
+spawn tss2_createkey --path=$KEY_PATH --type=$TYPES
 expect "Authorize object Password: "
 send "1\r"
 expect "Authorize object Retype password: "
@@ -51,7 +52,7 @@ EOF
 
 expect <<EOF
 # Try with missing path
-spawn tss2_createkey --authValue abc --type "noDa, decrypt"
+spawn tss2_createkey --authValue=abc --type="noDa, decrypt"
 set ret [wait]
 if {[lindex \$ret 2] || [lindex \$ret 3] != 1} {
     send_user "Command has not failed as expected\n"
@@ -59,11 +60,11 @@ if {[lindex \$ret 2] || [lindex \$ret 3] != 1} {
 }
 EOF
 
-tss2_import --path $POLICY_PCR --importData $PCR_POLICY_DATA
+tss2_import --path=$POLICY_PCR --importData=$PCR_POLICY_DATA
 
 expect <<EOF
 # Try interactive prompt with empty passwords
-spawn tss2_createkey --path $KEY_PATH --type "noDa, decrypt"
+spawn tss2_createkey --path=$KEY_PATH --type=$TYPES
 expect "Authorize object Password: "
 send "\r"
 expect "Authorize object Retype password: "
@@ -76,12 +77,12 @@ if {[lindex \$ret 2] || [lindex \$ret 3] != 0} {
 }
 EOF
 
-tss2_encrypt --keyPath $KEY_PATH --plainText $PLAIN_TEXT \
-    --cipherText $ENCRYPTED_FILE --force
+tss2_encrypt --keyPath=$KEY_PATH --plainText=$PLAIN_TEXT \
+    --cipherText=$ENCRYPTED_FILE --force
 
 expect <<EOF
 # Try with missing keypath
-spawn tss2_encrypt --plainText $PLAIN_TEXT --cipherText $ENCRYPTED_FILE
+spawn tss2_encrypt --plainText=$PLAIN_TEXT --cipherText=$ENCRYPTED_FILE
 set ret [wait]
 if {[lindex \$ret 2] || [lindex \$ret 3] != 1} {
     send_user "Command has not failed as expected\n"
@@ -91,7 +92,7 @@ EOF
 
 expect <<EOF
 # Try with missing plaintext
-spawn tss2_encrypt --keyPath $KEY_PATH --cipherText $ENCRYPTED_FILE
+spawn tss2_encrypt --keyPath=$KEY_PATH --cipherText=$ENCRYPTED_FILE
 set ret [wait]
 if {[lindex \$ret 2] || [lindex \$ret 3] != 1} {
     send_user "Command has not failed as expected\n"
@@ -101,7 +102,7 @@ EOF
 
 expect <<EOF
 # Try with missing ciphertext
-spawn tss2_encrypt --keyPath $KEY_PATH --plainText $PLAIN_TEXT
+spawn tss2_encrypt --keyPath=$KEY_PATH --plainText=$PLAIN_TEXT
 set ret [wait]
 if {[lindex \$ret 2] || [lindex \$ret 3] != 1} {
     send_user "Command has not failed as expected\n"
@@ -111,8 +112,8 @@ EOF
 
 expect <<EOF
 # Try with wrong plaintext file
-spawn tss2_encrypt --keyPath $KEY_PATH --plainText abc \
-    --cipherText $ENCRYPTED_FILE
+spawn tss2_encrypt --keyPath=$KEY_PATH --plainText=abc \
+    --cipherText=$ENCRYPTED_FILE
 set ret [wait]
 if {[lindex \$ret 2] || [lindex \$ret 3] != 1} {
     send_user "Command has not failed as expected\n"
@@ -122,7 +123,7 @@ EOF
 
 expect <<EOF
 # Try with missing ciphertext
-spawn tss2_decrypt --keyPath $KEY_PATH --plainText $DECRYPTED_FILE
+spawn tss2_decrypt --keyPath=$KEY_PATH --plainText=$DECRYPTED_FILE
 set ret [wait]
 if {[lindex \$ret 2] || [lindex \$ret 3] != 1} {
     send_user "Command has not failed as expected\n"
@@ -132,7 +133,7 @@ EOF
 
 expect <<EOF
 # Try with missing plaintext
-spawn tss2_decrypt --keyPath $KEY_PATH --cipherText $ENCRYPTED_FILE
+spawn tss2_decrypt --keyPath=$KEY_PATH --cipherText=$ENCRYPTED_FILE
 set ret [wait]
 if {[lindex \$ret 2] || [lindex \$ret 3] != 1} {
     send_user "Command has not failed as expected\n"
@@ -142,7 +143,7 @@ EOF
 
 expect <<EOF
 # Try with missing keyPath
-spawn tss2_decrypt --cipherText $ENCRYPTED_FILE --plainText $DECRYPTED_FILE
+spawn tss2_decrypt --cipherText=$ENCRYPTED_FILE --plainText=$DECRYPTED_FILE
 set ret [wait]
 if {[lindex \$ret 2] || [lindex \$ret 3] != 1} {
     send_user "Command has not failed as expected\n"
@@ -150,13 +151,45 @@ if {[lindex \$ret 2] || [lindex \$ret 3] != 1} {
 }
 EOF
 
-tss2_decrypt --keyPath $KEY_PATH --cipherText $ENCRYPTED_FILE \
-    --plainText $DECRYPTED_FILE --force
+tss2_decrypt --keyPath=$KEY_PATH --cipherText=$ENCRYPTED_FILE \
+    --plainText=$DECRYPTED_FILE --force
 
 
 if [ "`cat $DECRYPTED_FILE`" != "`cat $PLAIN_TEXT`" ]; then
   echo "Encryption/Decryption failed"
   exit 1
+fi
+
+tss2_delete --path=$KEY_PATH
+
+# Encrypt/Decrypt with password
+tss2_createkey --path=$KEY_PATH --type="noDa, decrypt" --authValue=abc
+tss2_encrypt --keyPath=$KEY_PATH --plainText=$PLAIN_TEXT \
+    --cipherText=$ENCRYPTED_FILE --force
+echo -n "Fail" > $DECRYPTED_FILE
+expect <<EOF
+spawn tss2_decrypt --keyPath=$KEY_PATH --cipherText=$ENCRYPTED_FILE \
+    --plainText=$DECRYPTED_FILE --force
+expect "Authorize object : "
+send "abc\r"
+set ret [wait]
+if {[lindex \$ret 2] || [lindex \$ret 3] != 0} {
+    send_user "Authorization failed\n"
+    exit 1
+}
+EOF
+
+if [ "`cat $DECRYPTED_FILE`" != "`cat $PLAIN_TEXT`" ]; then
+  echo "Encryption/Decryption failed"
+  exit 1
+fi
+
+# Try tss2_createkey with missing type. This only works for tpm2-tss >=2.4.2.
+# Therefore, make the test conditional
+VERSION="$(tss2_createkey -v | grep -Po 'fapi-version=.*' | grep -Eo '([0-9]+\.{1})+[0-9]' | sed 's/[^0-9]*//g')"
+if [ $VERSION -ge "242" ]; then
+    tss2_delete --path=$KEY_PATH
+    tss2_createkey --path=$KEY_PATH --authValue=abc
 fi
 
 exit 0

--- a/test/integration/fapi/fapi-export-key.sh
+++ b/test/integration/fapi/fapi-export-key.sh
@@ -8,7 +8,7 @@ start_up
 setup_fapi
 
 function cleanup {
-    tss2_delete --path /
+    tss2_delete --path=/
     shut_down
 }
 
@@ -24,11 +24,11 @@ LOADED_KEY="myNewParent"
 
 tss2_provision
 
-tss2_import --path $DUPLICATE_POLICY --importData $JSON_POLICY
+tss2_import --path=$DUPLICATE_POLICY --importData=$JSON_POLICY
 
 expect <<EOF
 # Try with missing path
-spawn tss2_import --importData $JSON_POLICY
+spawn tss2_import --importData=$JSON_POLICY
 set ret [wait]
 if {[lindex \$ret 2] || [lindex \$ret 3] != 1} {
     Command has not failed as expected\n"
@@ -38,7 +38,7 @@ EOF
 
 expect <<EOF
 # Try with missing importData
-spawn tss2_import --path $DUPLICATE_POLICY
+spawn tss2_import --path=$DUPLICATE_POLICY
 set ret [wait]
 if {[lindex \$ret 2] || [lindex \$ret 3] != 1} {
     Command has not failed as expected\n"
@@ -46,24 +46,24 @@ if {[lindex \$ret 2] || [lindex \$ret 3] != 1} {
 }
 EOF
 
-tss2_createkey --path $KEY_PATH_PARENT --type "restricted, decrypt, noDA" \
-    --authValue ""
+tss2_createkey --path=$KEY_PATH_PARENT --type="restricted, decrypt, noDA" \
+    --authValue=""
 
-tss2_exportkey --pathOfKeyToDuplicate $KEY_PATH_PARENT \
-    --exportedData $EXPORTED_PARENT_KEY --force
+tss2_exportkey --pathOfKeyToDuplicate=$KEY_PATH_PARENT \
+    --exportedData=$EXPORTED_PARENT_KEY --force
 
-tss2_import --path "ext/$LOADED_KEY" --importData $EXPORTED_PARENT_KEY
+tss2_import --path="ext/$LOADED_KEY" --importData=$EXPORTED_PARENT_KEY
 
-tss2_createkey --path $KEY_PATH --type "noDa, exportable, decrypt" \
-    --policyPath $DUPLICATE_POLICY --authValue ""
+tss2_createkey --path=$KEY_PATH --type="noDa, exportable, decrypt" \
+    --policyPath=$DUPLICATE_POLICY --authValue=""
 
-tss2_exportkey --pathOfKeyToDuplicate $KEY_PATH \
-    --pathToPublicKeyOfNewParent "ext/$LOADED_KEY" --exportedData $EXPORTED_KEY
+tss2_exportkey --pathOfKeyToDuplicate=$KEY_PATH \
+    --pathToPublicKeyOfNewParent="ext/$LOADED_KEY" --exportedData=$EXPORTED_KEY
 
 expect <<EOF
 # Try with missing exportedData
-spawn tss2_exportkey --pathOfKeyToDuplicate $KEY_PATH \
-    --pathToPublicKeyOfNewParent "ext/$LOADED_KEY"
+spawn tss2_exportkey --pathOfKeyToDuplicate=$KEY_PATH \
+    --pathToPublicKeyOfNewParent="ext/$LOADED_KEY"
 set ret [wait]
 if {[lindex \$ret 2] || [lindex \$ret 3] != 1} {
     Command has not failed as expected\n"
@@ -73,8 +73,8 @@ EOF
 
 expect <<EOF
 # Try with missing pathOfKeyToDuplicate
-spawn tss2_exportkey --pathToPublicKeyOfNewParent "ext/$LOADED_KEY" \
-    --exportedData $EXPORTED_KEY
+spawn tss2_exportkey --pathToPublicKeyOfNewParent="ext/$LOADED_KEY" \
+    --exportedData=$EXPORTED_KEY
 set ret [wait]
 if {[lindex \$ret 2] || [lindex \$ret 3] != 1} {
     Command has not failed as expected\n"
@@ -84,8 +84,8 @@ EOF
 
 expect <<EOF
 # Try to fail command
-spawn tss2_exportkey --pathOfKeyToDuplicate $KEY_PATH \
-    --pathToPublicKeyOfNewParent "ext/$LOADED_KEY" --exportedData
+spawn tss2_exportkey --pathOfKeyToDuplicate=$KEY_PATH \
+    --pathToPublicKeyOfNewParent="ext/$LOADED_KEY" --exportedData=
 set ret [wait]
 if {[lindex \$ret 2] || [lindex \$ret 3] != 1} {
     Command has not failed as expected\n"
@@ -95,8 +95,8 @@ EOF
 
 expect <<EOF
 # Try to fail writing to output
-spawn tss2_exportkey --pathOfKeyToDuplicate $KEY_PATH \
-    --pathToPublicKeyOfNewParent "ext/$LOADED_KEY" --exportedData $EXPORTED_KEY
+spawn tss2_exportkey --pathOfKeyToDuplicate=$KEY_PATH \
+    --pathToPublicKeyOfNewParent="ext/$LOADED_KEY" --exportedData=$EXPORTED_KEY
 set ret [wait]
 if {[lindex \$ret 2] || [lindex \$ret 3] != 1} {
     Command has not failed as expected\n"

--- a/test/integration/fapi/fapi-export-policy.sh
+++ b/test/integration/fapi/fapi-export-policy.sh
@@ -8,7 +8,7 @@ start_up
 setup_fapi
 
 function cleanup {
-    tss2_delete --path /
+    tss2_delete --path=/
     shut_down
 }
 
@@ -22,12 +22,12 @@ EXPORTED_POLICY=$TEMP_DIR/exported-pcr-policy
 
 tss2_provision
 
-tss2_import --path $JSON_POLICY --importData $POLICY_DATA
+tss2_import --path=$JSON_POLICY --importData=$POLICY_DATA
 
-tss2_createkey --path $KEY_PATH --type "noDa, sign" --policyPath $JSON_POLICY \
-    --authValue ""
+tss2_createkey --path=$KEY_PATH --type="noDa, sign" --policyPath=$JSON_POLICY \
+    --authValue=""
 
-tss2_exportpolicy --path $KEY_PATH --jsonPolicy $EXPORTED_POLICY --force
+tss2_exportpolicy --path=$KEY_PATH --jsonPolicy=$EXPORTED_POLICY --force
 
 if [ ! -s $EXPORTED_POLICY ]
 then
@@ -37,7 +37,7 @@ fi
 
 expect <<EOF
 # Try with missing path
-spawn tss2_exportpolicy --jsonPolicy $EXPORTED_POLICY
+spawn tss2_exportpolicy --jsonPolicy=$EXPORTED_POLICY
 set ret [wait]
 if {[lindex \$ret 2] || [lindex \$ret 3] != 1} {
     Command has not failed as expected\n"
@@ -47,7 +47,7 @@ EOF
 
 expect <<EOF
 # Try with missing jsonPolicy
-spawn tss2_exportpolicy --path $KEY_PATH
+spawn tss2_exportpolicy --path=$KEY_PATH
 set ret [wait]
 if {[lindex \$ret 2] || [lindex \$ret 3] != 1} {
     Command has not failed as expected\n"

--- a/test/integration/fapi/fapi-get-info.sh
+++ b/test/integration/fapi/fapi-get-info.sh
@@ -28,7 +28,7 @@ fi
 
 expect <<EOF
 # Try with missing info file
-spawn tss2_getinfo --info $DATA_OUTPUT_FILE
+spawn tss2_getinfo
 set ret [wait]
 if {[lindex \$ret 2] || [lindex \$ret 3] != 1} {
     Command has not failed as expected\n"

--- a/test/integration/fapi/fapi-get-info.sh
+++ b/test/integration/fapi/fapi-get-info.sh
@@ -8,7 +8,7 @@ start_up
 setup_fapi
 
 function cleanup {
-    tss2_delete --path /
+    tss2_delete --path=/
     shut_down
 }
 
@@ -18,7 +18,7 @@ DATA_OUTPUT_FILE=$TEMP_DIR/output.file
 
 tss2_provision
 
-tss2_getinfo --info $DATA_OUTPUT_FILE --force
+tss2_getinfo --info=$DATA_OUTPUT_FILE --force
 
 if [ ! -s $DATA_OUTPUT_FILE ]
 then

--- a/test/integration/fapi/fapi-get-platform-certificates.sh
+++ b/test/integration/fapi/fapi-get-platform-certificates.sh
@@ -10,7 +10,7 @@ setup_fapi
 PATH=${BUILDDIR}/tools/fapi:$PATH
 
 function cleanup {
-    tss2_delete --path /
+    tss2_delete --path=/
     shut_down
 }
 
@@ -32,7 +32,7 @@ EOF
 
 expect <<EOF
 # Try normal command; should fail since no certificates present
-spawn tss2_getplatformcertificates --certificates $CERTIFICATES_OUTPUT_FILE \
+spawn tss2_getplatformcertificates --certificates=$CERTIFICATES_OUTPUT_FILE \
     --force
 set ret [wait]
 if {[lindex \$ret 2] || [lindex \$ret 3] != 1} {

--- a/test/integration/fapi/fapi-get-random.sh
+++ b/test/integration/fapi/fapi-get-random.sh
@@ -52,5 +52,6 @@ EOF
 
 tss2_getrandom --numBytes 4 --data $OUTPUT_FILE --force
 
+tss2_getrandom --numBytes 4 --hex --data $OUTPUT_FILE --force
 
 exit 0

--- a/test/integration/fapi/fapi-get-random.sh
+++ b/test/integration/fapi/fapi-get-random.sh
@@ -10,7 +10,7 @@ setup_fapi
 PATH=${BUILDDIR}/tools/fapi:$PATH
 
 function cleanup {
-    tss2_delete --path /
+    tss2_delete --path=/
     shut_down
 }
 
@@ -22,7 +22,7 @@ tss2_provision
 
 expect <<EOF
 # Try with wrong size value
-spawn tss2_getrandom --numBytes a --data $OUTPUT_FILE --force
+spawn tss2_getrandom --numBytes=a --data=$OUTPUT_FILE --force
 set ret [wait]
 if {[lindex \$ret 2] || [lindex \$ret 3] != 1} {
     Command has not failed as expected\n"
@@ -32,7 +32,7 @@ EOF
 
 expect <<EOF
 # Try with missing output
-spawn tss2_getrandom --numBytes 20
+spawn tss2_getrandom --numBytes=20
 set ret [wait]
 if {[lindex \$ret 2] || [lindex \$ret 3] != 1} {
     Command has not failed as expected\n"
@@ -42,7 +42,7 @@ EOF
 
 expect <<EOF
 # Try with missing numBytes
-spawn tss2_getrandom --data $OUTPUT_FILE --force
+spawn tss2_getrandom --data=$OUTPUT_FILE --force
 set ret [wait]
 if {[lindex \$ret 2] || [lindex \$ret 3] != 1} {
     Command has not failed as expected\n"
@@ -50,8 +50,8 @@ if {[lindex \$ret 2] || [lindex \$ret 3] != 1} {
 }
 EOF
 
-tss2_getrandom --numBytes 4 --data $OUTPUT_FILE --force
+tss2_getrandom --numBytes=4 --data=$OUTPUT_FILE --force
 
-tss2_getrandom --numBytes 4 --hex --data $OUTPUT_FILE --force
+tss2_getrandom --numBytes=4 --hex --data=$OUTPUT_FILE --force
 
 exit 0

--- a/test/integration/fapi/fapi-get-tpm-blobs.sh
+++ b/test/integration/fapi/fapi-get-tpm-blobs.sh
@@ -8,7 +8,7 @@ start_up
 setup_fapi
 
 function cleanup {
-    tss2_delete --path /
+    tss2_delete --path=/
     shut_down
 }
 
@@ -23,18 +23,18 @@ POLICY_PCR=policy/pcr-policy
 
 tss2_provision
 
-tss2_import --path $POLICY_PCR --importData $PCR_POLICY_DATA
+tss2_import --path=$POLICY_PCR --importData=$PCR_POLICY_DATA
 
-tss2_createkey --path $KEY_PATH --policyPath $POLICY_PCR --type "noDa, sign" \
-    --authValue ""
+tss2_createkey --path=$KEY_PATH --policyPath=$POLICY_PCR --type="noDa, sign" \
+    --authValue=""
 
-tss2_gettpmblobs --path $KEY_PATH --tpm2bPublic $PUBLIC_KEY_FILE \
-    --tpm2bPrivate $PRIVATE_KEY_FILE --policy $POLICY_FILE --force
+tss2_gettpmblobs --path=$KEY_PATH --tpm2bPublic=$PUBLIC_KEY_FILE \
+    --tpm2bPrivate=$PRIVATE_KEY_FILE --policy=$POLICY_FILE --force
 
 expect <<EOF
 # Try with missing path
-spawn tss2_gettpmblobs --tpm2bPublic $PUBLIC_KEY_FILE \
-    --tpm2bPrivate $PRIVATE_KEY_FILE --policy $POLICY_FILE
+spawn tss2_gettpmblobs --tpm2bPublic=$PUBLIC_KEY_FILE \
+    --tpm2bPrivate=$PRIVATE_KEY_FILE --policy=$POLICY_FILE
 set ret [wait]
 if {[lindex \$ret 2] || [lindex \$ret 3] != 1} {
     Command has not failed as expected\n"
@@ -44,8 +44,8 @@ EOF
 
 expect <<EOF
 # Try with missing tpm2bPublic
-spawn tss2_gettpmblobs --path $KEY_PATH \
-    --tpm2bPrivate $PRIVATE_KEY_FILE --policy $POLICY_FILE
+spawn tss2_gettpmblobs --path=$KEY_PATH \
+    --tpm2bPrivate=$PRIVATE_KEY_FILE --policy=$POLICY_FILE
 set ret [wait]
 if {[lindex \$ret 2] || [lindex \$ret 3] != 1} {
     Command has not failed as expected\n"
@@ -55,8 +55,8 @@ EOF
 
 expect <<EOF
 # Try with missing tpm2bPrivate
-spawn tss2_gettpmblobs --path $KEY_PATH --tpm2bPublic $PUBLIC_KEY_FILE \
-    --policy $POLICY_FILE
+spawn tss2_gettpmblobs --path=$KEY_PATH --tpm2bPublic=$PUBLIC_KEY_FILE \
+    --policy=$POLICY_FILE
 set ret [wait]
 if {[lindex \$ret 2] || [lindex \$ret 3] != 1} {
     Command has not failed as expected\n"
@@ -66,8 +66,8 @@ EOF
 
 expect <<EOF
 # Try with missing policy
-spawn tss2_gettpmblobs --path $KEY_PATH --tpm2bPublic $PUBLIC_KEY_FILE \
-    --tpm2bPrivate $PRIVATE_KEY_FILE
+spawn tss2_gettpmblobs --path=$KEY_PATH --tpm2bPublic=$PUBLIC_KEY_FILE \
+    --tpm2bPrivate=$PRIVATE_KEY_FILE
 set ret [wait]
 if {[lindex \$ret 2] || [lindex \$ret 3] != 1} {
     Command has not failed as expected\n"
@@ -77,8 +77,8 @@ EOF
 
 expect <<EOF
 # Try with existing directory PUBLIC_KEY_FILE
-spawn tss2_gettpmblobs --path $KEY_PATH --tpm2bPublic $PUBLIC_KEY_FILE \
-    --tpm2bPrivate $PRIVATE_KEY_FILE --policy $POLICY_FILE
+spawn tss2_gettpmblobs --path=$KEY_PATH --tpm2bPublic=$PUBLIC_KEY_FILE \
+    --tpm2bPrivate=$PRIVATE_KEY_FILE --policy=$POLICY_FILE
 set ret [wait]
 if {[lindex \$ret 2] || [lindex \$ret 3] != 1} {
     Command has not failed as expected\n"
@@ -88,8 +88,8 @@ EOF
 
 expect <<EOF
 # Try with multiple stdout (1)
-spawn tss2_gettpmblobs --path $KEY_PATH --tpm2bPublic - \
-    --tpm2bPrivate - --policy $POLICY_FILE --force
+spawn tss2_gettpmblobs --path=$KEY_PATH --tpm2bPublic=- \
+    --tpm2bPrivate=- --policy=$POLICY_FILE --force
 set ret [wait]
 if {[lindex \$ret 2] || [lindex \$ret 3] != 1} {
     Command has not failed as expected\n"
@@ -99,8 +99,8 @@ EOF
 
 expect <<EOF
 # Try with multiple stdout (2)
-spawn tss2_gettpmblobs --path $KEY_PATH --tpm2bPublic $PUBLIC_KEY_FILE \
-    --tpm2bPrivate - --policy - --force
+spawn tss2_gettpmblobs --path=$KEY_PATH --tpm2bPublic=$PUBLIC_KEY_FILE \
+    --tpm2bPrivate=- --policy=- --force
 set ret [wait]
 if {[lindex \$ret 2] || [lindex \$ret 3] != 1} {
     Command has not failed as expected\n"
@@ -110,8 +110,8 @@ EOF
 
 expect <<EOF
 # Try with multiple stdout (3)
-spawn tss2_gettpmblobs --path $KEY_PATH --tpm2bPublic - \
-    --tpm2bPrivate $PRIVATE_KEY_FILE --policy - --force
+spawn tss2_gettpmblobs --path=$KEY_PATH --tpm2bPublic=- \
+    --tpm2bPrivate=$PRIVATE_KEY_FILE --policy=- --force
 set ret [wait]
 if {[lindex \$ret 2] || [lindex \$ret 3] != 1} {
     Command has not failed as expected\n"
@@ -121,8 +121,8 @@ EOF
 
 expect <<EOF
 # Try with multiple stdout (4)
-spawn tss2_gettpmblobs --path $KEY_PATH --tpm2bPublic - \
-    --tpm2bPrivate - --policy - --force
+spawn tss2_gettpmblobs --path=$KEY_PATH --tpm2bPublic=- \
+    --tpm2bPrivate=- --policy=- --force
 set ret [wait]
 if {[lindex \$ret 2] || [lindex \$ret 3] != 1} {
     Command has not failed as expected\n"

--- a/test/integration/fapi/fapi-key-change-auth.sh
+++ b/test/integration/fapi/fapi-key-change-auth.sh
@@ -8,7 +8,7 @@ start_up
 setup_fapi
 
 function cleanup {
-    tss2_delete --path /
+    tss2_delete --path=/
     shut_down
 }
 
@@ -21,17 +21,17 @@ DIGEST_FILE=$TEMP_DIR/digest.file
 SIGNATURE_FILE=$TEMP_DIR/signature.file
 PUBLIC_KEY_FILE=$TEMP_DIR/public_key.file
 IMPORTED_KEY_NAME=importedPubKey
-
+PADDINGS="RSA_PSS"
 set -x
 
 tss2_provision
 echo 0123456789012345678 > $DIGEST_FILE
-tss2_createkey --path $KEY_PATH --type "noDa, sign" --authValue $PW1
+tss2_createkey --path=$KEY_PATH --type="noDa, sign" --authValue=$PW1
 
 expect <<EOF
 # Try interactive prompt
-spawn tss2_sign --keyPath $KEY_PATH --padding "RSA_PSS" --digest $DIGEST_FILE \
-    --signature $SIGNATURE_FILE --publicKey $PUBLIC_KEY_FILE
+spawn tss2_sign --keyPath=$KEY_PATH --padding=$PADDINGS --digest=$DIGEST_FILE \
+    --signature=$SIGNATURE_FILE --publicKey=$PUBLIC_KEY_FILE
 expect "Authorize object: "
 send "$PW1\r"
 set ret [wait]
@@ -43,7 +43,7 @@ EOF
 
 expect <<EOF
 # Try interactive prompt with 2 different passwords
-spawn tss2_changeauth --entityPath $KEY_PATH
+spawn tss2_changeauth --entityPath=$KEY_PATH
 expect "Authorize object Password: "
 send "1\r"
 expect "Authorize object Retype password: "
@@ -67,7 +67,7 @@ EOF
 
 expect <<EOF
 # Try interactive prompt
-spawn tss2_changeauth --entityPath $KEY_PATH --authValue $PW2
+spawn tss2_changeauth --entityPath=$KEY_PATH --authValue=$PW2
 expect "Authorize object: "
 send "$PW1\r"
 set ret [wait]
@@ -77,12 +77,10 @@ if {[lindex \$ret 2] || [lindex \$ret 3] != 0} {
 }
 EOF
 
-# tss2_changeauth --entityPath $KEY_PATH --authValue $PW2
-
 expect <<EOF
 # Check if system asks for auth value
-spawn tss2_sign --keyPath $KEY_PATH --padding "RSA_PSS" --digest $DIGEST_FILE \
-    --signature $SIGNATURE_FILE --publicKey $PUBLIC_KEY_FILE --force
+spawn tss2_sign --keyPath=$KEY_PATH --padding=$PADDINGS --digest=$DIGEST_FILE \
+    --signature=$SIGNATURE_FILE --publicKey=$PUBLIC_KEY_FILE --force
 expect {
     "Authorize object: " {
     } eof {

--- a/test/integration/fapi/fapi-list.sh
+++ b/test/integration/fapi/fapi-list.sh
@@ -8,7 +8,7 @@ start_up
 setup_fapi
 
 function cleanup {
-    tss2_delete --path /
+    tss2_delete --path=/
     shut_down
 }
 
@@ -18,7 +18,7 @@ KEY_PATH=HS/SRK/myRSASign
 
 tss2_provision
 
-tss2_createkey --path $KEY_PATH --type "noDa, sign" --authValue ""
+tss2_createkey --path=$KEY_PATH --type="noDa, sign" --authValue=""
 
 tss2_list
 

--- a/test/integration/fapi/fapi-nv-extend.sh
+++ b/test/integration/fapi/fapi-nv-extend.sh
@@ -8,7 +8,7 @@ start_up
 setup_fapi
 
 function cleanup {
-    tss2_delete --path /
+    tss2_delete --path=/
     shut_down
 }
 
@@ -25,11 +25,11 @@ echo -n 01234567890123456789 > $LOG_DATA
 
 tss2_provision
 
-tss2_createnv --path $NV_PATH --type "noDa, pcr" --size 0 --authValue ""
+tss2_createnv --path=$NV_PATH --type="noDa, pcr" --size=0 --authValue=""
 
-tss2_nvextend --nvPath $NV_PATH --data $DATA_EXTEND_FILE --logData $LOG_DATA
+tss2_nvextend --nvPath=$NV_PATH --data=$DATA_EXTEND_FILE --logData=$LOG_DATA
 
-tss2_nvread --nvPath $NV_PATH --data $DATA_READ_FILE --logData $READ_LOG_DATA
+tss2_nvread --nvPath=$NV_PATH --data=$DATA_READ_FILE --logData=$READ_LOG_DATA
 
 if [ ! -f $READ_LOG_DATA ]; then
     echo "No log data returned"
@@ -38,7 +38,7 @@ fi
 
 expect <<EOF
 # Try with missing nvPath
-spawn tss2_nvextend --data $DATA_EXTEND_FILE --logData $LOG_DATA
+spawn tss2_nvextend --data=$DATA_EXTEND_FILE --logData=$LOG_DATA
 set ret [wait]
 if {[lindex \$ret 2] || [lindex \$ret 3] != 1} {
     Command has not failed as expected\n"
@@ -48,7 +48,7 @@ EOF
 
 expect <<EOF
 # Try with missing data
-spawn tss2_nvextend --nvPath $NV_PATH --logData $LOG_DATA
+spawn tss2_nvextend --nvPath=$NV_PATH --logData=$LOG_DATA
 set ret [wait]
 if {[lindex \$ret 2] || [lindex \$ret 3] != 1} {
     Command has not failed as expected\n"
@@ -58,7 +58,7 @@ EOF
 
 expect <<EOF
 # Try with multiple stdin
-spawn tss2_nvextend --nvPath $NV_PATH --data - --logData -
+spawn tss2_nvextend --nvPath=$NV_PATH --data=- --logData=-
 set ret [wait]
 if {[lindex \$ret 2] || [lindex \$ret 3] != 1} {
     Command has not failed as expected\n"

--- a/test/integration/fapi/fapi-nv-increment.sh
+++ b/test/integration/fapi/fapi-nv-increment.sh
@@ -8,7 +8,7 @@ start_up
 setup_fapi
 
 function cleanup {
-    tss2_delete --path /
+    tss2_delete --path=/
     shut_down
 }
 
@@ -21,18 +21,18 @@ POLICY_PCR=policy/pcr-policy
 
 tss2_provision
 
-tss2_import --path $POLICY_PCR --importData $PCR_POLICY_DATA
+tss2_import --path=$POLICY_PCR --importData=$PCR_POLICY_DATA
 
-tss2_createnv --path $NV_PATH --policyPath=$POLICY_PCR --type "counter, noDa" \
-    --size 0 --authValue ""
+tss2_createnv --path=$NV_PATH --policyPath=$POLICY_PCR --type="counter, noDa" \
+    --size=0 --authValue=""
 
-tss2_nvincrement --nvPath $NV_PATH
+tss2_nvincrement --nvPath=$NV_PATH
 
-tss2_nvread --nvPath $NV_PATH --data $NV_COUNTER_READ_FILE --force
+tss2_nvread --nvPath=$NV_PATH --data=$NV_COUNTER_READ_FILE --force
 
-tss2_nvincrement --nvPath $NV_PATH
+tss2_nvincrement --nvPath=$NV_PATH
 
-tss2_nvread --nvPath $NV_PATH --data $NV_COUNTER_READ_FILE --force
+tss2_nvread --nvPath=$NV_PATH --data=$NV_COUNTER_READ_FILE --force
 
 expect <<EOF
 # Try with missing nvPath

--- a/test/integration/fapi/fapi-nv-set-bits.sh
+++ b/test/integration/fapi/fapi-nv-set-bits.sh
@@ -8,7 +8,7 @@ start_up
 setup_fapi
 
 function cleanup {
-    tss2_delete --path /
+    tss2_delete --path=/
     shut_down
 }
 
@@ -19,13 +19,13 @@ BITMAP="0x0102030405060608"
 
 tss2_provision
 
-tss2_createnv --path $NV_PATH --type "noDa, bitfield" --size 0 --authValue ""
+tss2_createnv --path=$NV_PATH --type="noDa, bitfield" --size=0 --authValue=""
 
-tss2_nvsetbits --nvPath $NV_PATH --bitmap $BITMAP
+tss2_nvsetbits --nvPath=$NV_PATH --bitmap=$BITMAP
 
 expect <<EOF
 # Try with missing nvPath
-spawn tss2_nvsetbits --bitmap $BITMAP
+spawn tss2_nvsetbits --bitmap=$BITMAP
 set ret [wait]
 if {[lindex \$ret 2] || [lindex \$ret 3] != 1} {
     Command has not failed as expected\n"
@@ -35,7 +35,7 @@ EOF
 
 expect <<EOF
 # Try with missing bitmap
-spawn tss2_nvsetbits --nvPath $NV_PATH
+spawn tss2_nvsetbits --nvPath=$NV_PATH
 set ret [wait]
 if {[lindex \$ret 2] || [lindex \$ret 3] != 1} {
     Command has not failed as expected\n"
@@ -45,7 +45,7 @@ EOF
 
 expect <<EOF
 # Try with wrong bitmap
-spawn tss2_nvsetbits --nvPath $NV_PATH --bitmap abc
+spawn tss2_nvsetbits --nvPath=$NV_PATH --bitmap=abc
 set ret [wait]
 if {[lindex \$ret 2] || [lindex \$ret 3] != 1} {
     Command has not failed as expected\n"

--- a/test/integration/fapi/fapi-nv-write-authorize.sh
+++ b/test/integration/fapi/fapi-nv-write-authorize.sh
@@ -8,7 +8,7 @@ start_up
 setup_fapi
 
 function cleanup {
-    tss2_delete --path /
+    tss2_delete --path=/
     shut_down
 }
 
@@ -28,15 +28,15 @@ echo -n 01234567890123456789 > $DIGEST_FILE
 
 tss2_provision
 
-tss2_createnv --path $NV_PATH --type "noDa" --size 34 --authValue ""
+tss2_createnv --path=$NV_PATH --type="noDa" --size=34 --authValue=""
 
-tss2_import --path $AUTHORIZE_NV_POLICY --importData $AUTHORIZE_NV_POLICY_JSON
+tss2_import --path=$AUTHORIZE_NV_POLICY --importData=$AUTHORIZE_NV_POLICY_JSON
 
-tss2_import --path $POLICY_PCR --importData $PCR_POLICY_JSON
+tss2_import --path=$POLICY_PCR --importData=$PCR_POLICY_JSON
 
 expect <<EOF
 # Try if command is supported
-spawn tss2_writeauthorizenv --nvPath $NV_PATH --policyPath $POLICY_PCR
+spawn tss2_writeauthorizenv --nvPath=$NV_PATH --policyPath=$POLICY_PCR
 set ret [wait]
 if {[lindex \$ret 2] || [lindex \$ret 3] != 0} {
     send_user "Command has failed. If using a physical TPM, see log since it is
@@ -45,17 +45,17 @@ if {[lindex \$ret 2] || [lindex \$ret 3] != 0} {
 }
 EOF
 
-tss2_createkey --path $POLICY_SIGN_KEY_PATH --type "noDa, sign" --authValue ""
+tss2_createkey --path=$POLICY_SIGN_KEY_PATH --type="noDa, sign" --authValue=""
 
-tss2_createkey --path $SIGN_KEY_PATH --type "noDa, sign" \
-    --policyPath $AUTHORIZE_NV_POLICY  --authValue ""
+tss2_createkey --path=$SIGN_KEY_PATH --type="noDa, sign" \
+    --policyPath=$AUTHORIZE_NV_POLICY  --authValue=""
 
-tss2_sign --keyPath $SIGN_KEY_PATH --padding "RSA_PSS" --digest $DIGEST_FILE \
-    --signature $SIGNATURE_FILE --publicKey $PUBLIC_KEY_FILE
+tss2_sign --keyPath=$SIGN_KEY_PATH --padding="RSA_PSS" --digest=$DIGEST_FILE \
+    --signature=$SIGNATURE_FILE --publicKey=$PUBLIC_KEY_FILE
 
 expect <<EOF
 # Try with missing nvPath
-spawn tss2_writeauthorizenv --policyPath $POLICY_PCR
+spawn tss2_writeauthorizenv --policyPath=$POLICY_PCR
 set ret [wait]
 if {[lindex \$ret 2] || [lindex \$ret 3] != 1} {
     send_user "Command has not failed as expected\n"
@@ -65,7 +65,7 @@ EOF
 
 expect <<EOF
 # Try with missing policyPath
-spawn tss2_writeauthorizenv --nvPath $NV_PATH
+spawn tss2_writeauthorizenv --nvPath=$NV_PATH
 set ret [wait]
 if {[lindex \$ret 2] || [lindex \$ret 3] != 1} {
     send_user "Command has not failed as expected\n"
@@ -75,7 +75,7 @@ EOF
 
 expect <<EOF
 # Try to fail command
-spawn tss2_writeauthorizenv --nvPath /abc/def --policyPath $POLICY_PCR
+spawn tss2_writeauthorizenv --nvPath=/abc/def --policyPath=$POLICY_PCR
 set ret [wait]
 if {[lindex \$ret 2] || [lindex \$ret 3] != 1} {
     send_user "Command has not failed as expected\n"

--- a/test/integration/fapi/fapi-nv-write-read.sh
+++ b/test/integration/fapi/fapi-nv-write-read.sh
@@ -98,7 +98,7 @@ EOF
 
 expect <<EOF
 # Try with missing data
-spawn tss2_nvwrite --data $DATA_WRITE_FILE
+spawn tss2_nvwrite --nvPath $NV_PATH
 set ret [wait]
 if {[lindex \$ret 2] || [lindex \$ret 3] != 1} {
     Command has not failed as expected\n"
@@ -118,6 +118,47 @@ send "$PW\r"
 set ret [wait]
 if {[lindex \$ret 2] || [lindex \$ret 3] != 0} {
     send_user "Using interactive prompt with password has failed\n"
+    exit 1
+}
+EOF
+
+
+
+# Try with missing type
+tss2_delete --path $NV_PATH
+tss2_createnv --path $NV_PATH --size 20 --authValue=$PW
+
+# Try with size-0 supported types
+tss2_delete --path $NV_PATH
+tss2_createnv --path $NV_PATH --type "bitfield" --size 0 --authValue=$PW
+tss2_delete --path $NV_PATH
+tss2_createnv --path $NV_PATH --type "pcr" --size 0 --authValue=$PW
+tss2_delete --path $NV_PATH
+tss2_createnv --path $NV_PATH --type "counter" --size 0 --authValue=$PW
+tss2_delete --path $NV_PATH
+tss2_createnv --path $NV_PATH --type "bitfield" --authValue=$PW
+tss2_delete --path $NV_PATH
+tss2_createnv --path $NV_PATH --type "pcr" --authValue=$PW
+tss2_delete --path $NV_PATH
+tss2_createnv --path $NV_PATH --type "counter" --authValue=$PW
+tss2_delete --path $NV_PATH
+
+expect <<EOF
+# Try with missing size and no type
+spawn tss2_createnv --path $NV_PATH --authValue=$PW
+set ret [wait]
+if {[lindex \$ret 2] || [lindex \$ret 3] != 1} {
+    Command has not failed as expected\n"
+    exit 1
+}
+EOF
+
+expect <<EOF
+# Try with size=0 and no type
+spawn tss2_createnv --path $NV_PATH --size 0 --authValue=$PW
+set ret [wait]
+if {[lindex \$ret 2] || [lindex \$ret 3] != 1} {
+    Command has not failed as expected\n"
     exit 1
 }
 EOF

--- a/test/integration/fapi/fapi-nv-write-read.sh
+++ b/test/integration/fapi/fapi-nv-write-read.sh
@@ -8,7 +8,7 @@ start_up
 setup_fapi
 
 function cleanup {
-    tss2_delete --path /
+    tss2_delete --path=/
     shut_down
 }
 
@@ -23,24 +23,24 @@ tss2_provision
 
 echo 1234567890123456789 > $DATA_WRITE_FILE
 
-tss2_createnv --path $NV_PATH --type "noDa" --size 20 --authValue ""
+tss2_createnv --path=$NV_PATH --type="noDa" --size=20 --authValue=""
 
-tss2_nvwrite --nvPath $NV_PATH --data $DATA_WRITE_FILE
+tss2_nvwrite --nvPath=$NV_PATH --data=$DATA_WRITE_FILE
 
-tss2_nvread --nvPath $NV_PATH --data $DATA_READ_FILE --force
+tss2_nvread --nvPath=$NV_PATH --data=$DATA_READ_FILE --force
 
 if [ `cat $DATA_READ_FILE` !=  `cat $DATA_WRITE_FILE` ]; then
   echo "Test without password: Strings are not equal"
   exit 99
 fi
 
-tss2_delete --path $NV_PATH
+tss2_delete --path=$NV_PATH
 
-tss2_createnv --path $NV_PATH --type "noDa" --size 20 --authValue=$PW
+tss2_createnv --path=$NV_PATH --type="noDa" --size=20 --authValue=$PW
 
 expect <<EOF
 # Check if system asks for auth value and provide it
-spawn tss2_nvwrite --nvPath $NV_PATH --data $DATA_WRITE_FILE
+spawn tss2_nvwrite --nvPath=$NV_PATH --data=$DATA_WRITE_FILE
 expect {
     "Authorize object: " {
     } eof {
@@ -58,7 +58,7 @@ EOF
 
 expect <<EOF
 # Try with missing nvPath
-spawn tss2_nvread --data $DATA_READ_FILE --force
+spawn tss2_nvread --data=$DATA_READ_FILE --force
 set ret [wait]
 if {[lindex \$ret 2] || [lindex \$ret 3] != 1} {
     Command has not failed as expected\n"
@@ -68,7 +68,7 @@ EOF
 
 expect <<EOF
 # Try with missing data
-spawn tss2_nvread --nvPath $NV_PATH  --force
+spawn tss2_nvread --nvPath=$NV_PATH  --force
 set ret [wait]
 if {[lindex \$ret 2] || [lindex \$ret 3] != 1} {
     Command has not failed as expected\n"
@@ -78,7 +78,7 @@ EOF
 
 expect <<EOF
 # Try with multiple stdout (1)
-spawn tss2_nvread --nvPath $NV_PATH --data - --logData - --force
+spawn tss2_nvread --nvPath=$NV_PATH --data=- --logData=- --force
 set ret [wait]
 if {[lindex \$ret 2] || [lindex \$ret 3] != 1} {
     Command has not failed as expected\n"
@@ -88,7 +88,7 @@ EOF
 
 expect <<EOF
 # Try with missing nvPath
-spawn tss2_nvwrite --data $DATA_WRITE_FILE
+spawn tss2_nvwrite --data=$DATA_WRITE_FILE
 set ret [wait]
 if {[lindex \$ret 2] || [lindex \$ret 3] != 1} {
     Command has not failed as expected\n"
@@ -98,7 +98,7 @@ EOF
 
 expect <<EOF
 # Try with missing data
-spawn tss2_nvwrite --nvPath $NV_PATH
+spawn tss2_nvwrite --nvPath=$NV_PATH
 set ret [wait]
 if {[lindex \$ret 2] || [lindex \$ret 3] != 1} {
     Command has not failed as expected\n"
@@ -106,11 +106,12 @@ if {[lindex \$ret 2] || [lindex \$ret 3] != 1} {
 }
 EOF
 
-tss2_delete --path $NV_PATH
+tss2_delete --path=$NV_PATH
 
+NODA="noDa"
 expect <<EOF
 # Try interactive prompt
-spawn tss2_createnv --path $NV_PATH --type "noDa" --size 20
+spawn tss2_createnv --path=$NV_PATH --type=$NODA --size=20
 expect "Authorize object Password: "
 send "$PW\r"
 expect "Authorize object Retype password: "
@@ -122,30 +123,28 @@ if {[lindex \$ret 2] || [lindex \$ret 3] != 0} {
 }
 EOF
 
-
-
 # Try with missing type
-tss2_delete --path $NV_PATH
-tss2_createnv --path $NV_PATH --size 20 --authValue=$PW
+tss2_delete --path=$NV_PATH
+tss2_createnv --path=$NV_PATH --size=20 --authValue=$PW
 
 # Try with size-0 supported types
-tss2_delete --path $NV_PATH
-tss2_createnv --path $NV_PATH --type "bitfield" --size 0 --authValue=$PW
-tss2_delete --path $NV_PATH
-tss2_createnv --path $NV_PATH --type "pcr" --size 0 --authValue=$PW
-tss2_delete --path $NV_PATH
-tss2_createnv --path $NV_PATH --type "counter" --size 0 --authValue=$PW
-tss2_delete --path $NV_PATH
-tss2_createnv --path $NV_PATH --type "bitfield" --authValue=$PW
-tss2_delete --path $NV_PATH
-tss2_createnv --path $NV_PATH --type "pcr" --authValue=$PW
-tss2_delete --path $NV_PATH
-tss2_createnv --path $NV_PATH --type "counter" --authValue=$PW
-tss2_delete --path $NV_PATH
+tss2_delete --path=$NV_PATH
+tss2_createnv --path=$NV_PATH --type="bitfield" --size=0 --authValue=$PW
+tss2_delete --path=$NV_PATH
+tss2_createnv --path=$NV_PATH --type="pcr" --size=0 --authValue=$PW
+tss2_delete --path=$NV_PATH
+tss2_createnv --path=$NV_PATH --type="counter" --size=0 --authValue=$PW
+tss2_delete --path=$NV_PATH
+tss2_createnv --path=$NV_PATH --type="bitfield" --authValue=$PW
+tss2_delete --path=$NV_PATH
+tss2_createnv --path=$NV_PATH --type="pcr" --authValue=$PW
+tss2_delete --path=$NV_PATH
+tss2_createnv --path=$NV_PATH --type="counter" --authValue=$PW
+tss2_delete --path=$NV_PATH
 
 expect <<EOF
 # Try with missing size and no type
-spawn tss2_createnv --path $NV_PATH --authValue=$PW
+spawn tss2_createnv --path=$NV_PATH --authValue=$PW
 set ret [wait]
 if {[lindex \$ret 2] || [lindex \$ret 3] != 1} {
     Command has not failed as expected\n"
@@ -155,7 +154,7 @@ EOF
 
 expect <<EOF
 # Try with size=0 and no type
-spawn tss2_createnv --path $NV_PATH --size 0 --authValue=$PW
+spawn tss2_createnv --path=$NV_PATH --size=0 --authValue=$PW
 set ret [wait]
 if {[lindex \$ret 2] || [lindex \$ret 3] != 1} {
     Command has not failed as expected\n"

--- a/test/integration/fapi/fapi-pcr-extend-read.sh
+++ b/test/integration/fapi/fapi-pcr-extend-read.sh
@@ -8,7 +8,7 @@ start_up
 setup_fapi
 
 function cleanup {
-    tss2_delete --path /
+    tss2_delete --path=/
     shut_down
 }
 
@@ -24,11 +24,11 @@ echo "0,1,2,3,4,5,6,7,8,9" > $PCR_EVENT_DATA
 
 tss2_provision
 
-tss2_pcrextend --pcr 16 --data $PCR_EVENT_DATA \
-    --logData $PCR_LOG_FILE_WRITE
+tss2_pcrextend --pcr=16 --data=$PCR_EVENT_DATA \
+    --logData=$PCR_LOG_FILE_WRITE
 
-tss2_pcrread --pcrIndex 16 --pcrValue $PCR_DIGEST_FILE \
-    --pcrLog $PCR_LOG_FILE_READ --force
+tss2_pcrread --pcrIndex=16 --pcrValue=$PCR_DIGEST_FILE \
+    --pcrLog=$PCR_LOG_FILE_READ --force
 
 if [ ! -s $PCR_DIGEST_FILE ] || [ ! -s $PCR_LOG_FILE_READ ]; then
     echo "At least one returned file is empty"
@@ -37,7 +37,7 @@ fi
 
 expect <<EOF
 # Try with missing pcr
-spawn tss2_pcrextend --data $PCR_EVENT_DATA --logData $PCR_LOG_FILE_WRITE
+spawn tss2_pcrextend --data=$PCR_EVENT_DATA --logData=$PCR_LOG_FILE_WRITE
 set ret [wait]
 if {[lindex \$ret 2] || [lindex \$ret 3] != 1} {
     Command has not failed as expected\n"
@@ -47,7 +47,7 @@ EOF
 
 expect <<EOF
 # Try with missing data
-spawn tss2_pcrextend --pcr 16 --logData $PCR_LOG_FILE_WRITE
+spawn tss2_pcrextend --pcr=16 --logData=$PCR_LOG_FILE_WRITE
 set ret [wait]
 if {[lindex \$ret 2] || [lindex \$ret 3] != 1} {
     Command has not failed as expected\n"
@@ -57,8 +57,8 @@ EOF
 
 expect <<EOF
 # Try with wrong pcr
-spawn tss2_pcrextend --pcr abc --data $PCR_EVENT_DATA \
-    --logData $PCR_LOG_FILE_WRITE
+spawn tss2_pcrextend --pcr=abc --data=$PCR_EVENT_DATA \
+    --logData=$PCR_LOG_FILE_WRITE
 set ret [wait]
 if {[lindex \$ret 2] || [lindex \$ret 3] != 1} {
     Command has not failed as expected\n"
@@ -68,7 +68,7 @@ EOF
 
 expect <<EOF
 # Try with multiple stdins
-spawn tss2_pcrextend --pcr 16 --data - --logData -
+spawn tss2_pcrextend --pcr=16 --data=- --logData=-
 set ret [wait]
 if {[lindex \$ret 2] || [lindex \$ret 3] != 1} {
     Command has not failed as expected\n"
@@ -77,11 +77,11 @@ if {[lindex \$ret 2] || [lindex \$ret 3] != 1} {
 EOF
 
 # Try with missing logData
-tss2_pcrextend --pcr 16 --data $PCR_EVENT_DATA
+tss2_pcrextend --pcr=16 --data=$PCR_EVENT_DATA
 
 expect <<EOF
 # Try with missing pcrIndex
-spawn tss2_pcrread --pcrValue $PCR_DIGEST_FILE --pcrLog $PCR_LOG_FILE_READ --force
+spawn tss2_pcrread --pcrValue=$PCR_DIGEST_FILE --pcrLog=$PCR_LOG_FILE_READ --force
 set ret [wait]
 if {[lindex \$ret 2] || [lindex \$ret 3] != 1} {
     Command has not failed as expected\n"
@@ -90,15 +90,15 @@ if {[lindex \$ret 2] || [lindex \$ret 3] != 1} {
 EOF
 
 # Try with missing pcrValue
-tss2_pcrread --pcrIndex 16 --pcrLog $PCR_LOG_FILE_READ --force
+tss2_pcrread --pcrIndex=16 --pcrLog=$PCR_LOG_FILE_READ --force
 
 # Try with missing pcrLog
-tss2_pcrread --pcrIndex 16 --pcrValue $PCR_DIGEST_FILE --force
+tss2_pcrread --pcrIndex=16 --pcrValue=$PCR_DIGEST_FILE --force
 
 expect <<EOF
 # Try with multiple stdins (1)
-spawn tss2_pcrread --pcrIndex 16 --pcrValue - \
-    --pcrLog -
+spawn tss2_pcrread --pcrIndex=16 --pcrValue=- \
+    --pcrLog=-
 set ret [wait]
 if {[lindex \$ret 2] || [lindex \$ret 3] != 1} {
     Command has not failed as expected\n"
@@ -108,8 +108,8 @@ EOF
 
 expect <<EOF
 # Try with wrong pcrIndex
-spawn tss2_pcrread --pcrIndex abc --pcrValue $PCR_DIGEST_FILE \
-    --pcrLog $PCR_LOG_FILE_READ --force
+spawn tss2_pcrread --pcrIndex=abc --pcrValue=$PCR_DIGEST_FILE \
+    --pcrLog=$PCR_LOG_FILE_READ --force
 set ret [wait]
 if {[lindex \$ret 2] || [lindex \$ret 3] != 1} {
     Command has not failed as expected\n"

--- a/test/integration/fapi/fapi-pcr-extend-read.sh
+++ b/test/integration/fapi/fapi-pcr-extend-read.sh
@@ -76,9 +76,12 @@ if {[lindex \$ret 2] || [lindex \$ret 3] != 1} {
 }
 EOF
 
+# Try with missing logData
+tss2_pcrextend --pcr 16 --data $PCR_EVENT_DATA
+
 expect <<EOF
 # Try with missing pcrIndex
-spawn tss2_pcrread --pcrValue $PCR_DIGEST_FILE --pcrLog $PCR_LOG_FILE_READ
+spawn tss2_pcrread --pcrValue $PCR_DIGEST_FILE --pcrLog $PCR_LOG_FILE_READ --force
 set ret [wait]
 if {[lindex \$ret 2] || [lindex \$ret 3] != 1} {
     Command has not failed as expected\n"
@@ -86,25 +89,11 @@ if {[lindex \$ret 2] || [lindex \$ret 3] != 1} {
 }
 EOF
 
-expect <<EOF
 # Try with missing pcrValue
-spawn tss2_pcrread --pcrIndex 16 --pcrLog $PCR_LOG_FILE_READ
-set ret [wait]
-if {[lindex \$ret 2] || [lindex \$ret 3] != 1} {
-    Command has not failed as expected\n"
-    exit 1
-}
-EOF
+tss2_pcrread --pcrIndex 16 --pcrLog $PCR_LOG_FILE_READ --force
 
-expect <<EOF
 # Try with missing pcrLog
-spawn tss2_pcrread --pcrIndex 16 --pcrValue $PCR_DIGEST_FILE
-set ret [wait]
-if {[lindex \$ret 2] || [lindex \$ret 3] != 1} {
-    Command has not failed as expected\n"
-    exit 1
-}
-EOF
+tss2_pcrread --pcrIndex 16 --pcrValue $PCR_DIGEST_FILE --force
 
 expect <<EOF
 # Try with multiple stdins (1)
@@ -120,7 +109,7 @@ EOF
 expect <<EOF
 # Try with wrong pcrIndex
 spawn tss2_pcrread --pcrIndex abc --pcrValue $PCR_DIGEST_FILE \
-    --pcrLog $PCR_LOG_FILE_READ
+    --pcrLog $PCR_LOG_FILE_READ --force
 set ret [wait]
 if {[lindex \$ret 2] || [lindex \$ret 3] != 1} {
     Command has not failed as expected\n"

--- a/test/integration/fapi/fapi-provision.sh
+++ b/test/integration/fapi/fapi-provision.sh
@@ -11,7 +11,7 @@ function cleanup {
     # Since clean up should already been done during normal run of the test, a
     # failure is expected here. Therefore, we need to pass a successful
     # execution in any case
-    tss2_delete --path / || true
+    tss2_delete --path=/ || true
     shut_down
 }
 
@@ -19,13 +19,13 @@ trap cleanup EXIT
 
 tss2_provision
 
-PROFILE_NAME=$( tss2_list --searchPath / --pathList - | cut -d "/" -f2 )
+PROFILE_NAME=$( tss2_list --searchPath=/ --pathList=- | cut -d "/" -f2 )
 
-tss2_delete --path /
+tss2_delete --path=/
 
 expect <<EOF
 # Test if still objects in path
-spawn tss2_list --path
+spawn tss2_list --path=/
 set ret [wait]
 if {[lindex \$ret 2] || [lindex \$ret 3] != 1} {
     send_user "Still objects in path\n"

--- a/test/integration/fapi/fapi-quote-verify.sh
+++ b/test/integration/fapi/fapi-quote-verify.sh
@@ -8,7 +8,7 @@ start_up
 setup_fapi
 
 function cleanup {
-    tss2_delete --path /
+    tss2_delete --path=/
     shut_down
 }
 
@@ -27,25 +27,25 @@ printf "01234567890123456789" > $PCR_LOG
 
 tss2_provision
 
-tss2_createkey --path $KEY_PATH --type "noDa, restricted, sign" --authValue ""
+tss2_createkey --path=$KEY_PATH --type="noDa, restricted, sign" --authValue=""
 
-tss2_quote --keyPath $KEY_PATH --pcrList "16" --qualifyingData $NONCE_FILE \
-    --signature $SIGNATURE_FILE --pcrLog $PCR_LOG \
-    --certificate $CERTIFICATE_FILE --quoteInfo $QUOTE_INFO --force
+tss2_quote --keyPath=$KEY_PATH --pcrList="16" --qualifyingData=$NONCE_FILE \
+    --signature=$SIGNATURE_FILE --pcrLog=$PCR_LOG \
+    --certificate=$CERTIFICATE_FILE --quoteInfo=$QUOTE_INFO --force
 
-tss2_exportkey --pathOfKeyToDuplicate $KEY_PATH --exportedData $PUBLIC_QUOTE_KEY --force
-tss2_import --path "ext/myNewParent" --importData $PUBLIC_QUOTE_KEY
+tss2_exportkey --pathOfKeyToDuplicate=$KEY_PATH --exportedData=$PUBLIC_QUOTE_KEY --force
+tss2_import --path="ext/myNewParent" --importData=$PUBLIC_QUOTE_KEY
 
-tss2_verifyquote --publicKeyPath "ext/myNewParent" \
-    --qualifyingData $NONCE_FILE --quoteInfo $QUOTE_INFO \
-    --signature $SIGNATURE_FILE --pcrLog $PCR_LOG
+tss2_verifyquote --publicKeyPath="ext/myNewParent" \
+    --qualifyingData=$NONCE_FILE --quoteInfo=$QUOTE_INFO \
+    --signature=$SIGNATURE_FILE --pcrLog=$PCR_LOG
 
 expect <<EOF
 # Try with missing keyPath
-spawn tss2_quote --pcrList "16" \
-    --qualifyingData $NONCE_FILE --signature $SIGNATURE_FILE \
-    --pcrLog $PCR_LOG --certificate $CERTIFICATE_FILE \
-    --quoteInfo $QUOTE_INFO --force
+spawn tss2_quote --pcrList="16" \
+    --qualifyingData=$NONCE_FILE --signature=$SIGNATURE_FILE \
+    --pcrLog=$PCR_LOG --certificate=$CERTIFICATE_FILE \
+    --quoteInfo=$QUOTE_INFO --force
 set ret [wait]
 if {[lindex \$ret 2] || [lindex \$ret 3] != 1} {
     Command has not failed as expected\n"
@@ -56,9 +56,9 @@ EOF
 expect <<EOF
 # Try with missing pcrList
 spawn tss2_quote \
-    --qualifyingData $NONCE_FILE --signature $SIGNATURE_FILE \
-    --pcrLog $PCR_LOG --certificate $CERTIFICATE_FILE \
-    --quoteInfo $QUOTE_INFO --force
+    --qualifyingData=$NONCE_FILE --signature=$SIGNATURE_FILE \
+    --pcrLog=$PCR_LOG --certificate=$CERTIFICATE_FILE \
+    --quoteInfo=$QUOTE_INFO --force
 set ret [wait]
 if {[lindex \$ret 2] || [lindex \$ret 3] != 1} {
     Command has not failed as expected\n"
@@ -68,10 +68,10 @@ EOF
 
 expect <<EOF
 # Try with missing signature
-spawn tss2_quote --keyPath $KEY_PATH --pcrList "16" \
-    --qualifyingData $NONCE_FILE \
-    --pcrLog $PCR_LOG --certificate $CERTIFICATE_FILE \
-    --quoteInfo $QUOTE_INFO --force
+spawn tss2_quote --keyPath=$KEY_PATH --pcrList="16" \
+    --qualifyingData=$NONCE_FILE \
+    --pcrLog=$PCR_LOG --certificate=$CERTIFICATE_FILE \
+    --quoteInfo=$QUOTE_INFO --force
 set ret [wait]
 if {[lindex \$ret 2] || [lindex \$ret 3] != 1} {
     Command has not failed as expected\n"
@@ -81,9 +81,9 @@ EOF
 
 expect <<EOF
 # Try with missing quoteInfo
-spawn tss2_quote --keyPath $KEY_PATH --pcrList "16" \
-    --qualifyingData $NONCE_FILE --signature $SIGNATURE_FILE \
-    --pcrLog $PCR_LOG --certificate $CERTIFICATE_FILE \
+spawn tss2_quote --keyPath=$KEY_PATH --pcrList="16" \
+    --qualifyingData=$NONCE_FILE --signature=$SIGNATURE_FILE \
+    --pcrLog=$PCR_LOG --certificate=$CERTIFICATE_FILE \
     --force
 set ret [wait]
 if {[lindex \$ret 2] || [lindex \$ret 3] != 1} {
@@ -94,10 +94,10 @@ EOF
 
 expect <<EOF
 # Try with multiple stdout (1)
-spawn tss2_quote --keyPath $KEY_PATH --pcrList "16" \
-    --qualifyingData $NONCE_FILE --signature - \
-    --pcrLog - --certificate $CERTIFICATE_FILE \
-    --quoteInfo $QUOTE_INFO --force
+spawn tss2_quote --keyPath=$KEY_PATH --pcrList="16" \
+    --qualifyingData=$NONCE_FILE --signature=- \
+    --pcrLog=- --certificate=$CERTIFICATE_FILE \
+    --quoteInfo=$QUOTE_INFO --force
 set ret [wait]
 if {[lindex \$ret 2] || [lindex \$ret 3] != 1} {
     Command has not failed as expected\n"
@@ -107,10 +107,10 @@ EOF
 
 expect <<EOF
 # Try with multiple stdout (2)
-spawn tss2_quote --keyPath $KEY_PATH --pcrList "16" \
-    --qualifyingData $NONCE_FILE --signature $SIGNATURE_FILE \
-    --pcrLog - --certificate - \
-    --quoteInfo $QUOTE_INFO --force
+spawn tss2_quote --keyPath=$KEY_PATH --pcrList="16" \
+    --qualifyingData=$NONCE_FILE --signature=$SIGNATURE_FILE \
+    --pcrLog=- --certificate=- \
+    --quoteInfo=$QUOTE_INFO --force
 set ret [wait]
 if {[lindex \$ret 2] || [lindex \$ret 3] != 1} {
     Command has not failed as expected\n"
@@ -120,10 +120,10 @@ EOF
 
 expect <<EOF
 # Try with multiple stdout (3)
-spawn tss2_quote --keyPath $KEY_PATH --pcrList "16" \
-    --qualifyingData $NONCE_FILE --signature $SIGNATURE_FILE \
-    --pcrLog $PCR_LOG --certificate - \
-    --quoteInfo - --force
+spawn tss2_quote --keyPath=$KEY_PATH --pcrList="16" \
+    --qualifyingData=$NONCE_FILE --signature=$SIGNATURE_FILE \
+    --pcrLog=$PCR_LOG --certificate=- \
+    --quoteInfo=- --force
 set ret [wait]
 if {[lindex \$ret 2] || [lindex \$ret 3] != 1} {
     Command has not failed as expected\n"
@@ -133,10 +133,10 @@ EOF
 
 expect <<EOF
 # Try with multiple stdout (4)
-spawn tss2_quote --keyPath $KEY_PATH --pcrList "16" \
-    --qualifyingData - --signature $SIGNATURE_FILE \
-    --pcrLog - --certificate $CERTIFICATE_FILE \
-    --quoteInfo - --force
+spawn tss2_quote --keyPath=$KEY_PATH --pcrList "16" \
+    --qualifyingData=- --signature $SIGNATURE_FILE \
+    --pcrLog=- --certificate=$CERTIFICATE_FILE \
+    --quoteInfo=- --force
 set ret [wait]
 if {[lindex \$ret 2] || [lindex \$ret 3] != 1} {
     Command has not failed as expected\n"
@@ -146,9 +146,9 @@ EOF
 
 expect <<EOF
 # Try with wrong pcrs
-spawn tss2_quote --keyPath $KEY_PATH --pcrList abc --qualifyingData $NONCE_FILE \
-    --signature $SIGNATURE_FILE --pcrLog $PCR_LOG \
-    --certificate $CERTIFICATE_FILE --quoteInfo $QUOTE_INFO --force
+spawn tss2_quote --keyPath=$KEY_PATH --pcrList=abc --qualifyingData=$NONCE_FILE \
+    --signature=$SIGNATURE_FILE --pcrLog=$PCR_LOG \
+    --certificate=$CERTIFICATE_FILE --quoteInfo=$QUOTE_INFO --force
 set ret [wait]
 if {[lindex \$ret 2] || [lindex \$ret 3] != 1} {
     Command has not failed as expected\n"
@@ -158,9 +158,9 @@ EOF
 
 expect <<EOF
 # Fail quote
-spawn tss2_quote --keyPath "/abc/def" --pcrList "16" --qualifyingData $NONCE_FILE \
-    --signature $SIGNATURE_FILE --pcrLog $PCR_LOG \
-    --certificate $CERTIFICATE_FILE --quoteInfo $QUOTE_INFO --force
+spawn tss2_quote --keyPath="/abc/def" --pcrList="16" --qualifyingData=$NONCE_FILE \
+    --signature=$SIGNATURE_FILE --pcrLog=$PCR_LOG \
+    --certificate=$CERTIFICATE_FILE --quoteInfo=$QUOTE_INFO --force
 set ret [wait]
 if {[lindex \$ret 2] || [lindex \$ret 3] != 1} {
     Command has not failed as expected\n"
@@ -170,9 +170,9 @@ EOF
 
 expect <<EOF
 # Try with already existing directory
-spawn tss2_quote --keyPath $KEY_PATH --pcrList "16" --qualifyingData $NONCE_FILE \
-    --signature $SIGNATURE_FILE --pcrLog $PCR_LOG \
-    --certificate $CERTIFICATE_FILE --quoteInfo $QUOTE_INFO
+spawn tss2_quote --keyPath=$KEY_PATH --pcrList="16" --qualifyingData=$NONCE_FILE \
+    --signature=$SIGNATURE_FILE --pcrLog=$PCR_LOG \
+    --certificate=$CERTIFICATE_FILE --quoteInfo=$QUOTE_INFO
 set ret [wait]
 if {[lindex \$ret 2] || [lindex \$ret 3] != 1} {
     Command has not failed as expected\n"
@@ -181,28 +181,28 @@ if {[lindex \$ret 2] || [lindex \$ret 3] != 1} {
 EOF
 
 # Try with missing qualifyingData
-tss2_quote --keyPath $KEY_PATH --pcrList "16" \
-    --signature $SIGNATURE_FILE \
-    --pcrLog $PCR_LOG --certificate $CERTIFICATE_FILE \
-    --quoteInfo $QUOTE_INFO --force
+tss2_quote --keyPath=$KEY_PATH --pcrList="16" \
+    --signature=$SIGNATURE_FILE \
+    --pcrLog=$PCR_LOG --certificate=$CERTIFICATE_FILE \
+    --quoteInfo=$QUOTE_INFO --force
 
 # Try with missing pcrLog
-tss2_quote --keyPath $KEY_PATH --pcrList "16" \
-    --qualifyingData $NONCE_FILE --signature $SIGNATURE_FILE \
-    --certificate $CERTIFICATE_FILE \
-    --quoteInfo $QUOTE_INFO --force
+tss2_quote --keyPath=$KEY_PATH --pcrList="16" \
+    --qualifyingData=$NONCE_FILE --signature=$SIGNATURE_FILE \
+    --certificate=$CERTIFICATE_FILE \
+    --quoteInfo=$QUOTE_INFO --force
 
 # Try with missing certificate
-tss2_quote --keyPath $KEY_PATH --pcrList "16" \
-    --qualifyingData $NONCE_FILE --signature $SIGNATURE_FILE \
-    --pcrLog $PCR_LOG \
-    --quoteInfo $QUOTE_INFO --force
+tss2_quote --keyPath=$KEY_PATH --pcrList="16" \
+    --qualifyingData=$NONCE_FILE --signature=$SIGNATURE_FILE \
+    --pcrLog=$PCR_LOG \
+    --quoteInfo=$QUOTE_INFO --force
 
 expect <<EOF
 # Try with missing publicKeyPath
 spawn tss2_verifyquote \
-    --qualifyingData $NONCE_FILE --quoteInfo $QUOTE_INFO \
-    --signature $SIGNATURE_FILE
+    --qualifyingData=$NONCE_FILE --quoteInfo=$QUOTE_INFO \
+    --signature=$SIGNATURE_FILE
 set ret [wait]
 if {[lindex \$ret 2] || [lindex \$ret 3] != 1} {
     Command has not failed as expected\n"
@@ -212,9 +212,9 @@ EOF
 
 expect <<EOF
 # Try with missing quoteInfo
-spawn tss2_verifyquote --publicKeyPath "ext/myNewParent" \
-    --qualifyingData $NONCE_FILE \
-    --signature $SIGNATURE_FILE
+spawn tss2_verifyquote --publicKeyPath="ext/myNewParent" \
+    --qualifyingData=$NONCE_FILE \
+    --signature=$SIGNATURE_FILE
 set ret [wait]
 if {[lindex \$ret 2] || [lindex \$ret 3] != 1} {
     Command has not failed as expected\n"
@@ -224,8 +224,8 @@ EOF
 
 expect <<EOF
 # Try with missing signature
-spawn tss2_verifyquote --publicKeyPath "ext/myNewParent" \
-    --qualifyingData $NONCE_FILE --quoteInfo $QUOTE_INFO
+spawn tss2_verifyquote --publicKeyPath="ext/myNewParent" \
+    --qualifyingData=$NONCE_FILE --quoteInfo=$QUOTE_INFO
 set ret [wait]
 if {[lindex \$ret 2] || [lindex \$ret 3] != 1} {
     Command has not failed as expected\n"
@@ -235,9 +235,9 @@ EOF
 
 expect <<EOF
 # Try with multiple stdins (1)
-spawn tss2_verifyquote --publicKeyPath "ext/myNewParent" \
-    --qualifyingData - --quoteInfo - \
-    --signature $SIGNATURE_FILE --pcrLog $PCR_LOG
+spawn tss2_verifyquote --publicKeyPath="ext/myNewParent" \
+    --qualifyingData=- --quoteInfo=- \
+    --signature=$SIGNATURE_FILE --pcrLog=$PCR_LOG
 set ret [wait]
 if {[lindex \$ret 2] || [lindex \$ret 3] != 1} {
     Command has not failed as expected\n"
@@ -247,9 +247,9 @@ EOF
 
 expect <<EOF
 # Try with multiple stdins (2)
-spawn tss2_verifyquote --publicKeyPath "ext/myNewParent" \
-    --qualifyingData $NONCE_FILE --quoteInfo - \
-    --signature - --pcrLog $PCR_LOG
+spawn tss2_verifyquote --publicKeyPath="ext/myNewParent" \
+    --qualifyingData=$NONCE_FILE --quoteInfo=- \
+    --signature=- --pcrLog=$PCR_LOG
 set ret [wait]
 if {[lindex \$ret 2] || [lindex \$ret 3] != 1} {
     Command has not failed as expected\n"
@@ -259,9 +259,9 @@ EOF
 
 expect <<EOF
 # Try with multiple stdins (3)
-spawn tss2_verifyquote --publicKeyPath "ext/myNewParent" \
-    --qualifyingData $NONCE_FILE --quoteInfo $QUOTE_INFO \
-    --signature - --pcrLog -
+spawn tss2_verifyquote --publicKeyPath="ext/myNewParent" \
+    --qualifyingData=$NONCE_FILE --quoteInfo=$QUOTE_INFO \
+    --signature=- --pcrLog=-
 set ret [wait]
 if {[lindex \$ret 2] || [lindex \$ret 3] != 1} {
     Command has not failed as expected\n"
@@ -271,9 +271,9 @@ EOF
 
 expect <<EOF
 # Try with multiple stdins (4)
-spawn tss2_verifyquote --publicKeyPath "ext/myNewParent" \
-    --qualifyingData - --quoteInfo $QUOTE_INFO \
-    --signature $SIGNATURE_FILE --pcrLog -
+spawn tss2_verifyquote --publicKeyPath="ext/myNewParent" \
+    --qualifyingData=- --quoteInfo=$QUOTE_INFO \
+    --signature=$SIGNATURE_FILE --pcrLog=-
 set ret [wait]
 if {[lindex \$ret 2] || [lindex \$ret 3] != 1} {
     Command has not failed as expected\n"
@@ -283,9 +283,9 @@ EOF
 
 expect <<EOF
 # Try with multiple stdins (5)
-spawn tss2_verifyquote --publicKeyPath "ext/myNewParent" \
-    --qualifyingData $NONCE_FILE --quoteInfo - \
-    --signature - --pcrLog $PCR_LOG
+spawn tss2_verifyquote --publicKeyPath="ext/myNewParent" \
+    --qualifyingData=$NONCE_FILE --quoteInfo=- \
+    --signature=- --pcrLog=$PCR_LOG
 set ret [wait]
 if {[lindex \$ret 2] || [lindex \$ret 3] != 1} {
     Command has not failed as expected\n"
@@ -295,9 +295,9 @@ EOF
 
 expect <<EOF
 # Try with multiple stdins (6)
-spawn tss2_verifyquote --publicKeyPath "ext/myNewParent" \
-    --qualifyingData - --quoteInfo - \
-    --signature - --pcrLog -
+spawn tss2_verifyquote --publicKeyPath="ext/myNewParent" \
+    --qualifyingData=- --quoteInfo=- \
+    --signature=- --pcrLog=-
 set ret [wait]
 if {[lindex \$ret 2] || [lindex \$ret 3] != 1} {
     Command has not failed as expected\n"
@@ -307,9 +307,9 @@ EOF
 
 expect <<EOF
 # Try with wrong qualifyingData file
-spawn tss2_verifyquote --publicKeyPath "ext/myNewParent" \
-    --qualifyingData abc --quoteInfo $QUOTE_INFO \
-    --signature $SIGNATURE_FILE --pcrLog $PCR_LOG
+spawn tss2_verifyquote --publicKeyPath="ext/myNewParent" \
+    --qualifyingData=abc --quoteInfo=$QUOTE_INFO \
+    --signature=$SIGNATURE_FILE --pcrLog=$PCR_LOG
 set ret [wait]
 if {[lindex \$ret 2] || [lindex \$ret 3] != 1} {
     Command has not failed as expected\n"
@@ -319,9 +319,9 @@ EOF
 
 expect <<EOF
 # Try with wrong signature file
-spawn tss2_verifyquote --publicKeyPath "ext/myNewParent" \
-    --qualifyingData $NONCE_FILE --quoteInfo $QUOTE_INFO \
-    --signature abc --pcrLog $PCR_LOG
+spawn tss2_verifyquote --publicKeyPath="ext/myNewParent" \
+    --qualifyingData=$NONCE_FILE --quoteInfo=$QUOTE_INFO \
+    --signature=abc --pcrLog=$PCR_LOG
 set ret [wait]
 if {[lindex \$ret 2] || [lindex \$ret 3] != 1} {
     Command has not failed as expected\n"
@@ -331,9 +331,9 @@ EOF
 
 expect <<EOF
 # Try with wrong quoteInfo file
-spawn tss2_verifyquote --publicKeyPath "ext/myNewParent" \
-    --qualifyingData $NONCE_FILE --quoteInfo abc \
-    --signature $SIGNATURE_FILE --pcrLog $PCR_LOG
+spawn tss2_verifyquote --publicKeyPath="ext/myNewParent" \
+    --qualifyingData=$NONCE_FILE --quoteInfo=abc \
+    --signature=$SIGNATURE_FILE --pcrLog=$PCR_LOG
 set ret [wait]
 if {[lindex \$ret 2] || [lindex \$ret 3] != 1} {
     Command has not failed as expected\n"
@@ -343,9 +343,9 @@ EOF
 
 expect <<EOF
 # Try failing tss2_verifyquote
-spawn tss2_verifyquote --publicKeyPath "ext/abc" \
-    --qualifyingData $NONCE_FILE --quoteInfo abc \
-    --signature $SIGNATURE_FILE --pcrLog $PCR_LOG
+spawn tss2_verifyquote --publicKeyPath="ext/abc" \
+    --qualifyingData=$NONCE_FILE --quoteInfo=abc \
+    --signature=$SIGNATURE_FILE --pcrLog=$PCR_LOG
 set ret [wait]
 if {[lindex \$ret 2] || [lindex \$ret 3] != 1} {
     Command has not failed as expected\n"
@@ -354,8 +354,8 @@ if {[lindex \$ret 2] || [lindex \$ret 3] != 1} {
 EOF
 
 # Try with missing qualifyingData
-tss2_verifyquote --publicKeyPath "ext/myNewParent" \
-    --quoteInfo $QUOTE_INFO \
-    --signature $SIGNATURE_FILE
+tss2_verifyquote --publicKeyPath="ext/myNewParent" \
+    --quoteInfo=$QUOTE_INFO \
+    --signature=$SIGNATURE_FILE
 
 exit 0

--- a/test/integration/fapi/fapi-quote-verify.sh
+++ b/test/integration/fapi/fapi-quote-verify.sh
@@ -180,6 +180,24 @@ if {[lindex \$ret 2] || [lindex \$ret 3] != 1} {
 }
 EOF
 
+# Try with missing qualifyingData
+tss2_quote --keyPath $KEY_PATH --pcrList "16" \
+    --signature $SIGNATURE_FILE \
+    --pcrLog $PCR_LOG --certificate $CERTIFICATE_FILE \
+    --quoteInfo $QUOTE_INFO --force
+
+# Try with missing pcrLog
+tss2_quote --keyPath $KEY_PATH --pcrList "16" \
+    --qualifyingData $NONCE_FILE --signature $SIGNATURE_FILE \
+    --certificate $CERTIFICATE_FILE \
+    --quoteInfo $QUOTE_INFO --force
+
+# Try with missing certificate
+tss2_quote --keyPath $KEY_PATH --pcrList "16" \
+    --qualifyingData $NONCE_FILE --signature $SIGNATURE_FILE \
+    --pcrLog $PCR_LOG \
+    --quoteInfo $QUOTE_INFO --force
+
 expect <<EOF
 # Try with missing publicKeyPath
 spawn tss2_verifyquote \
@@ -334,5 +352,10 @@ if {[lindex \$ret 2] || [lindex \$ret 3] != 1} {
     exit 1
 }
 EOF
+
+# Try with missing qualifyingData
+tss2_verifyquote --publicKeyPath "ext/myNewParent" \
+    --quoteInfo $QUOTE_INFO \
+    --signature $SIGNATURE_FILE
 
 exit 0

--- a/test/integration/fapi/fapi-seal-unseal.sh
+++ b/test/integration/fapi/fapi-seal-unseal.sh
@@ -8,7 +8,7 @@ start_up
 setup_fapi
 
 function cleanup {
-    tss2_delete --path /
+    tss2_delete --path=/
     shut_down
 }
 
@@ -26,8 +26,8 @@ tss2_provision
 
 expect <<EOF
 # Try interactive prompt with different passwords
-spawn tss2_createseal --path $KEY_PATH --policyPath $POLICY_PCR --type "noDa" \
-    --data $SEALED_DATA_FILE
+spawn tss2_createseal --path=$KEY_PATH --policyPath=$POLICY_PCR --type="noDa" \
+    --data=$SEALED_DATA_FILE
 expect "Authorize object Password: "
 send "1\r"
 expect "Authorize object Retype password: "
@@ -42,7 +42,7 @@ EOF
 
 expect <<EOF
 # Try with missing path
-spawn tss2_createseal --type "noDa" --data $SEALED_DATA_FILE --authValue ""
+spawn tss2_createseal --type="noDa" --data=$SEALED_DATA_FILE --authValue=""
 set ret [wait]
 if {[lindex \$ret 2] || [lindex \$ret 3] != 1} {
     Command has not failed as expected\n"
@@ -50,21 +50,21 @@ if {[lindex \$ret 2] || [lindex \$ret 3] != 1} {
 }
 EOF
 
-tss2_import --path $POLICY_PCR --importData $PCR_POLICY_DATA
+tss2_import --path=$POLICY_PCR --importData=$PCR_POLICY_DATA
 
-tss2_createseal --path $KEY_PATH --policyPath $POLICY_PCR --type "noDa" \
-    --data $SEALED_DATA_FILE --authValue ""
-tss2_unseal --path $KEY_PATH --data $UNSEALED_DATA_FILE --force
+tss2_createseal --path=$KEY_PATH --policyPath=$POLICY_PCR --type="noDa" \
+    --data=$SEALED_DATA_FILE --authValue=""
+tss2_unseal --path=$KEY_PATH --data=$UNSEALED_DATA_FILE --force
 
 if [ "`xxd $UNSEALED_DATA_FILE`" != "`xxd $SEALED_DATA_FILE`" ]; then
   echo "Seal/Unseal failed"
   exit 1
 fi
 
-tss2_delete --path $KEY_PATH
-printf "$SEAL_DATA" | tss2_createseal --path $KEY_PATH --policyPath $POLICY_PCR --type "noDa" \
-    --data - --authValue ""
-UNSEALED_DATA=$(tss2_unseal --path $KEY_PATH --data - | xxd)
+tss2_delete --path=$KEY_PATH
+printf "$SEAL_DATA" | tss2_createseal --path=$KEY_PATH --policyPath=$POLICY_PCR --type="noDa" \
+    --data=- --authValue=""
+UNSEALED_DATA=$(tss2_unseal --path=$KEY_PATH --data=- | xxd)
 
 V1=$(printf "$SEAL_DATA" | xxd)
 V2=$UNSEALED_DATA
@@ -76,7 +76,7 @@ fi
 
 expect <<EOF
 # Try with missing path
-spawn tss2_unseal --data $UNSEALED_DATA_FILE --force
+spawn tss2_unseal --data=$UNSEALED_DATA_FILE --force
 set ret [wait]
 if {[lindex \$ret 2] || [lindex \$ret 3] != 1} {
     Command has not failed as expected\n"
@@ -85,11 +85,11 @@ if {[lindex \$ret 2] || [lindex \$ret 3] != 1} {
 EOF
 
 # Unseal with password
-tss2_delete --path $KEY_PATH
-tss2_createseal --path $KEY_PATH --data $SEALED_DATA_FILE --authValue "abc"
+tss2_delete --path=$KEY_PATH
+tss2_createseal --path=$KEY_PATH --data=$SEALED_DATA_FILE --authValue="abc"
 printf "" > $UNSEALED_DATA_FILE
 expect <<EOF
-spawn tss2_unseal --path $KEY_PATH --data $UNSEALED_DATA_FILE --force
+spawn tss2_unseal --path=$KEY_PATH --data=$UNSEALED_DATA_FILE --force
 expect "Authorize object : "
 send "abc\r"
 set ret [wait]
@@ -109,10 +109,10 @@ fi
 
 
 # Try with missing type
-tss2_delete --path $KEY_PATH
-tss2_createseal --path $KEY_PATH --data $SEALED_DATA_FILE --authValue ""
+tss2_delete --path=$KEY_PATH
+tss2_createseal --path $KEY_PATH --data=$SEALED_DATA_FILE --authValue=""
 # Try with missing data
-tss2_unseal --path $KEY_PATH --force
+tss2_unseal --path=$KEY_PATH --force
 
 
 

--- a/test/integration/fapi/fapi-set-get-app-data.sh
+++ b/test/integration/fapi/fapi-set-get-app-data.sh
@@ -61,4 +61,7 @@ if {[lindex \$ret 2] || [lindex \$ret 3] != 1} {
 }
 EOF
 
+# Try with missing appData
+tss2_getappdata --path $KEY_PATH
+
 exit 0

--- a/test/integration/fapi/fapi-set-get-app-data.sh
+++ b/test/integration/fapi/fapi-set-get-app-data.sh
@@ -8,7 +8,7 @@ start_up
 setup_fapi
 
 function cleanup {
-    tss2_delete --path /
+    tss2_delete --path=/
     shut_down
 }
 
@@ -22,12 +22,12 @@ echo -n "abcdef" > $APP_DATA_SET
 
 tss2_provision
 
-tss2_createkey --path $KEY_PATH --type "noDa, restricted, decrypt" \
-    --authValue ""
+tss2_createkey --path=$KEY_PATH --type="noDa, restricted, decrypt" \
+    --authValue=""
 
-tss2_setappdata --path $KEY_PATH --appData $APP_DATA_SET
+tss2_setappdata --path=$KEY_PATH --appData=$APP_DATA_SET
 
-tss2_getappdata --path $KEY_PATH --appData $APP_DATA_FILE --force
+tss2_getappdata --path=$KEY_PATH --appData=$APP_DATA_FILE --force
 
 if [ "$(< $APP_DATA_FILE)" !=  "$(< $APP_DATA_SET)" ]; then
   echo "Files are not equal"
@@ -53,7 +53,7 @@ fi
 
 expect <<EOF
 # Try with missing path
-spawn tss2_getappdata --appData $APP_DATA_FILE
+spawn tss2_getappdata --appData=$APP_DATA_FILE
 set ret [wait]
 if {[lindex \$ret 2] || [lindex \$ret 3] != 1} {
     Command has not failed as expected\n"
@@ -62,6 +62,6 @@ if {[lindex \$ret 2] || [lindex \$ret 3] != 1} {
 EOF
 
 # Try with missing appData
-tss2_getappdata --path $KEY_PATH
+tss2_getappdata --path=$KEY_PATH
 
 exit 0

--- a/test/integration/fapi/fapi-set-get-certificate.sh
+++ b/test/integration/fapi/fapi-set-get-certificate.sh
@@ -8,7 +8,7 @@ start_up
 setup_fapi
 
 function cleanup {
-    tss2_delete --path /
+    tss2_delete --path=/
     shut_down
 }
 
@@ -42,12 +42,12 @@ EOF
 
 tss2_provision
 
-tss2_createkey --path $KEY_PATH --type "noDa, restricted, decrypt" \
-    --authValue ""
+tss2_createkey --path=$KEY_PATH --type="noDa, restricted, decrypt" \
+    --authValue=""
 
-tss2_setcertificate --path $KEY_PATH --x509certData $WRITE_CERTIFICATE_FILE
+tss2_setcertificate --path=$KEY_PATH --x509certData=$WRITE_CERTIFICATE_FILE
 
-tss2_getcertificate --path $KEY_PATH --x509certData $READ_CERTIFICATE_FILE \
+tss2_getcertificate --path=$KEY_PATH --x509certData=$READ_CERTIFICATE_FILE \
     --force
 
 if [[ "$(< $READ_CERTIFICATE_FILE)" != "$(< $WRITE_CERTIFICATE_FILE)" ]]; then
@@ -57,7 +57,7 @@ fi
 
 expect <<EOF
 # Try with missing path
-spawn tss2_setcertificate --x509certData $WRITE_CERTIFICATE_FILE
+spawn tss2_setcertificate --x509certData=$WRITE_CERTIFICATE_FILE
 set ret [wait]
 if {[lindex \$ret 2] || [lindex \$ret 3] != 1} {
     Command has not failed as expected\n"
@@ -66,8 +66,8 @@ if {[lindex \$ret 2] || [lindex \$ret 3] != 1} {
 EOF
 
 # Try with missing cert, should set cert to empty
-tss2_setcertificate --path $KEY_PATH
-tss2_getcertificate --path $KEY_PATH --x509certData $READ_CERTIFICATE_FILE \
+tss2_setcertificate --path=$KEY_PATH
+tss2_getcertificate --path=$KEY_PATH --x509certData=$READ_CERTIFICATE_FILE \
     --force
 
 if [[ "$(< $READ_CERTIFICATE_FILE)" != "" ]]; then
@@ -77,7 +77,7 @@ fi
 
 expect <<EOF
 # Try with missing path
-spawn tss2_getcertificate --x509certData $READ_CERTIFICATE_FILE --force
+spawn tss2_getcertificate --x509certData=$READ_CERTIFICATE_FILE --force
 set ret [wait]
 if {[lindex \$ret 2] || [lindex \$ret 3] != 1} {
     Command has not failed as expected\n"
@@ -87,7 +87,7 @@ EOF
 
 expect <<EOF
 # Try with missing x509certData
-spawn tss2_getcertificate --path $KEY_PATH --force
+spawn tss2_getcertificate --path=$KEY_PATH --force
 set ret [wait]
 if {[lindex \$ret 2] || [lindex \$ret 3] != 1} {
     Command has not failed as expected\n"

--- a/test/integration/fapi/fapi-set-get-description.sh
+++ b/test/integration/fapi/fapi-set-get-description.sh
@@ -15,21 +15,20 @@ function cleanup {
 trap cleanup EXIT
 
 KEY_PATH=HS/SRK/myRSACrypt
-DESCRIPTION_SET=$TEMP_DIR/object-description
+# DESCRIPTION_SET=$TEMP_DIR/set_description.file
 DESCRIPTION_FILE=$TEMP_DIR/object_description.file
-
-echo -n "description data" > DESCRIPTION_SET
+DESCRIPTION_SET="description data"
 
 tss2_provision
 
 tss2_createkey --path $KEY_PATH --type "noDa, restricted, decrypt" \
     --authValue ""
 
-tss2_setdescription --path $KEY_PATH --description $DESCRIPTION_SET
+tss2_setdescription --path $KEY_PATH --description "$(echo $DESCRIPTION_SET)"
 
 tss2_getdescription --path $KEY_PATH --description $DESCRIPTION_FILE --force
 
-if [ `cat $DESCRIPTION_FILE` !=  "$DESCRIPTION_SET" ]; then
+if [ "$(< $DESCRIPTION_FILE)" !=  "$DESCRIPTION_SET" ]; then
   echo "Descriptions not equal"
   exit 1
 fi
@@ -43,6 +42,15 @@ if {[lindex \$ret 2] || [lindex \$ret 3] != 1} {
     exit 1
 }
 EOF
+
+# Try with missing description, should set description to empty
+tss2_setdescription --path $KEY_PATH
+tss2_getdescription --path $KEY_PATH --description $DESCRIPTION_FILE --force
+
+if [ "$(< $DESCRIPTION_FILE)" !=  "" ]; then
+  echo "Description is not empty"
+  exit 1
+fi
 
 expect <<EOF
 # Try with missing path

--- a/test/integration/fapi/fapi-set-get-description.sh
+++ b/test/integration/fapi/fapi-set-get-description.sh
@@ -8,7 +8,7 @@ start_up
 setup_fapi
 
 function cleanup {
-    tss2_delete --path /
+    tss2_delete --path=/
     shut_down
 }
 
@@ -21,12 +21,12 @@ DESCRIPTION_SET="description data"
 
 tss2_provision
 
-tss2_createkey --path $KEY_PATH --type "noDa, restricted, decrypt" \
-    --authValue ""
+tss2_createkey --path=$KEY_PATH --type="noDa, restricted, decrypt" \
+    --authValue=""
 
-tss2_setdescription --path $KEY_PATH --description "$(echo $DESCRIPTION_SET)"
+tss2_setdescription --path=$KEY_PATH --description="$(echo $DESCRIPTION_SET)"
 
-tss2_getdescription --path $KEY_PATH --description $DESCRIPTION_FILE --force
+tss2_getdescription --path=$KEY_PATH --description=$DESCRIPTION_FILE --force
 
 if [ "$(< $DESCRIPTION_FILE)" !=  "$DESCRIPTION_SET" ]; then
   echo "Descriptions not equal"
@@ -35,7 +35,7 @@ fi
 
 expect <<EOF
 # Try with missing path
-spawn tss2_setdescription --description $DESCRIPTION_SET
+spawn tss2_setdescription --description=$DESCRIPTION_SET
 set ret [wait]
 if {[lindex \$ret 2] || [lindex \$ret 3] != 1} {
     Command has not failed as expected\n"
@@ -44,8 +44,8 @@ if {[lindex \$ret 2] || [lindex \$ret 3] != 1} {
 EOF
 
 # Try with missing description, should set description to empty
-tss2_setdescription --path $KEY_PATH
-tss2_getdescription --path $KEY_PATH --description $DESCRIPTION_FILE --force
+tss2_setdescription --path=$KEY_PATH
+tss2_getdescription --path=$KEY_PATH --description=$DESCRIPTION_FILE --force
 
 if [ "$(< $DESCRIPTION_FILE)" !=  "" ]; then
   echo "Description is not empty"
@@ -54,7 +54,7 @@ fi
 
 expect <<EOF
 # Try with missing path
-spawn tss2_getdescription --description $DESCRIPTION_FILE
+spawn tss2_getdescription --description=$DESCRIPTION_FILE
 set ret [wait]
 if {[lindex \$ret 2] || [lindex \$ret 3] != 1} {
     Command has not failed as expected\n"
@@ -64,7 +64,7 @@ EOF
 
 expect <<EOF
 # Try with missing description
-spawn tss2_getdescription --path $KEY_PATH
+spawn tss2_getdescription --path=$KEY_PATH
 set ret [wait]
 if {[lindex \$ret 2] || [lindex \$ret 3] != 1} {
     Command has not failed as expected\n"

--- a/test/integration/fapi/fapi-sign-verify.sh
+++ b/test/integration/fapi/fapi-sign-verify.sh
@@ -8,7 +8,7 @@ start_up
 setup_fapi
 
 function cleanup {
-    tss2_delete --path /
+    tss2_delete --path=/
     shut_down
 }
 
@@ -23,26 +23,26 @@ PUB_KEY_DIR="ext"
 
 tss2_provision
 echo -n "01234567890123456789" > $DIGEST_FILE
-tss2_createkey --path $KEY_PATH --type "noDa, sign" --authValue ""
-echo -n `cat $DIGEST_FILE` | tss2_sign --digest - --keyPath $KEY_PATH \
-    --padding "RSA_PSS" --signature $SIGNATURE_FILE --publicKey $PUBLIC_KEY_FILE
+tss2_createkey --path=$KEY_PATH --type="noDa, sign" --authValue=""
+echo -n `cat $DIGEST_FILE` | tss2_sign --digest=- --keyPath=$KEY_PATH \
+    --padding="RSA_PSS" --signature=$SIGNATURE_FILE --publicKey=$PUBLIC_KEY_FILE
 
-tss2_import --path $IMPORTED_KEY_NAME --importData $PUBLIC_KEY_FILE
-tss2_verifysignature --keyPath $PUB_KEY_DIR/$IMPORTED_KEY_NAME \
-    --digest $DIGEST_FILE --signature $SIGNATURE_FILE
+tss2_import --path=$IMPORTED_KEY_NAME --importData=$PUBLIC_KEY_FILE
+tss2_verifysignature --keyPath=$PUB_KEY_DIR/$IMPORTED_KEY_NAME \
+    --digest=$DIGEST_FILE --signature=$SIGNATURE_FILE
 
 # Try without certificate
-tss2_sign --keyPath $KEY_PATH --padding "RSA_PSS" --digest $DIGEST_FILE \
-    --signature $SIGNATURE_FILE --publicKey $PUBLIC_KEY_FILE --force
+tss2_sign --keyPath=$KEY_PATH --padding="RSA_PSS" --digest=$DIGEST_FILE \
+    --signature=$SIGNATURE_FILE --publicKey=$PUBLIC_KEY_FILE --force
 
 # Try without public key
-tss2_sign --keyPath $KEY_PATH --padding "RSA_PSS" --digest $DIGEST_FILE \
-    --signature $SIGNATURE_FILE --force
+tss2_sign --keyPath=$KEY_PATH --padding="RSA_PSS" --digest=$DIGEST_FILE \
+    --signature=$SIGNATURE_FILE --force
 
 expect <<EOF
 # Try with missing keyPath
-spawn tss2_sign --padding "RSA_PSS" --digest $DIGEST_FILE \
-    --signature $SIGNATURE_FILE --publicKey $PUBLIC_KEY_FILE
+spawn tss2_sign --padding="RSA_PSS" --digest=$DIGEST_FILE \
+    --signature=$SIGNATURE_FILE --publicKey=$PUBLIC_KEY_FILE
 set ret [wait]
 if {[lindex \$ret 2] || [lindex \$ret 3] != 1} {
     Command has not failed as expected\n"
@@ -52,8 +52,8 @@ EOF
 
 expect <<EOF
 # Try with missing digest
-spawn tss2_sign --keyPath $KEY_PATH --padding "RSA_PSS" \
-    --signature $SIGNATURE_FILE --publicKey $PUBLIC_KEY_FILE
+spawn tss2_sign --keyPath=$KEY_PATH --padding="RSA_PSS" \
+    --signature=$SIGNATURE_FILE --publicKey=$PUBLIC_KEY_FILE
 set ret [wait]
 if {[lindex \$ret 2] || [lindex \$ret 3] != 1} {
     Command has not failed as expected\n"
@@ -63,8 +63,8 @@ EOF
 
 expect <<EOF
 # Try with missing signature
-spawn tss2_sign --keyPath $KEY_PATH --padding "RSA_PSS" --digest $DIGEST_FILE \
-    --publicKey $PUBLIC_KEY_FILE
+spawn tss2_sign --keyPath=$KEY_PATH --padding="RSA_PSS" --digest=$DIGEST_FILE \
+    --publicKey=$PUBLIC_KEY_FILE
 set ret [wait]
 if {[lindex \$ret 2] || [lindex \$ret 3] != 1} {
     Command has not failed as expected\n"
@@ -74,8 +74,8 @@ EOF
 
 expect <<EOF
 # Try with multiple stdins with publicKey and with certificate
-spawn tss2_sign --keyPath $KEY_PATH --padding "RSA_PSS" --digest $DIGEST_FILE \
-    --signature - --publicKey - --certificate -
+spawn tss2_sign --keyPath=$KEY_PATH --padding="RSA_PSS" --digest=$DIGEST_FILE \
+    --signature=- --publicKey=- --certificate -
 set ret [wait]
 if {[lindex \$ret 2] || [lindex \$ret 3] != 1} {
     Command has not failed as expected\n"
@@ -85,8 +85,8 @@ EOF
 
 expect <<EOF
 # Try with multiple stdins without publicKey and with certificate
-spawn tss2_sign --keyPath $KEY_PATH --padding "RSA_PSS" --digest $DIGEST_FILE \
-    --signature - --certificate -
+spawn tss2_sign --keyPath=$KEY_PATH --padding="RSA_PSS" --digest=$DIGEST_FILE \
+    --signature=- --certificate=-
 set ret [wait]
 if {[lindex \$ret 2] || [lindex \$ret 3] != 1} {
     Command has not failed as expected\n"
@@ -96,8 +96,8 @@ EOF
 
 expect <<EOF
 # Try with missing digest file
-spawn tss2_sign --keyPath $KEY_PATH --padding "RSA_PSS" --digest abc \
-    --signature $SIGNATURE_FILE --publicKey $PUBLIC_KEY_FILE
+spawn tss2_sign --keyPath=$KEY_PATH --padding="RSA_PSS" --digest=abc \
+    --signature=$SIGNATURE_FILE --publicKey=$PUBLIC_KEY_FILE
 set ret [wait]
 if {[lindex \$ret 2] || [lindex \$ret 3] != 1} {
     Command has not failed as expected\n"
@@ -108,7 +108,7 @@ EOF
 expect <<EOF
 # Try with missing keyPath
 spawn tss2_verifysignature \
-    --digest $DIGEST_FILE --signature $SIGNATURE_FILE
+    --digest=$DIGEST_FILE --signature=$SIGNATURE_FILE
 set ret [wait]
 if {[lindex \$ret 2] || [lindex \$ret 3] != 1} {
     Command has not failed as expected\n"
@@ -118,8 +118,8 @@ EOF
 
 expect <<EOF
 # Try with missing digest
-spawn tss2_verifysignature --keyPath $PUB_KEY_DIR/$IMPORTED_KEY_NAME \
-    --signature $SIGNATURE_FILE
+spawn tss2_verifysignature --keyPath=$PUB_KEY_DIR/$IMPORTED_KEY_NAME \
+    --signature=$SIGNATURE_FILE
 set ret [wait]
 if {[lindex \$ret 2] || [lindex \$ret 3] != 1} {
     Command has not failed as expected\n"
@@ -129,8 +129,8 @@ EOF
 
 expect <<EOF
 # Try with missing signature
-spawn tss2_verifysignature --keyPath $PUB_KEY_DIR/$IMPORTED_KEY_NAME \
-    --digest $DIGEST_FILE
+spawn tss2_verifysignature --keyPath=$PUB_KEY_DIR/$IMPORTED_KEY_NAME \
+    --digest=$DIGEST_FILE
 set ret [wait]
 if {[lindex \$ret 2] || [lindex \$ret 3] != 1} {
     Command has not failed as expected\n"
@@ -140,8 +140,8 @@ EOF
 
 expect <<EOF
 # Try with multiple stdins
-spawn tss2_verifysignature --keyPath $PUB_KEY_DIR/$IMPORTED_KEY_NAME \
-    --digest - --signature -
+spawn tss2_verifysignature --keyPath=$PUB_KEY_DIR/$IMPORTED_KEY_NAME \
+    --digest=- --signature=-
 set ret [wait]
 if {[lindex \$ret 2] || [lindex \$ret 3] != 1} {
     Command has not failed as expected\n"

--- a/test/integration/fapi/fapi-sign-verify.sh
+++ b/test/integration/fapi/fapi-sign-verify.sh
@@ -31,6 +31,13 @@ tss2_import --path $IMPORTED_KEY_NAME --importData $PUBLIC_KEY_FILE
 tss2_verifysignature --keyPath $PUB_KEY_DIR/$IMPORTED_KEY_NAME \
     --digest $DIGEST_FILE --signature $SIGNATURE_FILE
 
+# Try without certificate
+tss2_sign --keyPath $KEY_PATH --padding "RSA_PSS" --digest $DIGEST_FILE \
+    --signature $SIGNATURE_FILE --publicKey $PUBLIC_KEY_FILE --force
+
+# Try without public key
+tss2_sign --keyPath $KEY_PATH --padding "RSA_PSS" --digest $DIGEST_FILE \
+    --signature $SIGNATURE_FILE --force
 
 expect <<EOF
 # Try with missing keyPath

--- a/test/integration/fapi/fapi-testing-template.sh
+++ b/test/integration/fapi/fapi-testing-template.sh
@@ -20,6 +20,7 @@ PW=abc
 PLAIN_TEXT=$TEMP_DIR/plaintext.file
 KEY_PATH="HS/SRK/myRSACrypt"
 ENCRYPTED_FILE=$TEMP_DIR/encrypted.file
+VERSION_FILE=$TEMP_DIR/version.file
 echo -n "Secret Text!" > $PLAIN_TEXT
 
 expect <<EOF
@@ -47,5 +48,12 @@ if {[lindex \$ret 2] || [lindex \$ret 3] != 1} {
     exit 1
 }
 EOF
+
+tss2_getrandom -v > $VERSION_FILE
+VERSION=$(cat $VERSION_FILE | cut -d'=' -f 4)
+size=${#VERSION}
+if [ $size -ge 129 ]; then
+    echo "Error: Version length greater than 128 characters" ; exit 1
+fi
 
 exit 0

--- a/test/integration/fapi/fapi-testing-template.sh
+++ b/test/integration/fapi/fapi-testing-template.sh
@@ -10,7 +10,7 @@ setup_fapi
 function cleanup {
     # If this test is successful, no keys are created. Thus, command below will
     # always fail
-    tss2_delete --path / || true
+    tss2_delete --path=/ || true
     shut_down
 }
 

--- a/tools/fapi/tss2_authorizepolicy.c
+++ b/tools/fapi/tss2_authorizepolicy.c
@@ -64,7 +64,6 @@ int tss2_tool_onrun (FAPI_CONTEXT *fctx) {
         r = open_read_and_close (ctx.policyRef, (void**)&policyRef,
             &policyRefSize);
         if (r){
-            LOG_PERR ("open_read_and_close policyRef", r);
             return r;
         }
     }

--- a/tools/fapi/tss2_createseal.c
+++ b/tools/fapi/tss2_createseal.c
@@ -82,7 +82,6 @@ int tss2_tool_onrun (FAPI_CONTEXT *fctx) {
     size_t dataSize;
     TSS2_RC r = open_read_and_close (ctx.data, (void**)&data, &dataSize);
     if (r){
-        LOG_PERR ("open_read_and_close data", r);
         return r;
     }
 

--- a/tools/fapi/tss2_decrypt.c
+++ b/tools/fapi/tss2_decrypt.c
@@ -69,7 +69,6 @@ int tss2_tool_onrun (FAPI_CONTEXT *fctx) {
     TSS2_RC r = open_read_and_close (ctx.cipherText, (void**)&cipherText,
         &cipherTextSize);
     if (r){
-        LOG_PERR ("open_read_and_close cipherText", r);
         return r;
     }
 
@@ -88,7 +87,6 @@ int tss2_tool_onrun (FAPI_CONTEXT *fctx) {
     r = open_write_and_close (ctx.plainText, ctx.overwrite, plainText,
         plainTextSize);
     if (r){
-        LOG_PERR ("open_write_and_close plainText", r);
         return r;
     }
 

--- a/tools/fapi/tss2_encrypt.c
+++ b/tools/fapi/tss2_encrypt.c
@@ -69,7 +69,6 @@ int tss2_tool_onrun (FAPI_CONTEXT *fctx) {
     TSS2_RC r = open_read_and_close (ctx.plainText, (void**)&plainText,
         &plainTextSize);
     if (r){
-        LOG_PERR ("open_read_and_close plainText", r);
         return 1;
     }
 
@@ -89,7 +88,6 @@ int tss2_tool_onrun (FAPI_CONTEXT *fctx) {
     r = open_write_and_close (ctx.cipherText, ctx.overwrite, cipherText,
         cipherTextSize);
     if (r) {
-        LOG_PERR ("open_write_and_close cipherText", r);
         return 1;
     }
 

--- a/tools/fapi/tss2_exportkey.c
+++ b/tools/fapi/tss2_exportkey.c
@@ -73,7 +73,6 @@ int tss2_tool_onrun (FAPI_CONTEXT *fctx) {
     r = open_write_and_close (ctx.exportedData, ctx.overwrite, exportedData,
         strlen(exportedData));
     if (r){
-        LOG_PERR ("open_write_and_close exportedData", r);
         Fapi_Free (exportedData);
         return 1;
     }

--- a/tools/fapi/tss2_exportpolicy.c
+++ b/tools/fapi/tss2_exportpolicy.c
@@ -66,7 +66,6 @@ int tss2_tool_onrun (FAPI_CONTEXT *fctx) {
     /* Write returned data to file(s) */
     r = open_write_and_close (ctx.jsonPolicy, ctx.overwrite, jsonPolicy, 0);
     if (r){
-        LOG_PERR ("open_write_and_close buffer", r);
         return 1;
     }
 

--- a/tools/fapi/tss2_getappdata.c
+++ b/tools/fapi/tss2_getappdata.c
@@ -69,7 +69,6 @@ int tss2_tool_onrun (FAPI_CONTEXT *fctx) {
         r = open_write_and_close (ctx.data, ctx.overwrite, appData,
             appDataSize);
         if (r != TSS2_RC_SUCCESS) {
-            LOG_PERR ("open_write_and_close appData", r);
             return 1;
         }
     }

--- a/tools/fapi/tss2_getcertificate.c
+++ b/tools/fapi/tss2_getcertificate.c
@@ -67,7 +67,6 @@ int tss2_tool_onrun (FAPI_CONTEXT *fctx) {
     r = open_write_and_close (ctx.x509cert, ctx.overwrite, x509certData,
         strlen(x509certData));
     if (r){
-        LOG_PERR ("open_write_and_close x509certData", r);
         Fapi_Free (x509certData);
         return 1;
     }

--- a/tools/fapi/tss2_getdescription.c
+++ b/tools/fapi/tss2_getdescription.c
@@ -67,7 +67,6 @@ int tss2_tool_onrun (FAPI_CONTEXT *fctx) {
     r = open_write_and_close (ctx.description, ctx.overwrite, description,
         strlen(description));
     if (r){
-        LOG_PERR ("open_write_and_close description", r);
         Fapi_Free (description);
         return 1;
     }

--- a/tools/fapi/tss2_getinfo.c
+++ b/tools/fapi/tss2_getinfo.c
@@ -57,7 +57,6 @@ int tss2_tool_onrun (FAPI_CONTEXT *fctx) {
     /* Write returned data to file(s) */
     r = open_write_and_close (ctx.info, ctx.overwrite, info, 0);
     if (r) {
-        LOG_PERR ("open_write_and_close", r);
         Fapi_Free (info);
         return 1;
     }

--- a/tools/fapi/tss2_getplatformcertificates.c
+++ b/tools/fapi/tss2_getplatformcertificates.c
@@ -62,7 +62,6 @@ int tss2_tool_onrun (FAPI_CONTEXT *fctx) {
         r = open_write_and_close (ctx.certificates, ctx.overwrite,
             certificates, certificatesSize);
         if (r) {
-            LOG_PERR ("open_write_and_close certificates", r);
             Fapi_Free (certificates);
             return 1;
         }

--- a/tools/fapi/tss2_getrandom.c
+++ b/tools/fapi/tss2_getrandom.c
@@ -77,7 +77,6 @@ int tss2_tool_onrun (FAPI_CONTEXT *fctx) {
     r = open_write_and_close (ctx.filename, ctx.overwrite, data,
         ctx.numBytes);
     if (r){
-        LOG_PERR ("open_write_and_close output", r);
         Fapi_Free (data);
         return 1;
     }

--- a/tools/fapi/tss2_gettpmblobs.c
+++ b/tools/fapi/tss2_gettpmblobs.c
@@ -90,7 +90,6 @@ int tss2_tool_onrun (FAPI_CONTEXT *fctx) {
         r = open_write_and_close (ctx.tpm2bPublic, ctx.overwrite, tpm2bPublic,
             tpm2bPublicSize);
         if (r) {
-            LOG_PERR ("open_write_and_close tpm2bPublic", r);
             return 1;
         }
     }
@@ -99,7 +98,6 @@ int tss2_tool_onrun (FAPI_CONTEXT *fctx) {
         r = open_write_and_close (ctx.tpm2bPrivate, ctx.overwrite, tpm2bPrivate,
             tpm2bPrivateSize);
         if (r) {
-            LOG_PERR ("open_write_and_close tpm2bPrivate", r);
             Fapi_Free (tpm2bPublic);
             return 1;
         }
@@ -109,7 +107,6 @@ int tss2_tool_onrun (FAPI_CONTEXT *fctx) {
         r = open_write_and_close (ctx.policy, ctx.overwrite, policy,
             strlen(policy));
         if (r) {
-            LOG_PERR ("open_write_and_close policy", r);
             Fapi_Free (tpm2bPublic);
             Fapi_Free (tpm2bPrivate);
             return 1;

--- a/tools/fapi/tss2_import.c
+++ b/tools/fapi/tss2_import.c
@@ -52,7 +52,6 @@ int tss2_tool_onrun (FAPI_CONTEXT *fctx) {
     char *importData;
     TSS2_RC r = open_read_and_close (ctx.importData, (void**)&importData, NULL);
     if (r){
-        LOG_PERR("open_read_and_close input", r);
         return 1;
     }
 

--- a/tools/fapi/tss2_list.c
+++ b/tools/fapi/tss2_list.c
@@ -11,6 +11,7 @@ bool output_enabled = false;
 
 /* Context struct used to store passed command line parameters */
 static struct cxt {
+    bool  overwrite;
     char *searchPath;
     char *pathList;
 } ctx;
@@ -18,6 +19,9 @@ static struct cxt {
 /* Parse command line parameters */
 static bool on_option(char key, char *value) {
     switch (key) {
+    case 'f':
+        ctx.overwrite = true;
+        break;
     case 'p':
         ctx.searchPath = value;
         break;
@@ -31,10 +35,11 @@ static bool on_option(char key, char *value) {
 /* Define possible command line parameters */
 bool tss2_tool_onstart(tpm2_options **opts) {
     struct option topts[] = {
+        {"force"   , no_argument      , NULL, 'f'},
         {"searchPath", required_argument, NULL, 'p'},
         {"pathList",   required_argument, NULL, 'o'}
     };
-    return (*opts = tpm2_options_new ("p:o:", ARRAY_LEN(topts), topts,
+    return (*opts = tpm2_options_new ("fp:o:", ARRAY_LEN(topts), topts,
                                       on_option, NULL, 0)) != NULL;
 }
 
@@ -51,7 +56,7 @@ int tss2_tool_onrun (FAPI_CONTEXT *fctx) {
     }
 
     /* Write returned data to file(s) */
-    r = open_write_and_close (ctx.pathList, true, pathList,
+    r = open_write_and_close (ctx.pathList, ctx.overwrite, pathList,
         strlen(pathList));
     if (r){
         LOG_PERR ("open_write_and_close pathList", r);

--- a/tools/fapi/tss2_list.c
+++ b/tools/fapi/tss2_list.c
@@ -59,7 +59,6 @@ int tss2_tool_onrun (FAPI_CONTEXT *fctx) {
     r = open_write_and_close (ctx.pathList, ctx.overwrite, pathList,
         strlen(pathList));
     if (r){
-        LOG_PERR ("open_write_and_close pathList", r);
         Fapi_Free (pathList);
         return 1;
     }

--- a/tools/fapi/tss2_nvextend.c
+++ b/tools/fapi/tss2_nvextend.c
@@ -70,7 +70,6 @@ int tss2_tool_onrun (FAPI_CONTEXT *fctx) {
     size_t data_len;
     TSS2_RC r = open_read_and_close (ctx.data, (void**)&data, &data_len);
     if (r){
-        LOG_PERR ("open_read_and_close data", r);
         return 1;
     }
 
@@ -78,7 +77,6 @@ int tss2_tool_onrun (FAPI_CONTEXT *fctx) {
     if (ctx.logData){
         TSS2_RC r = open_read_and_close (ctx.logData, (void**)&logData, 0);
         if (r){
-            LOG_PERR ("open_read_and_close logData", r);
             free (data);
             return 1;
         }

--- a/tools/fapi/tss2_nvread.c
+++ b/tools/fapi/tss2_nvread.c
@@ -84,7 +84,6 @@ int tss2_tool_onrun (FAPI_CONTEXT *fctx) {
     /* Write returned data to file(s) */
     r = open_write_and_close (ctx.data, ctx.overwrite, data, data_len);
     if (r) {
-        LOG_PERR ("open_write_and_close data", r);
         return 1;
     }
 
@@ -93,7 +92,6 @@ int tss2_tool_onrun (FAPI_CONTEXT *fctx) {
             strlen(logData));
         if (r) {
             Fapi_Free (data);
-            LOG_PERR ("open_write_and_close logData", r);
             return 1;
         }
     }

--- a/tools/fapi/tss2_nvwrite.c
+++ b/tools/fapi/tss2_nvwrite.c
@@ -55,7 +55,6 @@ int tss2_tool_onrun (FAPI_CONTEXT *fctx) {
     size_t data_len;
     TSS2_RC r = open_read_and_close (ctx.data, (void**)&data, &data_len);
     if (r) {
-        LOG_PERR ("open_read_and_close data", r);
         return 1;
     }
 

--- a/tools/fapi/tss2_pcrextend.c
+++ b/tools/fapi/tss2_pcrextend.c
@@ -75,7 +75,6 @@ int tss2_tool_onrun (FAPI_CONTEXT *fctx) {
     TSS2_RC r = open_read_and_close (ctx.data, (void**)&data,
         &eventDataSize);
     if (r){
-        LOG_PERR ("open_read_and_close data", r);
         return -1;
     }
 
@@ -83,7 +82,6 @@ int tss2_tool_onrun (FAPI_CONTEXT *fctx) {
     if (ctx.logData) {
         r = open_read_and_close (ctx.logData, (void**)&logData, 0);
         if (r) {
-            LOG_PERR ("open_read_and_close logData", r);
             Fapi_Free (data);
             return -1;
         }

--- a/tools/fapi/tss2_pcrread.c
+++ b/tools/fapi/tss2_pcrread.c
@@ -87,7 +87,6 @@ int tss2_tool_onrun (FAPI_CONTEXT *fctx) {
             pcrValueSize);
         if (r) {
             Fapi_Free (pcrLog);
-            LOG_PERR ("open_write_and_close pcrValue", r);
             return 1;
         }
     }
@@ -96,7 +95,6 @@ int tss2_tool_onrun (FAPI_CONTEXT *fctx) {
         r =  open_write_and_close (ctx.pcrLog, ctx.overwrite, pcrLog, 0);
         if (r) {
             Fapi_Free (pcrValue);
-            LOG_PERR ("open_write_and_close pcrLog", r);
             return 1;
         }
     }

--- a/tools/fapi/tss2_quote.c
+++ b/tools/fapi/tss2_quote.c
@@ -147,7 +147,6 @@ int tss2_tool_onrun (FAPI_CONTEXT *fctx) {
         r = open_read_and_close (ctx.qualifyingData,
             (void*)&qualifyingData, &qualifyingDataSize);
         if (r) {
-          LOG_ERR ("open_read_and_close qualifyingData", r);
           free (ctx.pcrList);
           return 1;
         }
@@ -174,7 +173,6 @@ int tss2_tool_onrun (FAPI_CONTEXT *fctx) {
     if (ctx.quoteInfo && quoteInfo) {
         r = open_write_and_close (ctx.quoteInfo, ctx.overwrite, quoteInfo, 0);
         if (r) {
-            LOG_PERR ("open_write_and_close quoteInfo", r);
             Fapi_Free (quoteInfo);
             Fapi_Free (pcrLog);
             Fapi_Free (signature);
@@ -188,7 +186,6 @@ int tss2_tool_onrun (FAPI_CONTEXT *fctx) {
     if (ctx.pcrLog && pcrLog) {
         r = open_write_and_close (ctx.pcrLog, ctx.overwrite, pcrLog, 0);
         if (r) {
-            LOG_PERR ("open_write_and_close pcrLog", r);
             Fapi_Free (pcrLog);
             Fapi_Free (signature);
             Fapi_Free (certificate);
@@ -201,7 +198,6 @@ int tss2_tool_onrun (FAPI_CONTEXT *fctx) {
         r = open_write_and_close (ctx.signature, ctx.overwrite, signature,
             signatureSize);
         if (r) {
-            LOG_PERR ("open_write_and_close signature", r);
             Fapi_Free (signature);
             Fapi_Free (certificate);
             return 1;
@@ -213,7 +209,6 @@ int tss2_tool_onrun (FAPI_CONTEXT *fctx) {
         r = open_write_and_close (ctx.certificate, ctx.overwrite, certificate,
             strlen(certificate));
         if (r) {
-            LOG_PERR ("open_write_and_close certificate", r);
             Fapi_Free (certificate);
             return 1;
         }

--- a/tools/fapi/tss2_setcertificate.c
+++ b/tools/fapi/tss2_setcertificate.c
@@ -52,7 +52,6 @@ int tss2_tool_onrun (FAPI_CONTEXT *fctx) {
         r = open_read_and_close (ctx.x509cert, (void**)&x509certData,
             &x509certSize);
         if (r) {
-            LOG_PERR("open_read_and_close x509cert", r);
             return 1;
         }
     }

--- a/tools/fapi/tss2_sign.c
+++ b/tools/fapi/tss2_sign.c
@@ -99,7 +99,6 @@ int tss2_tool_onrun (FAPI_CONTEXT *fctx) {
     char *publicKey, *certificate = NULL;
     TSS2_RC r = open_read_and_close (ctx.digest, (void**)&digest, &digestSize);
     if (r){
-        LOG_PERR ("open_read_and_close digest", r);
         return 1;
     }
 
@@ -118,7 +117,6 @@ int tss2_tool_onrun (FAPI_CONTEXT *fctx) {
             r = open_write_and_close (ctx.certificate, ctx.overwrite,
                 certificate, strlen(certificate));
             if (r) {
-                LOG_PERR ("open_write_and_close certificate", r);
                 Fapi_Free (certificate);
                 Fapi_Free (signature);
                 Fapi_Free (publicKey);
@@ -131,7 +129,6 @@ int tss2_tool_onrun (FAPI_CONTEXT *fctx) {
         r = open_write_and_close (ctx.signature, ctx.overwrite, signature,
             signatureSize);
         if (r) {
-            LOG_PERR ("open_write_and_close certificate signature", r);
             Fapi_Free (signature);
             Fapi_Free (publicKey);
             return 1;
@@ -143,7 +140,6 @@ int tss2_tool_onrun (FAPI_CONTEXT *fctx) {
         r = open_write_and_close (ctx.publicKey, ctx.overwrite, publicKey,
                 strlen(publicKey));
         if (r) {
-            LOG_PERR ("open_write_and_close certificate publicKey", r);
             Fapi_Free (publicKey);
             return 1;
         }

--- a/tools/fapi/tss2_unseal.c
+++ b/tools/fapi/tss2_unseal.c
@@ -63,7 +63,6 @@ int tss2_tool_onrun (FAPI_CONTEXT *fctx) {
     if (ctx.data && data) {
         r = open_write_and_close (ctx.data, ctx.overwrite, data, size);
         if (r) {
-            LOG_PERR ("open_write_and_close data", r);
             Fapi_Free (data);
             return 1;
         }

--- a/tools/fapi/tss2_verifyquote.c
+++ b/tools/fapi/tss2_verifyquote.c
@@ -91,7 +91,6 @@ int tss2_tool_onrun (FAPI_CONTEXT *fctx) {
         r = open_read_and_close (ctx.qualifyingData,
             (void**)&qualifyingData, &qualifyingDataSize);
         if (r) {
-            LOG_PERR ("open_read_and_close qualifyingData", r);
             return -1;
         }
     }
@@ -101,7 +100,6 @@ int tss2_tool_onrun (FAPI_CONTEXT *fctx) {
     if (ctx.signature) {
         r = open_read_and_close (ctx.signature, (void**)&signature, &signatureSize);
         if (r) {
-            LOG_PERR ("open_read_and_close signature", r);
             free (qualifyingData);
             return -1;
         }
@@ -111,7 +109,6 @@ int tss2_tool_onrun (FAPI_CONTEXT *fctx) {
     if (ctx.quoteInfo) {
         r = open_read_and_close (ctx.quoteInfo, (void**)&quoteInfo, NULL);
         if (r) {
-            LOG_PERR ("open_read_and_close quoteInfo", r);
             free (qualifyingData);
             free (signature);
             return -1;
@@ -122,7 +119,6 @@ int tss2_tool_onrun (FAPI_CONTEXT *fctx) {
     if (ctx.pcrLog) {
         r = open_read_and_close (ctx.pcrLog, (void**)&pcrLog, NULL);
         if (r) {
-            LOG_PERR ("open_read_and_close pcrLog", r);
             free (qualifyingData);
             free (signature);
             free (quoteInfo);

--- a/tools/fapi/tss2_verifysignature.c
+++ b/tools/fapi/tss2_verifysignature.c
@@ -76,12 +76,10 @@ int tss2_tool_onrun (FAPI_CONTEXT *fctx) {
     size_t digestSize, signatureSize;
     TSS2_RC r = open_read_and_close (ctx.digest, (void**)&digest, &digestSize);
     if (r){
-        LOG_PERR("open_read_and_close digest", r);
         return 1;
     }
     r = open_read_and_close (ctx.signature, (void**)&signature, &signatureSize);
     if (r) {
-        LOG_PERR("open_read_and_close signature", r);
         free (digest);
         return 1;
     }


### PR DESCRIPTION
Some fixes for the tss2 tools: 
- tss2_*: Fix bash-completion for tss2_pcrextend and tss2_verifysignature
- tss2_*: Add force option to tss2_list
- tss2_*: Consistent force option for all fapi tools
- tss2_*: Do not decode non-TPM errors
- tss2_*: Enhance integration tests to test changes of optional/mandatory parameters
- tss2_*: Add --hex parameter to tss2_getrandom
- tss2_*: Fix autocompletion issue in all fapi tools
- tss2_*: Switch tss2_* to with-"="-style
- tss2_*: Add size parameter to tss2_createseal

Signed-off-by: Christian Plappert <christian.plappert@sit.fraunhofer.de>