### PR TITLE
tpm2_eventlog: compute PCR values based on the events

### DIFF
--- a/lib/tpm2_eventlog.c
+++ b/lib/tpm2_eventlog.c
@@ -52,11 +52,28 @@ bool foreach_digest2(tpm2_eventlog_ctx_t * ctx, int pcrId, TCG_DIGEST2 const *di
         }
 
         uint8_t * pcr = NULL;
+        if (pcrId > TPM2_MAX_PCRS) {
+            LOG_ERR("PCR%d > max %d", pcrId, TPM2_MAX_PCRS);
+        } else
         if (alg == TPM2_ALG_SHA1) {
             pcr = ctx->sha1_pcrs[pcrId];
+            ctx->sha1_used |= (1 << pcrId);
         } else
         if (alg == TPM2_ALG_SHA256) {
             pcr = ctx->sha256_pcrs[pcrId];
+            ctx->sha256_used |= (1 << pcrId);
+        } else
+        if (alg == TPM2_ALG_SHA384) {
+            pcr = ctx->sha384_pcrs[pcrId];
+            ctx->sha384_used |= (1 << pcrId);
+        } else
+        if (alg == TPM2_ALG_SHA512) {
+            pcr = ctx->sha512_pcrs[pcrId];
+            ctx->sha512_used |= (1 << pcrId);
+        } else
+        if (alg == TPM2_ALG_SM3_256) {
+            pcr = ctx->sm3_256_pcrs[pcrId];
+            ctx->sm3_256_used |= (1 << pcrId);
         } else {
             LOG_WARN("PCR%d algorithm %d unsupported", pcrId, alg);
         }

