### PR TITLE
tpm2 print enhancements

### DIFF
--- a/lib/files.c
+++ b/lib/files.c
@@ -753,6 +753,8 @@ LOAD_TYPE(TPM2B_ECC_POINT, ecc_point)
 
 LOAD_TYPE(TPM2B_ECC_PARAMETER, ecc_parameter)
 
+LOAD_TYPE_FILE(TPMS_ATTEST, attest)
+
 tool_rc files_tpm2b_attest_to_tpms_attest(TPM2B_ATTEST *quoted, TPMS_ATTEST *attest) {
 
     size_t offset = 0;

--- a/lib/files.h
+++ b/lib/files.h
@@ -540,4 +540,17 @@ bool files_read_bytes(FILE *out, UINT8 data[], size_t size);
  */
 tool_rc files_tpm2b_attest_to_tpms_attest(TPM2B_ATTEST *quoted, TPMS_ATTEST *attest);
 
+/**
+ * Loads a TPMS_ATTEST from disk.
+ * @param f
+ *  The file to load.
+ * @param path
+ *  The path to load from.
+ * @param attest
+ *  The attest structure to fill up.
+ * @return
+ *  True on success, false otherwise.
+ */
+bool files_load_attest_file(FILE *f, const char *path, TPMS_ATTEST *attest);
+
 #endif /* FILES_H */

--- a/lib/tpm2_util.c
+++ b/lib/tpm2_util.c
@@ -248,36 +248,6 @@ void tpm2_util_hexdump(const BYTE *data, size_t len) {
     tpm2_util_hexdump2(stdout, data, len);
 }
 
-bool tpm2_util_hexdump_file(FILE *fd, size_t len) {
-    BYTE* buff = (BYTE*) malloc(len);
-    if (!buff) {
-        LOG_ERR("malloc() failed");
-        return false;
-    }
-
-    bool res = files_read_bytes(fd, buff, len);
-    if (!res) {
-        LOG_ERR("Failed to read file");
-        free(buff);
-        return false;
-    }
-
-    tpm2_util_hexdump(buff, len);
-
-    free(buff);
-    return true;
-}
-
-bool tpm2_util_print_tpm2b_file(FILE *fd) {
-    UINT16 len;
-    bool res = files_read_16(fd, &len);
-    if (!res) {
-        LOG_ERR("File read failed");
-        return false;
-    }
-    return tpm2_util_hexdump_file(fd, len);
-}
-
 bool tpm2_util_is_big_endian(void) {
 
     uint32_t test_word;

--- a/lib/tpm2_util.h
+++ b/lib/tpm2_util.h
@@ -207,21 +207,6 @@ void tpm2_util_hexdump2(FILE *f, const BYTE *data, size_t len);
 bool tpm2_util_bin_from_hex_or_file(const char *input, UINT16 *len, BYTE *buffer);
 
 /**
- * Prints a file as a hex string to stdout if quiet mode
- * is not enabled.
- * ie no -Q option.
- *
- * @param fd
- *  A readable open file.
- * @param len
- *  The length of the data to read and print.
- * @return
- *  true if len bytes were successfully read and printed,
- *  false otherwise
- */
-bool tpm2_util_hexdump_file(FILE *fd, size_t len);
-
-/**
  * Prints a TPM2B as a hex dump respecting the -Q option
  * to stdout.
  *
@@ -257,13 +242,6 @@ static inline bool tpm2_util_is_pcr_select_bit_set(
         TPMS_PCR_SELECTION *pcr_selection, UINT32 pcr) {
     return (pcr_selection->pcrSelect[((pcr) / 8)] & (1 << ((pcr) % 8)));
 }
-
-/**
- * Reads a TPM2B object from FILE* and prints data in hex.
- * @param fd
- *  A readable open file.
- */
-bool tpm2_util_print_tpm2b_file(FILE *fd);
 
 /**
  * Checks if the host is big endian

--- a/test/integration/tests/print.sh
+++ b/test/integration/tests/print.sh
@@ -81,4 +81,13 @@ with open("$print_file") as fd:
     print("OK")
 pyscript
 
+# negative testing
+trap - ERR
+
+tpm2_print $quote_file
+if [ $? -eq 0 ]; then
+  echo "Expected tpm2_print without -t to fail"
+  exit 1
+fi
+
 exit 0

--- a/tools/misc/tpm2_print.c
+++ b/tools/misc/tpm2_print.c
@@ -409,6 +409,17 @@ tool_rc tpm2_tool_onrun(ESYS_CONTEXT *ectx, tpm2_option_flags flags) {
 
     FILE* fd = stdin;
 
+    if (!ctx.file.handler) {
+        /*
+         * TODO: This could be automated by each
+         * type having an interrogation function. If it passes,
+         * then use the associated handler. For now, make -t
+         * mandatory.
+         */
+        LOG_ERR("Must specify -t/--type");
+        return tool_rc_general_error;
+    }
+
     if (ctx.file.path) {
         LOG_INFO("Reading from file %s", ctx.file.path);
         fd = fopen(ctx.file.path, "rb");


### PR DESCRIPTION
- Fix missing -t option causes segfault #2078
- Cleanup TPMS attest parsing, no need to manually walk it with an fread, just use libmu.