### PR TITLE
test: add tcti-cmd test

### DIFF
--- a/test/integration/tests/send-tcti-cmd.sh
+++ b/test/integration/tests/send-tcti-cmd.sh
@@ -1,0 +1,19 @@
+# SPDX-License-Identifier: BSD-3-Clause
+
+# skip if tcti-cmd not installed
+pkg-config --exists tss2-tcti-cmd
+if [ $? -ne 0 ]; then
+  exit 077
+fi
+
+source helpers.sh
+
+start_up
+
+random="$(tpm2 getrandom -T"cmd:tpm2 send" --hex 32)"
+
+count="$(echo -n "$random" | wc -c)"
+
+test "$count" -eq 64
+
+exit 0


### PR DESCRIPTION
Add test that runs a tpm2-tools command, tpm2 getrandom, with the
command tcti and the tpm2 send command. Skip if the tss2-tcti-cmd
package is not installed. This will keep this test backwards compat with
older versions of the TSS.

Signed-off-by: William Roberts <william.c.roberts@intel.com>