### PR TITLE
Make all of the helper functions in each tool static

### DIFF
--- a/tools/tpm2_clear.c
+++ b/tools/tpm2_clear.c
@@ -34,7 +34,7 @@ static bool on_option(char key, char *value) {
     return true;
 }
 
-bool on_arg(int argc, char **argv) {
+static bool on_arg(int argc, char **argv) {
 
     if (argc > 1) {
         LOG_ERR("Specify a single auth value");

--- a/tools/tpm2_clearcontrol.c
+++ b/tools/tpm2_clearcontrol.c
@@ -51,7 +51,7 @@ static tool_rc clearcontrol(ESYS_CONTEXT *ectx) {
     ctx.disable_clear, NULL);
 }
 
-bool on_arg(int argc, char **argv) {
+static bool on_arg(int argc, char **argv) {
 
     if (argc > 1) {
         LOG_ERR("Specify single set/clear operation as s|c|0|1.");

--- a/tools/tpm2_commit.c
+++ b/tools/tpm2_commit.c
@@ -118,7 +118,7 @@ static tool_rc check_options(void) {
     return tool_rc_success;
 }
 
-tool_rc process_inputs(ESYS_CONTEXT *ectx) {
+static tool_rc process_inputs(ESYS_CONTEXT *ectx) {
 
     tool_rc rc = tpm2_util_object_load_auth(ectx, ctx.signing_key.ctx_path,
             ctx.signing_key.auth_str, &ctx.signing_key.object, false,
@@ -147,7 +147,7 @@ tool_rc process_inputs(ESYS_CONTEXT *ectx) {
     return tool_rc_success;
 }
 
-tool_rc process_outputs(void) {
+static tool_rc process_outputs(void) {
 
     bool result = files_save_ecc_point(ctx.K, ctx.eccpoint_K_data_path);
     if (!result) {

--- a/tools/tpm2_createek.c
+++ b/tools/tpm2_createek.c
@@ -419,7 +419,7 @@ out:
     return rc;
 }
 
-void tpm2_onexit(void) {
+void tpm2_tool_onexit(void) {
 
     tpm2_hierarchy_pdata_free(&ctx.objdata);
 }

--- a/tools/tpm2_createpolicy.c
+++ b/tools/tpm2_createpolicy.c
@@ -164,7 +164,7 @@ tool_rc tpm2_tool_onrun(ESYS_CONTEXT *ectx, tpm2_option_flags flags) {
     return parse_policy_type_specific_command(ectx);
 }
 
-void tpm2_onexit(void) {
+void tpm2_tool_onexit(void) {
 
     free(pctx.common_policy_options.policy_digest);
 }

--- a/tools/tpm2_createprimary.c
+++ b/tools/tpm2_createprimary.c
@@ -274,7 +274,7 @@ tool_rc tpm2_tool_onstop(ESYS_CONTEXT *ectx) {
     return tpm2_session_close(&ctx.parent.session);
 }
 
-void tpm2_onexit(void) {
+void tpm2_tool_onexit(void) {
 
     tpm2_hierarchy_pdata_free(&ctx.objdata);
 }

--- a/tools/tpm2_ecdhkeygen.c
+++ b/tools/tpm2_ecdhkeygen.c
@@ -69,7 +69,7 @@ static tool_rc check_options(void) {
     return tool_rc_success;
 }
 
-tool_rc process_outputs(void) {
+static tool_rc process_outputs(void) {
 
     bool result = files_save_ecc_point(ctx.Q, ctx.ecdh_pub_path);
     if (!result) {

--- a/tools/tpm2_ecdhzgen.c
+++ b/tools/tpm2_ecdhzgen.c
@@ -75,7 +75,7 @@ static tool_rc check_options(void) {
     return tool_rc_success;
 }
 
-tool_rc process_inputs(ESYS_CONTEXT *ectx) {
+static tool_rc process_inputs(ESYS_CONTEXT *ectx) {
 
     tool_rc  rc = tpm2_util_object_load_auth(ectx, ctx.ecc_key.ctx_path,
         ctx.ecc_key.auth_str, &ctx.ecc_key.object, false,

--- a/tools/tpm2_ecephermal.c
+++ b/tools/tpm2_ecephermal.c
@@ -97,7 +97,7 @@ static tool_rc check_options(void) {
     return tool_rc_success;
 }
 
-tool_rc process_outputs(void) {
+static tool_rc process_outputs(void) {
 
     FILE *fp = fopen(ctx.commit_counter_path, "wb");
     bool result = files_write_16(fp, ctx.counter);

--- a/tools/tpm2_getcommandauditdigest.c
+++ b/tools/tpm2_getcommandauditdigest.c
@@ -166,7 +166,7 @@ static tool_rc process_inputs(ESYS_CONTEXT *ectx) {
     return tool_rc_success;
 }
 
-tool_rc process_outputs(ESYS_CONTEXT *ectx) {
+static tool_rc process_outputs(ESYS_CONTEXT *ectx) {
 
     UNUSED(ectx);
 

--- a/tools/tpm2_getsessionauditdigest.c
+++ b/tools/tpm2_getsessionauditdigest.c
@@ -188,7 +188,7 @@ static tool_rc process_inputs(ESYS_CONTEXT *ectx) {
     return tool_rc_success;
 }
 
-tool_rc process_outputs(ESYS_CONTEXT *ectx) {
+static tool_rc process_outputs(ESYS_CONTEXT *ectx) {
 
     UNUSED(ectx);
 

--- a/tools/tpm2_hierarchycontrol.c
+++ b/tools/tpm2_hierarchycontrol.c
@@ -60,7 +60,7 @@ static tool_rc hierarchycontrol(ESYS_CONTEXT *ectx) {
     return rc;
 }
 
-bool on_arg(int argc, char **argv) {
+static bool on_arg(int argc, char **argv) {
 
     switch (argc) {
     case 2:

--- a/tools/tpm2_policyauthorizenv.c
+++ b/tools/tpm2_policyauthorizenv.c
@@ -80,7 +80,8 @@ bool tpm2_tool_onstart(tpm2_options **opts) {
     return *opts != NULL;
 }
 
-bool is_input_option_args_valid(void) {
+#if 0
+static bool is_input_option_args_valid(void) {
 
     if (!ctx.session_path) {
         LOG_ERR("Must specify -S session file.");
@@ -94,6 +95,7 @@ bool is_input_option_args_valid(void) {
 
     return true;
 }
+#endif
 
 tool_rc tpm2_tool_onrun(ESYS_CONTEXT *ectx, tpm2_option_flags flags) {
 

--- a/tools/tpm2_policyauthvalue.c
+++ b/tools/tpm2_policyauthvalue.c
@@ -46,7 +46,7 @@ bool tpm2_tool_onstart(tpm2_options **opts) {
     return *opts != NULL;
 }
 
-bool is_input_option_args_valid(void) {
+static bool is_input_option_args_valid(void) {
 
     if (!ctx.session_path) {
         LOG_ERR("Must specify -S session file.");

--- a/tools/tpm2_policycommandcode.c
+++ b/tools/tpm2_policycommandcode.c
@@ -31,7 +31,7 @@ static bool on_option(char key, char *value) {
     return true;
 }
 
-bool is_input_option_args_valid(void) {
+static bool is_input_option_args_valid(void) {
 
     if (!ctx.session_path) {
         LOG_ERR("Must specify -S session file.");
@@ -41,7 +41,7 @@ bool is_input_option_args_valid(void) {
     return true;
 }
 
-bool on_arg(int argc, char **argv) {
+static bool on_arg(int argc, char **argv) {
 
     if (argc > 1) {
         LOG_ERR("Specify only the TPM2 command code.");

--- a/tools/tpm2_policycphash.c
+++ b/tools/tpm2_policycphash.c
@@ -64,7 +64,7 @@ bool tpm2_tool_onstart(tpm2_options **opts) {
     return *opts != NULL;
 }
 
-bool is_input_option_args_valid(void) {
+static bool is_input_option_args_valid(void) {
 
     if (!ctx.session_file_path) {
         LOG_ERR("Must specify -S session file.");

--- a/tools/tpm2_policyduplicationselect.c
+++ b/tools/tpm2_policyduplicationselect.c
@@ -43,7 +43,7 @@ static bool on_option(char key, char *value) {
     return true;
 }
 
-bool is_input_option_args_valid(void) {
+static bool is_input_option_args_valid(void) {
 
     if (!ctx.session_path) {
         LOG_ERR("Must specify -S session file.");

--- a/tools/tpm2_policylocality.c
+++ b/tools/tpm2_policylocality.c
@@ -32,7 +32,7 @@ static bool on_option(char key, char *value) {
     return true;
 }
 
-bool is_input_option_args_valid(void) {
+static bool is_input_option_args_valid(void) {
 
     if (!ctx.session_path) {
         LOG_ERR("Must specify -S session file.");
@@ -42,7 +42,7 @@ bool is_input_option_args_valid(void) {
     return true;
 }
 
-bool on_arg(int argc, char **argv) {
+static bool on_arg(int argc, char **argv) {
 
     if (argc > 1) {
         LOG_ERR("Specify only the TPM2 locality.");

--- a/tools/tpm2_policynamehash.c
+++ b/tools/tpm2_policynamehash.c
@@ -67,7 +67,7 @@ bool tpm2_tool_onstart(tpm2_options **opts) {
     return *opts != NULL;
 }
 
-bool is_input_option_args_valid(void) {
+static bool is_input_option_args_valid(void) {
 
     if (!ctx.session_file_path) {
         LOG_ERR("Must specify -S session file.");

--- a/tools/tpm2_policynv.c
+++ b/tools/tpm2_policynv.c
@@ -157,7 +157,8 @@ bool tpm2_tool_onstart(tpm2_options **opts) {
     return *opts != NULL;
 }
 
-bool is_input_option_args_valid(void) {
+#if 0
+static bool is_input_option_args_valid(void) {
 
     if (!ctx.session_path) {
         LOG_ERR("Must specify -S session file.");
@@ -170,6 +171,7 @@ bool is_input_option_args_valid(void) {
     }
     return true;
 }
+#endif
 
 tool_rc tpm2_tool_onrun(ESYS_CONTEXT *ectx, tpm2_option_flags flags) {
 

--- a/tools/tpm2_policynvwritten.c
+++ b/tools/tpm2_policynvwritten.c
@@ -34,7 +34,7 @@ static bool on_option(char key, char *value) {
     return true;
 }
 
-bool is_input_option_args_valid(void) {
+static bool is_input_option_args_valid(void) {
 
     if (!ctx.session_path) {
         LOG_ERR("Must specify -S session file.");
@@ -44,7 +44,7 @@ bool is_input_option_args_valid(void) {
     return true;
 }
 
-bool on_arg(int argc, char **argv) {
+static bool on_arg(int argc, char **argv) {
 
     if (argc > 1) {
         LOG_ERR("Specify single NV written SET/CLEAR operation as s|c|0|1.");

--- a/tools/tpm2_policyor.c
+++ b/tools/tpm2_policyor.c
@@ -77,7 +77,7 @@ bool tpm2_tool_onstart(tpm2_options **opts) {
     return *opts != NULL;
 }
 
-bool is_input_option_args_valid(void) {
+static bool is_input_option_args_valid(void) {
 
     if (!ctx.session_path) {
         LOG_ERR("Must specify -S session file.");

--- a/tools/tpm2_policypassword.c
+++ b/tools/tpm2_policypassword.c
@@ -46,7 +46,7 @@ bool tpm2_tool_onstart(tpm2_options **opts) {
     return *opts != NULL;
 }
 
-bool is_input_option_args_valid(void) {
+static bool is_input_option_args_valid(void) {
 
     if (!ctx.session_path) {
         LOG_ERR("Must specify -S session file.");

--- a/tools/tpm2_policysecret.c
+++ b/tools/tpm2_policysecret.c
@@ -85,7 +85,7 @@ static bool on_option(char key, char *value) {
     return result;
 }
 
-bool on_arg(int argc, char **argv) {
+static bool on_arg(int argc, char **argv) {
 
     if (argc > 1) {
         LOG_ERR("Specify a single auth value");
@@ -122,7 +122,7 @@ bool tpm2_tool_onstart(tpm2_options **opts) {
     return *opts != NULL;
 }
 
-bool is_input_option_args_valid(void) {
+static bool is_input_option_args_valid(void) {
 
     if (!ctx.extended_session_path) {
         LOG_ERR("Must specify -S session file.");

--- a/tools/tpm2_policysigned.c
+++ b/tools/tpm2_policysigned.c
@@ -136,7 +136,7 @@ bool tpm2_tool_onstart(tpm2_options **opts) {
     return *opts != NULL;
 }
 
-bool is_input_option_args_valid(void) {
+static bool is_input_option_args_valid(void) {
 
     if (!ctx.context_arg) {
             LOG_ERR("Must specify verifying key context -c.");

--- a/tools/tpm2_policytemplate.c
+++ b/tools/tpm2_policytemplate.c
@@ -67,7 +67,7 @@ bool tpm2_tool_onstart(tpm2_options **opts) {
     return *opts != NULL;
 }
 
-bool is_input_option_args_valid(void) {
+static bool is_input_option_args_valid(void) {
 
     if (!ctx.session_file_path) {
         LOG_ERR("Must specify -S session file.");

--- a/tools/tpm2_policyticket.c
+++ b/tools/tpm2_policyticket.c
@@ -71,7 +71,7 @@ bool tpm2_tool_onstart(tpm2_options **opts) {
     return *opts != NULL;
 }
 
-bool is_input_option_args_valid(void) {
+static bool is_input_option_args_valid(void) {
 
     if (!ctx.session_path) {
         LOG_ERR("Must specify -S session file.");

--- a/tools/tpm2_setcommandauditstatus.c
+++ b/tools/tpm2_setcommandauditstatus.c
@@ -56,7 +56,7 @@ static bool on_option(char key, char *value) {
     return true;
 }
 
-bool on_arg(int argc, char **argv) {
+static bool on_arg(int argc, char **argv) {
 
     if (argc > 1 || !argc) {
         LOG_ERR("Specify a TPM2 command to add/ remove from audit list.");

--- a/tools/tpm2_zgen2phase.c
+++ b/tools/tpm2_zgen2phase.c
@@ -154,7 +154,7 @@ static tool_rc process_inputs(ESYS_CONTEXT *ectx) {
     return tool_rc_success;
 }
 
-tool_rc process_outputs(void) {
+static tool_rc process_outputs(void) {
 
     bool result = files_save_ecc_point(ctx.Z1, ctx.output_z1_path);
     if (!result) {


### PR DESCRIPTION
A few of the program had various helper functions exported; this makes them all static so that they do not conflict with each other when combined in a busybox style executable.

It also identified that `tools/tpm2_policynv.c` and `tools/tpm2_policyauthorizenv.c` do not use their `is_input_option_args_valid()` function, and that a few tools had `tpm2_onexit()` functions where it seems like `tpm2_tool_onexit()` was intended.