### PR TITLE
Makefile.am: use relative instead of absolute symlinks for tpm2_*

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -338,7 +338,7 @@ tpm2_tools = \
 install-exec-hook:
 	for tool in $(notdir $(basename $(tpm2_tools))) ; do \
 		$(LN_S) -f \
-		"$(DESTDIR)$(bindir)/tpm2$(EXEEXT)" \
+		"tpm2$(EXEEXT)" \
 		"$(DESTDIR)$(bindir)/$$tool$(EXEEXT)" ; \
 	done
 


### PR DESCRIPTION
Using absolute symlinks does not work when using DESTDIR, e.g. for distribution packaging, because the files will not be found any more once the installation directory has been moved to its final location. Using relative symlinks works fine since all files are in the same directory and seems to be the norm for symlinks in `@bindir@` anyway.

Fixes: 61d4ae3e7b4b5c1d3cd9a2e66e6ca589929e2d4e
Fixes: #2102