### PR TITLE
tss2 tools: Some fixes

### DIFF
--- a/lib/tpm2_options.c
+++ b/lib/tpm2_options.c
@@ -5,6 +5,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include <ctype.h>
 
 #include <fcntl.h>
 #include <libgen.h>
@@ -190,8 +191,14 @@ void tpm2_print_usage(const char *command, struct tpm2_options *tool_opts) {
             } else {
                 printf(" ");
             }
-            printf("[ -%c | --%s%s]", opt->val, opt->name,
-                    opt->has_arg ? "=<value>" : "");
+            if (isalpha(opt->val)) {
+                printf("[ -%c | --%s%s]", opt->val, opt->name,
+                        opt->has_arg ? "=<value>" : "");
+            }
+            else {
+                printf("[ --%s%s]", opt->name,
+                        opt->has_arg ? "=<value>" : "");
+            }
             if ((i + 1) % 4 == 0) {
                 printf("\n");
                 indent = true;

--- a/tools/fapi/tss2_authorizepolicy.c
+++ b/tools/fapi/tss2_authorizepolicy.c
@@ -73,10 +73,11 @@ int tss2_tool_onrun (FAPI_CONTEXT *fctx) {
         policyRefSize);
     if (r != TSS2_RC_SUCCESS){
         LOG_PERR ("Fapi_AuthorizePolicy", r);
+        free (policyRef);
         return r;
     }
 
-    free(policyRef);
+    free (policyRef);
 
     return r;
 }

--- a/tools/fapi/tss2_createseal.c
+++ b/tools/fapi/tss2_createseal.c
@@ -121,10 +121,11 @@ int tss2_tool_onrun (FAPI_CONTEXT *fctx) {
         if(has_asked_for_password){
             free (ctx.authValue);
         }
+        free (data);
         LOG_PERR ("Fapi_CreateSeal", r);
         return 1;
     }
-    Fapi_Free(data);
+    free (data);
     if(has_asked_for_password){
         free (ctx.authValue);
     }

--- a/tools/fapi/tss2_createseal.c
+++ b/tools/fapi/tss2_createseal.c
@@ -46,6 +46,10 @@ static bool on_option(char key, char *value) {
                 " larger than 2**32 - 1\n", value);
             return false;
         }
+        if (ctx.size == 0) {
+            LOG_ERR("Size parameter must be larger than 0\n");
+            return false;
+        }
         break;
     }
     return true;
@@ -73,9 +77,15 @@ int tss2_tool_onrun (FAPI_CONTEXT *fctx) {
         return -1;
     }
 
+    if (!ctx.data && !ctx.size) {
+        fprintf (stderr, "One of --data or --size "\
+        "must be used\n");
+        return -1;
+    }
+
     if (ctx.data && ctx.size) {
         fprintf (stderr, "Only one of --data and --size "\
-        "can be used");
+        "can be used\n");
         return -1;
     }
 

--- a/tools/fapi/tss2_decrypt.c
+++ b/tools/fapi/tss2_decrypt.c
@@ -78,6 +78,7 @@ int tss2_tool_onrun (FAPI_CONTEXT *fctx) {
     r = Fapi_Decrypt (fctx, ctx.keyPath, cipherText, cipherTextSize,
         &plainText, &plainTextSize);
     if (r != TSS2_RC_SUCCESS) {
+        free(cipherText);
         LOG_PERR ("Fapi_Decrypt", r);
         return 1;
     }

--- a/tools/fapi/tss2_nvextend.c
+++ b/tools/fapi/tss2_nvextend.c
@@ -85,6 +85,8 @@ int tss2_tool_onrun (FAPI_CONTEXT *fctx) {
     /* Execute FAPI command with passed arguments */
     r = Fapi_NvExtend(fctx, ctx.nvPath, data, data_len, logData);
     if (r != TSS2_RC_SUCCESS){
+        free (data);
+        free (logData);
         LOG_PERR("Fapi_NvExtend", r);
         return 1;
     }

--- a/tools/fapi/tss2_nvwrite.c
+++ b/tools/fapi/tss2_nvwrite.c
@@ -61,6 +61,7 @@ int tss2_tool_onrun (FAPI_CONTEXT *fctx) {
     /* Execute FAPI command with passed arguments */
     r = Fapi_NvWrite(fctx, ctx.nvPath, data, data_len);
     if (r != TSS2_RC_SUCCESS){
+        free (data);
         LOG_PERR ("Fapi_NvWrite", r);
         return 1;
     }

--- a/tools/fapi/tss2_pcrextend.c
+++ b/tools/fapi/tss2_pcrextend.c
@@ -82,7 +82,7 @@ int tss2_tool_onrun (FAPI_CONTEXT *fctx) {
     if (ctx.logData) {
         r = open_read_and_close (ctx.logData, (void**)&logData, 0);
         if (r) {
-            Fapi_Free (data);
+            free (data);
             return -1;
         }
     }
@@ -90,6 +90,7 @@ int tss2_tool_onrun (FAPI_CONTEXT *fctx) {
     /* Execute FAPI command with passed arguments */
     r = Fapi_PcrExtend(fctx, ctx.pcr, data, eventDataSize, logData);
     if (r != TSS2_RC_SUCCESS){
+        free (data);
         free (logData);
         LOG_PERR ("Fapi_PcrExtend", r);
         return 1;

--- a/tools/fapi/tss2_verifyquote.c
+++ b/tools/fapi/tss2_verifyquote.c
@@ -131,6 +131,10 @@ int tss2_tool_onrun (FAPI_CONTEXT *fctx) {
         qualifyingDataSize, quoteInfo, signature, signatureSize,
         pcrLog);
     if (r != TSS2_RC_SUCCESS){
+        free (qualifyingData);
+        free (signature);
+        free (quoteInfo);
+        free (pcrLog);
         LOG_PERR ("Fapi_VerifyQuote", r);
         return 1;
     }

--- a/tools/fapi/tss2_verifysignature.c
+++ b/tools/fapi/tss2_verifysignature.c
@@ -88,6 +88,8 @@ int tss2_tool_onrun (FAPI_CONTEXT *fctx) {
     r = Fapi_VerifySignature (fctx, ctx.publicKeyPath,
         digest, digestSize, signature, signatureSize);
     if (r != TSS2_RC_SUCCESS){
+        free (digest);
+        free (signature);
         LOG_PERR("Fapi_Key_VerifySignature", r);
         return 1;
     }


### PR DESCRIPTION
This PR fixes the following issues

- tss2_createseal: Make parameters data or size mandatory
- tpm2_print_usage: Do not try to print a short option if there is none
- tss2_*: Fix some memory leaks and use correct free function

Signed-off-by: Christian Plappert <christian.plappert@sit.fraunhofer.de>