--- a/lib/tpm2_eventlog.c
+++ b/lib/tpm2_eventlog.c
@@ -28,7 +28,7 @@ bool digest2_accumulator_callback(TCG_DIGEST2 const *digest, size_t size,
  * hold the digest. The size of the digest is passed to the callback in the
  * 'size' parameter.
  */
-bool foreach_digest2(tpm2_eventlog_ctx_t * ctx, int pcrId, TCG_DIGEST2 const *digest, size_t count, size_t size) {
+bool foreach_digest2(tpm2_eventlog_ctx_t *ctx, unsigned pcr_index, TCG_DIGEST2 const *digest, size_t count, size_t size) {
 
     if (digest == NULL) {
         LOG_ERR("digest cannot be NULL");
@@ -51,35 +51,30 @@ bool foreach_digest2(tpm2_eventlog_ctx_t * ctx, int pcrId, TCG_DIGEST2 const *di
             return false;
         }
 
-        uint8_t * pcr = NULL;
-        if (pcrId > TPM2_MAX_PCRS) {
-            LOG_ERR("PCR%d > max %d", pcrId, TPM2_MAX_PCRS);
-        } else
-        if (alg == TPM2_ALG_SHA1) {
-            pcr = ctx->sha1_pcrs[pcrId];
-            ctx->sha1_used |= (1 << pcrId);
-        } else
-        if (alg == TPM2_ALG_SHA256) {
-            pcr = ctx->sha256_pcrs[pcrId];
-            ctx->sha256_used |= (1 << pcrId);
-        } else
-        if (alg == TPM2_ALG_SHA384) {
-            pcr = ctx->sha384_pcrs[pcrId];
-            ctx->sha384_used |= (1 << pcrId);
-        } else
-        if (alg == TPM2_ALG_SHA512) {
-            pcr = ctx->sha512_pcrs[pcrId];
-            ctx->sha512_used |= (1 << pcrId);
-        } else
-        if (alg == TPM2_ALG_SM3_256) {
-            pcr = ctx->sm3_256_pcrs[pcrId];
-            ctx->sm3_256_used |= (1 << pcrId);
+        uint8_t *pcr = NULL;
+        if (pcr_index > TPM2_MAX_PCRS) {
+            LOG_ERR("PCR%d > max %d", pcr_index, TPM2_MAX_PCRS);
+        } else if (alg == TPM2_ALG_SHA1) {
+            pcr = ctx->sha1_pcrs[pcr_index];
+            ctx->sha1_used |= (1 << pcr_index);
+        } else if (alg == TPM2_ALG_SHA256) {
+            pcr = ctx->sha256_pcrs[pcr_index];
+            ctx->sha256_used |= (1 << pcr_index);
+        } else if (alg == TPM2_ALG_SHA384) {
+            pcr = ctx->sha384_pcrs[pcr_index];
+            ctx->sha384_used |= (1 << pcr_index);
+        } else if (alg == TPM2_ALG_SHA512) {
+            pcr = ctx->sha512_pcrs[pcr_index];
+            ctx->sha512_used |= (1 << pcr_index);
+        } else if (alg == TPM2_ALG_SM3_256) {
+            pcr = ctx->sm3_256_pcrs[pcr_index];
+            ctx->sm3_256_used |= (1 << pcr_index);
         } else {
-            LOG_WARN("PCR%d algorithm %d unsupported", pcrId, alg);
+            LOG_WARN("PCR%d algorithm %d unsupported", pcr_index, alg);
         }
 
         if (pcr && !tpm2_openssl_pcr_extend(alg, pcr, digest->Digest, alg_size)) {
-            LOG_ERR("PCR%d extend failed", pcrId);
+            LOG_ERR("PCR%d extend failed", pcr_index);
             return false;
         }
 
@@ -201,7 +196,7 @@ bool parse_event2(TCG_EVENT_HEADER2 const *eventhdr, size_t buf_size,
     return true;
 }
 
-bool foreach_event2(tpm2_eventlog_ctx_t * ctx, TCG_EVENT_HEADER2 const *eventhdr_start, size_t size) {
+bool foreach_event2(tpm2_eventlog_ctx_t *ctx, TCG_EVENT_HEADER2 const *eventhdr_start, size_t size) {
 
     if (eventhdr_start == NULL) {
         LOG_ERR("invalid parameter");

--- a/lib/tpm2_eventlog.c
+++ b/lib/tpm2_eventlog.c
@@ -28,7 +28,7 @@ bool digest2_accumulator_callback(TCG_DIGEST2 const *digest, size_t size,
  * hold the digest. The size of the digest is passed to the callback in the
  * 'size' parameter.
  */
-bool foreach_digest2(tpm2_eventlog_ctx_t *ctx, unsigned pcr_index, TCG_DIGEST2 const *digest, size_t count, size_t size) {
+bool foreach_digest2(tpm2_eventlog_context *ctx, unsigned pcr_index, TCG_DIGEST2 const *digest, size_t count, size_t size) {
 
     if (digest == NULL) {
         LOG_ERR("digest cannot be NULL");
@@ -168,7 +168,7 @@ bool parse_event2(TCG_EVENT_HEADER2 const *eventhdr, size_t buf_size,
     }
     *event_size = sizeof(*eventhdr);
 
-    tpm2_eventlog_ctx_t ctx = {
+    tpm2_eventlog_context ctx = {
         .data = digests_size,
         .digest2_cb = digest2_accumulator_callback,
     };
@@ -196,7 +196,7 @@ bool parse_event2(TCG_EVENT_HEADER2 const *eventhdr, size_t buf_size,
     return true;
 }
 
-bool foreach_event2(tpm2_eventlog_ctx_t *ctx, TCG_EVENT_HEADER2 const *eventhdr_start, size_t size) {
+bool foreach_event2(tpm2_eventlog_context *ctx, TCG_EVENT_HEADER2 const *eventhdr_start, size_t size) {
 
     if (eventhdr_start == NULL) {
         LOG_ERR("invalid parameter");
@@ -334,7 +334,7 @@ bool specid_event(TCG_EVENT const *event, size_t size,
     return true;
 }
 
-bool parse_eventlog(tpm2_eventlog_ctx_t *ctx, BYTE const *eventlog, size_t size) {
+bool parse_eventlog(tpm2_eventlog_context *ctx, BYTE const *eventlog, size_t size) {
 
     TCG_EVENT_HEADER2 *next;
     TCG_EVENT *event = (TCG_EVENT*)eventlog;

--- a/lib/tpm2_eventlog.c
+++ b/lib/tpm2_eventlog.c
@@ -223,11 +223,9 @@ bool foreach_event2(tpm2_eventlog_ctx_t * ctx, TCG_EVENT_HEADER2 const *eventhdr
         }
 
         /* digest callback foreach digest */
-        if (ctx->digest2_cb != NULL) {
-            ret = foreach_digest2(ctx, eventhdr->PCRIndex, eventhdr->Digests, eventhdr->DigestCount, digests_size);
-            if (ret != true) {
-                return false;
-            }
+        ret = foreach_digest2(ctx, eventhdr->PCRIndex, eventhdr->Digests, eventhdr->DigestCount, digests_size);
+        if (ret != true) {
+            return false;
         }
 
         ret = parse_event2body(event, eventhdr->EventType);

--- a/lib/tpm2_eventlog.h
+++ b/lib/tpm2_eventlog.h
@@ -18,7 +18,7 @@ typedef bool (*EVENT2DATA_CALLBACK)(TCG_EVENT2 const *event, UINT32 type,
 typedef bool (*SPECID_CALLBACK)(TCG_EVENT const *event, void *data);
 
 typedef struct {
-    void * data;
+    void *data;
     SPECID_CALLBACK specid_cb;
     EVENT2_CALLBACK event2hdr_cb;
     DIGEST2_CALLBACK digest2_cb;
@@ -39,7 +39,8 @@ bool digest2_accumulator_callback(TCG_DIGEST2 const *digest, size_t size,
                                   void *data);
 
 bool parse_event2body(TCG_EVENT2 const *event, UINT32 type);
-bool foreach_digest2(tpm2_eventlog_ctx_t *ctx, int pcrId, TCG_DIGEST2 const *event_hdr, size_t count, size_t size);
+bool foreach_digest2(tpm2_eventlog_ctx_t *ctx, unsigned pcr_index,
+                     TCG_DIGEST2 const *event_hdr, size_t count, size_t size);
 bool parse_event2(TCG_EVENT_HEADER2 const *eventhdr, size_t buf_size,
                   size_t *event_size, size_t *digests_size);
 bool foreach_event2(tpm2_eventlog_ctx_t *ctx, TCG_EVENT_HEADER2 const *eventhdr_start, size_t size);

--- a/lib/tpm2_eventlog.h
+++ b/lib/tpm2_eventlog.h
@@ -23,8 +23,16 @@ typedef struct {
     EVENT2_CALLBACK event2hdr_cb;
     DIGEST2_CALLBACK digest2_cb;
     EVENT2DATA_CALLBACK event2_cb;
+    uint32_t sha1_used;
+    uint32_t sha256_used;
+    uint32_t sha384_used;
+    uint32_t sha512_used;
+    uint32_t sm3_256_used;
     uint8_t sha1_pcrs[TPM2_MAX_PCRS][TPM2_SHA1_DIGEST_SIZE];
     uint8_t sha256_pcrs[TPM2_MAX_PCRS][TPM2_SHA256_DIGEST_SIZE];
+    uint8_t sha384_pcrs[TPM2_MAX_PCRS][TPM2_SHA384_DIGEST_SIZE];
+    uint8_t sha512_pcrs[TPM2_MAX_PCRS][TPM2_SHA512_DIGEST_SIZE];
+    uint8_t sm3_256_pcrs[TPM2_MAX_PCRS][TPM2_SM3_256_DIGEST_SIZE];
 } tpm2_eventlog_ctx_t;
 
 bool digest2_accumulator_callback(TCG_DIGEST2 const *digest, size_t size,

--- a/lib/tpm2_eventlog.h
+++ b/lib/tpm2_eventlog.h
@@ -33,18 +33,18 @@ typedef struct {
     uint8_t sha384_pcrs[TPM2_MAX_PCRS][TPM2_SHA384_DIGEST_SIZE];
     uint8_t sha512_pcrs[TPM2_MAX_PCRS][TPM2_SHA512_DIGEST_SIZE];
     uint8_t sm3_256_pcrs[TPM2_MAX_PCRS][TPM2_SM3_256_DIGEST_SIZE];
-} tpm2_eventlog_ctx_t;
+} tpm2_eventlog_context;
 
 bool digest2_accumulator_callback(TCG_DIGEST2 const *digest, size_t size,
                                   void *data);
 
 bool parse_event2body(TCG_EVENT2 const *event, UINT32 type);
-bool foreach_digest2(tpm2_eventlog_ctx_t *ctx, unsigned pcr_index,
+bool foreach_digest2(tpm2_eventlog_context *ctx, unsigned pcr_index,
                      TCG_DIGEST2 const *event_hdr, size_t count, size_t size);
 bool parse_event2(TCG_EVENT_HEADER2 const *eventhdr, size_t buf_size,
                   size_t *event_size, size_t *digests_size);
-bool foreach_event2(tpm2_eventlog_ctx_t *ctx, TCG_EVENT_HEADER2 const *eventhdr_start, size_t size);
+bool foreach_event2(tpm2_eventlog_context *ctx, TCG_EVENT_HEADER2 const *eventhdr_start, size_t size);
 bool specid_event(TCG_EVENT const *event, size_t size, TCG_EVENT_HEADER2 **next);
-bool parse_eventlog(tpm2_eventlog_ctx_t *ctx, BYTE const *eventlog, size_t size);
+bool parse_eventlog(tpm2_eventlog_context *ctx, BYTE const *eventlog, size_t size);
 
 #endif

--- a/lib/tpm2_eventlog.h
+++ b/lib/tpm2_eventlog.h
@@ -17,23 +17,25 @@ typedef bool (*EVENT2DATA_CALLBACK)(TCG_EVENT2 const *event, UINT32 type,
                                     void *data);
 typedef bool (*SPECID_CALLBACK)(TCG_EVENT const *event, void *data);
 
+typedef struct {
+    void * data;
+    SPECID_CALLBACK specid_cb;
+    EVENT2_CALLBACK event2hdr_cb;
+    DIGEST2_CALLBACK digest2_cb;
+    EVENT2DATA_CALLBACK event2_cb;
+    uint8_t sha1_pcrs[TPM2_MAX_PCRS][TPM2_SHA1_DIGEST_SIZE];
+    uint8_t sha256_pcrs[TPM2_MAX_PCRS][TPM2_SHA256_DIGEST_SIZE];
+} tpm2_eventlog_ctx_t;
+
 bool digest2_accumulator_callback(TCG_DIGEST2 const *digest, size_t size,
                                   void *data);
 
 bool parse_event2body(TCG_EVENT2 const *event, UINT32 type);
-bool foreach_digest2(TCG_DIGEST2 const *event_hdr, size_t count, size_t size,
-                     DIGEST2_CALLBACK callback, void *data);
+bool foreach_digest2(tpm2_eventlog_ctx_t *ctx, int pcrId, TCG_DIGEST2 const *event_hdr, size_t count, size_t size);
 bool parse_event2(TCG_EVENT_HEADER2 const *eventhdr, size_t buf_size,
                   size_t *event_size, size_t *digests_size);
-bool foreach_event2(TCG_EVENT_HEADER2 const *eventhdr_start, size_t size,
-                    EVENT2_CALLBACK event2hdr_cb,
-                    DIGEST2_CALLBACK digest2_cb,
-                    EVENT2DATA_CALLBACK event2_cb, void *data);
+bool foreach_event2(tpm2_eventlog_ctx_t *ctx, TCG_EVENT_HEADER2 const *eventhdr_start, size_t size);
 bool specid_event(TCG_EVENT const *event, size_t size, TCG_EVENT_HEADER2 **next);
-bool parse_eventlog(BYTE const *eventlog, size_t size,
-                    SPECID_CALLBACK specid_cb,
-                    EVENT2_CALLBACK event2hdr_cb,
-                    DIGEST2_CALLBACK digest2_cb,
-                    EVENT2DATA_CALLBACK event2_cb, void *data);
+bool parse_eventlog(tpm2_eventlog_ctx_t *ctx, BYTE const *eventlog, size_t size);
 
 #endif

--- a/lib/tpm2_eventlog_yaml.c
+++ b/lib/tpm2_eventlog_yaml.c
@@ -407,18 +407,59 @@ static void yaml_eventlog_pcrs(tpm2_eventlog_ctx_t *ctx) {
 
     tpm2_tool_output("pcrs:\n");
 
-    tpm2_tool_output("  sha1:\n");
-    for(unsigned i = 0 ; i < TPM2_MAX_PCRS ; i++) {
-        bytes_to_str(ctx->sha1_pcrs[i], sizeof(ctx->sha1_pcrs[i]),
-            hexstr, sizeof(hexstr));
-        tpm2_tool_output("    %2d : 0x%s\n", i, hexstr);
+    if (ctx->sha1_used != 0) {
+        tpm2_tool_output("  sha1:\n");
+        for(unsigned i = 0 ; i < TPM2_MAX_PCRS ; i++) {
+            if ((ctx->sha1_used & (1 << i)) == 0)
+                continue;
+            bytes_to_str(ctx->sha1_pcrs[i], sizeof(ctx->sha1_pcrs[i]),
+                hexstr, sizeof(hexstr));
+            tpm2_tool_output("    %2d : 0x%s\n", i, hexstr);
+        }
     }
 
-    tpm2_tool_output("  sha256:\n");
-    for(unsigned i = 0 ; i < TPM2_MAX_PCRS ; i++) {
-        bytes_to_str(ctx->sha256_pcrs[i], sizeof(ctx->sha256_pcrs[i]),
-            hexstr, sizeof(hexstr));
-        tpm2_tool_output("    %2d : 0x%s\n", i, hexstr);
+    if (ctx->sha256_used != 0) {
+        tpm2_tool_output("  sha256:\n");
+        for(unsigned i = 0 ; i < TPM2_MAX_PCRS ; i++) {
+            if ((ctx->sha256_used & (1 << i)) == 0)
+                continue;
+            bytes_to_str(ctx->sha256_pcrs[i], sizeof(ctx->sha256_pcrs[i]),
+                hexstr, sizeof(hexstr));
+            tpm2_tool_output("    %2d : 0x%s\n", i, hexstr);
+        }
+    }
+
+    if (ctx->sha384_used != 0) {
+        tpm2_tool_output("  sha384:\n");
+        for(unsigned i = 0 ; i < TPM2_MAX_PCRS ; i++) {
+            if ((ctx->sha384_used & (1 << i)) == 0)
+                continue;
+            bytes_to_str(ctx->sha384_pcrs[i], sizeof(ctx->sha384_pcrs[i]),
+                hexstr, sizeof(hexstr));
+            tpm2_tool_output("    %2d : 0x%s\n", i, hexstr);
+        }
+    }
+
+    if (ctx->sha512_used != 0) {
+        tpm2_tool_output("  sha512:\n");
+        for(unsigned i = 0 ; i < TPM2_MAX_PCRS ; i++) {
+            if ((ctx->sha512_used & (1 << i)) == 0)
+                continue;
+            bytes_to_str(ctx->sha512_pcrs[i], sizeof(ctx->sha512_pcrs[i]),
+                hexstr, sizeof(hexstr));
+            tpm2_tool_output("    %2d : 0x%s\n", i, hexstr);
+        }
+    }
+
+    if (ctx->sm3_256_used != 0) {
+        tpm2_tool_output("  sm3_256:\n");
+        for(unsigned i = 0 ; i < TPM2_MAX_PCRS ; i++) {
+            if ((ctx->sm3_256_used & (1 << i)) == 0)
+                continue;
+            bytes_to_str(ctx->sm3_256_pcrs[i], sizeof(ctx->sm3_256_pcrs[i]),
+                hexstr, sizeof(hexstr));
+            tpm2_tool_output("    %2d : 0x%s\n", i, hexstr);
+        }
     }
 }
 

--- a/lib/tpm2_eventlog_yaml.c
+++ b/lib/tpm2_eventlog_yaml.c
@@ -409,7 +409,7 @@ bool yaml_specid_callback(TCG_EVENT const *event, void *data) {
     return yaml_specid_event(event, count);
 }
 
-static void yaml_eventlog_pcrs(tpm2_eventlog_ctx_t *ctx) {
+static void yaml_eventlog_pcrs(tpm2_eventlog_context *ctx) {
 
     char hexstr[DIGEST_HEX_STRING_MAX] = { 0, };
 
@@ -474,7 +474,7 @@ static void yaml_eventlog_pcrs(tpm2_eventlog_ctx_t *ctx) {
 bool yaml_eventlog(UINT8 const *eventlog, size_t size) {
 
     size_t count = 0;
-    tpm2_eventlog_ctx_t ctx = {
+    tpm2_eventlog_context ctx = {
         .data = &count,
         .specid_cb = yaml_specid_callback,
         .event2hdr_cb = yaml_event2hdr_callback,

--- a/lib/tpm2_eventlog_yaml.c
+++ b/lib/tpm2_eventlog_yaml.c
@@ -93,10 +93,12 @@ void yaml_event2hdr(TCG_EVENT_HEADER2 const *eventhdr, size_t size) {
 
     (void)size;
 
-    tpm2_tool_output("  PCRIndex: %d\n", eventhdr->PCRIndex);
-    tpm2_tool_output("  EventType: %s\n",
-           eventtype_to_string(eventhdr->EventType));
-    tpm2_tool_output("  DigestCount: %d\n", eventhdr->DigestCount);
+    tpm2_tool_output("    PCRIndex: %d\n"
+                     "    EventType: %s\n"
+                     "    DigestCount: %d\n",
+                     eventhdr->PCRIndex,
+                     eventtype_to_string(eventhdr->EventType),
+                     eventhdr->DigestCount);
 
     return;
 }
@@ -106,12 +108,12 @@ void yaml_event2hdr(TCG_EVENT_HEADER2 const *eventhdr, size_t size) {
 bool yaml_digest2(TCG_DIGEST2 const *digest, size_t size) {
 
     char hexstr[DIGEST_HEX_STRING_MAX] = { 0, };
-
-    tpm2_tool_output("    - AlgorithmId: %s\n",
-           tpm2_alg_util_algtostr(digest->AlgorithmId,
-                                  tpm2_alg_util_flags_hash));
     bytes_to_str(digest->Digest, size, hexstr, sizeof(hexstr));
-    tpm2_tool_output("      Digest: %s\n", hexstr);
+
+    tpm2_tool_output("      - AlgorithmId: %s\n"
+                     "        Digest: %s\n",
+                     tpm2_alg_util_algtostr(digest->AlgorithmId, tpm2_alg_util_flags_hash),
+                     hexstr);
 
     return true;
 }
@@ -182,7 +184,7 @@ static bool yaml_uefi_post_code(const TCG_EVENT2 * const event)
     const size_t len = event->EventSize;
 
     tpm2_tool_output(
-        "  Event: '%.*s'\n",
+        "    Event: '%.*s'\n",
         (int) len,
         data);
     return true;
@@ -197,10 +199,12 @@ static bool yaml_uefi_var(UEFI_VARIABLE_DATA *data) {
     bool ret;
     char uuidstr[37] = { 0 };
 
-    tpm2_tool_output("  Event:\n");
     uuid_unparse_lower(data->VariableName, uuidstr);
-    tpm2_tool_output("    - VariableName: %s\n      UnicodeNameLength: %"
-                     PRIu64 "\n      VariableDataLength: %" PRIu64 "\n",
+
+    tpm2_tool_output("    Event:\n"
+                     "    - VariableName: %s\n"
+                     "      UnicodeNameLength: %"PRIu64"\n"
+                     "      VariableDataLength: %" PRIu64 "\n",
                      uuidstr, data->UnicodeNameLength,
                      data->VariableDataLength);
 
@@ -214,15 +218,17 @@ static bool yaml_uefi_var(UEFI_VARIABLE_DATA *data) {
 /* TCG PC Client FPF section 9.2.5 */
 bool yaml_uefi_platfwblob(UEFI_PLATFORM_FIRMWARE_BLOB *data) {
 
-    tpm2_tool_output("  Event:\n    - BlobBase: 0x%" PRIx64 "\n      "
-                     "BlobLength: 0x%" PRIx64 "\n", data->BlobBase,
+    tpm2_tool_output("    Event:\n"
+                     "      - BlobBase: 0x%" PRIx64 "\n"
+                     "        BlobLength: 0x%" PRIx64 "\n",
+                     data->BlobBase,
                      data->BlobLength);
     return true;
 }
 /* TCG PC Client PFP section 9.4.4 */
 bool yaml_uefi_action(UINT8 const *action, size_t size) {
 
-    tpm2_tool_output("  Event: '%.*s'\n", (int) size, action);
+    tpm2_tool_output("    Event: '%.*s'\n", (int) size, action);
 
     return true;
 }
@@ -236,15 +242,16 @@ bool yaml_uefi_image_load(UEFI_IMAGE_LOAD_EVENT *data, size_t size) {
         return false;
     }
 
-    tpm2_tool_output("  Event:\n    - ImageLocationInMemory: 0x%" PRIx64 "\n"
-                     "      ImageLengthInMemory: %" PRIu64 "\n      "
-                     "ImageLinkTimeAddress: 0x%" PRIx64 "\n      "
-                     "LengthOfDevicePath: %" PRIu64 "\n",
+    tpm2_tool_output("    Event:\n"
+                     "      - ImageLocationInMemory: 0x%" PRIx64 "\n"
+                     "        ImageLengthInMemory: %" PRIu64 "\n"
+                     "        ImageLinkTimeAddress: 0x%" PRIx64 "\n"
+                     "        LengthOfDevicePath: %" PRIu64 "\n",
                      data->ImageLocationInMemory, data->ImageLengthInMemory,
                      data->ImageLinkTimeAddress, data->LengthOfDevicePath);
 
     bytes_to_str(data->DevicePath, size - sizeof(*data), buf, devpath_len);
-    tpm2_tool_output("      DevicePath: %s\n", buf);
+    tpm2_tool_output("        DevicePath: %s\n", buf);
 
     free(buf);
     return true;
@@ -254,7 +261,7 @@ bool yaml_event2data(TCG_EVENT2 const *event, UINT32 type) {
 
     char hexstr[EVENT_BUF_MAX] = { 0, };
 
-    tpm2_tool_output("  EventSize: %" PRIu32 "\n", event->EventSize);
+    tpm2_tool_output("    EventSize: %" PRIu32 "\n", event->EventSize);
 
     if (event->EventSize == 0) {
         return true;
@@ -279,7 +286,7 @@ bool yaml_event2data(TCG_EVENT2 const *event, UINT32 type) {
                                     event->EventSize);
     default:
         bytes_to_str(event->Event, event->EventSize, hexstr, sizeof(hexstr));
-        tpm2_tool_output("  Event: %s\n", hexstr);
+        tpm2_tool_output("    Event: %s\n", hexstr);
         return true;
     }
 }
@@ -307,25 +314,26 @@ bool yaml_event2hdr_callback(TCG_EVENT_HEADER2 const *eventhdr, size_t size,
         return false;
     }
 
-    tpm2_tool_output("- Event[%zu]:\n", (*count)++);
+    tpm2_tool_output("  - EventNum: %zu\n", (*count)++);
 
     yaml_event2hdr(eventhdr, size);
 
-    tpm2_tool_output("  Digests:\n");
+    tpm2_tool_output("    Digests:\n");
 
     return true;
 }
 void yaml_eventhdr(TCG_EVENT const *event, size_t *count) {
 
     /* digest is 20 bytes, 2 chars / byte and null terminator for string*/
-    char digest_hex[41] = { '\0', };
+    char digest_hex[2*sizeof(event->digest) + 1] = {};
     bytes_to_str(event->digest, sizeof(event->digest), digest_hex, sizeof(digest_hex));
 
-    tpm2_tool_output("- Event[%zu]:\n"
-                     "  PCRIndex: %" PRIu32 "\n"
-                     "  EventType: %s\n"
-                     "  Digest: %s\n"
-                     "  EventSize: %" PRIu32 "\n", (*count)++, event->pcrIndex,
+    tpm2_tool_output("  - EventNum: %zu\n"
+                     "    PCRIndex: %" PRIu32 "\n"
+                     "    EventType: %s\n"
+                     "    Digest: %s\n"
+                     "    EventSize: %" PRIu32 "\n",
+                     (*count)++, event->pcrIndex,
                      eventtype_to_string(event->eventType), digest_hex,
                      event->eventDataSize);
 }
@@ -336,15 +344,15 @@ void yaml_specid(TCG_SPECID_EVENT* specid) {
     char sig_str[sizeof(specid->Signature) + 1] = { '\0', };
     memcpy(sig_str, specid->Signature, sizeof(specid->Signature));
 
-    tpm2_tool_output("  SpecID:\n"
-                     "    - Signature: %s\n"
-                     "      platformClass: %" PRIu32 "\n"
-                     "      specVersionMinor: %" PRIu8 "\n"
-                     "      specVersionMajor: %" PRIu8 "\n"
-                     "      specErrata: %" PRIu8 "\n"
-                     "      uintnSize: %" PRIu8 "\n"
-                     "      numberOfAlgorithms: %" PRIu32 "\n"
-                     "      Algorithms:\n",
+    tpm2_tool_output("    SpecID:\n"
+                     "      - Signature: %s\n"
+                     "        platformClass: %" PRIu32 "\n"
+                     "        specVersionMinor: %" PRIu8 "\n"
+                     "        specVersionMajor: %" PRIu8 "\n"
+                     "        specErrata: %" PRIu8 "\n"
+                     "        uintnSize: %" PRIu8 "\n"
+                     "        numberOfAlgorithms: %" PRIu32 "\n"
+                     "        Algorithms:\n",
                      sig_str,
                      specid->platformClass, specid->specVersionMinor,
                      specid->specVersionMajor, specid->specErrata,
@@ -355,9 +363,9 @@ void yaml_specid(TCG_SPECID_EVENT* specid) {
 void yaml_specid_algs(TCG_SPECID_ALG const *alg, size_t count) {
 
     for (size_t i = 0; i < count; ++i, ++alg) {
-        tpm2_tool_output("        - Algorithm[%zu]:\n"
-                         "          algorithmId: %s\n"
-                         "          digestSize: %" PRIu16 "\n",
+        tpm2_tool_output("          - Algorithm[%zu]:\n"
+                         "            algorithmId: %s\n"
+                         "            digestSize: %" PRIu16 "\n",
                          i,
                          tpm2_alg_util_algtostr(alg->algorithmId,
                                                 tpm2_alg_util_flags_hash),
@@ -368,7 +376,7 @@ bool yaml_specid_vendor(TCG_VENDOR_INFO *vendor) {
 
     char *vendinfo_str;
 
-    tpm2_tool_output("      vendorInfoSize: %" PRIu8 "\n", vendor->vendorInfoSize);
+    tpm2_tool_output("        vendorInfoSize: %" PRIu8 "\n", vendor->vendorInfoSize);
     if (vendor->vendorInfoSize == 0) {
         return true;
     }
@@ -380,7 +388,7 @@ bool yaml_specid_vendor(TCG_VENDOR_INFO *vendor) {
     }
     bytes_to_str(vendor->vendorInfo, vendor->vendorInfoSize, vendinfo_str,
                  vendor->vendorInfoSize * 2 + 1);
-    tpm2_tool_output("      vendorInfo: %s\n", vendinfo_str);
+    tpm2_tool_output("        vendorInfo: %s\n", vendinfo_str);
     free(vendinfo_str);
     return true;
 }
@@ -414,7 +422,7 @@ static void yaml_eventlog_pcrs(tpm2_eventlog_ctx_t *ctx) {
                 continue;
             bytes_to_str(ctx->sha1_pcrs[i], sizeof(ctx->sha1_pcrs[i]),
                 hexstr, sizeof(hexstr));
-            tpm2_tool_output("    %2d : 0x%s\n", i, hexstr);
+            tpm2_tool_output("    %-2d : 0x%s\n", i, hexstr);
         }
     }
 
@@ -425,7 +433,7 @@ static void yaml_eventlog_pcrs(tpm2_eventlog_ctx_t *ctx) {
                 continue;
             bytes_to_str(ctx->sha256_pcrs[i], sizeof(ctx->sha256_pcrs[i]),
                 hexstr, sizeof(hexstr));
-            tpm2_tool_output("    %2d : 0x%s\n", i, hexstr);
+            tpm2_tool_output("    %-2d : 0x%s\n", i, hexstr);
         }
     }
 
@@ -436,7 +444,7 @@ static void yaml_eventlog_pcrs(tpm2_eventlog_ctx_t *ctx) {
                 continue;
             bytes_to_str(ctx->sha384_pcrs[i], sizeof(ctx->sha384_pcrs[i]),
                 hexstr, sizeof(hexstr));
-            tpm2_tool_output("    %2d : 0x%s\n", i, hexstr);
+            tpm2_tool_output("    %-2d : 0x%s\n", i, hexstr);
         }
     }
 
@@ -447,7 +455,7 @@ static void yaml_eventlog_pcrs(tpm2_eventlog_ctx_t *ctx) {
                 continue;
             bytes_to_str(ctx->sha512_pcrs[i], sizeof(ctx->sha512_pcrs[i]),
                 hexstr, sizeof(hexstr));
-            tpm2_tool_output("    %2d : 0x%s\n", i, hexstr);
+            tpm2_tool_output("    %-2d : 0x%s\n", i, hexstr);
         }
     }
 
@@ -458,7 +466,7 @@ static void yaml_eventlog_pcrs(tpm2_eventlog_ctx_t *ctx) {
                 continue;
             bytes_to_str(ctx->sm3_256_pcrs[i], sizeof(ctx->sm3_256_pcrs[i]),
                 hexstr, sizeof(hexstr));
-            tpm2_tool_output("    %2d : 0x%s\n", i, hexstr);
+            tpm2_tool_output("    %-2d : 0x%s\n", i, hexstr);
         }
     }
 }
@@ -475,6 +483,7 @@ bool yaml_eventlog(UINT8 const *eventlog, size_t size) {
     };
 
     tpm2_tool_output("---\n");
+    tpm2_tool_output("events:\n");
     bool rc = parse_eventlog(&ctx, eventlog, size);
     if (!rc) {
         return rc;

--- a/lib/tpm2_eventlog_yaml.c
+++ b/lib/tpm2_eventlog_yaml.c
@@ -6,9 +6,6 @@
 #include <uchar.h>
 
 #include <tss2/tss2_tpm2_types.h>
-#include <openssl/buffer.h>
-#include <openssl/evp.h>
-#include <openssl/sha.h>
 
 #include "log.h"
 #include "efi_event.h"
@@ -18,49 +15,7 @@
 #include "tpm2_tool.h"
 #include "tpm2_tool_output.h"
 
-typedef struct {
-    size_t count;
-    int pcr;
-    SHA256_CTX sha256;
-    SHA_CTX sha1;
-    uint8_t sha1_pcrs[TPM2_MAX_PCRS][SHA_DIGEST_LENGTH];
-    uint8_t sha256_pcrs[TPM2_MAX_PCRS][SHA256_DIGEST_LENGTH];
-} tpm2_eventlog_ctx_t;
-
-/*
- * update the PCR with this digest.
- * Assumes that ctx->pcr has been set by another callback.
- * Mismatches of sizes will be warned about, but are not fatal errors.
- */
-static void tpm2_eventlog_extend(tpm2_eventlog_ctx_t *ctx, unsigned alg, const void *digest, size_t size) {
-
-    if (ctx->pcr == -1) {
-        // ignore this one.
-    } else
-    if (ctx->pcr >= TPM2_MAX_PCRS) {
-        LOG_WARN("PCR%d is invalid", ctx->pcr);
-    } else
-    if (alg == TPM2_ALG_SHA1 && size == sizeof(ctx->sha1_pcrs[0])) {
-        void * const pcr = ctx->sha1_pcrs[ctx->pcr];
-        SHA1_Init(&ctx->sha1);
-        SHA1_Update(&ctx->sha1, pcr, size);
-        SHA1_Update(&ctx->sha1, digest, size);
-        SHA1_Final(pcr, &ctx->sha1);
-    } else
-    if (alg == TPM2_ALG_SHA256 && size == sizeof(ctx->sha256_pcrs[0])) {
-        void * const pcr = ctx->sha256_pcrs[ctx->pcr];
-        SHA256_Init(&ctx->sha256);
-        SHA256_Update(&ctx->sha256, pcr, size);
-        SHA256_Update(&ctx->sha256, digest, size);
-        SHA256_Final(pcr, &ctx->sha256);
-    } else {
-        // unhandled PCR digest algorithm/size combo.
-        LOG_WARN("PCR%d: extended with invalid algorithm %d and size %zu",
-            ctx->pcr, alg, size);
-    }
-}
-
-static char const *eventtype_to_string (UINT32 event_type) {
+char const *eventtype_to_string (UINT32 event_type) {
 
     switch (event_type) {
     case EV_PREBOOT_CERT:
@@ -125,7 +80,7 @@ static char const *eventtype_to_string (UINT32 event_type) {
         return "Unknown event type";
     }
 }
-static void bytes_to_str(uint8_t const *buf, size_t size, char *dest, size_t dest_size) {
+void bytes_to_str(uint8_t const *buf, size_t size, char *dest, size_t dest_size) {
 
     size_t i, j;
 
@@ -134,7 +89,7 @@ static void bytes_to_str(uint8_t const *buf, size_t size, char *dest, size_t des
     }
     dest[j] = '\0';
 }
-static void yaml_event2hdr(TCG_EVENT_HEADER2 const *eventhdr, size_t size) {
+void yaml_event2hdr(TCG_EVENT_HEADER2 const *eventhdr, size_t size) {
 
     (void)size;
 
@@ -148,21 +103,19 @@ static void yaml_event2hdr(TCG_EVENT_HEADER2 const *eventhdr, size_t size) {
 /* converting byte buffer to hex string requires 2x, plus 1 for '\0' */
 #define BYTES_TO_HEX_STRING_SIZE(byte_count) (byte_count * 2 + 1)
 #define DIGEST_HEX_STRING_MAX BYTES_TO_HEX_STRING_SIZE(TPM2_MAX_DIGEST_BUFFER)
-static bool yaml_digest2(TCG_DIGEST2 const *digest, size_t size, tpm2_eventlog_ctx_t * ctx) {
+bool yaml_digest2(TCG_DIGEST2 const *digest, size_t size) {
 
     char hexstr[DIGEST_HEX_STRING_MAX] = { 0, };
-    const unsigned alg = digest->AlgorithmId;
 
     tpm2_tool_output("    - AlgorithmId: %s\n",
-           tpm2_alg_util_algtostr(alg, tpm2_alg_util_flags_hash));
+           tpm2_alg_util_algtostr(digest->AlgorithmId,
+                                  tpm2_alg_util_flags_hash));
     bytes_to_str(digest->Digest, size, hexstr, sizeof(hexstr));
     tpm2_tool_output("      Digest: %s\n", hexstr);
 
-    tpm2_eventlog_extend(ctx, alg, digest->Digest, size);
-
     return true;
 }
-static bool yaml_uefi_var_unicodename(UEFI_VARIABLE_DATA *data) {
+bool yaml_uefi_var_unicodename(UEFI_VARIABLE_DATA *data) {
 
     int ret = 0;
     char *mbstr = NULL, *tmp = NULL;
@@ -259,7 +212,7 @@ static bool yaml_uefi_var(UEFI_VARIABLE_DATA *data) {
     return yaml_uefi_var_data(data);
 }
 /* TCG PC Client FPF section 9.2.5 */
-static bool yaml_uefi_platfwblob(UEFI_PLATFORM_FIRMWARE_BLOB *data) {
+bool yaml_uefi_platfwblob(UEFI_PLATFORM_FIRMWARE_BLOB *data) {
 
     tpm2_tool_output("  Event:\n    - BlobBase: 0x%" PRIx64 "\n      "
                      "BlobLength: 0x%" PRIx64 "\n", data->BlobBase,
@@ -267,14 +220,14 @@ static bool yaml_uefi_platfwblob(UEFI_PLATFORM_FIRMWARE_BLOB *data) {
     return true;
 }
 /* TCG PC Client PFP section 9.4.4 */
-static bool yaml_uefi_action(UINT8 const *action, size_t size) {
+bool yaml_uefi_action(UINT8 const *action, size_t size) {
 
     tpm2_tool_output("  Event: '%.*s'\n", (int) size, action);
 
     return true;
 }
 /* TCG PC Client PFP section 9.2.3 */
-static bool yaml_uefi_image_load(UEFI_IMAGE_LOAD_EVENT *data, size_t size) {
+bool yaml_uefi_image_load(UEFI_IMAGE_LOAD_EVENT *data, size_t size) {
 
     size_t devpath_len = (size - sizeof(*data)) * 2 + 1;
     char *buf = calloc (1, devpath_len);
@@ -297,7 +250,7 @@ static bool yaml_uefi_image_load(UEFI_IMAGE_LOAD_EVENT *data, size_t size) {
     return true;
 }
 #define EVENT_BUF_MAX BYTES_TO_HEX_STRING_SIZE(1024)
-static bool yaml_event2data(TCG_EVENT2 const *event, UINT32 type) {
+bool yaml_event2data(TCG_EVENT2 const *event, UINT32 type) {
 
     char hexstr[EVENT_BUF_MAX] = { 0, };
 
@@ -330,34 +283,31 @@ static bool yaml_event2data(TCG_EVENT2 const *event, UINT32 type) {
         return true;
     }
 }
-static bool yaml_event2data_callback(TCG_EVENT2 const *event, UINT32 type,
+bool yaml_event2data_callback(TCG_EVENT2 const *event, UINT32 type,
                               void *data) {
 
     (void)data;
 
     return yaml_event2data(event, type);
 }
-static bool yaml_digest2_callback(TCG_DIGEST2 const *digest, size_t size,
+bool yaml_digest2_callback(TCG_DIGEST2 const *digest, size_t size,
                             void *data_in) {
 
-    tpm2_eventlog_ctx_t * ctx = data_in;
-    return yaml_digest2(digest, size, ctx);
+    (void)data_in;
+    return yaml_digest2(digest, size);
 }
 
-static bool yaml_event2hdr_callback(TCG_EVENT_HEADER2 const *eventhdr, size_t size,
+bool yaml_event2hdr_callback(TCG_EVENT_HEADER2 const *eventhdr, size_t size,
                              void *data_in) {
 
-    tpm2_eventlog_ctx_t * const ctx = data_in;
+    size_t *count = (size_t*)data_in;
 
-    if (ctx == NULL) {
+    if (count == NULL) {
         LOG_ERR("callback requires user data");
         return false;
     }
 
-    // store the current PCR for future processing
-    ctx->pcr = eventhdr->PCRIndex;
-
-    tpm2_tool_output("- Event[%zu]:\n", ctx->count++);
+    tpm2_tool_output("- Event[%zu]:\n", (*count)++);
 
     yaml_event2hdr(eventhdr, size);
 
@@ -365,7 +315,7 @@ static bool yaml_event2hdr_callback(TCG_EVENT_HEADER2 const *eventhdr, size_t si
 
     return true;
 }
-static void yaml_eventhdr(TCG_EVENT const *event, tpm2_eventlog_ctx_t *ctx) {
+void yaml_eventhdr(TCG_EVENT const *event, size_t *count) {
 
     /* digest is 20 bytes, 2 chars / byte and null terminator for string*/
     char digest_hex[41] = { '\0', };
@@ -375,17 +325,12 @@ static void yaml_eventhdr(TCG_EVENT const *event, tpm2_eventlog_ctx_t *ctx) {
                      "  PCRIndex: %" PRIu32 "\n"
                      "  EventType: %s\n"
                      "  Digest: %s\n"
-                     "  EventSize: %" PRIu32 "\n", ctx->count++, event->pcrIndex,
+                     "  EventSize: %" PRIu32 "\n", (*count)++, event->pcrIndex,
                      eventtype_to_string(event->eventType), digest_hex,
                      event->eventDataSize);
-
-    if (event->eventType != EV_NO_ACTION) {
-        ctx->pcr = event->pcrIndex;
-        tpm2_eventlog_extend(ctx, TPM2_ALG_SHA1, event->digest, sizeof(event->digest));
-    }
 }
 
-static void yaml_specid(TCG_SPECID_EVENT* specid) {
+void yaml_specid(TCG_SPECID_EVENT* specid) {
 
     /* 'Signature' defined as byte buf, spec treats it like string w/o null. */
     char sig_str[sizeof(specid->Signature) + 1] = { '\0', };
@@ -407,7 +352,7 @@ static void yaml_specid(TCG_SPECID_EVENT* specid) {
                      specid->numberOfAlgorithms);
 
 }
-static void yaml_specid_algs(TCG_SPECID_ALG const *alg, size_t count) {
+void yaml_specid_algs(TCG_SPECID_ALG const *alg, size_t count) {
 
     for (size_t i = 0; i < count; ++i, ++alg) {
         tpm2_tool_output("        - Algorithm[%zu]:\n"
@@ -419,7 +364,7 @@ static void yaml_specid_algs(TCG_SPECID_ALG const *alg, size_t count) {
                          alg->digestSize);
     }
 }
-static bool yaml_specid_vendor(TCG_VENDOR_INFO *vendor) {
+bool yaml_specid_vendor(TCG_VENDOR_INFO *vendor) {
 
     char *vendinfo_str;
 
@@ -439,21 +384,21 @@ static bool yaml_specid_vendor(TCG_VENDOR_INFO *vendor) {
     free(vendinfo_str);
     return true;
 }
-static bool yaml_specid_event(TCG_EVENT const *event, tpm2_eventlog_ctx_t *ctx) {
+bool yaml_specid_event(TCG_EVENT const *event, size_t *count) {
 
     TCG_SPECID_EVENT *specid = (TCG_SPECID_EVENT*)event->event;
     TCG_SPECID_ALG *alg = (TCG_SPECID_ALG*)specid->digestSizes;
     TCG_VENDOR_INFO *vendor = (TCG_VENDOR_INFO*)(alg + specid->numberOfAlgorithms);
 
-    yaml_eventhdr(event, ctx);
+    yaml_eventhdr(event, count);
     yaml_specid(specid);
     yaml_specid_algs(alg, specid->numberOfAlgorithms);
     return yaml_specid_vendor(vendor);
 }
-static bool yaml_specid_callback(TCG_EVENT const *event, void *data) {
+bool yaml_specid_callback(TCG_EVENT const *event, void *data) {
 
-    tpm2_eventlog_ctx_t * const ctx = data;
-    return yaml_specid_event(event, ctx);
+    size_t *count = (size_t*)data;
+    return yaml_specid_event(event, count);
 }
 
 static void yaml_eventlog_pcrs(tpm2_eventlog_ctx_t *ctx) {
@@ -479,16 +424,20 @@ static void yaml_eventlog_pcrs(tpm2_eventlog_ctx_t *ctx) {
 
 bool yaml_eventlog(UINT8 const *eventlog, size_t size) {
 
-    tpm2_eventlog_ctx_t ctx = {};
+    size_t count = 0;
+    tpm2_eventlog_ctx_t ctx = {
+        .data = &count,
+        .specid_cb = yaml_specid_callback,
+        .event2hdr_cb = yaml_event2hdr_callback,
+        .digest2_cb = yaml_digest2_callback,
+        .event2_cb = yaml_event2data_callback,
+    };
 
     tpm2_tool_output("---\n");
-    bool rc = parse_eventlog(eventlog, size,
-                          yaml_specid_callback,
-                          yaml_event2hdr_callback,
-                          yaml_digest2_callback,
-                          yaml_event2data_callback, &ctx);
-    if (!rc)
+    bool rc = parse_eventlog(&ctx, eventlog, size);
+    if (!rc) {
         return rc;
+    }
 
     yaml_eventlog_pcrs(&ctx);
     return true;

--- a/lib/tpm2_eventlog_yaml.h
+++ b/lib/tpm2_eventlog_yaml.h
@@ -8,6 +8,16 @@
 #include "efi_event.h"
 #include "tpm2_eventlog.h"
 
+char const *eventtype_to_string (UINT32 event_type);
+void yaml_event2hdr(TCG_EVENT_HEADER2 const *event_hdr, size_t size);
+bool yaml_digest2(TCG_DIGEST2 const *digest, size_t size);
+bool yaml_uefi_var_unicodename(UEFI_VARIABLE_DATA *data);
+bool yaml_event2data(TCG_EVENT2 const *event, UINT32 type);
+bool yaml_digest2_callback(TCG_DIGEST2 const *digest, size_t size, void *data);
+bool yaml_event2hdr_callback(TCG_EVENT_HEADER2 const *event_hdr, size_t size,
+                             void *data);
+bool yaml_event2data_callback(TCG_EVENT2 const *event, UINT32 type, void *data);
+
 bool yaml_eventlog(UINT8 const *eventlog, size_t size);
 
 #endif

--- a/lib/tpm2_eventlog_yaml.h
+++ b/lib/tpm2_eventlog_yaml.h
@@ -8,16 +8,6 @@
 #include "efi_event.h"
 #include "tpm2_eventlog.h"
 
-char const *eventtype_to_string (UINT32 event_type);
-void yaml_event2hdr(TCG_EVENT_HEADER2 const *event_hdr, size_t size);
-bool yaml_digest2(TCG_DIGEST2 const *digest, size_t size);
-bool yaml_uefi_var_unicodename(UEFI_VARIABLE_DATA *data);
-bool yaml_event2data(TCG_EVENT2 const *event, UINT32 type);
-bool yaml_digest2_callback(TCG_DIGEST2 const *digest, size_t size, void *data);
-bool yaml_event2hdr_callback(TCG_EVENT_HEADER2 const *event_hdr, size_t size,
-                             void *data);
-bool yaml_event2data_callback(TCG_EVENT2 const *event, UINT32 type, void *data);
-
 bool yaml_eventlog(UINT8 const *eventlog, size_t size);
 
 #endif

--- a/lib/tpm2_openssl.h
+++ b/lib/tpm2_openssl.h
@@ -138,6 +138,22 @@ bool tpm2_openssl_hash_pcr_banks(TPMI_ALG_HASH hashAlg,
         TPML_PCR_SELECTION *pcr_select, tpm2_pcrs *pcrs, TPM2B_DIGEST *digest);
 
 /**
+ * Extend a PCR with a new digest.
+ * @param halg
+ *  The hashing algorithm to use.
+ * @param pcr
+ *  A buffer with the current value of the PCR, will be updated in place.
+ * @param data
+ *  The new digest to be added to the current PCR.
+ * @param length
+ *  Length of the new data to be added to the digest.
+ * @return
+ *  true on success, false on error.
+ */
+bool tpm2_openssl_pcr_extend(TPMI_ALG_HASH halg, BYTE *pcr,
+        const BYTE *data, UINT16 length);
+
+/**
  * Obtains an OpenSSL EVP_CIPHER_CTX dealing with version
  * API changes in OSSL.
  *

--- a/lib/tpm2_util.h
+++ b/lib/tpm2_util.h
@@ -228,7 +228,7 @@ static inline void _tpm2_util_print_tpm2b(TPM2B *buffer) {
  *   buffer the TPM2B to print.
  */
 #define tpm2_util_print_tpm2b2(o, b) _tpm2_util_print_tpm2b2(o, (TPM2B *)b)
-static inline void _tpm2_util_print_tpm2b2(FILE *out, TPM2B *buffer) {
+static inline void _tpm2_util_print_tpm2b2(FILE *out, const TPM2B *buffer) {
 
     return tpm2_util_hexdump2(out, buffer->buffer, buffer->size);
 }
@@ -239,7 +239,7 @@ static inline void _tpm2_util_print_tpm2b2(FILE *out, TPM2B *buffer) {
  * @param pcr the PCR ID to check selection status of.
  */
 static inline bool tpm2_util_is_pcr_select_bit_set(
-        TPMS_PCR_SELECTION *pcr_selection, UINT32 pcr) {
+        const TPMS_PCR_SELECTION *pcr_selection, UINT32 pcr) {
     return (pcr_selection->pcrSelect[((pcr) / 8)] & (1 << ((pcr) % 8)));
 }
 

--- a/test/integration/tests/eventlog.sh
+++ b/test/integration/tests/eventlog.sh
@@ -1,5 +1,9 @@
 # SPDX-License-Identifier: BSD-3-Clause
 
+yaml_validate() {
+    python -c 'import yaml,sys; yaml.safe_load(sys.stdin)'
+}
+
 expect_fail() {
     $@
     if [ $? -eq 0 ]; then
@@ -8,12 +12,13 @@ expect_fail() {
     fi
 }
 expect_pass() {
-    $@
+    $@ | yaml_validate
     if [ $? -ne 0 ]; then
         echo "passing test case failed"
         exit 1;
     fi
 }
+
 expect_fail tpm2 eventlog
 expect_fail tpm2 eventlog foo
 expect_fail tpm2 eventlog foo bar

--- a/test/unit/test_tpm2_eventlog.c
+++ b/test/unit/test_tpm2_eventlog.c
@@ -12,6 +12,7 @@
 #include "tpm2_eventlog.h"
 
 #define TCG_DIGEST2_SHA1_SIZE (sizeof(TCG_DIGEST2) + TPM2_SHA_DIGEST_SIZE)
+#define TCG_DIGEST2_SHA256_SIZE (sizeof(TCG_DIGEST2) + TPM2_SHA256_DIGEST_SIZE)
 
 static bool foreach_digest2_test_callback(TCG_DIGEST2 const *digest, size_t size, void *data){
 
@@ -51,11 +52,43 @@ static void test_foreach_digest2(void **state) {
 static void test_foreach_digest2_cbnull(void **state){
 
     (void)state;
-    uint8_t buf [TCG_DIGEST2_SHA1_SIZE] = { 0, };
+    uint8_t buf [TCG_DIGEST2_SHA1_SIZE] = { };
     TCG_DIGEST2* digest = (TCG_DIGEST2*)buf;
 
     tpm2_eventlog_ctx_t ctx = {};
     assert_true(foreach_digest2(&ctx, 0, digest, 1, TCG_DIGEST2_SHA1_SIZE));
+}
+static void test_sha1(void **state){
+
+    (void)state;
+    uint8_t buf [TCG_DIGEST2_SHA1_SIZE] = { 0, };
+    uint8_t sha1sum[] = { 0x31,0x19,0x5d,0x69,0x35,0x16,0x3c,0x79,0xa9,0x67,0x22,0xba,0x7d,0x4b,0x11,0x35,0x24,0x89,0xf4,0x8b };
+    const int pcrIndex = 3;
+
+    TCG_DIGEST2 * digest = (TCG_DIGEST2*) buf;
+    digest->AlgorithmId = TPM2_ALG_SHA1,
+    memcpy(digest->Digest, "the magic words are:", TPM2_SHA1_DIGEST_SIZE);
+
+    tpm2_eventlog_ctx_t ctx = {};
+    assert_true(foreach_digest2(&ctx, pcrIndex, digest, 1, TCG_DIGEST2_SHA1_SIZE));
+    // memcmp() == 0 if the buffers match
+    assert_false(memcmp(ctx.sha1_pcrs[pcrIndex], sha1sum, sizeof(sha1sum)));
+}
+static void test_sha256(void **state){
+
+    (void)state;
+    uint8_t buf [TCG_DIGEST2_SHA256_SIZE] = { };
+    uint8_t sha256sum[TPM2_SHA256_DIGEST_SIZE] = { 0x51,0xea,0x4e,0xa4,0x98,0xaa,0xe2,0x52,0xf4,0xe7,0xff,0x4b,0x13,0xb6,0x3f,0xe5,0xb5,0x7a,0xf8,0x21,0xa4,0x84,0x4e,0xe2,0x6f,0xd8,0xdd,0x25,0xa4,0x2b,0x33,0x23 };
+    const int pcrIndex = 3;
+
+    TCG_DIGEST2 * digest = (TCG_DIGEST2*) buf;
+    digest->AlgorithmId = TPM2_ALG_SHA256,
+    memcpy(digest->Digest, "The Magic Words are Squeamish Ossifrage, for RSA-129 (from 1977)", TPM2_SHA256_DIGEST_SIZE);
+
+    tpm2_eventlog_ctx_t ctx = {};
+    assert_true(foreach_digest2(&ctx, pcrIndex, digest, 1, TCG_DIGEST2_SHA256_SIZE));
+    // memcmp() == 0 if the buffers match
+    assert_false(memcmp(ctx.sha256_pcrs[pcrIndex], sha256sum, sizeof(sha256sum)));
 }
 static void test_foreach_digest2_cbfail(void **state){
 
@@ -468,6 +501,8 @@ int main(void) {
         cmocka_unit_test(test_foreach_digest2),
         cmocka_unit_test(test_foreach_digest2_cbfail),
         cmocka_unit_test(test_foreach_digest2_cbnull),
+        cmocka_unit_test(test_sha1),
+        cmocka_unit_test(test_sha256),
         cmocka_unit_test(test_digest2_accumulator_callback),
         cmocka_unit_test(test_digest2_accumulator_callback_null),
         cmocka_unit_test(test_parse_event2_badhdr),

--- a/test/unit/test_tpm2_eventlog.c
+++ b/test/unit/test_tpm2_eventlog.c
@@ -25,7 +25,7 @@ static bool foreach_digest2_test_callback(TCG_DIGEST2 const *digest, size_t size
 static void test_foreach_digest2_null(void **state){
 
     (void)state;
-    tpm2_eventlog_ctx_t ctx = {0};
+    tpm2_eventlog_context ctx = {0};
 
     assert_false(foreach_digest2(&ctx, 0, NULL, 0, sizeof(TCG_DIGEST2)));
 }
@@ -34,7 +34,7 @@ static void test_foreach_digest2_size(void **state) {
     (void)state;
     uint8_t buf [sizeof(TCG_DIGEST2) - 1] = { 0, };
     TCG_DIGEST2 *digest = (TCG_DIGEST2*)buf;
-    tpm2_eventlog_ctx_t ctx = { .digest2_cb = foreach_digest2_test_callback };
+    tpm2_eventlog_context ctx = { .digest2_cb = foreach_digest2_test_callback };
 
     assert_false(foreach_digest2(&ctx, 0, digest, 1, sizeof(TCG_DIGEST2) - 1));
 }
@@ -46,7 +46,7 @@ static void test_foreach_digest2(void **state) {
 
     will_return(foreach_digest2_test_callback, true);
 
-    tpm2_eventlog_ctx_t ctx = { .digest2_cb = foreach_digest2_test_callback };
+    tpm2_eventlog_context ctx = { .digest2_cb = foreach_digest2_test_callback };
     assert_true(foreach_digest2(&ctx, 0, digest, 1, TCG_DIGEST2_SHA1_SIZE));
 }
 static void test_foreach_digest2_cbnull(void **state){
@@ -55,7 +55,7 @@ static void test_foreach_digest2_cbnull(void **state){
     uint8_t buf [TCG_DIGEST2_SHA1_SIZE] = {0};
     TCG_DIGEST2* digest = (TCG_DIGEST2*)buf;
 
-    tpm2_eventlog_ctx_t ctx = {0};
+    tpm2_eventlog_context ctx = {0};
     assert_true(foreach_digest2(&ctx, 0, digest, 1, TCG_DIGEST2_SHA1_SIZE));
 }
 static void test_sha1(void **state){
@@ -72,7 +72,7 @@ static void test_sha1(void **state){
     digest->AlgorithmId = TPM2_ALG_SHA1,
     memcpy(digest->Digest, "the magic words are:", TPM2_SHA1_DIGEST_SIZE);
 
-    tpm2_eventlog_ctx_t ctx = {0};
+    tpm2_eventlog_context ctx = {0};
     assert_true(foreach_digest2(&ctx, pcr_index, digest, 1, TCG_DIGEST2_SHA1_SIZE));
     assert_memory_equal(ctx.sha1_pcrs[pcr_index], sha1sum, sizeof(sha1sum));
 }
@@ -92,7 +92,7 @@ static void test_sha256(void **state){
     digest->AlgorithmId = TPM2_ALG_SHA256,
     memcpy(digest->Digest, "The Magic Words are Squeamish Ossifrage, for RSA-129 (from 1977)", TPM2_SHA256_DIGEST_SIZE);
 
-    tpm2_eventlog_ctx_t ctx = {0};
+    tpm2_eventlog_context ctx = {0};
     assert_true(foreach_digest2(&ctx, pcr_index, digest, 1, TCG_DIGEST2_SHA256_SIZE));
     assert_memory_equal(ctx.sha256_pcrs[pcr_index], sha256sum, sizeof(sha256sum));
 }
@@ -104,7 +104,7 @@ static void test_foreach_digest2_cbfail(void **state){
 
     will_return(foreach_digest2_test_callback, false);
 
-    tpm2_eventlog_ctx_t ctx = { .digest2_cb = foreach_digest2_test_callback };
+    tpm2_eventlog_context ctx = { .digest2_cb = foreach_digest2_test_callback };
     assert_false(foreach_digest2(&ctx, 0, digest, 1, TCG_DIGEST2_SHA1_SIZE));
 }
 static void test_digest2_accumulator_callback(void **state) {
@@ -208,7 +208,7 @@ static void test_foreach_event2(void **state){
     will_return(foreach_digest2_test_callback, true);
     will_return(test_event2_callback, true);
 
-    tpm2_eventlog_ctx_t ctx = {
+    tpm2_eventlog_context ctx = {
         .digest2_cb = foreach_digest2_test_callback,
         .event2_cb = test_event2_callback,
         .event2hdr_cb = test_event2hdr_callback,
@@ -229,7 +229,7 @@ static void test_foreach_event2_event2hdr_fail(void **state){
 
     will_return(test_event2hdr_callback, false);
 
-    tpm2_eventlog_ctx_t ctx = {
+    tpm2_eventlog_context ctx = {
         .event2hdr_cb = test_event2hdr_callback,
     };
     assert_false(foreach_event2(&ctx, eventhdr, sizeof(buf)));
@@ -249,7 +249,7 @@ static void test_foreach_event2_digest2_fail(void **state){
     will_return(test_event2hdr_callback, true);
     will_return(foreach_digest2_test_callback, false);
 
-    tpm2_eventlog_ctx_t ctx = {
+    tpm2_eventlog_context ctx = {
         .digest2_cb = foreach_digest2_test_callback,
         .event2hdr_cb = test_event2hdr_callback,
     };
@@ -272,7 +272,7 @@ static void test_foreach_event2_parse_event2body_fail(void **state){
     will_return(test_event2hdr_callback, true);
     will_return(foreach_digest2_test_callback, true);
 
-    tpm2_eventlog_ctx_t ctx = {
+    tpm2_eventlog_context ctx = {
         .digest2_cb = foreach_digest2_test_callback,
         .event2hdr_cb = test_event2hdr_callback,
     };
@@ -294,7 +294,7 @@ static void test_foreach_event2_event2body_fail(void **state){
     will_return(foreach_digest2_test_callback, true);
     will_return(test_event2_callback, false);
 
-    tpm2_eventlog_ctx_t ctx = {
+    tpm2_eventlog_context ctx = {
         .event2hdr_cb = test_event2hdr_callback,
         .digest2_cb = foreach_digest2_test_callback,
         .event2_cb = test_event2_callback,

--- a/test/unit/test_tpm2_eventlog.c
+++ b/test/unit/test_tpm2_eventlog.c
@@ -24,16 +24,18 @@ static bool foreach_digest2_test_callback(TCG_DIGEST2 const *digest, size_t size
 static void test_foreach_digest2_null(void **state){
 
     (void)state;
+    tpm2_eventlog_ctx_t ctx = {};
 
-    assert_false(foreach_digest2(NULL, 0, sizeof(TCG_DIGEST2), NULL, NULL));
+    assert_false(foreach_digest2(&ctx, 0, NULL, 0, sizeof(TCG_DIGEST2)));
 }
 static void test_foreach_digest2_size(void **state) {
 
     (void)state;
     uint8_t buf [sizeof(TCG_DIGEST2) - 1] = { 0, };
     TCG_DIGEST2 *digest = (TCG_DIGEST2*)buf;
+    tpm2_eventlog_ctx_t ctx = { .digest2_cb = foreach_digest2_test_callback };
 
-    assert_false(foreach_digest2(digest, 1, sizeof(TCG_DIGEST2) - 1, foreach_digest2_test_callback, NULL));
+    assert_false(foreach_digest2(&ctx, 0, digest, 1, sizeof(TCG_DIGEST2) - 1));
 }
 static void test_foreach_digest2(void **state) {
 
@@ -42,7 +44,9 @@ static void test_foreach_digest2(void **state) {
     TCG_DIGEST2* digest = (TCG_DIGEST2*)buf;
 
     will_return(foreach_digest2_test_callback, true);
-    assert_true(foreach_digest2(digest, 1, TCG_DIGEST2_SHA1_SIZE, foreach_digest2_test_callback, NULL));
+
+    tpm2_eventlog_ctx_t ctx = { .digest2_cb = foreach_digest2_test_callback };
+    assert_true(foreach_digest2(&ctx, 0, digest, 1, TCG_DIGEST2_SHA1_SIZE));
 }
 static void test_foreach_digest2_cbnull(void **state){
 
@@ -50,7 +54,8 @@ static void test_foreach_digest2_cbnull(void **state){
     uint8_t buf [TCG_DIGEST2_SHA1_SIZE] = { 0, };
     TCG_DIGEST2* digest = (TCG_DIGEST2*)buf;
 
-    assert_true(foreach_digest2(digest, 1, TCG_DIGEST2_SHA1_SIZE, NULL, NULL));
+    tpm2_eventlog_ctx_t ctx = {};
+    assert_true(foreach_digest2(&ctx, 0, digest, 1, TCG_DIGEST2_SHA1_SIZE));
 }
 static void test_foreach_digest2_cbfail(void **state){
 
@@ -59,7 +64,9 @@ static void test_foreach_digest2_cbfail(void **state){
     TCG_DIGEST2* digest = (TCG_DIGEST2*)buf;
 
     will_return(foreach_digest2_test_callback, false);
-    assert_false(foreach_digest2(digest, 1, TCG_DIGEST2_SHA1_SIZE, foreach_digest2_test_callback, NULL));
+
+    tpm2_eventlog_ctx_t ctx = { .digest2_cb = foreach_digest2_test_callback };
+    assert_false(foreach_digest2(&ctx, 0, digest, 1, TCG_DIGEST2_SHA1_SIZE));
 }
 static void test_digest2_accumulator_callback(void **state) {
 
@@ -146,12 +153,6 @@ static void test_parse_event2_badeventbuf(void **state){
 
     assert_false(parse_event2(eventhdr, sizeof(buf), &size_event, &size_digest));
 }
-static void test_foreach_event2_null(void **state){
-
-    (void)state;
-
-    assert_false(foreach_event2(NULL, 0, NULL, NULL, NULL, NULL));
-}
 static void test_foreach_event2(void **state){
 
     (void)state;
@@ -167,9 +168,13 @@ static void test_foreach_event2(void **state){
     will_return(test_event2hdr_callback, true);
     will_return(foreach_digest2_test_callback, true);
     will_return(test_event2_callback, true);
-    assert_true(foreach_event2(eventhdr, sizeof(buf), test_event2hdr_callback,
-                               foreach_digest2_test_callback,
-                               test_event2_callback, NULL));
+
+    tpm2_eventlog_ctx_t ctx = {
+        .digest2_cb = foreach_digest2_test_callback,
+        .event2_cb = test_event2_callback,
+        .event2hdr_cb = test_event2hdr_callback,
+    };
+    assert_true(foreach_event2(&ctx, eventhdr, sizeof(buf)));
 }
 static void test_foreach_event2_event2hdr_fail(void **state){
 
@@ -184,8 +189,11 @@ static void test_foreach_event2_event2hdr_fail(void **state){
     event->EventSize = 1;
 
     will_return(test_event2hdr_callback, false);
-    assert_false(foreach_event2(eventhdr, sizeof(buf), test_event2hdr_callback,
-                                NULL, NULL, NULL));
+
+    tpm2_eventlog_ctx_t ctx = {
+        .event2hdr_cb = test_event2hdr_callback,
+    };
+    assert_false(foreach_event2(&ctx, eventhdr, sizeof(buf)));
 }
 static void test_foreach_event2_digest2_fail(void **state){
 
@@ -201,9 +209,12 @@ static void test_foreach_event2_digest2_fail(void **state){
 
     will_return(test_event2hdr_callback, true);
     will_return(foreach_digest2_test_callback, false);
-    assert_false(foreach_event2(eventhdr, sizeof(buf),
-                                test_event2hdr_callback,
-                                foreach_digest2_test_callback, NULL, NULL));
+
+    tpm2_eventlog_ctx_t ctx = {
+        .digest2_cb = foreach_digest2_test_callback,
+        .event2hdr_cb = test_event2hdr_callback,
+    };
+    assert_false(foreach_event2(&ctx, eventhdr, sizeof(buf)));
 }
 static void test_foreach_event2_parse_event2body_fail(void **state){
 
@@ -221,9 +232,12 @@ static void test_foreach_event2_parse_event2body_fail(void **state){
 
     will_return(test_event2hdr_callback, true);
     will_return(foreach_digest2_test_callback, true);
-    assert_false(foreach_event2(eventhdr, sizeof(buf),
-                                test_event2hdr_callback,
-                                foreach_digest2_test_callback, NULL, NULL));
+
+    tpm2_eventlog_ctx_t ctx = {
+        .digest2_cb = foreach_digest2_test_callback,
+        .event2hdr_cb = test_event2hdr_callback,
+    };
+    assert_false(foreach_event2(&ctx, eventhdr, sizeof(buf)));
 }
 static void test_foreach_event2_event2body_fail(void **state){
 
@@ -240,10 +254,13 @@ static void test_foreach_event2_event2body_fail(void **state){
     will_return(test_event2hdr_callback, true);
     will_return(foreach_digest2_test_callback, true);
     will_return(test_event2_callback, false);
-    assert_false(foreach_event2(eventhdr, sizeof(buf),
-                                test_event2hdr_callback,
-                                foreach_digest2_test_callback,
-                                test_event2_callback, NULL));
+
+    tpm2_eventlog_ctx_t ctx = {
+        .event2hdr_cb = test_event2hdr_callback,
+        .digest2_cb = foreach_digest2_test_callback,
+        .event2_cb = test_event2_callback,
+    };
+    assert_false(foreach_event2(&ctx, eventhdr, sizeof(buf)));
 }
 static void test_parse_event2body_uefivar_badsize(void **state){
 
@@ -457,7 +474,6 @@ int main(void) {
         cmocka_unit_test(test_parse_event2_baddigest),
         cmocka_unit_test(test_parse_event2_badeventsize),
         cmocka_unit_test(test_parse_event2_badeventbuf),
-        cmocka_unit_test(test_foreach_event2_null),
         cmocka_unit_test(test_foreach_event2),
         cmocka_unit_test(test_foreach_event2_event2hdr_fail),
         cmocka_unit_test(test_foreach_event2_event2body_fail),

--- a/test/unit/test_tpm2_eventlog.c
+++ b/test/unit/test_tpm2_eventlog.c
@@ -25,7 +25,7 @@ static bool foreach_digest2_test_callback(TCG_DIGEST2 const *digest, size_t size
 static void test_foreach_digest2_null(void **state){
 
     (void)state;
-    tpm2_eventlog_ctx_t ctx = {};
+    tpm2_eventlog_ctx_t ctx = {0};
 
     assert_false(foreach_digest2(&ctx, 0, NULL, 0, sizeof(TCG_DIGEST2)));
 }
@@ -52,43 +52,49 @@ static void test_foreach_digest2(void **state) {
 static void test_foreach_digest2_cbnull(void **state){
 
     (void)state;
-    uint8_t buf [TCG_DIGEST2_SHA1_SIZE] = { };
+    uint8_t buf [TCG_DIGEST2_SHA1_SIZE] = {0};
     TCG_DIGEST2* digest = (TCG_DIGEST2*)buf;
 
-    tpm2_eventlog_ctx_t ctx = {};
+    tpm2_eventlog_ctx_t ctx = {0};
     assert_true(foreach_digest2(&ctx, 0, digest, 1, TCG_DIGEST2_SHA1_SIZE));
 }
 static void test_sha1(void **state){
 
     (void)state;
     uint8_t buf [TCG_DIGEST2_SHA1_SIZE] = { 0, };
-    uint8_t sha1sum[] = { 0x31,0x19,0x5d,0x69,0x35,0x16,0x3c,0x79,0xa9,0x67,0x22,0xba,0x7d,0x4b,0x11,0x35,0x24,0x89,0xf4,0x8b };
-    const int pcrIndex = 3;
+    const uint8_t sha1sum[] = {
+        0x31,0x19,0x5d,0x69,0x35,0x16,0x3c,0x79,0xa9,0x67,
+        0x22,0xba,0x7d,0x4b,0x11,0x35,0x24,0x89,0xf4,0x8b,
+    };
+    const int pcr_index = 3;
 
     TCG_DIGEST2 * digest = (TCG_DIGEST2*) buf;
     digest->AlgorithmId = TPM2_ALG_SHA1,
     memcpy(digest->Digest, "the magic words are:", TPM2_SHA1_DIGEST_SIZE);
 
-    tpm2_eventlog_ctx_t ctx = {};
-    assert_true(foreach_digest2(&ctx, pcrIndex, digest, 1, TCG_DIGEST2_SHA1_SIZE));
-    // memcmp() == 0 if the buffers match
-    assert_false(memcmp(ctx.sha1_pcrs[pcrIndex], sha1sum, sizeof(sha1sum)));
+    tpm2_eventlog_ctx_t ctx = {0};
+    assert_true(foreach_digest2(&ctx, pcr_index, digest, 1, TCG_DIGEST2_SHA1_SIZE));
+    assert_memory_equal(ctx.sha1_pcrs[pcr_index], sha1sum, sizeof(sha1sum));
 }
 static void test_sha256(void **state){
 
     (void)state;
-    uint8_t buf [TCG_DIGEST2_SHA256_SIZE] = { };
-    uint8_t sha256sum[TPM2_SHA256_DIGEST_SIZE] = { 0x51,0xea,0x4e,0xa4,0x98,0xaa,0xe2,0x52,0xf4,0xe7,0xff,0x4b,0x13,0xb6,0x3f,0xe5,0xb5,0x7a,0xf8,0x21,0xa4,0x84,0x4e,0xe2,0x6f,0xd8,0xdd,0x25,0xa4,0x2b,0x33,0x23 };
-    const int pcrIndex = 3;
+    uint8_t buf [TCG_DIGEST2_SHA256_SIZE] = {0};
+    const uint8_t sha256sum[] = {
+        0x51,0xea,0x4e,0xa4,0x98,0xaa,0xe2,0x52,
+        0xf4,0xe7,0xff,0x4b,0x13,0xb6,0x3f,0xe5,
+        0xb5,0x7a,0xf8,0x21,0xa4,0x84,0x4e,0xe2,
+        0x6f,0xd8,0xdd,0x25,0xa4,0x2b,0x33,0x23,
+    };
+    const int pcr_index = 3;
 
     TCG_DIGEST2 * digest = (TCG_DIGEST2*) buf;
     digest->AlgorithmId = TPM2_ALG_SHA256,
     memcpy(digest->Digest, "The Magic Words are Squeamish Ossifrage, for RSA-129 (from 1977)", TPM2_SHA256_DIGEST_SIZE);
 
-    tpm2_eventlog_ctx_t ctx = {};
-    assert_true(foreach_digest2(&ctx, pcrIndex, digest, 1, TCG_DIGEST2_SHA256_SIZE));
-    // memcmp() == 0 if the buffers match
-    assert_false(memcmp(ctx.sha256_pcrs[pcrIndex], sha256sum, sizeof(sha256sum)));
+    tpm2_eventlog_ctx_t ctx = {0};
+    assert_true(foreach_digest2(&ctx, pcr_index, digest, 1, TCG_DIGEST2_SHA256_SIZE));
+    assert_memory_equal(ctx.sha256_pcrs[pcr_index], sha256sum, sizeof(sha256sum));
 }
 static void test_foreach_digest2_cbfail(void **state){
 

--- a/tools/misc/tpm2_checkquote.c
+++ b/tools/misc/tpm2_checkquote.c
@@ -266,6 +266,7 @@ static tool_rc init(void) {
     TPM2B_ATTEST *msg = NULL;
     TPML_PCR_SELECTION pcr_select;
     tpm2_pcrs * pcrs;
+    tpm2_pcrs temp_pcrs;
     tool_rc return_value = tool_rc_general_error;
 
     msg = message_from_file(ctx.msg_file_path);
@@ -315,7 +316,6 @@ static tool_rc init(void) {
     }
 
     if (ctx.flags.pcr) {
-        tpm2_pcrs temp_pcrs;
         if (pcrs_from_file(ctx.pcr_file_path, &pcr_select, &temp_pcrs)) {
             /* pcrs_from_file() logs specific error no need to here */
             pcrs = &temp_pcrs;
@@ -342,7 +342,7 @@ static tool_rc init(void) {
         }
     }
 
-    if (ctx.flags.eventlog) {
+    if (ctx.flags.eventlog && ctx.flags.pcr) {
         tpm2_eventlog_ctx_t eventlog_ctx = {};
         if (!eventlog_from_file(&eventlog_ctx, ctx.eventlog_path)) {
             LOG_ERR("Failed to process eventlog");

--- a/tools/misc/tpm2_checkquote.c
+++ b/tools/misc/tpm2_checkquote.c
@@ -219,7 +219,7 @@ out:
     return result;
 }
 
-static bool eventlog_from_file(tpm2_eventlog_ctx_t * ctx, const char *file_path) {
+static bool eventlog_from_file(tpm2_eventlog_ctx_t * evctx, const char *file_path) {
 
     unsigned long size;
 
@@ -244,7 +244,7 @@ static bool eventlog_from_file(tpm2_eventlog_ctx_t * ctx, const char *file_path)
         return false;
     }
 
-    bool rc = parse_eventlog(ctx, eventlog, size);
+    bool rc = parse_eventlog(evctx, eventlog, size);
     free(eventlog);
 
     return rc;
@@ -378,6 +378,15 @@ static tool_rc init(void) {
                 } else
                 if (sel->hash == TPM2_ALG_SHA256 && pcr->size == TPM2_SHA256_DIGEST_SIZE) {
                     pcr_e = eventlog_ctx.sha256_pcrs[pcr_id];
+                } else
+                if (sel->hash == TPM2_ALG_SHA384 && pcr->size == TPM2_SHA384_DIGEST_SIZE) {
+                    pcr_e = eventlog_ctx.sha384_pcrs[pcr_id];
+                } else
+                if (sel->hash == TPM2_ALG_SHA512 && pcr->size == TPM2_SHA512_DIGEST_SIZE) {
+                    pcr_e = eventlog_ctx.sha512_pcrs[pcr_id];
+                } else
+                if (sel->hash == TPM2_ALG_SM3_256 && pcr->size == TPM2_SM3_256_DIGEST_SIZE) {
+                    pcr_e = eventlog_ctx.sm3_256_pcrs[pcr_id];
                 } else {
                     LOG_WARN("PCR%u unsupported algorithm/size %u/%u", pcr_id, sel->hash, pcr->size);
                     eventlog_fail = 1;

--- a/tools/misc/tpm2_checkquote.c
+++ b/tools/misc/tpm2_checkquote.c
@@ -219,7 +219,7 @@ out:
     return result;
 }
 
-static bool eventlog_from_file(tpm2_eventlog_ctx_t *evctx, const char *file_path) {
+static bool eventlog_from_file(tpm2_eventlog_context *evctx, const char *file_path) {
 
     unsigned long size;
 
@@ -353,7 +353,7 @@ static tool_rc init(void) {
         if (pcr_select.count > TPM2_NUM_PCR_BANKS)
             goto err;
 
-        tpm2_eventlog_ctx_t eventlog_ctx = {};
+        tpm2_eventlog_context eventlog_ctx = {};
         bool rc = eventlog_from_file(&eventlog_ctx, ctx.eventlog_path);
         if (!rc) {
             LOG_ERR("Failed to process eventlog");

--- a/tools/misc/tpm2_checkquote.c
+++ b/tools/misc/tpm2_checkquote.c
@@ -343,6 +343,16 @@ static tool_rc init(void) {
     }
 
     if (ctx.flags.eventlog && ctx.flags.pcr) {
+        if (pcrs_from_file(ctx.pcr_file_path, &pcr_select, &temp_pcrs)) {
+            /* pcrs_from_file() logs specific error no need to here */
+            pcrs = &temp_pcrs;
+        } else {
+            goto err;
+        }
+
+        if (pcr_select.count > TPM2_NUM_PCR_BANKS)
+            goto err;
+
         tpm2_eventlog_ctx_t eventlog_ctx = {};
         if (!eventlog_from_file(&eventlog_ctx, ctx.eventlog_path)) {
             LOG_ERR("Failed to process eventlog");


### PR DESCRIPTION
This patch computes the PCR values for the sha1 and sha256 hashes based on the events in the log and outputs an additional yaml section with the predicted PCRs to make it easy to compare to the attested quote.