### PR TITLE
man/tpm2_create: fix seal data size to 128 from 256

### DIFF
--- a/man/tpm2_create.1.md
+++ b/man/tpm2_create.1.md
@@ -12,7 +12,7 @@
 
 **tpm2_create**(1) - Create a child object. The object can either be a key or
 a sealing object. A sealing object allows to seal user data to the TPM, with a
-maximum size of 256 bytes. Additionally it will load the created object if the
+maximum size of 128 bytes. Additionally it will load the created object if the
 **-c** is specified.
 
 # OPTIONS


### PR DESCRIPTION
The seal data was incorrectly stated at 256 bytes, when it is limited by
the spec to 128 bytes.

See section 12.7 of:
  - https://trustedcomputinggroup.org/wp-content/uploads/TCG_TPM2_r1p59_Part3_Commands_pub.pdf

Fixes: #2083

Signed-off-by: William Roberts <william.c.roberts@intel.com>