### PR TITLE
Bundle the FAPI tss2 tools into a single executable

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -44,7 +44,7 @@ noinst_LIBRARIES = $(LIB_COMMON)
 lib_libcommon_a_SOURCES = $(LIB_SRC)
 lib_libcommon_a_CFLAGS = -fPIC $(AM_CFLAGS)
 
-tools_fapi_tss2_CFLAGS = $(FAPI_CFLAGS)
+tools_fapi_tss2_CFLAGS = $(FAPI_CFLAGS) -DTSS2_TOOLS_MAX="$(words $(tss2_tools))"
 tools_fapi_tss2_LDFLAGS = $(TSS2_FAPI_LIBS)
 tools_fapi_tss2_SOURCES = \
 	tools/fapi/tss2_template.c \

--- a/Makefile.am
+++ b/Makefile.am
@@ -36,44 +36,7 @@ TESTS =
 
 if HAVE_FAPI
 
-bin_PROGRAMS += \
-    tools/fapi/tss2_decrypt \
-    tools/fapi/tss2_encrypt \
-    tools/fapi/tss2_list \
-    tools/fapi/tss2_changeauth \
-    tools/fapi/tss2_delete \
-    tools/fapi/tss2_import \
-    tools/fapi/tss2_getinfo \
-    tools/fapi/tss2_createkey \
-    tools/fapi/tss2_createseal \
-    tools/fapi/tss2_exportkey \
-    tools/fapi/tss2_getcertificate \
-    tools/fapi/tss2_getplatformcertificates \
-    tools/fapi/tss2_gettpmblobs \
-    tools/fapi/tss2_getappdata \
-    tools/fapi/tss2_setappdata \
-    tools/fapi/tss2_setcertificate \
-    tools/fapi/tss2_sign \
-    tools/fapi/tss2_verifysignature \
-    tools/fapi/tss2_verifyquote \
-    tools/fapi/tss2_createnv \
-    tools/fapi/tss2_nvextend \
-    tools/fapi/tss2_nvincrement \
-    tools/fapi/tss2_nvread \
-    tools/fapi/tss2_nvsetbits \
-    tools/fapi/tss2_nvwrite \
-    tools/fapi/tss2_getdescription \
-    tools/fapi/tss2_setdescription \
-    tools/fapi/tss2_pcrextend \
-    tools/fapi/tss2_quote \
-    tools/fapi/tss2_pcrread \
-    tools/fapi/tss2_authorizepolicy \
-    tools/fapi/tss2_exportpolicy \
-    tools/fapi/tss2_import \
-    tools/fapi/tss2_provision \
-    tools/fapi/tss2_getrandom \
-    tools/fapi/tss2_unseal \
-    tools/fapi/tss2_writeauthorizenv
+bin_PROGRAMS += tools/fapi/tss2
 
 endif
 
@@ -81,150 +44,52 @@ noinst_LIBRARIES = $(LIB_COMMON)
 lib_libcommon_a_SOURCES = $(LIB_SRC)
 lib_libcommon_a_CFLAGS = -fPIC $(AM_CFLAGS)
 
-tools_fapi_tss2_decrypt_CFLAGS = $(FAPI_CFLAGS)
-tools_fapi_tss2_decrypt_LDFLAGS = $(TSS2_FAPI_LIBS)
-tools_fapi_tss2_decrypt_SOURCES = tools/fapi/tss2_template.c tools/fapi/tss2_template.h \
-    tools/fapi/tss2_decrypt.c
+tools_fapi_tss2_CFLAGS = $(FAPI_CFLAGS)
+tools_fapi_tss2_LDFLAGS = $(TSS2_FAPI_LIBS)
+tools_fapi_tss2_SOURCES = \
+	tools/fapi/tss2_template.c \
+	tools/fapi/tss2_template.h \
+	$(tss2_tools)
 
-tools_fapi_tss2_encrypt_CFLAGS = $(FAPI_CFLAGS)
-tools_fapi_tss2_encrypt_LDFLAGS = $(TSS2_FAPI_LIBS)
-tools_fapi_tss2_encrypt_SOURCES = tools/fapi/tss2_template.c tools/fapi/tss2_encrypt.c
+tss2_tools = \
+    tools/fapi/tss2_decrypt.c \
+    tools/fapi/tss2_encrypt.c \
+    tools/fapi/tss2_list.c \
+    tools/fapi/tss2_changeauth.c \
+    tools/fapi/tss2_delete.c \
+    tools/fapi/tss2_import.c \
+    tools/fapi/tss2_getinfo.c \
+    tools/fapi/tss2_createkey.c \
+    tools/fapi/tss2_createseal.c \
+    tools/fapi/tss2_exportkey.c \
+    tools/fapi/tss2_getcertificate.c \
+    tools/fapi/tss2_getplatformcertificates.c \
+    tools/fapi/tss2_gettpmblobs.c \
+    tools/fapi/tss2_getappdata.c \
+    tools/fapi/tss2_setappdata.c \
+    tools/fapi/tss2_setcertificate.c \
+    tools/fapi/tss2_sign.c \
+    tools/fapi/tss2_verifysignature.c \
+    tools/fapi/tss2_verifyquote.c \
+    tools/fapi/tss2_createnv.c \
+    tools/fapi/tss2_nvextend.c \
+    tools/fapi/tss2_nvincrement.c \
+    tools/fapi/tss2_nvread.c \
+    tools/fapi/tss2_nvsetbits.c \
+    tools/fapi/tss2_nvwrite.c \
+    tools/fapi/tss2_getdescription.c \
+    tools/fapi/tss2_setdescription.c \
+    tools/fapi/tss2_pcrextend.c \
+    tools/fapi/tss2_quote.c \
+    tools/fapi/tss2_pcrread.c \
+    tools/fapi/tss2_authorizepolicy.c \
+    tools/fapi/tss2_exportpolicy.c \
+    tools/fapi/tss2_import.c \
+    tools/fapi/tss2_provision.c \
+    tools/fapi/tss2_getrandom.c \
+    tools/fapi/tss2_unseal.c \
+    tools/fapi/tss2_writeauthorizenv.c
 
-tools_fapi_tss2_list_CFLAGS = $(FAPI_CFLAGS)
-tools_fapi_tss2_list_LDFLAGS = $(TSS2_FAPI_LIBS)
-tools_fapi_tss2_list_SOURCES = tools/fapi/tss2_template.c tools/fapi/tss2_list.c
-
-tools_fapi_tss2_changeauth_CFLAGS = $(FAPI_CFLAGS)
-tools_fapi_tss2_changeauth_LDFLAGS = $(TSS2_FAPI_LIBS)
-tools_fapi_tss2_changeauth_SOURCES = tools/fapi/tss2_template.c tools/fapi/tss2_changeauth.c
-
-tools_fapi_tss2_delete_CFLAGS = $(FAPI_CFLAGS)
-tools_fapi_tss2_delete_LDFLAGS = $(TSS2_FAPI_LIBS)
-tools_fapi_tss2_delete_SOURCES = tools/fapi/tss2_template.c tools/fapi/tss2_delete.c
-
-tools_fapi_tss2_import_CFLAGS = $(FAPI_CFLAGS)
-tools_fapi_tss2_import_LDFLAGS = $(TSS2_FAPI_LIBS)
-tools_fapi_tss2_import_SOURCES = tools/fapi/tss2_template.c tools/fapi/tss2_import.c
-
-tools_fapi_tss2_createkey_CFLAGS = $(FAPI_CFLAGS)
-tools_fapi_tss2_createkey_LDFLAGS = $(TSS2_FAPI_LIBS)
-tools_fapi_tss2_createkey_SOURCES = tools/fapi/tss2_template.c tools/fapi/tss2_createkey.c
-
-tools_fapi_tss2_createseal_CFLAGS = $(FAPI_CFLAGS)
-tools_fapi_tss2_createseal_LDFLAGS = $(TSS2_FAPI_LIBS)
-tools_fapi_tss2_createseal_SOURCES = tools/fapi/tss2_template.c tools/fapi/tss2_createseal.c
-
-tools_fapi_tss2_getcertificate_CFLAGS = $(FAPI_CFLAGS)
-tools_fapi_tss2_getcertificate_LDFLAGS = $(TSS2_FAPI_LIBS)
-tools_fapi_tss2_getcertificate_SOURCES = tools/fapi/tss2_template.c tools/fapi/tss2_getcertificate.c
-
-tools_fapi_tss2_getplatformcertificates_CFLAGS = $(FAPI_CFLAGS)
-tools_fapi_tss2_getplatformcertificates_LDFLAGS = $(TSS2_FAPI_LIBS)
-tools_fapi_tss2_getplatformcertificates_SOURCES = tools/fapi/tss2_template.c tools/fapi/tss2_getplatformcertificates.c
-
-tools_fapi_tss2_gettpmblobs_CFLAGS = $(FAPI_CFLAGS)
-tools_fapi_tss2_gettpmblobs_LDFLAGS = $(TSS2_FAPI_LIBS)
-tools_fapi_tss2_gettpmblobs_SOURCES = tools/fapi/tss2_template.c tools/fapi/tss2_gettpmblobs.c
-
-tools_fapi_tss2_getappdata_CFLAGS = $(FAPI_CFLAGS)
-tools_fapi_tss2_getappdata_LDFLAGS = $(TSS2_FAPI_LIBS)
-tools_fapi_tss2_getappdata_SOURCES = tools/fapi/tss2_template.c tools/fapi/tss2_getappdata.c
-
-tools_fapi_tss2_setappdata_CFLAGS = $(FAPI_CFLAGS)
-tools_fapi_tss2_setappdata_LDFLAGS = $(TSS2_FAPI_LIBS)
-tools_fapi_tss2_setappdata_SOURCES = tools/fapi/tss2_template.c tools/fapi/tss2_setappdata.c
-
-tools_fapi_tss2_exportkey_CFLAGS = $(FAPI_CFLAGS)
-tools_fapi_tss2_exportkey_LDFLAGS = $(TSS2_FAPI_LIBS)
-tools_fapi_tss2_exportkey_SOURCES = tools/fapi/tss2_template.c tools/fapi/tss2_exportkey.c
-
-tools_fapi_tss2_setcertificate_CFLAGS = $(FAPI_CFLAGS)
-tools_fapi_tss2_setcertificate_LDFLAGS = $(TSS2_FAPI_LIBS)
-tools_fapi_tss2_setcertificate_SOURCES = tools/fapi/tss2_template.c tools/fapi/tss2_setcertificate.c
-
-tools_fapi_tss2_sign_CFLAGS = $(FAPI_CFLAGS)
-tools_fapi_tss2_sign_LDFLAGS = $(TSS2_FAPI_LIBS)
-tools_fapi_tss2_sign_SOURCES = tools/fapi/tss2_template.c tools/fapi/tss2_sign.c
-
-tools_fapi_tss2_verifysignature_CFLAGS = $(FAPI_CFLAGS)
-tools_fapi_tss2_verifysignature_LDFLAGS = $(TSS2_FAPI_LIBS)
-tools_fapi_tss2_verifysignature_SOURCES = tools/fapi/tss2_template.c tools/fapi/tss2_verifysignature.c
-
-tools_fapi_tss2_verifyquote_CFLAGS = $(FAPI_CFLAGS)
-tools_fapi_tss2_verifyquote_LDFLAGS = $(TSS2_FAPI_LIBS)
-tools_fapi_tss2_verifyquote_SOURCES = tools/fapi/tss2_template.c tools/fapi/tss2_verifyquote.c
-
-tools_fapi_tss2_createnv_CFLAGS = $(FAPI_CFLAGS)
-tools_fapi_tss2_createnv_LDFLAGS = $(TSS2_FAPI_LIBS)
-tools_fapi_tss2_createnv_SOURCES = tools/fapi/tss2_template.c tools/fapi/tss2_createnv.c
-
-tools_fapi_tss2_nvextend_CFLAGS = $(FAPI_CFLAGS)
-tools_fapi_tss2_nvextend_LDFLAGS = $(TSS2_FAPI_LIBS)
-tools_fapi_tss2_nvextend_SOURCES = tools/fapi/tss2_template.c tools/fapi/tss2_nvextend.c
-
-tools_fapi_tss2_nvincrement_CFLAGS = $(FAPI_CFLAGS)
-tools_fapi_tss2_nvincrement_LDFLAGS = $(TSS2_FAPI_LIBS)
-tools_fapi_tss2_nvincrement_SOURCES = tools/fapi/tss2_template.c tools/fapi/tss2_nvincrement.c
-
-tools_fapi_tss2_nvread_CFLAGS = $(FAPI_CFLAGS)
-tools_fapi_tss2_nvread_LDFLAGS = $(TSS2_FAPI_LIBS)
-tools_fapi_tss2_nvread_SOURCES = tools/fapi/tss2_template.c tools/fapi/tss2_nvread.c
-
-tools_fapi_tss2_nvsetbits_CFLAGS = $(FAPI_CFLAGS)
-tools_fapi_tss2_nvsetbits_LDFLAGS = $(TSS2_FAPI_LIBS)
-tools_fapi_tss2_nvsetbits_SOURCES = tools/fapi/tss2_template.c tools/fapi/tss2_nvsetbits.c
-
-tools_fapi_tss2_nvwrite_CFLAGS = $(FAPI_CFLAGS)
-tools_fapi_tss2_nvwrite_LDFLAGS = $(TSS2_FAPI_LIBS)
-tools_fapi_tss2_nvwrite_SOURCES = tools/fapi/tss2_template.c tools/fapi/tss2_nvwrite.c
-
-tools_fapi_tss2_getinfo_CFLAGS = $(FAPI_CFLAGS)
-tools_fapi_tss2_getinfo_LDFLAGS = $(TSS2_FAPI_LIBS)
-tools_fapi_tss2_getinfo_SOURCES = tools/fapi/tss2_template.c tools/fapi/tss2_getinfo.c
-
-tools_fapi_tss2_getdescription_CFLAGS = $(FAPI_CFLAGS)
-tools_fapi_tss2_getdescription_LDFLAGS = $(TSS2_FAPI_LIBS)
-tools_fapi_tss2_getdescription_SOURCES = tools/fapi/tss2_template.c tools/fapi/tss2_getdescription.c
-
-tools_fapi_tss2_setdescription_CFLAGS = $(FAPI_CFLAGS)
-tools_fapi_tss2_setdescription_LDFLAGS = $(TSS2_FAPI_LIBS)
-tools_fapi_tss2_setdescription_SOURCES = tools/fapi/tss2_template.c tools/fapi/tss2_setdescription.c
-
-tools_fapi_tss2_pcrextend_CFLAGS = $(FAPI_CFLAGS)
-tools_fapi_tss2_pcrextend_LDFLAGS = $(TSS2_FAPI_LIBS)
-tools_fapi_tss2_pcrextend_SOURCES = tools/fapi/tss2_template.c tools/fapi/tss2_pcrextend.c
-
-tools_fapi_tss2_quote_CFLAGS = $(FAPI_CFLAGS)
-tools_fapi_tss2_quote_LDFLAGS = $(TSS2_FAPI_LIBS)
-tools_fapi_tss2_quote_SOURCES = tools/fapi/tss2_template.c tools/fapi/tss2_quote.c
-
-tools_fapi_tss2_pcrread_CFLAGS = $(FAPI_CFLAGS)
-tools_fapi_tss2_pcrread_LDFLAGS = $(TSS2_FAPI_LIBS)
-tools_fapi_tss2_pcrread_SOURCES = tools/fapi/tss2_template.c tools/fapi/tss2_pcrread.c
-
-tools_fapi_tss2_authorizepolicy_CFLAGS = $(FAPI_CFLAGS)
-tools_fapi_tss2_authorizepolicy_LDFLAGS = $(TSS2_FAPI_LIBS)
-tools_fapi_tss2_authorizepolicy_SOURCES = tools/fapi/tss2_template.c tools/fapi/tss2_authorizepolicy.c
-
-tools_fapi_tss2_exportpolicy_CFLAGS = $(FAPI_CFLAGS)
-tools_fapi_tss2_exportpolicy_LDFLAGS = $(TSS2_FAPI_LIBS)
-tools_fapi_tss2_exportpolicy_SOURCES = tools/fapi/tss2_template.c tools/fapi/tss2_exportpolicy.c
-
-tools_fapi_tss2_unseal_CFLAGS = $(FAPI_CFLAGS)
-tools_fapi_tss2_unseal_LDFLAGS = $(TSS2_FAPI_LIBS)
-tools_fapi_tss2_unseal_SOURCES = tools/fapi/tss2_template.c tools/fapi/tss2_unseal.c
-
-tools_fapi_tss2_provision_CFLAGS = $(FAPI_CFLAGS)
-tools_fapi_tss2_provision_LDFLAGS = $(TSS2_FAPI_LIBS)
-tools_fapi_tss2_provision_SOURCES = tools/fapi/tss2_template.c tools/fapi/tss2_provision.c
-
-tools_fapi_tss2_getrandom_CFLAGS = $(FAPI_CFLAGS)
-tools_fapi_tss2_getrandom_LDFLAGS = $(TSS2_FAPI_LIBS)
-tools_fapi_tss2_getrandom_SOURCES = tools/fapi/tss2_template.c tools/fapi/tss2_getrandom.c
-
-tools_fapi_tss2_writeauthorizenv_CFLAGS = $(FAPI_CFLAGS)
-tools_fapi_tss2_writeauthorizenv_LDFLAGS = $(TSS2_FAPI_LIBS)
-tools_fapi_tss2_writeauthorizenv_SOURCES = tools/fapi/tss2_template.c tools/fapi/tss2_writeauthorizenv.c
 
 # Bundle all the tools into a single program similar to busybox
 bin_PROGRAMS += tools/tpm2

--- a/Makefile.am
+++ b/Makefile.am
@@ -199,9 +199,14 @@ tpm2_tools = \
     tools/tpm2_ecdhzgen.c \
     tools/tpm2_zgen2phase.c
 
-# Create the symlinks for each tool to the tpm2 bundled executable
+# Create the symlinks for each tool to the tpm2 and optional tss2 bundled executables
+all_tools = $(tpm2_tools)
+if HAVE_FAPI
+all_tools += $(tss2_tools)
+endif
+
 install-exec-hook:
-	for tool in $(notdir $(basename $(tpm2_tools))) ; do \
+	for tool in $(notdir $(basename $(all_tools))) ; do \
 		$(LN_S) -f \
 		"tpm2$(EXEEXT)" \
 		"$(DESTDIR)$(bindir)/$$tool$(EXEEXT)" ; \

--- a/test/integration/fapi/fapi-authorize-policy.sh
+++ b/test/integration/fapi/fapi-authorize-policy.sh
@@ -8,7 +8,7 @@ start_up
 setup_fapi
 
 function cleanup {
-    tss2_delete --path=/
+    tss2 delete --path=/
     shut_down
 }
 
@@ -28,27 +28,27 @@ DIGEST_FILE=$TEMP_DIR/digest.file
 echo -n 01234567890123456789012345678901 > $DIGEST_FILE
 echo 'f0f1f2f3f4f5f6f7f8f9' | xxd -r -p > $POLICY_REF
 
-tss2_provision
+tss2 provision
 
-tss2_import --path=$POLICY_PCR --importData=$PCR_POLICY_DATA
+tss2 import --path=$POLICY_PCR --importData=$PCR_POLICY_DATA
 
-tss2_import --path=$POLICY_AUTHORIZE --importData=$AUTHORIZE_POLICY_DATA
+tss2 import --path=$POLICY_AUTHORIZE --importData=$AUTHORIZE_POLICY_DATA
 
-tss2_createkey --path=$POLICY_SIGN_KEY_PATH --type="noDa, sign" --authValue=""
+tss2 createkey --path=$POLICY_SIGN_KEY_PATH --type="noDa, sign" --authValue=""
 
-tss2_authorizepolicy --keyPath=$POLICY_SIGN_KEY_PATH --policyPath=$POLICY_PCR \
+tss2 authorizepolicy --keyPath=$POLICY_SIGN_KEY_PATH --policyPath=$POLICY_PCR \
     --policyRef=$POLICY_REF
 
-tss2_createkey --path=$KEY_PATH --type="noDa, sign" \
+tss2 createkey --path=$KEY_PATH --type="noDa, sign" \
     --policyPath=$POLICY_AUTHORIZE --authValue=""
 
-tss2_sign --keyPath=$KEY_PATH --padding="RSA_PSS" --digest=$DIGEST_FILE \
+tss2 sign --keyPath=$KEY_PATH --padding="RSA_PSS" --digest=$DIGEST_FILE \
     --signature=$SIGNATURE_FILE --publicKey=$PUBLIC_KEY_FILE
 
 
 expect <<EOF
 # Try with missing policyPath
-spawn tss2_authorizepolicy --keyPath=$POLICY_SIGN_KEY_PATH \
+spawn tss2 authorizepolicy --keyPath=$POLICY_SIGN_KEY_PATH \
     --policyRef=$POLICY_REF
 set ret [wait]
 if {[lindex \$ret 2] || [lindex \$ret 3] != 1} {
@@ -59,7 +59,7 @@ EOF
 
 expect <<EOF
 # Try with missing keyPath
-spawn tss2_authorizepolicy \
+spawn tss2 authorizepolicy \
     --policyPath=$POLICY_PCR --policyRef=$POLICY_REF
 set ret [wait]
 if {[lindex \$ret 2] || [lindex \$ret 3] != 1} {

--- a/test/integration/fapi/fapi-branch-select.sh
+++ b/test/integration/fapi/fapi-branch-select.sh
@@ -8,7 +8,7 @@ start_up
 setup_fapi
 
 function cleanup {
-    tss2_delete --path=/
+    tss2 delete --path=/
     shut_down
 }
 
@@ -31,28 +31,28 @@ echo 'f0f1f2f3f4f5f6f7f8f9' | xxd -r -p > $POLICY_REF
 
 PADDINGS="RSA_PSS"
 
-tss2_provision
+tss2 provision
 
-tss2_import --path=$POLICY_PCR --importData=$PCR_POLICY_DATA
+tss2 import --path=$POLICY_PCR --importData=$PCR_POLICY_DATA
 
-tss2_import --path=$POLICY_PCR2 --importData=$PCR_POLICY_DATA
+tss2 import --path=$POLICY_PCR2 --importData=$PCR_POLICY_DATA
 
-tss2_import --path=$POLICY_AUTHORIZE --importData=$AUTHORIZE_POLICY_DATA
+tss2 import --path=$POLICY_AUTHORIZE --importData=$AUTHORIZE_POLICY_DATA
 
-tss2_createkey --path=$POLICY_SIGN_KEY_PATH --type="noDa, sign" --authValue=""
+tss2 createkey --path=$POLICY_SIGN_KEY_PATH --type="noDa, sign" --authValue=""
 
-tss2_authorizepolicy --keyPath=$POLICY_SIGN_KEY_PATH --policyPath=$POLICY_PCR \
+tss2 authorizepolicy --keyPath=$POLICY_SIGN_KEY_PATH --policyPath=$POLICY_PCR \
     --policyRef=$POLICY_REF
 
-tss2_authorizepolicy --keyPath=$POLICY_SIGN_KEY_PATH --policyPath=$POLICY_PCR2 \
+tss2 authorizepolicy --keyPath=$POLICY_SIGN_KEY_PATH --policyPath=$POLICY_PCR2 \
     --policyRef=$POLICY_REF
 
-tss2_createkey --path=$KEY_PATH --type="noDa, sign" \
+tss2 createkey --path=$KEY_PATH --type="noDa, sign" \
     --policyPath=$POLICY_AUTHORIZE --authValue=""
 
 expect <<EOF
 # Check if system asks for branch selection
-spawn tss2_sign --keyPath=$KEY_PATH --padding=$PADDINGS --digest=$DIGEST_FILE \
+spawn tss2 sign --keyPath=$KEY_PATH --padding=$PADDINGS --digest=$DIGEST_FILE \
     --signature=$SIGNATURE_FILE --publicKey=$PUBLIC_KEY_FILE
 expect {
     "Your choice: " {
@@ -71,7 +71,7 @@ EOF
 
 expect <<EOF
 # Selecting wrong branch
-spawn tss2_sign --keyPath=$KEY_PATH --padding=$PADDINGS --digest=$DIGEST_FILE \
+spawn tss2 sign --keyPath=$KEY_PATH --padding=$PADDINGS --digest=$DIGEST_FILE \
     --signature=$SIGNATURE_FILE --publicKey=$PUBLIC_KEY_FILE
 expect {
     "Your choice: " {

--- a/test/integration/fapi/fapi-encrypt-decrypt.sh
+++ b/test/integration/fapi/fapi-encrypt-decrypt.sh
@@ -7,7 +7,7 @@ start_up
 setup_fapi
 
 function cleanup {
-    tss2_delete --path=/
+    tss2 delete --path=/
     shut_down
 }
 
@@ -25,11 +25,11 @@ echo -n "Secret Text!" > $PLAIN_TEXT
 
 set -x
 
-tss2_provision
+tss2 provision
 
 expect <<EOF
 # Try interactive prompt with 2 different passwords
-spawn tss2_createkey --path=$KEY_PATH --type=$TYPES
+spawn tss2 createkey --path=$KEY_PATH --type=$TYPES
 expect "Authorize object Password: "
 send "1\r"
 expect "Authorize object Retype password: "
@@ -52,7 +52,7 @@ EOF
 
 expect <<EOF
 # Try with missing path
-spawn tss2_createkey --authValue=abc --type="noDa, decrypt"
+spawn tss2 createkey --authValue=abc --type="noDa, decrypt"
 set ret [wait]
 if {[lindex \$ret 2] || [lindex \$ret 3] != 1} {
     send_user "Command has not failed as expected\n"
@@ -60,11 +60,11 @@ if {[lindex \$ret 2] || [lindex \$ret 3] != 1} {
 }
 EOF
 
-tss2_import --path=$POLICY_PCR --importData=$PCR_POLICY_DATA
+tss2 import --path=$POLICY_PCR --importData=$PCR_POLICY_DATA
 
 expect <<EOF
 # Try interactive prompt with empty passwords
-spawn tss2_createkey --path=$KEY_PATH --type=$TYPES
+spawn tss2 createkey --path=$KEY_PATH --type=$TYPES
 expect "Authorize object Password: "
 send "\r"
 expect "Authorize object Retype password: "
@@ -77,12 +77,12 @@ if {[lindex \$ret 2] || [lindex \$ret 3] != 0} {
 }
 EOF
 
-tss2_encrypt --keyPath=$KEY_PATH --plainText=$PLAIN_TEXT \
+tss2 encrypt --keyPath=$KEY_PATH --plainText=$PLAIN_TEXT \
     --cipherText=$ENCRYPTED_FILE --force
 
 expect <<EOF
 # Try with missing keypath
-spawn tss2_encrypt --plainText=$PLAIN_TEXT --cipherText=$ENCRYPTED_FILE
+spawn tss2 encrypt --plainText=$PLAIN_TEXT --cipherText=$ENCRYPTED_FILE
 set ret [wait]
 if {[lindex \$ret 2] || [lindex \$ret 3] != 1} {
     send_user "Command has not failed as expected\n"
@@ -92,7 +92,7 @@ EOF
 
 expect <<EOF
 # Try with missing plaintext
-spawn tss2_encrypt --keyPath=$KEY_PATH --cipherText=$ENCRYPTED_FILE
+spawn tss2 encrypt --keyPath=$KEY_PATH --cipherText=$ENCRYPTED_FILE
 set ret [wait]
 if {[lindex \$ret 2] || [lindex \$ret 3] != 1} {
     send_user "Command has not failed as expected\n"
@@ -102,7 +102,7 @@ EOF
 
 expect <<EOF
 # Try with missing ciphertext
-spawn tss2_encrypt --keyPath=$KEY_PATH --plainText=$PLAIN_TEXT
+spawn tss2 encrypt --keyPath=$KEY_PATH --plainText=$PLAIN_TEXT
 set ret [wait]
 if {[lindex \$ret 2] || [lindex \$ret 3] != 1} {
     send_user "Command has not failed as expected\n"
@@ -112,7 +112,7 @@ EOF
 
 expect <<EOF
 # Try with wrong plaintext file
-spawn tss2_encrypt --keyPath=$KEY_PATH --plainText=abc \
+spawn tss2 encrypt --keyPath=$KEY_PATH --plainText=abc \
     --cipherText=$ENCRYPTED_FILE
 set ret [wait]
 if {[lindex \$ret 2] || [lindex \$ret 3] != 1} {
@@ -123,7 +123,7 @@ EOF
 
 expect <<EOF
 # Try with missing ciphertext
-spawn tss2_decrypt --keyPath=$KEY_PATH --plainText=$DECRYPTED_FILE
+spawn tss2 decrypt --keyPath=$KEY_PATH --plainText=$DECRYPTED_FILE
 set ret [wait]
 if {[lindex \$ret 2] || [lindex \$ret 3] != 1} {
     send_user "Command has not failed as expected\n"
@@ -133,7 +133,7 @@ EOF
 
 expect <<EOF
 # Try with missing plaintext
-spawn tss2_decrypt --keyPath=$KEY_PATH --cipherText=$ENCRYPTED_FILE
+spawn tss2 decrypt --keyPath=$KEY_PATH --cipherText=$ENCRYPTED_FILE
 set ret [wait]
 if {[lindex \$ret 2] || [lindex \$ret 3] != 1} {
     send_user "Command has not failed as expected\n"
@@ -143,7 +143,7 @@ EOF
 
 expect <<EOF
 # Try with missing keyPath
-spawn tss2_decrypt --cipherText=$ENCRYPTED_FILE --plainText=$DECRYPTED_FILE
+spawn tss2 decrypt --cipherText=$ENCRYPTED_FILE --plainText=$DECRYPTED_FILE
 set ret [wait]
 if {[lindex \$ret 2] || [lindex \$ret 3] != 1} {
     send_user "Command has not failed as expected\n"
@@ -151,7 +151,7 @@ if {[lindex \$ret 2] || [lindex \$ret 3] != 1} {
 }
 EOF
 
-tss2_decrypt --keyPath=$KEY_PATH --cipherText=$ENCRYPTED_FILE \
+tss2 decrypt --keyPath=$KEY_PATH --cipherText=$ENCRYPTED_FILE \
     --plainText=$DECRYPTED_FILE --force
 
 
@@ -160,15 +160,15 @@ if [ "`cat $DECRYPTED_FILE`" != "`cat $PLAIN_TEXT`" ]; then
   exit 1
 fi
 
-tss2_delete --path=$KEY_PATH
+tss2 delete --path=$KEY_PATH
 
 # Encrypt/Decrypt with password
-tss2_createkey --path=$KEY_PATH --type="noDa, decrypt" --authValue=abc
-tss2_encrypt --keyPath=$KEY_PATH --plainText=$PLAIN_TEXT \
+tss2 createkey --path=$KEY_PATH --type="noDa, decrypt" --authValue=abc
+tss2 encrypt --keyPath=$KEY_PATH --plainText=$PLAIN_TEXT \
     --cipherText=$ENCRYPTED_FILE --force
 echo -n "Fail" > $DECRYPTED_FILE
 expect <<EOF
-spawn tss2_decrypt --keyPath=$KEY_PATH --cipherText=$ENCRYPTED_FILE \
+spawn tss2 decrypt --keyPath=$KEY_PATH --cipherText=$ENCRYPTED_FILE \
     --plainText=$DECRYPTED_FILE --force
 expect "Authorize object : "
 send "abc\r"
@@ -184,12 +184,12 @@ if [ "`cat $DECRYPTED_FILE`" != "`cat $PLAIN_TEXT`" ]; then
   exit 1
 fi
 
-# Try tss2_createkey with missing type. This only works for tpm2-tss >=2.4.2.
+# Try tss2 createkey with missing type. This only works for tpm2-tss >=2.4.2.
 # Therefore, make the test conditional
-VERSION="$(tss2_createkey -v | grep -Po 'fapi-version=.*' | grep -Eo '([0-9]+\.{1})+[0-9]' | sed 's/[^0-9]*//g')"
+VERSION="$(tss2 createkey -v | grep -Po 'fapi-version=.*' | grep -Eo '([0-9]+\.{1})+[0-9]' | sed 's/[^0-9]*//g')"
 if [ $VERSION -ge "242" ]; then
-    tss2_delete --path=$KEY_PATH
-    tss2_createkey --path=$KEY_PATH --authValue=abc
+    tss2 delete --path=$KEY_PATH
+    tss2 createkey --path=$KEY_PATH --authValue=abc
 fi
 
 exit 0

--- a/test/integration/fapi/fapi-export-key.sh
+++ b/test/integration/fapi/fapi-export-key.sh
@@ -8,7 +8,7 @@ start_up
 setup_fapi
 
 function cleanup {
-    tss2_delete --path=/
+    tss2 delete --path=/
     shut_down
 }
 
@@ -22,13 +22,13 @@ EXPORTED_KEY=$TEMP_DIR/exportedKey
 EXPORTED_PARENT_KEY=$TEMP_DIR/exportedParentKey
 LOADED_KEY="myNewParent"
 
-tss2_provision
+tss2 provision
 
-tss2_import --path=$DUPLICATE_POLICY --importData=$JSON_POLICY
+tss2 import --path=$DUPLICATE_POLICY --importData=$JSON_POLICY
 
 expect <<EOF
 # Try with missing path
-spawn tss2_import --importData=$JSON_POLICY
+spawn tss2 import --importData=$JSON_POLICY
 set ret [wait]
 if {[lindex \$ret 2] || [lindex \$ret 3] != 1} {
     Command has not failed as expected\n"
@@ -38,7 +38,7 @@ EOF
 
 expect <<EOF
 # Try with missing importData
-spawn tss2_import --path=$DUPLICATE_POLICY
+spawn tss2 import --path=$DUPLICATE_POLICY
 set ret [wait]
 if {[lindex \$ret 2] || [lindex \$ret 3] != 1} {
     Command has not failed as expected\n"
@@ -46,23 +46,23 @@ if {[lindex \$ret 2] || [lindex \$ret 3] != 1} {
 }
 EOF
 
-tss2_createkey --path=$KEY_PATH_PARENT --type="restricted, decrypt, noDA" \
+tss2 createkey --path=$KEY_PATH_PARENT --type="restricted, decrypt, noDA" \
     --authValue=""
 
-tss2_exportkey --pathOfKeyToDuplicate=$KEY_PATH_PARENT \
+tss2 exportkey --pathOfKeyToDuplicate=$KEY_PATH_PARENT \
     --exportedData=$EXPORTED_PARENT_KEY --force
 
-tss2_import --path="ext/$LOADED_KEY" --importData=$EXPORTED_PARENT_KEY
+tss2 import --path="ext/$LOADED_KEY" --importData=$EXPORTED_PARENT_KEY
 
-tss2_createkey --path=$KEY_PATH --type="noDa, exportable, decrypt" \
+tss2 createkey --path=$KEY_PATH --type="noDa, exportable, decrypt" \
     --policyPath=$DUPLICATE_POLICY --authValue=""
 
-tss2_exportkey --pathOfKeyToDuplicate=$KEY_PATH \
+tss2 exportkey --pathOfKeyToDuplicate=$KEY_PATH \
     --pathToPublicKeyOfNewParent="ext/$LOADED_KEY" --exportedData=$EXPORTED_KEY
 
 expect <<EOF
 # Try with missing exportedData
-spawn tss2_exportkey --pathOfKeyToDuplicate=$KEY_PATH \
+spawn tss2 exportkey --pathOfKeyToDuplicate=$KEY_PATH \
     --pathToPublicKeyOfNewParent="ext/$LOADED_KEY"
 set ret [wait]
 if {[lindex \$ret 2] || [lindex \$ret 3] != 1} {
@@ -73,7 +73,7 @@ EOF
 
 expect <<EOF
 # Try with missing pathOfKeyToDuplicate
-spawn tss2_exportkey --pathToPublicKeyOfNewParent="ext/$LOADED_KEY" \
+spawn tss2 exportkey --pathToPublicKeyOfNewParent="ext/$LOADED_KEY" \
     --exportedData=$EXPORTED_KEY
 set ret [wait]
 if {[lindex \$ret 2] || [lindex \$ret 3] != 1} {
@@ -84,7 +84,7 @@ EOF
 
 expect <<EOF
 # Try to fail command
-spawn tss2_exportkey --pathOfKeyToDuplicate=$KEY_PATH \
+spawn tss2 exportkey --pathOfKeyToDuplicate=$KEY_PATH \
     --pathToPublicKeyOfNewParent="ext/$LOADED_KEY" --exportedData=
 set ret [wait]
 if {[lindex \$ret 2] || [lindex \$ret 3] != 1} {
@@ -95,7 +95,7 @@ EOF
 
 expect <<EOF
 # Try to fail writing to output
-spawn tss2_exportkey --pathOfKeyToDuplicate=$KEY_PATH \
+spawn tss2 exportkey --pathOfKeyToDuplicate=$KEY_PATH \
     --pathToPublicKeyOfNewParent="ext/$LOADED_KEY" --exportedData=$EXPORTED_KEY
 set ret [wait]
 if {[lindex \$ret 2] || [lindex \$ret 3] != 1} {

--- a/test/integration/fapi/fapi-export-policy.sh
+++ b/test/integration/fapi/fapi-export-policy.sh
@@ -8,7 +8,7 @@ start_up
 setup_fapi
 
 function cleanup {
-    tss2_delete --path=/
+    tss2 delete --path=/
     shut_down
 }
 
@@ -20,14 +20,14 @@ POLICY_DATA=$TEMP_DIR/pol_pcr16_0.json
 JSON_POLICY=policy/pcr-policy
 EXPORTED_POLICY=$TEMP_DIR/exported-pcr-policy
 
-tss2_provision
+tss2 provision
 
-tss2_import --path=$JSON_POLICY --importData=$POLICY_DATA
+tss2 import --path=$JSON_POLICY --importData=$POLICY_DATA
 
-tss2_createkey --path=$KEY_PATH --type="noDa, sign" --policyPath=$JSON_POLICY \
+tss2 createkey --path=$KEY_PATH --type="noDa, sign" --policyPath=$JSON_POLICY \
     --authValue=""
 
-tss2_exportpolicy --path=$KEY_PATH --jsonPolicy=$EXPORTED_POLICY --force
+tss2 exportpolicy --path=$KEY_PATH --jsonPolicy=$EXPORTED_POLICY --force
 
 if [ ! -s $EXPORTED_POLICY ]
 then
@@ -37,7 +37,7 @@ fi
 
 expect <<EOF
 # Try with missing path
-spawn tss2_exportpolicy --jsonPolicy=$EXPORTED_POLICY
+spawn tss2 exportpolicy --jsonPolicy=$EXPORTED_POLICY
 set ret [wait]
 if {[lindex \$ret 2] || [lindex \$ret 3] != 1} {
     Command has not failed as expected\n"
@@ -47,7 +47,7 @@ EOF
 
 expect <<EOF
 # Try with missing jsonPolicy
-spawn tss2_exportpolicy --path=$KEY_PATH
+spawn tss2 exportpolicy --path=$KEY_PATH
 set ret [wait]
 if {[lindex \$ret 2] || [lindex \$ret 3] != 1} {
     Command has not failed as expected\n"

--- a/test/integration/fapi/fapi-get-info.sh
+++ b/test/integration/fapi/fapi-get-info.sh
@@ -8,7 +8,7 @@ start_up
 setup_fapi
 
 function cleanup {
-    tss2_delete --path=/
+    tss2 delete --path=/
     shut_down
 }
 
@@ -16,9 +16,9 @@ trap cleanup EXIT
 
 DATA_OUTPUT_FILE=$TEMP_DIR/output.file
 
-tss2_provision
+tss2 provision
 
-tss2_getinfo --info=$DATA_OUTPUT_FILE --force
+tss2 getinfo --info=$DATA_OUTPUT_FILE --force
 
 if [ ! -s $DATA_OUTPUT_FILE ]
 then
@@ -28,7 +28,7 @@ fi
 
 expect <<EOF
 # Try with missing info file
-spawn tss2_getinfo
+spawn tss2 getinfo
 set ret [wait]
 if {[lindex \$ret 2] || [lindex \$ret 3] != 1} {
     Command has not failed as expected\n"

--- a/test/integration/fapi/fapi-get-platform-certificates.sh
+++ b/test/integration/fapi/fapi-get-platform-certificates.sh
@@ -10,7 +10,7 @@ setup_fapi
 PATH=${BUILDDIR}/tools/fapi:$PATH
 
 function cleanup {
-    tss2_delete --path=/
+    tss2 delete --path=/
     shut_down
 }
 
@@ -18,11 +18,11 @@ trap cleanup EXIT
 
 CERTIFICATES_OUTPUT_FILE=$TEMP_DIR/certificates_output.file
 
-tss2_provision
+tss2 provision
 
 expect <<EOF
 # Try with missing certificates
-spawn tss2_getplatformcertificates
+spawn tss2 getplatformcertificates
 set ret [wait]
 if {[lindex \$ret 2] || [lindex \$ret 3] != 1} {
     Command has not failed as expected\n"
@@ -32,7 +32,7 @@ EOF
 
 expect <<EOF
 # Try normal command; should fail since no certificates present
-spawn tss2_getplatformcertificates --certificates=$CERTIFICATES_OUTPUT_FILE \
+spawn tss2 getplatformcertificates --certificates=$CERTIFICATES_OUTPUT_FILE \
     --force
 set ret [wait]
 if {[lindex \$ret 2] || [lindex \$ret 3] != 1} {

--- a/test/integration/fapi/fapi-get-random.sh
+++ b/test/integration/fapi/fapi-get-random.sh
@@ -10,7 +10,7 @@ setup_fapi
 PATH=${BUILDDIR}/tools/fapi:$PATH
 
 function cleanup {
-    tss2_delete --path=/
+    tss2 delete --path=/
     shut_down
 }
 
@@ -18,11 +18,11 @@ trap cleanup EXIT
 
 OUTPUT_FILE="$TEMP_DIR/output.file"
 
-tss2_provision
+tss2 provision
 
 expect <<EOF
 # Try with wrong size value
-spawn tss2_getrandom --numBytes=a --data=$OUTPUT_FILE --force
+spawn tss2 getrandom --numBytes=a --data=$OUTPUT_FILE --force
 set ret [wait]
 if {[lindex \$ret 2] || [lindex \$ret 3] != 1} {
     Command has not failed as expected\n"
@@ -32,7 +32,7 @@ EOF
 
 expect <<EOF
 # Try with missing output
-spawn tss2_getrandom --numBytes=20
+spawn tss2 getrandom --numBytes=20
 set ret [wait]
 if {[lindex \$ret 2] || [lindex \$ret 3] != 1} {
     Command has not failed as expected\n"
@@ -42,7 +42,7 @@ EOF
 
 expect <<EOF
 # Try with missing numBytes
-spawn tss2_getrandom --data=$OUTPUT_FILE --force
+spawn tss2 getrandom --data=$OUTPUT_FILE --force
 set ret [wait]
 if {[lindex \$ret 2] || [lindex \$ret 3] != 1} {
     Command has not failed as expected\n"
@@ -50,8 +50,8 @@ if {[lindex \$ret 2] || [lindex \$ret 3] != 1} {
 }
 EOF
 
-tss2_getrandom --numBytes=4 --data=$OUTPUT_FILE --force
+tss2 getrandom --numBytes=4 --data=$OUTPUT_FILE --force
 
-tss2_getrandom --numBytes=4 --hex --data=$OUTPUT_FILE --force
+tss2 getrandom --numBytes=4 --hex --data=$OUTPUT_FILE --force
 
 exit 0

--- a/test/integration/fapi/fapi-get-tpm-blobs.sh
+++ b/test/integration/fapi/fapi-get-tpm-blobs.sh
@@ -8,7 +8,7 @@ start_up
 setup_fapi
 
 function cleanup {
-    tss2_delete --path=/
+    tss2 delete --path=/
     shut_down
 }
 
@@ -21,19 +21,19 @@ POLICY_FILE=$TEMP_DIR/policy.file
 PCR_POLICY_DATA=$TEMP_DIR/pol_pcr16_0.json
 POLICY_PCR=policy/pcr-policy
 
-tss2_provision
+tss2 provision
 
-tss2_import --path=$POLICY_PCR --importData=$PCR_POLICY_DATA
+tss2 import --path=$POLICY_PCR --importData=$PCR_POLICY_DATA
 
-tss2_createkey --path=$KEY_PATH --policyPath=$POLICY_PCR --type="noDa, sign" \
+tss2 createkey --path=$KEY_PATH --policyPath=$POLICY_PCR --type="noDa, sign" \
     --authValue=""
 
-tss2_gettpmblobs --path=$KEY_PATH --tpm2bPublic=$PUBLIC_KEY_FILE \
+tss2 gettpmblobs --path=$KEY_PATH --tpm2bPublic=$PUBLIC_KEY_FILE \
     --tpm2bPrivate=$PRIVATE_KEY_FILE --policy=$POLICY_FILE --force
 
 expect <<EOF
 # Try with missing path
-spawn tss2_gettpmblobs --tpm2bPublic=$PUBLIC_KEY_FILE \
+spawn tss2 gettpmblobs --tpm2bPublic=$PUBLIC_KEY_FILE \
     --tpm2bPrivate=$PRIVATE_KEY_FILE --policy=$POLICY_FILE
 set ret [wait]
 if {[lindex \$ret 2] || [lindex \$ret 3] != 1} {
@@ -44,7 +44,7 @@ EOF
 
 expect <<EOF
 # Try with missing tpm2bPublic
-spawn tss2_gettpmblobs --path=$KEY_PATH \
+spawn tss2 gettpmblobs --path=$KEY_PATH \
     --tpm2bPrivate=$PRIVATE_KEY_FILE --policy=$POLICY_FILE
 set ret [wait]
 if {[lindex \$ret 2] || [lindex \$ret 3] != 1} {
@@ -55,7 +55,7 @@ EOF
 
 expect <<EOF
 # Try with missing tpm2bPrivate
-spawn tss2_gettpmblobs --path=$KEY_PATH --tpm2bPublic=$PUBLIC_KEY_FILE \
+spawn tss2 gettpmblobs --path=$KEY_PATH --tpm2bPublic=$PUBLIC_KEY_FILE \
     --policy=$POLICY_FILE
 set ret [wait]
 if {[lindex \$ret 2] || [lindex \$ret 3] != 1} {
@@ -66,7 +66,7 @@ EOF
 
 expect <<EOF
 # Try with missing policy
-spawn tss2_gettpmblobs --path=$KEY_PATH --tpm2bPublic=$PUBLIC_KEY_FILE \
+spawn tss2 gettpmblobs --path=$KEY_PATH --tpm2bPublic=$PUBLIC_KEY_FILE \
     --tpm2bPrivate=$PRIVATE_KEY_FILE
 set ret [wait]
 if {[lindex \$ret 2] || [lindex \$ret 3] != 1} {
@@ -77,7 +77,7 @@ EOF
 
 expect <<EOF
 # Try with existing directory PUBLIC_KEY_FILE
-spawn tss2_gettpmblobs --path=$KEY_PATH --tpm2bPublic=$PUBLIC_KEY_FILE \
+spawn tss2 gettpmblobs --path=$KEY_PATH --tpm2bPublic=$PUBLIC_KEY_FILE \
     --tpm2bPrivate=$PRIVATE_KEY_FILE --policy=$POLICY_FILE
 set ret [wait]
 if {[lindex \$ret 2] || [lindex \$ret 3] != 1} {
@@ -88,7 +88,7 @@ EOF
 
 expect <<EOF
 # Try with multiple stdout (1)
-spawn tss2_gettpmblobs --path=$KEY_PATH --tpm2bPublic=- \
+spawn tss2 gettpmblobs --path=$KEY_PATH --tpm2bPublic=- \
     --tpm2bPrivate=- --policy=$POLICY_FILE --force
 set ret [wait]
 if {[lindex \$ret 2] || [lindex \$ret 3] != 1} {
@@ -99,7 +99,7 @@ EOF
 
 expect <<EOF
 # Try with multiple stdout (2)
-spawn tss2_gettpmblobs --path=$KEY_PATH --tpm2bPublic=$PUBLIC_KEY_FILE \
+spawn tss2 gettpmblobs --path=$KEY_PATH --tpm2bPublic=$PUBLIC_KEY_FILE \
     --tpm2bPrivate=- --policy=- --force
 set ret [wait]
 if {[lindex \$ret 2] || [lindex \$ret 3] != 1} {
@@ -110,7 +110,7 @@ EOF
 
 expect <<EOF
 # Try with multiple stdout (3)
-spawn tss2_gettpmblobs --path=$KEY_PATH --tpm2bPublic=- \
+spawn tss2 gettpmblobs --path=$KEY_PATH --tpm2bPublic=- \
     --tpm2bPrivate=$PRIVATE_KEY_FILE --policy=- --force
 set ret [wait]
 if {[lindex \$ret 2] || [lindex \$ret 3] != 1} {
@@ -121,7 +121,7 @@ EOF
 
 expect <<EOF
 # Try with multiple stdout (4)
-spawn tss2_gettpmblobs --path=$KEY_PATH --tpm2bPublic=- \
+spawn tss2 gettpmblobs --path=$KEY_PATH --tpm2bPublic=- \
     --tpm2bPrivate=- --policy=- --force
 set ret [wait]
 if {[lindex \$ret 2] || [lindex \$ret 3] != 1} {

--- a/test/integration/fapi/fapi-key-change-auth.sh
+++ b/test/integration/fapi/fapi-key-change-auth.sh
@@ -8,7 +8,7 @@ start_up
 setup_fapi
 
 function cleanup {
-    tss2_delete --path=/
+    tss2 delete --path=/
     shut_down
 }
 
@@ -24,13 +24,13 @@ IMPORTED_KEY_NAME=importedPubKey
 PADDINGS="RSA_PSS"
 set -x
 
-tss2_provision
+tss2 provision
 echo 0123456789012345678 > $DIGEST_FILE
-tss2_createkey --path=$KEY_PATH --type="noDa, sign" --authValue=$PW1
+tss2 createkey --path=$KEY_PATH --type="noDa, sign" --authValue=$PW1
 
 expect <<EOF
 # Try interactive prompt
-spawn tss2_sign --keyPath=$KEY_PATH --padding=$PADDINGS --digest=$DIGEST_FILE \
+spawn tss2 sign --keyPath=$KEY_PATH --padding=$PADDINGS --digest=$DIGEST_FILE \
     --signature=$SIGNATURE_FILE --publicKey=$PUBLIC_KEY_FILE
 expect "Authorize object: "
 send "$PW1\r"
@@ -43,7 +43,7 @@ EOF
 
 expect <<EOF
 # Try interactive prompt with 2 different passwords
-spawn tss2_changeauth --entityPath=$KEY_PATH
+spawn tss2 changeauth --entityPath=$KEY_PATH
 expect "Authorize object Password: "
 send "1\r"
 expect "Authorize object Retype password: "
@@ -67,7 +67,7 @@ EOF
 
 expect <<EOF
 # Try interactive prompt
-spawn tss2_changeauth --entityPath=$KEY_PATH --authValue=$PW2
+spawn tss2 changeauth --entityPath=$KEY_PATH --authValue=$PW2
 expect "Authorize object: "
 send "$PW1\r"
 set ret [wait]
@@ -79,7 +79,7 @@ EOF
 
 expect <<EOF
 # Check if system asks for auth value
-spawn tss2_sign --keyPath=$KEY_PATH --padding=$PADDINGS --digest=$DIGEST_FILE \
+spawn tss2 sign --keyPath=$KEY_PATH --padding=$PADDINGS --digest=$DIGEST_FILE \
     --signature=$SIGNATURE_FILE --publicKey=$PUBLIC_KEY_FILE --force
 expect {
     "Authorize object: " {

--- a/test/integration/fapi/fapi-list.sh
+++ b/test/integration/fapi/fapi-list.sh
@@ -8,7 +8,7 @@ start_up
 setup_fapi
 
 function cleanup {
-    tss2_delete --path=/
+    tss2 delete --path=/
     shut_down
 }
 
@@ -16,16 +16,16 @@ trap cleanup EXIT
 
 KEY_PATH=HS/SRK/myRSASign
 
-tss2_provision
+tss2 provision
 
-tss2_createkey --path=$KEY_PATH --type="noDa, sign" --authValue=""
+tss2 createkey --path=$KEY_PATH --type="noDa, sign" --authValue=""
 
-tss2_list
+tss2 list
 
-PROFILE_NAME=$( tss2_list --searchPath= --pathList=- | cut -d "/" -f2 )
+PROFILE_NAME=$( tss2 list --searchPath= --pathList=- | cut -d "/" -f2 )
 SIGN_OBJECT=/$PROFILE_NAME/$KEY_PATH
 
-if [ `tss2_list --searchPath=$KEY_PATH --pathList=-` != $SIGN_OBJECT ]; then
+if [ `tss2 list --searchPath=$KEY_PATH --pathList=-` != $SIGN_OBJECT ]; then
   echo "tss2_list single object failed"
   exit 1
 fi

--- a/test/integration/fapi/fapi-nv-extend.sh
+++ b/test/integration/fapi/fapi-nv-extend.sh
@@ -8,7 +8,7 @@ start_up
 setup_fapi
 
 function cleanup {
-    tss2_delete --path=/
+    tss2 delete --path=/
     shut_down
 }
 
@@ -23,13 +23,13 @@ READ_LOG_DATA=$TEMP_DIR/read_log.data
 echo -n 01234567890123456789 > $DATA_EXTEND_FILE
 echo -n 01234567890123456789 > $LOG_DATA
 
-tss2_provision
+tss2 provision
 
-tss2_createnv --path=$NV_PATH --type="noDa, pcr" --size=0 --authValue=""
+tss2 createnv --path=$NV_PATH --type="noDa, pcr" --size=0 --authValue=""
 
-tss2_nvextend --nvPath=$NV_PATH --data=$DATA_EXTEND_FILE --logData=$LOG_DATA
+tss2 nvextend --nvPath=$NV_PATH --data=$DATA_EXTEND_FILE --logData=$LOG_DATA
 
-tss2_nvread --nvPath=$NV_PATH --data=$DATA_READ_FILE --logData=$READ_LOG_DATA
+tss2 nvread --nvPath=$NV_PATH --data=$DATA_READ_FILE --logData=$READ_LOG_DATA
 
 if [ ! -f $READ_LOG_DATA ]; then
     echo "No log data returned"
@@ -38,7 +38,7 @@ fi
 
 expect <<EOF
 # Try with missing nvPath
-spawn tss2_nvextend --data=$DATA_EXTEND_FILE --logData=$LOG_DATA
+spawn tss2 nvextend --data=$DATA_EXTEND_FILE --logData=$LOG_DATA
 set ret [wait]
 if {[lindex \$ret 2] || [lindex \$ret 3] != 1} {
     Command has not failed as expected\n"
@@ -48,7 +48,7 @@ EOF
 
 expect <<EOF
 # Try with missing data
-spawn tss2_nvextend --nvPath=$NV_PATH --logData=$LOG_DATA
+spawn tss2 nvextend --nvPath=$NV_PATH --logData=$LOG_DATA
 set ret [wait]
 if {[lindex \$ret 2] || [lindex \$ret 3] != 1} {
     Command has not failed as expected\n"
@@ -58,7 +58,7 @@ EOF
 
 expect <<EOF
 # Try with multiple stdin
-spawn tss2_nvextend --nvPath=$NV_PATH --data=- --logData=-
+spawn tss2 nvextend --nvPath=$NV_PATH --data=- --logData=-
 set ret [wait]
 if {[lindex \$ret 2] || [lindex \$ret 3] != 1} {
     Command has not failed as expected\n"
@@ -68,7 +68,7 @@ EOF
 
 expect <<EOF
 # Try with multiple stdin
-spawn tss2_nvextend --nvPath $NV_PATH --data - --logData -
+spawn tss2 nvextend --nvPath $NV_PATH --data - --logData -
 set ret [wait]
 if {[lindex \$ret 2] || [lindex \$ret 3] != 1} {
     Command has not failed as expected\n"

--- a/test/integration/fapi/fapi-nv-increment.sh
+++ b/test/integration/fapi/fapi-nv-increment.sh
@@ -8,7 +8,7 @@ start_up
 setup_fapi
 
 function cleanup {
-    tss2_delete --path=/
+    tss2 delete --path=/
     shut_down
 }
 
@@ -19,24 +19,24 @@ NV_COUNTER_READ_FILE=$TEMP_DIR/nv_counter_read_data.file
 PCR_POLICY_DATA=$TEMP_DIR/pol_pcr16_0.json
 POLICY_PCR=policy/pcr-policy
 
-tss2_provision
+tss2 provision
 
-tss2_import --path=$POLICY_PCR --importData=$PCR_POLICY_DATA
+tss2 import --path=$POLICY_PCR --importData=$PCR_POLICY_DATA
 
-tss2_createnv --path=$NV_PATH --policyPath=$POLICY_PCR --type="counter, noDa" \
+tss2 createnv --path=$NV_PATH --policyPath=$POLICY_PCR --type="counter, noDa" \
     --size=0 --authValue=""
 
-tss2_nvincrement --nvPath=$NV_PATH
+tss2 nvincrement --nvPath=$NV_PATH
 
-tss2_nvread --nvPath=$NV_PATH --data=$NV_COUNTER_READ_FILE --force
+tss2 nvread --nvPath=$NV_PATH --data=$NV_COUNTER_READ_FILE --force
 
-tss2_nvincrement --nvPath=$NV_PATH
+tss2 nvincrement --nvPath=$NV_PATH
 
-tss2_nvread --nvPath=$NV_PATH --data=$NV_COUNTER_READ_FILE --force
+tss2 nvread --nvPath=$NV_PATH --data=$NV_COUNTER_READ_FILE --force
 
 expect <<EOF
 # Try with missing nvPath
-spawn tss2_nvincrement
+spawn tss2 nvincrement
 set ret [wait]
 if {[lindex \$ret 2] || [lindex \$ret 3] != 1} {
     Command has not failed as expected\n"

--- a/test/integration/fapi/fapi-nv-set-bits.sh
+++ b/test/integration/fapi/fapi-nv-set-bits.sh
@@ -8,7 +8,7 @@ start_up
 setup_fapi
 
 function cleanup {
-    tss2_delete --path=/
+    tss2 delete --path=/
     shut_down
 }
 
@@ -17,15 +17,15 @@ trap cleanup EXIT
 NV_PATH="/nv/Owner/NvBitmap"
 BITMAP="0x0102030405060608"
 
-tss2_provision
+tss2 provision
 
-tss2_createnv --path=$NV_PATH --type="noDa, bitfield" --size=0 --authValue=""
+tss2 createnv --path=$NV_PATH --type="noDa, bitfield" --size=0 --authValue=""
 
-tss2_nvsetbits --nvPath=$NV_PATH --bitmap=$BITMAP
+tss2 nvsetbits --nvPath=$NV_PATH --bitmap=$BITMAP
 
 expect <<EOF
 # Try with missing nvPath
-spawn tss2_nvsetbits --bitmap=$BITMAP
+spawn tss2 nvsetbits --bitmap=$BITMAP
 set ret [wait]
 if {[lindex \$ret 2] || [lindex \$ret 3] != 1} {
     Command has not failed as expected\n"
@@ -35,7 +35,7 @@ EOF
 
 expect <<EOF
 # Try with missing bitmap
-spawn tss2_nvsetbits --nvPath=$NV_PATH
+spawn tss2 nvsetbits --nvPath=$NV_PATH
 set ret [wait]
 if {[lindex \$ret 2] || [lindex \$ret 3] != 1} {
     Command has not failed as expected\n"
@@ -45,7 +45,7 @@ EOF
 
 expect <<EOF
 # Try with wrong bitmap
-spawn tss2_nvsetbits --nvPath=$NV_PATH --bitmap=abc
+spawn tss2 nvsetbits --nvPath=$NV_PATH --bitmap=abc
 set ret [wait]
 if {[lindex \$ret 2] || [lindex \$ret 3] != 1} {
     Command has not failed as expected\n"

--- a/test/integration/fapi/fapi-nv-write-authorize.sh
+++ b/test/integration/fapi/fapi-nv-write-authorize.sh
@@ -8,7 +8,7 @@ start_up
 setup_fapi
 
 function cleanup {
-    tss2_delete --path=/
+    tss2 delete --path=/
     shut_down
 }
 
@@ -26,17 +26,17 @@ PUBLIC_KEY_FILE=$TEMP_DIR/public_key.file
 DIGEST_FILE=$TEMP_DIR/digest.file
 echo -n 01234567890123456789 > $DIGEST_FILE
 
-tss2_provision
+tss2 provision
 
-tss2_createnv --path=$NV_PATH --type="noDa" --size=34 --authValue=""
+tss2 createnv --path=$NV_PATH --type="noDa" --size=34 --authValue=""
 
-tss2_import --path=$AUTHORIZE_NV_POLICY --importData=$AUTHORIZE_NV_POLICY_JSON
+tss2 import --path=$AUTHORIZE_NV_POLICY --importData=$AUTHORIZE_NV_POLICY_JSON
 
-tss2_import --path=$POLICY_PCR --importData=$PCR_POLICY_JSON
+tss2 import --path=$POLICY_PCR --importData=$PCR_POLICY_JSON
 
 expect <<EOF
 # Try if command is supported
-spawn tss2_writeauthorizenv --nvPath=$NV_PATH --policyPath=$POLICY_PCR
+spawn tss2 writeauthorizenv --nvPath=$NV_PATH --policyPath=$POLICY_PCR
 set ret [wait]
 if {[lindex \$ret 2] || [lindex \$ret 3] != 0} {
     send_user "Command has failed. If using a physical TPM, see log since it is
@@ -45,17 +45,17 @@ if {[lindex \$ret 2] || [lindex \$ret 3] != 0} {
 }
 EOF
 
-tss2_createkey --path=$POLICY_SIGN_KEY_PATH --type="noDa, sign" --authValue=""
+tss2 createkey --path=$POLICY_SIGN_KEY_PATH --type="noDa, sign" --authValue=""
 
-tss2_createkey --path=$SIGN_KEY_PATH --type="noDa, sign" \
+tss2 createkey --path=$SIGN_KEY_PATH --type="noDa, sign" \
     --policyPath=$AUTHORIZE_NV_POLICY  --authValue=""
 
-tss2_sign --keyPath=$SIGN_KEY_PATH --padding="RSA_PSS" --digest=$DIGEST_FILE \
+tss2 sign --keyPath=$SIGN_KEY_PATH --padding="RSA_PSS" --digest=$DIGEST_FILE \
     --signature=$SIGNATURE_FILE --publicKey=$PUBLIC_KEY_FILE
 
 expect <<EOF
 # Try with missing nvPath
-spawn tss2_writeauthorizenv --policyPath=$POLICY_PCR
+spawn tss2 writeauthorizenv --policyPath=$POLICY_PCR
 set ret [wait]
 if {[lindex \$ret 2] || [lindex \$ret 3] != 1} {
     send_user "Command has not failed as expected\n"
@@ -65,7 +65,7 @@ EOF
 
 expect <<EOF
 # Try with missing policyPath
-spawn tss2_writeauthorizenv --nvPath=$NV_PATH
+spawn tss2 writeauthorizenv --nvPath=$NV_PATH
 set ret [wait]
 if {[lindex \$ret 2] || [lindex \$ret 3] != 1} {
     send_user "Command has not failed as expected\n"
@@ -75,7 +75,7 @@ EOF
 
 expect <<EOF
 # Try to fail command
-spawn tss2_writeauthorizenv --nvPath=/abc/def --policyPath=$POLICY_PCR
+spawn tss2 writeauthorizenv --nvPath=/abc/def --policyPath=$POLICY_PCR
 set ret [wait]
 if {[lindex \$ret 2] || [lindex \$ret 3] != 1} {
     send_user "Command has not failed as expected\n"

--- a/test/integration/fapi/fapi-nv-write-read.sh
+++ b/test/integration/fapi/fapi-nv-write-read.sh
@@ -8,7 +8,7 @@ start_up
 setup_fapi
 
 function cleanup {
-    tss2_delete --path=/
+    tss2 delete --path=/
     shut_down
 }
 
@@ -19,28 +19,28 @@ NV_PATH=/nv/Owner/myNVwrite
 DATA_WRITE_FILE=$TEMP_DIR/nv_write_data.file
 DATA_READ_FILE=$TEMP_DIR/nv_read_data.file
 
-tss2_provision
+tss2 provision
 
 echo 1234567890123456789 > $DATA_WRITE_FILE
 
-tss2_createnv --path=$NV_PATH --type="noDa" --size=20 --authValue=""
+tss2 createnv --path=$NV_PATH --type="noDa" --size=20 --authValue=""
 
-tss2_nvwrite --nvPath=$NV_PATH --data=$DATA_WRITE_FILE
+tss2 nvwrite --nvPath=$NV_PATH --data=$DATA_WRITE_FILE
 
-tss2_nvread --nvPath=$NV_PATH --data=$DATA_READ_FILE --force
+tss2 nvread --nvPath=$NV_PATH --data=$DATA_READ_FILE --force
 
 if [ `cat $DATA_READ_FILE` !=  `cat $DATA_WRITE_FILE` ]; then
   echo "Test without password: Strings are not equal"
   exit 99
 fi
 
-tss2_delete --path=$NV_PATH
+tss2 delete --path=$NV_PATH
 
-tss2_createnv --path=$NV_PATH --type="noDa" --size=20 --authValue=$PW
+tss2 createnv --path=$NV_PATH --type="noDa" --size=20 --authValue=$PW
 
 expect <<EOF
 # Check if system asks for auth value and provide it
-spawn tss2_nvwrite --nvPath=$NV_PATH --data=$DATA_WRITE_FILE
+spawn tss2 nvwrite --nvPath=$NV_PATH --data=$DATA_WRITE_FILE
 expect {
     "Authorize object: " {
     } eof {
@@ -58,7 +58,7 @@ EOF
 
 expect <<EOF
 # Try with missing nvPath
-spawn tss2_nvread --data=$DATA_READ_FILE --force
+spawn tss2 nvread --data=$DATA_READ_FILE --force
 set ret [wait]
 if {[lindex \$ret 2] || [lindex \$ret 3] != 1} {
     Command has not failed as expected\n"
@@ -68,7 +68,7 @@ EOF
 
 expect <<EOF
 # Try with missing data
-spawn tss2_nvread --nvPath=$NV_PATH  --force
+spawn tss2 nvread --nvPath=$NV_PATH  --force
 set ret [wait]
 if {[lindex \$ret 2] || [lindex \$ret 3] != 1} {
     Command has not failed as expected\n"
@@ -78,7 +78,7 @@ EOF
 
 expect <<EOF
 # Try with multiple stdout (1)
-spawn tss2_nvread --nvPath=$NV_PATH --data=- --logData=- --force
+spawn tss2 nvread --nvPath=$NV_PATH --data=- --logData=- --force
 set ret [wait]
 if {[lindex \$ret 2] || [lindex \$ret 3] != 1} {
     Command has not failed as expected\n"
@@ -88,7 +88,7 @@ EOF
 
 expect <<EOF
 # Try with multiple stdout (1)
-spawn tss2_nvread --nvPath $NV_PATH --data - --logData - --force
+spawn tss2 nvread --nvPath $NV_PATH --data - --logData - --force
 set ret [wait]
 if {[lindex \$ret 2] || [lindex \$ret 3] != 1} {
     Command has not failed as expected\n"
@@ -98,7 +98,7 @@ EOF
 
 expect <<EOF
 # Try with missing nvPath
-spawn tss2_nvwrite --data=$DATA_WRITE_FILE
+spawn tss2 nvwrite --data=$DATA_WRITE_FILE
 set ret [wait]
 if {[lindex \$ret 2] || [lindex \$ret 3] != 1} {
     Command has not failed as expected\n"
@@ -108,7 +108,7 @@ EOF
 
 expect <<EOF
 # Try with missing data
-spawn tss2_nvwrite --nvPath=$NV_PATH
+spawn tss2 nvwrite --nvPath=$NV_PATH
 set ret [wait]
 if {[lindex \$ret 2] || [lindex \$ret 3] != 1} {
     Command has not failed as expected\n"
@@ -116,12 +116,12 @@ if {[lindex \$ret 2] || [lindex \$ret 3] != 1} {
 }
 EOF
 
-tss2_delete --path=$NV_PATH
+tss2 delete --path=$NV_PATH
 
 NODA="noDa"
 expect <<EOF
 # Try interactive prompt
-spawn tss2_createnv --path=$NV_PATH --type=$NODA --size=20
+spawn tss2 createnv --path=$NV_PATH --type=$NODA --size=20
 expect "Authorize object Password: "
 send "$PW\r"
 expect "Authorize object Retype password: "
@@ -134,27 +134,27 @@ if {[lindex \$ret 2] || [lindex \$ret 3] != 0} {
 EOF
 
 # Try with missing type
-tss2_delete --path=$NV_PATH
-tss2_createnv --path=$NV_PATH --size=20 --authValue=$PW
+tss2 delete --path=$NV_PATH
+tss2 createnv --path=$NV_PATH --size=20 --authValue=$PW
 
 # Try with size-0 supported types
-tss2_delete --path=$NV_PATH
-tss2_createnv --path=$NV_PATH --type="bitfield" --size=0 --authValue=$PW
-tss2_delete --path=$NV_PATH
-tss2_createnv --path=$NV_PATH --type="pcr" --size=0 --authValue=$PW
-tss2_delete --path=$NV_PATH
-tss2_createnv --path=$NV_PATH --type="counter" --size=0 --authValue=$PW
-tss2_delete --path=$NV_PATH
-tss2_createnv --path=$NV_PATH --type="bitfield" --authValue=$PW
-tss2_delete --path=$NV_PATH
-tss2_createnv --path=$NV_PATH --type="pcr" --authValue=$PW
-tss2_delete --path=$NV_PATH
-tss2_createnv --path=$NV_PATH --type="counter" --authValue=$PW
-tss2_delete --path=$NV_PATH
+tss2 delete --path=$NV_PATH
+tss2 createnv --path=$NV_PATH --type="bitfield" --size=0 --authValue=$PW
+tss2 delete --path=$NV_PATH
+tss2 createnv --path=$NV_PATH --type="pcr" --size=0 --authValue=$PW
+tss2 delete --path=$NV_PATH
+tss2 createnv --path=$NV_PATH --type="counter" --size=0 --authValue=$PW
+tss2 delete --path=$NV_PATH
+tss2 createnv --path=$NV_PATH --type="bitfield" --authValue=$PW
+tss2 delete --path=$NV_PATH
+tss2 createnv --path=$NV_PATH --type="pcr" --authValue=$PW
+tss2 delete --path=$NV_PATH
+tss2 createnv --path=$NV_PATH --type="counter" --authValue=$PW
+tss2 delete --path=$NV_PATH
 
 expect <<EOF
 # Try with missing size and no type
-spawn tss2_createnv --path=$NV_PATH --authValue=$PW
+spawn tss2 createnv --path=$NV_PATH --authValue=$PW
 set ret [wait]
 if {[lindex \$ret 2] || [lindex \$ret 3] != 1} {
     Command has not failed as expected\n"
@@ -164,7 +164,7 @@ EOF
 
 expect <<EOF
 # Try with size=0 and no type
-spawn tss2_createnv --path=$NV_PATH --size=0 --authValue=$PW
+spawn tss2 createnv --path=$NV_PATH --size=0 --authValue=$PW
 set ret [wait]
 if {[lindex \$ret 2] || [lindex \$ret 3] != 1} {
     Command has not failed as expected\n"

--- a/test/integration/fapi/fapi-pcr-extend-read.sh
+++ b/test/integration/fapi/fapi-pcr-extend-read.sh
@@ -8,7 +8,7 @@ start_up
 setup_fapi
 
 function cleanup {
-    tss2_delete --path=/
+    tss2 delete --path=/
     shut_down
 }
 
@@ -22,12 +22,12 @@ PCR_LOG_FILE_READ=$TEMP_DIR/pcr_log_read.file
 PCR_EVENT_DATA=$TEMP_DIR/pcr_event_data.file
 echo "0,1,2,3,4,5,6,7,8,9" > $PCR_EVENT_DATA
 
-tss2_provision
+tss2 provision
 
-tss2_pcrextend --pcr=16 --data=$PCR_EVENT_DATA \
+tss2 pcrextend --pcr=16 --data=$PCR_EVENT_DATA \
     --logData=$PCR_LOG_FILE_WRITE
 
-tss2_pcrread --pcrIndex=16 --pcrValue=$PCR_DIGEST_FILE \
+tss2 pcrread --pcrIndex=16 --pcrValue=$PCR_DIGEST_FILE \
     --pcrLog=$PCR_LOG_FILE_READ --force
 
 if [ ! -s $PCR_DIGEST_FILE ] || [ ! -s $PCR_LOG_FILE_READ ]; then
@@ -37,7 +37,7 @@ fi
 
 expect <<EOF
 # Try with missing pcr
-spawn tss2_pcrextend --data=$PCR_EVENT_DATA --logData=$PCR_LOG_FILE_WRITE
+spawn tss2 pcrextend --data=$PCR_EVENT_DATA --logData=$PCR_LOG_FILE_WRITE
 set ret [wait]
 if {[lindex \$ret 2] || [lindex \$ret 3] != 1} {
     Command has not failed as expected\n"
@@ -47,7 +47,7 @@ EOF
 
 expect <<EOF
 # Try with missing data
-spawn tss2_pcrextend --pcr=16 --logData=$PCR_LOG_FILE_WRITE
+spawn tss2 pcrextend --pcr=16 --logData=$PCR_LOG_FILE_WRITE
 set ret [wait]
 if {[lindex \$ret 2] || [lindex \$ret 3] != 1} {
     Command has not failed as expected\n"
@@ -57,7 +57,7 @@ EOF
 
 expect <<EOF
 # Try with wrong pcr
-spawn tss2_pcrextend --pcr=abc --data=$PCR_EVENT_DATA \
+spawn tss2 pcrextend --pcr=abc --data=$PCR_EVENT_DATA \
     --logData=$PCR_LOG_FILE_WRITE
 set ret [wait]
 if {[lindex \$ret 2] || [lindex \$ret 3] != 1} {
@@ -68,7 +68,7 @@ EOF
 
 expect <<EOF
 # Try with multiple stdins
-spawn tss2_pcrextend --pcr=16 --data=- --logData=-
+spawn tss2 pcrextend --pcr=16 --data=- --logData=-
 set ret [wait]
 if {[lindex \$ret 2] || [lindex \$ret 3] != 1} {
     Command has not failed as expected\n"
@@ -77,11 +77,11 @@ if {[lindex \$ret 2] || [lindex \$ret 3] != 1} {
 EOF
 
 # Try with missing logData
-tss2_pcrextend --pcr=16 --data=$PCR_EVENT_DATA
+tss2 pcrextend --pcr=16 --data=$PCR_EVENT_DATA
 
 expect <<EOF
 # Try with missing pcrIndex
-spawn tss2_pcrread --pcrValue=$PCR_DIGEST_FILE --pcrLog=$PCR_LOG_FILE_READ --force
+spawn tss2 pcrread --pcrValue=$PCR_DIGEST_FILE --pcrLog=$PCR_LOG_FILE_READ --force
 set ret [wait]
 if {[lindex \$ret 2] || [lindex \$ret 3] != 1} {
     Command has not failed as expected\n"
@@ -90,14 +90,14 @@ if {[lindex \$ret 2] || [lindex \$ret 3] != 1} {
 EOF
 
 # Try with missing pcrValue
-tss2_pcrread --pcrIndex=16 --pcrLog=$PCR_LOG_FILE_READ --force
+tss2 pcrread --pcrIndex=16 --pcrLog=$PCR_LOG_FILE_READ --force
 
 # Try with missing pcrLog
-tss2_pcrread --pcrIndex=16 --pcrValue=$PCR_DIGEST_FILE --force
+tss2 pcrread --pcrIndex=16 --pcrValue=$PCR_DIGEST_FILE --force
 
 expect <<EOF
 # Try with multiple stdins (1)
-spawn tss2_pcrread --pcrIndex=16 --pcrValue=- \
+spawn tss2 pcrread --pcrIndex=16 --pcrValue=- \
     --pcrLog=-
 set ret [wait]
 if {[lindex \$ret 2] || [lindex \$ret 3] != 1} {
@@ -108,7 +108,7 @@ EOF
 
 expect <<EOF
 # Try with wrong pcrIndex
-spawn tss2_pcrread --pcrIndex=abc --pcrValue=$PCR_DIGEST_FILE \
+spawn tss2 pcrread --pcrIndex=abc --pcrValue=$PCR_DIGEST_FILE \
     --pcrLog=$PCR_LOG_FILE_READ --force
 set ret [wait]
 if {[lindex \$ret 2] || [lindex \$ret 3] != 1} {

--- a/test/integration/fapi/fapi-provision.sh
+++ b/test/integration/fapi/fapi-provision.sh
@@ -11,21 +11,21 @@ function cleanup {
     # Since clean up should already been done during normal run of the test, a
     # failure is expected here. Therefore, we need to pass a successful
     # execution in any case
-    tss2_delete --path=/ || true
+    tss2 delete --path=/ || true
     shut_down
 }
 
 trap cleanup EXIT
 
-tss2_provision
+tss2 provision
 
-PROFILE_NAME=$( tss2_list --searchPath=/ --pathList=- | cut -d "/" -f2 )
+PROFILE_NAME=$( tss2 list --searchPath=/ --pathList=- | cut -d "/" -f2 )
 
-tss2_delete --path=/
+tss2 delete --path=/
 
 expect <<EOF
 # Test if still objects in path
-spawn tss2_list --path=/
+spawn tss2 list --path=/
 set ret [wait]
 if {[lindex \$ret 2] || [lindex \$ret 3] != 1} {
     send_user "Still objects in path\n"

--- a/test/integration/fapi/fapi-quote-verify.sh
+++ b/test/integration/fapi/fapi-quote-verify.sh
@@ -8,7 +8,7 @@ start_up
 setup_fapi
 
 function cleanup {
-    tss2_delete --path=/
+    tss2 delete --path=/
     shut_down
 }
 
@@ -25,24 +25,24 @@ PCR_LOG=$TEMP_DIR/pcr.log
 printf "01234567890123456789" > $NONCE_FILE
 printf "01234567890123456789" > $PCR_LOG
 
-tss2_provision
+tss2 provision
 
-tss2_createkey --path=$KEY_PATH --type="noDa, restricted, sign" --authValue=""
+tss2 createkey --path=$KEY_PATH --type="noDa, restricted, sign" --authValue=""
 
-tss2_quote --keyPath=$KEY_PATH --pcrList="16" --qualifyingData=$NONCE_FILE \
+tss2 quote --keyPath=$KEY_PATH --pcrList="16" --qualifyingData=$NONCE_FILE \
     --signature=$SIGNATURE_FILE --pcrLog=$PCR_LOG \
     --certificate=$CERTIFICATE_FILE --quoteInfo=$QUOTE_INFO --force
 
-tss2_exportkey --pathOfKeyToDuplicate=$KEY_PATH --exportedData=$PUBLIC_QUOTE_KEY --force
-tss2_import --path="ext/myNewParent" --importData=$PUBLIC_QUOTE_KEY
+tss2 exportkey --pathOfKeyToDuplicate=$KEY_PATH --exportedData=$PUBLIC_QUOTE_KEY --force
+tss2 import --path="ext/myNewParent" --importData=$PUBLIC_QUOTE_KEY
 
-tss2_verifyquote --publicKeyPath="ext/myNewParent" \
+tss2 verifyquote --publicKeyPath="ext/myNewParent" \
     --qualifyingData=$NONCE_FILE --quoteInfo=$QUOTE_INFO \
     --signature=$SIGNATURE_FILE --pcrLog=$PCR_LOG
 
 expect <<EOF
 # Try with missing keyPath
-spawn tss2_quote --pcrList="16" \
+spawn tss2 quote --pcrList="16" \
     --qualifyingData=$NONCE_FILE --signature=$SIGNATURE_FILE \
     --pcrLog=$PCR_LOG --certificate=$CERTIFICATE_FILE \
     --quoteInfo=$QUOTE_INFO --force
@@ -55,7 +55,7 @@ EOF
 
 expect <<EOF
 # Try with missing pcrList
-spawn tss2_quote \
+spawn tss2 quote \
     --qualifyingData=$NONCE_FILE --signature=$SIGNATURE_FILE \
     --pcrLog=$PCR_LOG --certificate=$CERTIFICATE_FILE \
     --quoteInfo=$QUOTE_INFO --force
@@ -68,7 +68,7 @@ EOF
 
 expect <<EOF
 # Try with missing signature
-spawn tss2_quote --keyPath=$KEY_PATH --pcrList="16" \
+spawn tss2 quote --keyPath=$KEY_PATH --pcrList="16" \
     --qualifyingData=$NONCE_FILE \
     --pcrLog=$PCR_LOG --certificate=$CERTIFICATE_FILE \
     --quoteInfo=$QUOTE_INFO --force
@@ -81,7 +81,7 @@ EOF
 
 expect <<EOF
 # Try with missing quoteInfo
-spawn tss2_quote --keyPath=$KEY_PATH --pcrList="16" \
+spawn tss2 quote --keyPath=$KEY_PATH --pcrList="16" \
     --qualifyingData=$NONCE_FILE --signature=$SIGNATURE_FILE \
     --pcrLog=$PCR_LOG --certificate=$CERTIFICATE_FILE \
     --force
@@ -94,7 +94,7 @@ EOF
 
 expect <<EOF
 # Try with multiple stdout (1)
-spawn tss2_quote --keyPath=$KEY_PATH --pcrList="16" \
+spawn tss2 quote --keyPath=$KEY_PATH --pcrList="16" \
     --qualifyingData=$NONCE_FILE --signature=- \
     --pcrLog=- --certificate=$CERTIFICATE_FILE \
     --quoteInfo=$QUOTE_INFO --force
@@ -107,7 +107,7 @@ EOF
 
 expect <<EOF
 # Try with multiple stdout (2)
-spawn tss2_quote --keyPath=$KEY_PATH --pcrList="16" \
+spawn tss2 quote --keyPath=$KEY_PATH --pcrList="16" \
     --qualifyingData=$NONCE_FILE --signature=$SIGNATURE_FILE \
     --pcrLog=- --certificate=- \
     --quoteInfo=$QUOTE_INFO --force
@@ -120,7 +120,7 @@ EOF
 
 expect <<EOF
 # Try with multiple stdout (3)
-spawn tss2_quote --keyPath=$KEY_PATH --pcrList="16" \
+spawn tss2 quote --keyPath=$KEY_PATH --pcrList="16" \
     --qualifyingData=$NONCE_FILE --signature=$SIGNATURE_FILE \
     --pcrLog=$PCR_LOG --certificate=- \
     --quoteInfo=- --force
@@ -133,7 +133,7 @@ EOF
 
 expect <<EOF
 # Try with multiple stdout (4)
-spawn tss2_quote --keyPath=$KEY_PATH --pcrList "16" \
+spawn tss2 quote --keyPath=$KEY_PATH --pcrList "16" \
     --qualifyingData=- --signature $SIGNATURE_FILE \
     --pcrLog=- --certificate=$CERTIFICATE_FILE \
     --quoteInfo=- --force
@@ -146,7 +146,7 @@ EOF
 
 expect <<EOF
 # Try with wrong pcrs
-spawn tss2_quote --keyPath=$KEY_PATH --pcrList=abc --qualifyingData=$NONCE_FILE \
+spawn tss2 quote --keyPath=$KEY_PATH --pcrList=abc --qualifyingData=$NONCE_FILE \
     --signature=$SIGNATURE_FILE --pcrLog=$PCR_LOG \
     --certificate=$CERTIFICATE_FILE --quoteInfo=$QUOTE_INFO --force
 set ret [wait]
@@ -158,7 +158,7 @@ EOF
 
 expect <<EOF
 # Fail quote
-spawn tss2_quote --keyPath="/abc/def" --pcrList="16" --qualifyingData=$NONCE_FILE \
+spawn tss2 quote --keyPath="/abc/def" --pcrList="16" --qualifyingData=$NONCE_FILE \
     --signature=$SIGNATURE_FILE --pcrLog=$PCR_LOG \
     --certificate=$CERTIFICATE_FILE --quoteInfo=$QUOTE_INFO --force
 set ret [wait]
@@ -170,7 +170,7 @@ EOF
 
 expect <<EOF
 # Try with already existing directory
-spawn tss2_quote --keyPath=$KEY_PATH --pcrList="16" --qualifyingData=$NONCE_FILE \
+spawn tss2 quote --keyPath=$KEY_PATH --pcrList="16" --qualifyingData=$NONCE_FILE \
     --signature=$SIGNATURE_FILE --pcrLog=$PCR_LOG \
     --certificate=$CERTIFICATE_FILE --quoteInfo=$QUOTE_INFO
 set ret [wait]
@@ -181,26 +181,26 @@ if {[lindex \$ret 2] || [lindex \$ret 3] != 1} {
 EOF
 
 # Try with missing qualifyingData
-tss2_quote --keyPath=$KEY_PATH --pcrList="16" \
+tss2 quote --keyPath=$KEY_PATH --pcrList="16" \
     --signature=$SIGNATURE_FILE \
     --pcrLog=$PCR_LOG --certificate=$CERTIFICATE_FILE \
     --quoteInfo=$QUOTE_INFO --force
 
 # Try with missing pcrLog
-tss2_quote --keyPath=$KEY_PATH --pcrList="16" \
+tss2 quote --keyPath=$KEY_PATH --pcrList="16" \
     --qualifyingData=$NONCE_FILE --signature=$SIGNATURE_FILE \
     --certificate=$CERTIFICATE_FILE \
     --quoteInfo=$QUOTE_INFO --force
 
 # Try with missing certificate
-tss2_quote --keyPath=$KEY_PATH --pcrList="16" \
+tss2 quote --keyPath=$KEY_PATH --pcrList="16" \
     --qualifyingData=$NONCE_FILE --signature=$SIGNATURE_FILE \
     --pcrLog=$PCR_LOG \
     --quoteInfo=$QUOTE_INFO --force
 
 expect <<EOF
 # Try with missing publicKeyPath
-spawn tss2_verifyquote \
+spawn tss2 verifyquote \
     --qualifyingData=$NONCE_FILE --quoteInfo=$QUOTE_INFO \
     --signature=$SIGNATURE_FILE
 set ret [wait]
@@ -212,7 +212,7 @@ EOF
 
 expect <<EOF
 # Try with missing quoteInfo
-spawn tss2_verifyquote --publicKeyPath="ext/myNewParent" \
+spawn tss2 verifyquote --publicKeyPath="ext/myNewParent" \
     --qualifyingData=$NONCE_FILE \
     --signature=$SIGNATURE_FILE
 set ret [wait]
@@ -224,7 +224,7 @@ EOF
 
 expect <<EOF
 # Try with missing signature
-spawn tss2_verifyquote --publicKeyPath="ext/myNewParent" \
+spawn tss2 verifyquote --publicKeyPath="ext/myNewParent" \
     --qualifyingData=$NONCE_FILE --quoteInfo=$QUOTE_INFO
 set ret [wait]
 if {[lindex \$ret 2] || [lindex \$ret 3] != 1} {
@@ -235,7 +235,7 @@ EOF
 
 expect <<EOF
 # Try with multiple stdins (1)
-spawn tss2_verifyquote --publicKeyPath="ext/myNewParent" \
+spawn tss2 verifyquote --publicKeyPath="ext/myNewParent" \
     --qualifyingData=- --quoteInfo=- \
     --signature=$SIGNATURE_FILE --pcrLog=$PCR_LOG
 set ret [wait]
@@ -247,7 +247,7 @@ EOF
 
 expect <<EOF
 # Try with multiple stdins (2)
-spawn tss2_verifyquote --publicKeyPath="ext/myNewParent" \
+spawn tss2 verifyquote --publicKeyPath="ext/myNewParent" \
     --qualifyingData=$NONCE_FILE --quoteInfo=- \
     --signature=- --pcrLog=$PCR_LOG
 set ret [wait]
@@ -259,7 +259,7 @@ EOF
 
 expect <<EOF
 # Try with multiple stdins (3)
-spawn tss2_verifyquote --publicKeyPath="ext/myNewParent" \
+spawn tss2 verifyquote --publicKeyPath="ext/myNewParent" \
     --qualifyingData=$NONCE_FILE --quoteInfo=$QUOTE_INFO \
     --signature=- --pcrLog=-
 set ret [wait]
@@ -271,7 +271,7 @@ EOF
 
 expect <<EOF
 # Try with multiple stdins (4)
-spawn tss2_verifyquote --publicKeyPath="ext/myNewParent" \
+spawn tss2 verifyquote --publicKeyPath="ext/myNewParent" \
     --qualifyingData=- --quoteInfo=$QUOTE_INFO \
     --signature=$SIGNATURE_FILE --pcrLog=-
 set ret [wait]
@@ -283,7 +283,7 @@ EOF
 
 expect <<EOF
 # Try with multiple stdins (5)
-spawn tss2_verifyquote --publicKeyPath="ext/myNewParent" \
+spawn tss2 verifyquote --publicKeyPath="ext/myNewParent" \
     --qualifyingData=$NONCE_FILE --quoteInfo=- \
     --signature=- --pcrLog=$PCR_LOG
 set ret [wait]
@@ -295,7 +295,7 @@ EOF
 
 expect <<EOF
 # Try with multiple stdins (6)
-spawn tss2_verifyquote --publicKeyPath="ext/myNewParent" \
+spawn tss2 verifyquote --publicKeyPath="ext/myNewParent" \
     --qualifyingData=- --quoteInfo=- \
     --signature=- --pcrLog=-
 set ret [wait]
@@ -307,7 +307,7 @@ EOF
 
 expect <<EOF
 # Try with wrong qualifyingData file
-spawn tss2_verifyquote --publicKeyPath="ext/myNewParent" \
+spawn tss2 verifyquote --publicKeyPath="ext/myNewParent" \
     --qualifyingData=abc --quoteInfo=$QUOTE_INFO \
     --signature=$SIGNATURE_FILE --pcrLog=$PCR_LOG
 set ret [wait]
@@ -319,7 +319,7 @@ EOF
 
 expect <<EOF
 # Try with wrong signature file
-spawn tss2_verifyquote --publicKeyPath="ext/myNewParent" \
+spawn tss2 verifyquote --publicKeyPath="ext/myNewParent" \
     --qualifyingData=$NONCE_FILE --quoteInfo=$QUOTE_INFO \
     --signature=abc --pcrLog=$PCR_LOG
 set ret [wait]
@@ -331,7 +331,7 @@ EOF
 
 expect <<EOF
 # Try with wrong quoteInfo file
-spawn tss2_verifyquote --publicKeyPath="ext/myNewParent" \
+spawn tss2 verifyquote --publicKeyPath="ext/myNewParent" \
     --qualifyingData=$NONCE_FILE --quoteInfo=abc \
     --signature=$SIGNATURE_FILE --pcrLog=$PCR_LOG
 set ret [wait]
@@ -342,8 +342,8 @@ if {[lindex \$ret 2] || [lindex \$ret 3] != 1} {
 EOF
 
 expect <<EOF
-# Try failing tss2_verifyquote
-spawn tss2_verifyquote --publicKeyPath="ext/abc" \
+# Try failing tss2 verifyquote
+spawn tss2 verifyquote --publicKeyPath="ext/abc" \
     --qualifyingData=$NONCE_FILE --quoteInfo=abc \
     --signature=$SIGNATURE_FILE --pcrLog=$PCR_LOG
 set ret [wait]
@@ -354,7 +354,7 @@ if {[lindex \$ret 2] || [lindex \$ret 3] != 1} {
 EOF
 
 # Try with missing qualifyingData
-tss2_verifyquote --publicKeyPath="ext/myNewParent" \
+tss2 verifyquote --publicKeyPath="ext/myNewParent" \
     --quoteInfo=$QUOTE_INFO \
     --signature=$SIGNATURE_FILE
 

--- a/test/integration/fapi/fapi-seal-unseal.sh
+++ b/test/integration/fapi/fapi-seal-unseal.sh
@@ -8,7 +8,7 @@ start_up
 setup_fapi
 
 function cleanup {
-    tss2_delete --path=/
+    tss2 delete --path=/
     shut_down
 }
 
@@ -23,11 +23,11 @@ PCR_POLICY_DATA=$TEMP_DIR/pol_pcr16_0.json
 POLICY_PCR=policy/pcr-policy
 COUNT_FILE=$TEMP_DIR/count.file
 
-tss2_provision
+tss2 provision
 
 expect <<EOF
 # Try interactive prompt with different passwords
-spawn tss2_createseal --path=$KEY_PATH --policyPath=$POLICY_PCR --type="noDa" \
+spawn tss2 createseal --path=$KEY_PATH --policyPath=$POLICY_PCR --type="noDa" \
     --data=$SEALED_DATA_FILE
 expect "Authorize object Password: "
 send "1\r"
@@ -43,7 +43,7 @@ EOF
 
 expect <<EOF
 # Try with missing path
-spawn tss2_createseal --type="noDa" --data=$SEALED_DATA_FILE --authValue=""
+spawn tss2 createseal --type="noDa" --data=$SEALED_DATA_FILE --authValue=""
 set ret [wait]
 if {[lindex \$ret 2] || [lindex \$ret 3] != 1} {
     Command has not failed as expected\n"
@@ -51,21 +51,21 @@ if {[lindex \$ret 2] || [lindex \$ret 3] != 1} {
 }
 EOF
 
-tss2_import --path=$POLICY_PCR --importData=$PCR_POLICY_DATA
+tss2 import --path=$POLICY_PCR --importData=$PCR_POLICY_DATA
 
-tss2_createseal --path=$KEY_PATH --policyPath=$POLICY_PCR --type="noDa" \
+tss2 createseal --path=$KEY_PATH --policyPath=$POLICY_PCR --type="noDa" \
     --data=$SEALED_DATA_FILE --authValue=""
-tss2_unseal --path=$KEY_PATH --data=$UNSEALED_DATA_FILE --force
+tss2 unseal --path=$KEY_PATH --data=$UNSEALED_DATA_FILE --force
 
 if [ "`xxd $UNSEALED_DATA_FILE`" != "`xxd $SEALED_DATA_FILE`" ]; then
   echo "Seal/Unseal failed"
   exit 1
 fi
 
-tss2_delete --path=$KEY_PATH
-printf "$SEAL_DATA" | tss2_createseal --path=$KEY_PATH --policyPath=$POLICY_PCR --type="noDa" \
+tss2 delete --path=$KEY_PATH
+printf "$SEAL_DATA" | tss2 createseal --path=$KEY_PATH --policyPath=$POLICY_PCR --type="noDa" \
     --data=- --authValue=""
-UNSEALED_DATA=$(tss2_unseal --path=$KEY_PATH --data=- | xxd)
+UNSEALED_DATA=$(tss2 unseal --path=$KEY_PATH --data=- | xxd)
 
 V1=$(printf "$SEAL_DATA" | xxd)
 V2=$UNSEALED_DATA
@@ -77,7 +77,7 @@ fi
 
 expect <<EOF
 # Try with missing path
-spawn tss2_unseal --data=$UNSEALED_DATA_FILE --force
+spawn tss2 unseal --data=$UNSEALED_DATA_FILE --force
 set ret [wait]
 if {[lindex \$ret 2] || [lindex \$ret 3] != 1} {
     Command has not failed as expected\n"
@@ -86,11 +86,11 @@ if {[lindex \$ret 2] || [lindex \$ret 3] != 1} {
 EOF
 
 # Unseal with password
-tss2_delete --path=$KEY_PATH
-tss2_createseal --path=$KEY_PATH --data=$SEALED_DATA_FILE --authValue="abc"
+tss2 delete --path=$KEY_PATH
+tss2 createseal --path=$KEY_PATH --data=$SEALED_DATA_FILE --authValue="abc"
 printf "" > $UNSEALED_DATA_FILE
 expect <<EOF
-spawn tss2_unseal --path=$KEY_PATH --data=$UNSEALED_DATA_FILE --force
+spawn tss2 unseal --path=$KEY_PATH --data=$UNSEALED_DATA_FILE --force
 expect "Authorize object : "
 send "abc\r"
 set ret [wait]
@@ -110,17 +110,17 @@ fi
 
 
 # Try with missing type
-tss2_delete --path=$KEY_PATH
-tss2_createseal --path $KEY_PATH --data=$SEALED_DATA_FILE --authValue=""
+tss2 delete --path=$KEY_PATH
+tss2 createseal --path $KEY_PATH --data=$SEALED_DATA_FILE --authValue=""
 # Try with missing data
-tss2_unseal --path=$KEY_PATH --force
+tss2 unseal --path=$KEY_PATH --force
 
 # Try with size parameter
-tss2_delete --path $KEY_PATH
+tss2 delete --path $KEY_PATH
 
 expect <<EOF
 # Try with size and data
-spawn tss2_createseal --path $KEY_PATH --data $UNSEALED_DATA_FILE --size 6 --authValue ""
+spawn tss2 createseal --path $KEY_PATH --data $UNSEALED_DATA_FILE --size 6 --authValue ""
 set ret [wait]
 if {[lindex \$ret 2] || [lindex \$ret 3] != 1} {
     Command has not failed as expected\n"
@@ -130,7 +130,7 @@ EOF
 
 expect <<EOF
 # Try with wrong size
-spawn tss2_createseal --path $KEY_PATH  --size abc --authValue ""
+spawn tss2 createseal --path $KEY_PATH  --size abc --authValue ""
 set ret [wait]
 if {[lindex \$ret 2] || [lindex \$ret 3] != 1} {
     Command has not failed as expected\n"
@@ -140,7 +140,7 @@ EOF
 
 expect <<EOF
 # Try with wrong size
-spawn tss2_createseal --path $KEY_PATH  --size 4294967296 --authValue ""
+spawn tss2 createseal --path $KEY_PATH  --size 4294967296 --authValue ""
 set ret [wait]
 if {[lindex \$ret 2] || [lindex \$ret 3] != 1} {
     Command has not failed as expected\n"
@@ -148,8 +148,8 @@ if {[lindex \$ret 2] || [lindex \$ret 3] != 1} {
 }
 EOF
 
-tss2_createseal --path $KEY_PATH --size 15 --authValue ""
-tss2_unseal --path $KEY_PATH --data $UNSEALED_DATA_FILE --force
+tss2 createseal --path $KEY_PATH --size 15 --authValue ""
+tss2 unseal --path $KEY_PATH --data $UNSEALED_DATA_FILE --force
 
 wc -c $UNSEALED_DATA_FILE | awk '{print $1}'> $COUNT_FILE
 
@@ -161,7 +161,7 @@ fi
 printf "" > $SEALED_DATA_FILE
 expect <<EOF
 # Try with empty seal file
-spawn tss2_createseal --path $KEY_PATH --data $SEALED_DATA_FILE --authValue ""
+spawn tss2 createseal --path $KEY_PATH --data $SEALED_DATA_FILE --authValue ""
 set ret [wait]
 if {[lindex \$ret 2] || [lindex \$ret 3] != 1} {
     Command has not failed as expected\n"

--- a/test/integration/fapi/fapi-set-get-app-data.sh
+++ b/test/integration/fapi/fapi-set-get-app-data.sh
@@ -8,7 +8,7 @@ start_up
 setup_fapi
 
 function cleanup {
-    tss2_delete --path=/
+    tss2 delete --path=/
     shut_down
 }
 
@@ -20,14 +20,14 @@ APP_DATA_FILE=$TEMP_DIR/app_data.file
 
 echo -n "abcdef" > $APP_DATA_SET
 
-tss2_provision
+tss2 provision
 
-tss2_createkey --path=$KEY_PATH --type="noDa, restricted, decrypt" \
+tss2 createkey --path=$KEY_PATH --type="noDa, restricted, decrypt" \
     --authValue=""
 
-tss2_setappdata --path=$KEY_PATH --appData=$APP_DATA_SET
+tss2 setappdata --path=$KEY_PATH --appData=$APP_DATA_SET
 
-tss2_getappdata --path=$KEY_PATH --appData=$APP_DATA_FILE --force
+tss2 getappdata --path=$KEY_PATH --appData=$APP_DATA_FILE --force
 
 if [ "$(< $APP_DATA_FILE)" !=  "$(< $APP_DATA_SET)" ]; then
   echo "Files are not equal"
@@ -35,16 +35,16 @@ if [ "$(< $APP_DATA_FILE)" !=  "$(< $APP_DATA_SET)" ]; then
 fi
 
 echo -n "" > $APP_DATA_FILE
-tss2_setappdata --path $KEY_PATH
-tss2_getappdata --path $KEY_PATH --appData $APP_DATA_FILE --force
+tss2 setappdata --path $KEY_PATH
+tss2 getappdata --path $KEY_PATH --appData $APP_DATA_FILE --force
 
 if [ "$(< $APP_DATA_FILE)" !=  "" ]; then
   echo "File not empty"
   exit 99
 fi
 
-echo -n "123" | tss2_setappdata --path $KEY_PATH --appData -
-tss2_getappdata --path $KEY_PATH --appData $APP_DATA_FILE --force
+echo -n "123" | tss2 setappdata --path $KEY_PATH --appData -
+tss2 getappdata --path $KEY_PATH --appData $APP_DATA_FILE --force
 
 if [ "$(< $APP_DATA_FILE)" !=  "123" ]; then
   echo "Files are not equal"
@@ -53,7 +53,7 @@ fi
 
 expect <<EOF
 # Try with missing path
-spawn tss2_getappdata --appData=$APP_DATA_FILE
+spawn tss2 getappdata --appData=$APP_DATA_FILE
 set ret [wait]
 if {[lindex \$ret 2] || [lindex \$ret 3] != 1} {
     Command has not failed as expected\n"
@@ -62,6 +62,6 @@ if {[lindex \$ret 2] || [lindex \$ret 3] != 1} {
 EOF
 
 # Try with missing appData
-tss2_getappdata --path=$KEY_PATH
+tss2 getappdata --path=$KEY_PATH
 
 exit 0

--- a/test/integration/fapi/fapi-set-get-certificate.sh
+++ b/test/integration/fapi/fapi-set-get-certificate.sh
@@ -8,7 +8,7 @@ start_up
 setup_fapi
 
 function cleanup {
-    tss2_delete --path=/
+    tss2 delete --path=/
     shut_down
 }
 
@@ -40,14 +40,14 @@ cat > $WRITE_CERTIFICATE_FILE <<EOF
     -----END CERTIFICATE-----\n"
 EOF
 
-tss2_provision
+tss2 provision
 
-tss2_createkey --path=$KEY_PATH --type="noDa, restricted, decrypt" \
+tss2 createkey --path=$KEY_PATH --type="noDa, restricted, decrypt" \
     --authValue=""
 
-tss2_setcertificate --path=$KEY_PATH --x509certData=$WRITE_CERTIFICATE_FILE
+tss2 setcertificate --path=$KEY_PATH --x509certData=$WRITE_CERTIFICATE_FILE
 
-tss2_getcertificate --path=$KEY_PATH --x509certData=$READ_CERTIFICATE_FILE \
+tss2 getcertificate --path=$KEY_PATH --x509certData=$READ_CERTIFICATE_FILE \
     --force
 
 if [[ "$(< $READ_CERTIFICATE_FILE)" != "$(< $WRITE_CERTIFICATE_FILE)" ]]; then
@@ -57,7 +57,7 @@ fi
 
 expect <<EOF
 # Try with missing path
-spawn tss2_setcertificate --x509certData=$WRITE_CERTIFICATE_FILE
+spawn tss2 setcertificate --x509certData=$WRITE_CERTIFICATE_FILE
 set ret [wait]
 if {[lindex \$ret 2] || [lindex \$ret 3] != 1} {
     Command has not failed as expected\n"
@@ -66,8 +66,8 @@ if {[lindex \$ret 2] || [lindex \$ret 3] != 1} {
 EOF
 
 # Try with missing cert, should set cert to empty
-tss2_setcertificate --path=$KEY_PATH
-tss2_getcertificate --path=$KEY_PATH --x509certData=$READ_CERTIFICATE_FILE \
+tss2 setcertificate --path=$KEY_PATH
+tss2 getcertificate --path=$KEY_PATH --x509certData=$READ_CERTIFICATE_FILE \
     --force
 
 if [[ "$(< $READ_CERTIFICATE_FILE)" != "" ]]; then
@@ -77,7 +77,7 @@ fi
 
 expect <<EOF
 # Try with missing path
-spawn tss2_getcertificate --x509certData=$READ_CERTIFICATE_FILE --force
+spawn tss2 getcertificate --x509certData=$READ_CERTIFICATE_FILE --force
 set ret [wait]
 if {[lindex \$ret 2] || [lindex \$ret 3] != 1} {
     Command has not failed as expected\n"
@@ -87,7 +87,7 @@ EOF
 
 expect <<EOF
 # Try with missing x509certData
-spawn tss2_getcertificate --path=$KEY_PATH --force
+spawn tss2 getcertificate --path=$KEY_PATH --force
 set ret [wait]
 if {[lindex \$ret 2] || [lindex \$ret 3] != 1} {
     Command has not failed as expected\n"

--- a/test/integration/fapi/fapi-set-get-description.sh
+++ b/test/integration/fapi/fapi-set-get-description.sh
@@ -8,7 +8,7 @@ start_up
 setup_fapi
 
 function cleanup {
-    tss2_delete --path=/
+    tss2 delete --path=/
     shut_down
 }
 
@@ -19,14 +19,14 @@ KEY_PATH=HS/SRK/myRSACrypt
 DESCRIPTION_FILE=$TEMP_DIR/object_description.file
 DESCRIPTION_SET="description data"
 
-tss2_provision
+tss2 provision
 
-tss2_createkey --path=$KEY_PATH --type="noDa, restricted, decrypt" \
+tss2 createkey --path=$KEY_PATH --type="noDa, restricted, decrypt" \
     --authValue=""
 
-tss2_setdescription --path=$KEY_PATH --description="$(echo $DESCRIPTION_SET)"
+tss2 setdescription --path=$KEY_PATH --description="$(echo $DESCRIPTION_SET)"
 
-tss2_getdescription --path=$KEY_PATH --description=$DESCRIPTION_FILE --force
+tss2 getdescription --path=$KEY_PATH --description=$DESCRIPTION_FILE --force
 
 if [ "$(< $DESCRIPTION_FILE)" !=  "$DESCRIPTION_SET" ]; then
   echo "Descriptions not equal"
@@ -35,7 +35,7 @@ fi
 
 expect <<EOF
 # Try with missing path
-spawn tss2_setdescription --description=$DESCRIPTION_SET
+spawn tss2 setdescription --description=$DESCRIPTION_SET
 set ret [wait]
 if {[lindex \$ret 2] || [lindex \$ret 3] != 1} {
     Command has not failed as expected\n"
@@ -44,8 +44,8 @@ if {[lindex \$ret 2] || [lindex \$ret 3] != 1} {
 EOF
 
 # Try with missing description, should set description to empty
-tss2_setdescription --path=$KEY_PATH
-tss2_getdescription --path=$KEY_PATH --description=$DESCRIPTION_FILE --force
+tss2 setdescription --path=$KEY_PATH
+tss2 getdescription --path=$KEY_PATH --description=$DESCRIPTION_FILE --force
 
 if [ "$(< $DESCRIPTION_FILE)" !=  "" ]; then
   echo "Description is not empty"
@@ -54,7 +54,7 @@ fi
 
 expect <<EOF
 # Try with missing path
-spawn tss2_getdescription --description=$DESCRIPTION_FILE
+spawn tss2 getdescription --description=$DESCRIPTION_FILE
 set ret [wait]
 if {[lindex \$ret 2] || [lindex \$ret 3] != 1} {
     Command has not failed as expected\n"
@@ -64,7 +64,7 @@ EOF
 
 expect <<EOF
 # Try with missing description
-spawn tss2_getdescription --path=$KEY_PATH
+spawn tss2 getdescription --path=$KEY_PATH
 set ret [wait]
 if {[lindex \$ret 2] || [lindex \$ret 3] != 1} {
     Command has not failed as expected\n"

--- a/test/integration/fapi/fapi-sign-verify.sh
+++ b/test/integration/fapi/fapi-sign-verify.sh
@@ -8,7 +8,7 @@ start_up
 setup_fapi
 
 function cleanup {
-    tss2_delete --path=/
+    tss2 delete --path=/
     shut_down
 }
 
@@ -21,27 +21,27 @@ PUBLIC_KEY_FILE=$TEMP_DIR/public_key.file
 IMPORTED_KEY_NAME="importedPubKey"
 PUB_KEY_DIR="ext"
 
-tss2_provision
+tss2 provision
 echo -n "01234567890123456789" > $DIGEST_FILE
-tss2_createkey --path=$KEY_PATH --type="noDa, sign" --authValue=""
-echo -n `cat $DIGEST_FILE` | tss2_sign --digest=- --keyPath=$KEY_PATH \
+tss2 createkey --path=$KEY_PATH --type="noDa, sign" --authValue=""
+echo -n `cat $DIGEST_FILE` | tss2 sign --digest=- --keyPath=$KEY_PATH \
     --padding="RSA_PSS" --signature=$SIGNATURE_FILE --publicKey=$PUBLIC_KEY_FILE
 
-tss2_import --path=$IMPORTED_KEY_NAME --importData=$PUBLIC_KEY_FILE
-tss2_verifysignature --keyPath=$PUB_KEY_DIR/$IMPORTED_KEY_NAME \
+tss2 import --path=$IMPORTED_KEY_NAME --importData=$PUBLIC_KEY_FILE
+tss2 verifysignature --keyPath=$PUB_KEY_DIR/$IMPORTED_KEY_NAME \
     --digest=$DIGEST_FILE --signature=$SIGNATURE_FILE
 
 # Try without certificate
-tss2_sign --keyPath=$KEY_PATH --padding="RSA_PSS" --digest=$DIGEST_FILE \
+tss2 sign --keyPath=$KEY_PATH --padding="RSA_PSS" --digest=$DIGEST_FILE \
     --signature=$SIGNATURE_FILE --publicKey=$PUBLIC_KEY_FILE --force
 
 # Try without public key
-tss2_sign --keyPath=$KEY_PATH --padding="RSA_PSS" --digest=$DIGEST_FILE \
+tss2 sign --keyPath=$KEY_PATH --padding="RSA_PSS" --digest=$DIGEST_FILE \
     --signature=$SIGNATURE_FILE --force
 
 expect <<EOF
 # Try with missing keyPath
-spawn tss2_sign --padding="RSA_PSS" --digest=$DIGEST_FILE \
+spawn tss2 sign --padding="RSA_PSS" --digest=$DIGEST_FILE \
     --signature=$SIGNATURE_FILE --publicKey=$PUBLIC_KEY_FILE
 set ret [wait]
 if {[lindex \$ret 2] || [lindex \$ret 3] != 1} {
@@ -52,7 +52,7 @@ EOF
 
 expect <<EOF
 # Try with missing digest
-spawn tss2_sign --keyPath=$KEY_PATH --padding="RSA_PSS" \
+spawn tss2 sign --keyPath=$KEY_PATH --padding="RSA_PSS" \
     --signature=$SIGNATURE_FILE --publicKey=$PUBLIC_KEY_FILE
 set ret [wait]
 if {[lindex \$ret 2] || [lindex \$ret 3] != 1} {
@@ -63,7 +63,7 @@ EOF
 
 expect <<EOF
 # Try with missing signature
-spawn tss2_sign --keyPath=$KEY_PATH --padding="RSA_PSS" --digest=$DIGEST_FILE \
+spawn tss2 sign --keyPath=$KEY_PATH --padding="RSA_PSS" --digest=$DIGEST_FILE \
     --publicKey=$PUBLIC_KEY_FILE
 set ret [wait]
 if {[lindex \$ret 2] || [lindex \$ret 3] != 1} {
@@ -74,7 +74,7 @@ EOF
 
 expect <<EOF
 # Try with multiple stdins with publicKey and with certificate
-spawn tss2_sign --keyPath=$KEY_PATH --padding="RSA_PSS" --digest=$DIGEST_FILE \
+spawn tss2 sign --keyPath=$KEY_PATH --padding="RSA_PSS" --digest=$DIGEST_FILE \
     --signature=- --publicKey=- --certificate -
 set ret [wait]
 if {[lindex \$ret 2] || [lindex \$ret 3] != 1} {
@@ -85,7 +85,7 @@ EOF
 
 expect <<EOF
 # Try with multiple stdins without publicKey and with certificate
-spawn tss2_sign --keyPath=$KEY_PATH --padding="RSA_PSS" --digest=$DIGEST_FILE \
+spawn tss2 sign --keyPath=$KEY_PATH --padding="RSA_PSS" --digest=$DIGEST_FILE \
     --signature=- --certificate=-
 set ret [wait]
 if {[lindex \$ret 2] || [lindex \$ret 3] != 1} {
@@ -96,7 +96,7 @@ EOF
 
 expect <<EOF
 # Try with missing digest file
-spawn tss2_sign --keyPath=$KEY_PATH --padding="RSA_PSS" --digest=abc \
+spawn tss2 sign --keyPath=$KEY_PATH --padding="RSA_PSS" --digest=abc \
     --signature=$SIGNATURE_FILE --publicKey=$PUBLIC_KEY_FILE
 set ret [wait]
 if {[lindex \$ret 2] || [lindex \$ret 3] != 1} {
@@ -107,7 +107,7 @@ EOF
 
 expect <<EOF
 # Try with missing keyPath
-spawn tss2_verifysignature \
+spawn tss2 verifysignature \
     --digest=$DIGEST_FILE --signature=$SIGNATURE_FILE
 set ret [wait]
 if {[lindex \$ret 2] || [lindex \$ret 3] != 1} {
@@ -118,7 +118,7 @@ EOF
 
 expect <<EOF
 # Try with missing digest
-spawn tss2_verifysignature --keyPath=$PUB_KEY_DIR/$IMPORTED_KEY_NAME \
+spawn tss2 verifysignature --keyPath=$PUB_KEY_DIR/$IMPORTED_KEY_NAME \
     --signature=$SIGNATURE_FILE
 set ret [wait]
 if {[lindex \$ret 2] || [lindex \$ret 3] != 1} {
@@ -129,7 +129,7 @@ EOF
 
 expect <<EOF
 # Try with missing signature
-spawn tss2_verifysignature --keyPath=$PUB_KEY_DIR/$IMPORTED_KEY_NAME \
+spawn tss2 verifysignature --keyPath=$PUB_KEY_DIR/$IMPORTED_KEY_NAME \
     --digest=$DIGEST_FILE
 set ret [wait]
 if {[lindex \$ret 2] || [lindex \$ret 3] != 1} {
@@ -140,7 +140,7 @@ EOF
 
 expect <<EOF
 # Try with multiple stdins
-spawn tss2_verifysignature --keyPath=$PUB_KEY_DIR/$IMPORTED_KEY_NAME \
+spawn tss2 verifysignature --keyPath=$PUB_KEY_DIR/$IMPORTED_KEY_NAME \
     --digest=- --signature=-
 set ret [wait]
 if {[lindex \$ret 2] || [lindex \$ret 3] != 1} {

--- a/test/integration/fapi/fapi-testing-template.sh
+++ b/test/integration/fapi/fapi-testing-template.sh
@@ -10,7 +10,7 @@ setup_fapi
 function cleanup {
     # If this test is successful, no keys are created. Thus, command below will
     # always fail
-    tss2_delete --path=/ || true
+    tss2 delete --path=/ || true
     shut_down
 }
 
@@ -25,7 +25,7 @@ echo -n "Secret Text!" > $PLAIN_TEXT
 
 expect <<EOF
 # Try with wrong help argument
-spawn tss2_provision -h abc
+spawn tss2 provision -h abc
 set ret [wait]
 if {[lindex \$ret 2] || [lindex \$ret 3] != 1} {
     Command has not failed as expected\n"
@@ -33,15 +33,15 @@ if {[lindex \$ret 2] || [lindex \$ret 3] != 1} {
 }
 EOF
 
-tss2_provision -h man
+tss2 provision -h man
 
-tss2_provision -h no-man
+tss2 provision -h no-man
 
-tss2_provision -v
+tss2 provision -v
 
 expect <<EOF
 # Try with wrong option
-spawn tss2_provision -abcdef
+spawn tss2 provision -abcdef
 set ret [wait]
 if {[lindex \$ret 2] || [lindex \$ret 3] != 1} {
     Command has not failed as expected\n"
@@ -49,7 +49,7 @@ if {[lindex \$ret 2] || [lindex \$ret 3] != 1} {
 }
 EOF
 
-tss2_getrandom -v > $VERSION_FILE
+tss2 getrandom -v > $VERSION_FILE
 VERSION=$(cat $VERSION_FILE | cut -d'=' -f 4)
 size=${#VERSION}
 if [ $size -ge 129 ]; then

--- a/tools/fapi/tss2_authorizepolicy.c
+++ b/tools/fapi/tss2_authorizepolicy.c
@@ -5,9 +5,6 @@
 #include <string.h>
 #include "tools/fapi/tss2_template.h"
 
-/* needed by tpm2_util and tpm2_option functions */
-bool output_enabled = false;
-
 /* Context struct used to store passed commandline parameters */
 static struct cxt {
     char  const *policyPath;
@@ -32,7 +29,7 @@ static bool on_option(char key, char *value) {
 }
 
 /* Define possible commandline parameters */
-bool tss2_tool_onstart(tpm2_options **opts) {
+static bool tss2_tool_onstart(tpm2_options **opts) {
     struct option topts[] = {
         {"policyPath", required_argument, NULL, 'P'},
         {"keyPath",    required_argument, NULL, 'p'},
@@ -43,7 +40,7 @@ bool tss2_tool_onstart(tpm2_options **opts) {
 }
 
 /* Execute specific tool */
-int tss2_tool_onrun (FAPI_CONTEXT *fctx) {
+static int tss2_tool_onrun (FAPI_CONTEXT *fctx) {
     /* Check availability of required parameters */
     if (!ctx.policyPath) {
         fprintf (stderr, "policy path to sign is missing, pass" \
@@ -81,3 +78,5 @@ int tss2_tool_onrun (FAPI_CONTEXT *fctx) {
 
     return r;
 }
+
+TSS2_TOOL_REGISTER("authorize_policy", tss2_tool_onstart, tss2_tool_onrun, NULL)

--- a/tools/fapi/tss2_authorizepolicy.c
+++ b/tools/fapi/tss2_authorizepolicy.c
@@ -79,4 +79,4 @@ static int tss2_tool_onrun (FAPI_CONTEXT *fctx) {
     return r;
 }
 
-TSS2_TOOL_REGISTER("authorize_policy", tss2_tool_onstart, tss2_tool_onrun, NULL)
+TSS2_TOOL_REGISTER("authorizepolicy", tss2_tool_onstart, tss2_tool_onrun, NULL)

--- a/tools/fapi/tss2_changeauth.c
+++ b/tools/fapi/tss2_changeauth.c
@@ -6,11 +6,8 @@
 
 #include "tools/fapi/tss2_template.h"
 
-/* needed by tpm2_util and tpm2_option functions */
-bool output_enabled = false;
-
 /* needed to conditionally free variable authValue */
-bool has_asked_for_password = false;
+static bool has_asked_for_password = false;
 
 /* Context struct used to store passed commandline parameters */
 static struct cxt {
@@ -32,7 +29,7 @@ static bool on_option(char key, char *value) {
 }
 
 /* Define possible commandline parameters */
-bool tss2_tool_onstart(tpm2_options **opts) {
+static bool tss2_tool_onstart(tpm2_options **opts) {
     struct option topts[] = {
         {"authValue",  required_argument, NULL, 'a'},
         {"entityPath", required_argument, NULL, 'p'}
@@ -42,7 +39,7 @@ bool tss2_tool_onstart(tpm2_options **opts) {
 }
 
 /* Execute specific tool */
-int tss2_tool_onrun (FAPI_CONTEXT *fctx) {
+static int tss2_tool_onrun (FAPI_CONTEXT *fctx) {
     /* Check availability of required parameters */
     if (!ctx.entityPath) {
         fprintf (stderr, "No entity path provided, use --entityPath\n");
@@ -74,3 +71,5 @@ int tss2_tool_onrun (FAPI_CONTEXT *fctx) {
 
     return 0;
 }
+
+TSS2_TOOL_REGISTER("changeauth", tss2_tool_onstart, tss2_tool_onrun, NULL)

--- a/tools/fapi/tss2_createkey.c
+++ b/tools/fapi/tss2_createkey.c
@@ -6,11 +6,8 @@
 
 #include "tools/fapi/tss2_template.h"
 
-/* needed by tpm2_util and tpm2_option functions */
-bool output_enabled = false;
-
 /* needed to conditionally free variable authValue */
-bool has_asked_for_password = false;
+static bool has_asked_for_password = false;
 
 /* Context struct used to store passed commandline parameters */
 static struct cxt {
@@ -40,7 +37,7 @@ static bool on_option(char key, char *value) {
 }
 
 /* Define possible commandline parameters */
-bool tss2_tool_onstart(tpm2_options **opts) {
+static bool tss2_tool_onstart(tpm2_options **opts) {
     struct option topts[] = {
         {"path",       required_argument, NULL, 'p'},
         {"type",       required_argument, NULL, 't'},
@@ -52,7 +49,7 @@ bool tss2_tool_onstart(tpm2_options **opts) {
 }
 
 /* Execute specific tool */
-int tss2_tool_onrun (FAPI_CONTEXT *fctx) {
+static int tss2_tool_onrun (FAPI_CONTEXT *fctx) {
     /* Check availability of required parameters */
     if (!ctx.keyPath) {
         fprintf (stderr, "key path missing, use --path\n");
@@ -85,3 +82,5 @@ int tss2_tool_onrun (FAPI_CONTEXT *fctx) {
 
     return r;
 }
+
+TSS2_TOOL_REGISTER("createkey", tss2_tool_onstart, tss2_tool_onrun, NULL)

--- a/tools/fapi/tss2_createnv.c
+++ b/tools/fapi/tss2_createnv.c
@@ -7,11 +7,8 @@
 
 #include "tools/fapi/tss2_template.h"
 
-/* needed by tpm2_util and tpm2_option functions */
-bool output_enabled = false;
-
 /* needed to conditionally free variable authValue */
-bool has_asked_for_password = false;
+static bool has_asked_for_password = false;
 
 /* Context struct used to store passed commandline parameters */
 static struct cxt {
@@ -49,7 +46,7 @@ static bool on_option(char key, char *value) {
 }
 
 /* Define possible commandline parameters */
-bool tss2_tool_onstart(tpm2_options **opts) {
+static bool tss2_tool_onstart(tpm2_options **opts) {
     struct option topts[] = {
         {"path",       required_argument, NULL, 'p'},
         {"type",       required_argument, NULL, 't'},
@@ -62,7 +59,7 @@ bool tss2_tool_onstart(tpm2_options **opts) {
 }
 
 /* Execute specific tool */
-int tss2_tool_onrun (FAPI_CONTEXT *fctx) {
+static int tss2_tool_onrun (FAPI_CONTEXT *fctx) {
     /* Check availability of required parameters */
     if (!ctx.nvPath) {
         fprintf (stderr, "No NV path provided, use --path\n");
@@ -112,3 +109,5 @@ int tss2_tool_onrun (FAPI_CONTEXT *fctx) {
 
     return r;
 }
+
+TSS2_TOOL_REGISTER("createenv", tss2_tool_onstart, tss2_tool_onrun, NULL)

--- a/tools/fapi/tss2_createnv.c
+++ b/tools/fapi/tss2_createnv.c
@@ -110,4 +110,4 @@ static int tss2_tool_onrun (FAPI_CONTEXT *fctx) {
     return r;
 }
 
-TSS2_TOOL_REGISTER("createenv", tss2_tool_onstart, tss2_tool_onrun, NULL)
+TSS2_TOOL_REGISTER("createnv", tss2_tool_onstart, tss2_tool_onrun, NULL)

--- a/tools/fapi/tss2_createseal.c
+++ b/tools/fapi/tss2_createseal.c
@@ -6,11 +6,8 @@
 
 #include "tools/fapi/tss2_template.h"
 
-/* needed by tpm2_util and tpm2_option functions */
-bool output_enabled = false;
-
 /* needed to conditionally free variable authValue */
-bool has_asked_for_password = false;
+static bool has_asked_for_password = false;
 
 /* Context struct used to store passed command line parameters */
 static struct cxt {
@@ -56,7 +53,7 @@ static bool on_option(char key, char *value) {
 }
 
 /* Define possible command line parameters */
-bool tss2_tool_onstart(tpm2_options **opts) {
+static bool tss2_tool_onstart(tpm2_options **opts) {
     struct option topts[] = {
         {"path",       required_argument, NULL, 'p'},
         {"type",       required_argument, NULL, 't'},
@@ -70,7 +67,7 @@ bool tss2_tool_onstart(tpm2_options **opts) {
 }
 
 /* Execute specific tool */
-int tss2_tool_onrun (FAPI_CONTEXT *fctx) {
+static int tss2_tool_onrun (FAPI_CONTEXT *fctx) {
     /* Check availability of required parameters */
     if (!ctx.keyPath) {
         fprintf (stderr, "key path missing, use --path\n");
@@ -131,3 +128,5 @@ int tss2_tool_onrun (FAPI_CONTEXT *fctx) {
     }
     return 0;
 }
+
+TSS2_TOOL_REGISTER("createseal", tss2_tool_onstart, tss2_tool_onrun, NULL)

--- a/tools/fapi/tss2_decrypt.c
+++ b/tools/fapi/tss2_decrypt.c
@@ -5,9 +5,6 @@
 #include <stdio.h>
 #include "tools/fapi/tss2_template.h"
 
-/* needed by tpm2_util and tpm2_option functions */
-bool output_enabled = false;
-
 /* Context struct used to store passed command line parameters */
 static struct cxt {
     char const *keyPath;
@@ -36,7 +33,7 @@ static bool on_option(char key, char *value) {
 }
 
 /* Define possible command line parameters */
-bool tss2_tool_onstart(tpm2_options **opts) {
+static bool tss2_tool_onstart(tpm2_options **opts) {
     struct option topts[] = {
         {"keyPath",     required_argument, NULL, 'p'},
         {"cipherText", required_argument, NULL, 'i'},
@@ -48,7 +45,7 @@ bool tss2_tool_onstart(tpm2_options **opts) {
 }
 
 /* Execute specific tool */
-int tss2_tool_onrun (FAPI_CONTEXT *fctx) {
+static int tss2_tool_onrun (FAPI_CONTEXT *fctx) {
     /* Check availability of required parameters */
     if (!ctx.keyPath) {
         fprintf (stderr, "No key path provided, use --keyPath\n");
@@ -94,3 +91,5 @@ int tss2_tool_onrun (FAPI_CONTEXT *fctx) {
     Fapi_Free (plainText);
     return r;
 }
+
+TSS2_TOOL_REGISTER("decrypt", tss2_tool_onstart, tss2_tool_onrun, NULL)

--- a/tools/fapi/tss2_delete.c
+++ b/tools/fapi/tss2_delete.c
@@ -4,9 +4,6 @@
 
 #include "tools/fapi/tss2_template.h"
 
-/* needed by tpm2_util and tpm2_option functions */
-bool output_enabled = false;
-
 static char *path;
 
 /* Parse commandline parameters */
@@ -20,7 +17,7 @@ static bool on_option(char key, char *value) {
 }
 
 /* Define possible commandline parameters */
-bool tss2_tool_onstart(tpm2_options **opts) {
+static bool tss2_tool_onstart(tpm2_options **opts) {
     struct option topts[] = {
         {"path", required_argument, NULL, 'p'}
     };
@@ -29,7 +26,7 @@ bool tss2_tool_onstart(tpm2_options **opts) {
 }
 
 /* Execute specific tool */
-int tss2_tool_onrun (FAPI_CONTEXT *fctx) {
+static int tss2_tool_onrun (FAPI_CONTEXT *fctx) {
     if (!path) {
         fprintf (stderr, "No path to the entity provided, use --path\n");
         return -1;
@@ -43,3 +40,5 @@ int tss2_tool_onrun (FAPI_CONTEXT *fctx) {
     }
     return 0;
 }
+
+TSS2_TOOL_REGISTER("delete", tss2_tool_onstart, tss2_tool_onrun, NULL)

--- a/tools/fapi/tss2_encrypt.c
+++ b/tools/fapi/tss2_encrypt.c
@@ -5,9 +5,6 @@
 #include <stdio.h>
 #include "tools/fapi/tss2_template.h"
 
-/* needed by tpm2_util and tpm2_option functions */
-bool output_enabled = false;
-
 /* Context struct used to store passed commandline parameters */
 static struct cxt {
     char const *keyPath;
@@ -36,7 +33,7 @@ static bool on_option(char key, char *value) {
 }
 
 /* Define possible commandline parameters */
-bool tss2_tool_onstart(tpm2_options **opts) {
+static bool tss2_tool_onstart(tpm2_options **opts) {
     struct option topts[] = {
         {"keyPath",     required_argument, NULL, 'p'},
         {"plainText",   required_argument, NULL, 'i'},
@@ -48,7 +45,7 @@ bool tss2_tool_onstart(tpm2_options **opts) {
 }
 
 /* Execute specific tool */
-int tss2_tool_onrun (FAPI_CONTEXT *fctx) {
+static int tss2_tool_onrun (FAPI_CONTEXT *fctx) {
     /* Check availability of required parameters */
     if (!ctx.keyPath) {
         fprintf (stderr, "No key path provided, use --keyPath\n");
@@ -94,3 +91,5 @@ int tss2_tool_onrun (FAPI_CONTEXT *fctx) {
     Fapi_Free (cipherText);
     return 0;
 }
+
+TSS2_TOOL_REGISTER("encrypt", tss2_tool_onstart, tss2_tool_onrun, NULL)

--- a/tools/fapi/tss2_exportkey.c
+++ b/tools/fapi/tss2_exportkey.c
@@ -6,9 +6,6 @@
 #include <string.h>
 #include "tools/fapi/tss2_template.h"
 
-/* needed by tpm2_util and tpm2_option functions */
-bool output_enabled = false;
-
 /* Context struct used to store passed command line parameters */
 static struct cxt {
     char const *pathOfKeyToDuplicate;
@@ -37,7 +34,7 @@ static bool on_option(char key, char *value) {
 }
 
 /* Define possible command line parameters */
-bool tss2_tool_onstart(tpm2_options **opts) {
+static bool tss2_tool_onstart(tpm2_options **opts) {
     struct option topts[] = {
         {"pathToPublicKeyOfNewParent",  required_argument, NULL, 'e'},
         {"force",                       no_argument      , NULL, 'f'},
@@ -49,7 +46,7 @@ bool tss2_tool_onstart(tpm2_options **opts) {
 }
 
 /* Execute specific tool */
-int tss2_tool_onrun (FAPI_CONTEXT *fctx) {
+static int tss2_tool_onrun (FAPI_CONTEXT *fctx) {
     /* Check availability of required parameters */
     if (!ctx.exportedData) {
         fprintf (stderr, "exported data missing, use --output\n");
@@ -80,3 +77,5 @@ int tss2_tool_onrun (FAPI_CONTEXT *fctx) {
     Fapi_Free (exportedData);
     return 0;
 }
+
+TSS2_TOOL_REGISTER("exportkey", tss2_tool_onstart, tss2_tool_onrun, NULL)

--- a/tools/fapi/tss2_exportpolicy.c
+++ b/tools/fapi/tss2_exportpolicy.c
@@ -5,9 +5,6 @@
 #include <stdlib.h>
 #include "tools/fapi/tss2_template.h"
 
-/* needed by tpm2_util and tpm2_option functions */
-bool output_enabled = false;
-
 /* Context struct used to store passed command line parameters */
 static struct cxt {
     char *path;
@@ -32,7 +29,7 @@ static bool on_option(char key, char *value) {
 }
 
 /* Define possible command line parameters */
-bool tss2_tool_onstart(tpm2_options **opts) {
+static bool tss2_tool_onstart(tpm2_options **opts) {
     struct option topts[] = {
         {"force",       no_argument      , NULL, 'f'},
         {"path",        required_argument, NULL, 'p'},
@@ -44,7 +41,7 @@ bool tss2_tool_onstart(tpm2_options **opts) {
 }
 
 /* Execute specific tool */
-int tss2_tool_onrun (FAPI_CONTEXT *fctx) {
+static int tss2_tool_onrun (FAPI_CONTEXT *fctx) {
     /* Check availability of required parameters */
     if (!ctx.path) {
         fprintf (stderr, "path parameter is missing, pass --path\n");
@@ -72,3 +69,5 @@ int tss2_tool_onrun (FAPI_CONTEXT *fctx) {
     Fapi_Free (jsonPolicy);
     return 0;
 }
+
+TSS2_TOOL_REGISTER("exportpolicy", tss2_tool_onstart, tss2_tool_onrun, NULL)

--- a/tools/fapi/tss2_getappdata.c
+++ b/tools/fapi/tss2_getappdata.c
@@ -7,9 +7,6 @@
 
 #include "tools/fapi/tss2_template.h"
 
-/* needed by tpm2_util and tpm2_option functions */
-bool output_enabled = false;
-
 /* Context struct used to store passed commandline parameters */
 static struct cxt {
     char const *data;
@@ -34,7 +31,7 @@ static bool on_option(char key, char *value) {
 }
 
 /* Define possible commandline parameters */
-bool tss2_tool_onstart(tpm2_options **opts) {
+static bool tss2_tool_onstart(tpm2_options **opts) {
     struct option topts[] = {
         {"path", required_argument, NULL, 'p'},
         {"appData", required_argument, NULL, 'o'},
@@ -46,7 +43,7 @@ bool tss2_tool_onstart(tpm2_options **opts) {
 }
 
 /* Execute specific tool */
-int tss2_tool_onrun (FAPI_CONTEXT *fctx) {
+static int tss2_tool_onrun (FAPI_CONTEXT *fctx) {
     /* Check availability of required parameters */
     if (!ctx.path) {
         fprintf (stderr, "path is missing, use --path\n");
@@ -77,3 +74,5 @@ int tss2_tool_onrun (FAPI_CONTEXT *fctx) {
     Fapi_Free (appData);
     return 0;
 }
+
+TSS2_TOOL_REGISTER("getappdata", tss2_tool_onstart, tss2_tool_onrun, NULL)

--- a/tools/fapi/tss2_getcertificate.c
+++ b/tools/fapi/tss2_getcertificate.c
@@ -6,9 +6,6 @@
 #include <string.h>
 #include "tools/fapi/tss2_template.h"
 
-/* needed by tpm2_util and tpm2_option functions */
-bool output_enabled = false;
-
 /* Context struct used to store passed command line parameters */
 static struct cxt {
     char const *path;
@@ -33,7 +30,7 @@ static bool on_option(char key, char *value) {
 }
 
 /* Define possible command line parameters */
-bool tss2_tool_onstart(tpm2_options **opts) {
+static bool tss2_tool_onstart(tpm2_options **opts) {
     struct option topts[] = {
         {"force"   , no_argument      , NULL, 'f'},
         {"path"    , required_argument, NULL, 'p'},
@@ -44,7 +41,7 @@ bool tss2_tool_onstart(tpm2_options **opts) {
 }
 
 /* Execute specific tool */
-int tss2_tool_onrun (FAPI_CONTEXT *fctx) {
+static int tss2_tool_onrun (FAPI_CONTEXT *fctx) {
     /* Check availability of required parameters */
     if (!ctx.path) {
         fprintf (stderr, "path missing, use --path\n");
@@ -74,3 +71,5 @@ int tss2_tool_onrun (FAPI_CONTEXT *fctx) {
 
     return 0;
 }
+
+TSS2_TOOL_REGISTER("getcertificate", tss2_tool_onstart, tss2_tool_onrun, NULL)

--- a/tools/fapi/tss2_getdescription.c
+++ b/tools/fapi/tss2_getdescription.c
@@ -6,9 +6,6 @@
 #include <unistd.h>
 #include "tools/fapi/tss2_template.h"
 
-/* needed by tpm2_util and tpm2_option functions */
-bool output_enabled = false;
-
 /* Context struct used to store passed command line parameters */
 static struct cxt {
     char const *path;
@@ -33,7 +30,7 @@ static bool on_option(char key, char *value) {
 }
 
 /* Define possible command line parameters */
-bool tss2_tool_onstart(tpm2_options **opts) {
+static bool tss2_tool_onstart(tpm2_options **opts) {
     struct option topts[] = {
         {"path"        , required_argument, NULL, 'p'},
         {"description" , required_argument, NULL, 'o'},
@@ -44,7 +41,7 @@ bool tss2_tool_onstart(tpm2_options **opts) {
 }
 
 /* Execute specific tool */
-int tss2_tool_onrun (FAPI_CONTEXT *fctx) {
+static int tss2_tool_onrun (FAPI_CONTEXT *fctx) {
     /* Check availability of required parameters */
     if (!ctx.path) {
         fprintf (stderr, "path is missing, use --path\n");
@@ -74,3 +71,5 @@ int tss2_tool_onrun (FAPI_CONTEXT *fctx) {
 
     return 0;
 }
+
+TSS2_TOOL_REGISTER("getdescription", tss2_tool_onstart, tss2_tool_onrun, NULL)

--- a/tools/fapi/tss2_getinfo.c
+++ b/tools/fapi/tss2_getinfo.c
@@ -5,9 +5,6 @@
 #include <stdlib.h>
 #include "tools/fapi/tss2_template.h"
 
-/* needed by tpm2_util and tpm2_option functions */
-bool output_enabled = false;
-
 /* Context struct used to store passed commandline parameters */
 static struct cxt {
     char *info;
@@ -28,7 +25,7 @@ static bool on_option(char key, char *value) {
 }
 
 /* Define possible commandline parameters */
-bool tss2_tool_onstart(tpm2_options **opts) {
+static bool tss2_tool_onstart(tpm2_options **opts) {
     struct option topts[] = {
         {"force"   , no_argument      , NULL, 'f'},
         /* output file */
@@ -39,7 +36,7 @@ bool tss2_tool_onstart(tpm2_options **opts) {
 }
 
 /* Execute specific tool */
-int tss2_tool_onrun (FAPI_CONTEXT *fctx) {
+static int tss2_tool_onrun (FAPI_CONTEXT *fctx) {
     /* Check availability of required parameters */
     if (!ctx.info) {
         fprintf (stderr, "info parameter is missing, pass --info\n");
@@ -64,3 +61,5 @@ int tss2_tool_onrun (FAPI_CONTEXT *fctx) {
     Fapi_Free (info);
     return 0;
 }
+
+TSS2_TOOL_REGISTER("getinfo", tss2_tool_onstart, tss2_tool_onrun, NULL)

--- a/tools/fapi/tss2_getplatformcertificates.c
+++ b/tools/fapi/tss2_getplatformcertificates.c
@@ -6,9 +6,6 @@
 #include <string.h>
 #include "tools/fapi/tss2_template.h"
 
-/* needed by tpm2_util and tpm2_option functions */
-bool output_enabled = false;
-
 /* Context struct used to store passed commandline parameters */
 static struct cxt {
     char const *certificates;
@@ -29,7 +26,7 @@ static bool on_option(char key, char *value) {
 }
 
 /* Define possible commandline parameters */
-bool tss2_tool_onstart(tpm2_options **opts) {
+static bool tss2_tool_onstart(tpm2_options **opts) {
     struct option topts[] = {
         {"force",           no_argument      , NULL, 'f'},
         {"certificates",    required_argument, NULL, 'o'}
@@ -39,7 +36,7 @@ bool tss2_tool_onstart(tpm2_options **opts) {
 }
 
 /* Execute specific tool */
-int tss2_tool_onrun (FAPI_CONTEXT *fctx) {
+static int tss2_tool_onrun (FAPI_CONTEXT *fctx) {
     /* Check availability of required parameters */
     if (!ctx.certificates) {
         fprintf (stderr, "certificates missing, use --certificates\n");
@@ -71,3 +68,5 @@ int tss2_tool_onrun (FAPI_CONTEXT *fctx) {
 
     return 0;
 }
+
+TSS2_TOOL_REGISTER("getplatformcertificates", tss2_tool_onstart, tss2_tool_onrun, NULL)

--- a/tools/fapi/tss2_getrandom.c
+++ b/tools/fapi/tss2_getrandom.c
@@ -6,9 +6,6 @@
 
 #include "tools/fapi/tss2_template.h"
 
-/* needed by tpm2_util and tpm2_option functions */
-bool output_enabled = false;
-
 /* Context struct used to store passed commandline parameters */
 static struct cxt {
     size_t  numBytes;
@@ -46,7 +43,7 @@ static bool on_option(char key, char *value) {
 }
 
 /* Define possible commandline parameters */
-bool tss2_tool_onstart(tpm2_options **opts) {
+static bool tss2_tool_onstart(tpm2_options **opts) {
     struct option topts[] = {
         {"numBytes", required_argument, NULL, 'n'},
         {"force"    , no_argument      , NULL, 'f'},
@@ -59,7 +56,7 @@ bool tss2_tool_onstart(tpm2_options **opts) {
 }
 
 /* Execute specific tool */
-int tss2_tool_onrun (FAPI_CONTEXT *fctx) {
+static int tss2_tool_onrun (FAPI_CONTEXT *fctx) {
     /* Check availability of required parameters */
     if (!ctx.filename) {
         fprintf (stderr, "No filename for data was provided, use --data\n");
@@ -100,3 +97,5 @@ int tss2_tool_onrun (FAPI_CONTEXT *fctx) {
     Fapi_Free (data);
     return r;
 }
+
+TSS2_TOOL_REGISTER("getrandom", tss2_tool_onstart, tss2_tool_onrun, NULL)

--- a/tools/fapi/tss2_gettpmblobs.c
+++ b/tools/fapi/tss2_gettpmblobs.c
@@ -6,9 +6,6 @@
 #include <string.h>
 #include "tools/fapi/tss2_template.h"
 
-/* needed by tpm2_util and tpm2_option functions */
-bool output_enabled = false;
-
 /* Context struct used to store passed command line parameters */
 static struct cxt {
     char const *path;
@@ -41,7 +38,7 @@ static bool on_option(char key, char *value) {
 }
 
 /* Define possible command line parameters */
-bool tss2_tool_onstart(tpm2_options **opts) {
+static bool tss2_tool_onstart(tpm2_options **opts) {
     struct option topts[] = {
         {"force"   , no_argument      , NULL, 'f'},
         {"path"    , required_argument, NULL, 'p'},
@@ -54,7 +51,7 @@ bool tss2_tool_onstart(tpm2_options **opts) {
 }
 
 /* Execute specific tool */
-int tss2_tool_onrun (FAPI_CONTEXT *fctx) {
+static int tss2_tool_onrun (FAPI_CONTEXT *fctx) {
     /* Check availability of required parameters */
     if (!ctx.path) {
         fprintf (stderr, "path missing, use --path\n");
@@ -119,3 +116,5 @@ int tss2_tool_onrun (FAPI_CONTEXT *fctx) {
 
     return 0;
 }
+
+TSS2_TOOL_REGISTER("gettpmblobs", tss2_tool_onstart, tss2_tool_onrun, NULL)

--- a/tools/fapi/tss2_import.c
+++ b/tools/fapi/tss2_import.c
@@ -4,9 +4,6 @@
 #include <stdlib.h>
 #include "tools/fapi/tss2_template.h"
 
-/* needed by tpm2_util and tpm2_option functions */
-bool output_enabled = false;
-
 /* Context struct used to store passed command line parameters */
 static struct cxt {
     char *path;
@@ -27,7 +24,7 @@ static bool on_option(char key, char *value) {
 }
 
 /* Define possible command line parameters */
-bool tss2_tool_onstart(tpm2_options **opts) {
+static bool tss2_tool_onstart(tpm2_options **opts) {
     struct option topts[] = {
         {"importData", required_argument, NULL, 'i'},
         {"path"  , required_argument, NULL, 'p'}
@@ -37,7 +34,7 @@ bool tss2_tool_onstart(tpm2_options **opts) {
 }
 
 /* Execute specific tool */
-int tss2_tool_onrun (FAPI_CONTEXT *fctx) {
+static int tss2_tool_onrun (FAPI_CONTEXT *fctx) {
     /* Check availability of required parameters */
     if (!ctx.path) {
         fprintf (stderr, "path parameter is missing, pass --path\n");
@@ -67,3 +64,5 @@ int tss2_tool_onrun (FAPI_CONTEXT *fctx) {
 
     return 0;
 }
+
+TSS2_TOOL_REGISTER("import", tss2_tool_onstart, tss2_tool_onrun, NULL)

--- a/tools/fapi/tss2_list.c
+++ b/tools/fapi/tss2_list.c
@@ -6,9 +6,6 @@
 
 #include "tools/fapi/tss2_template.h"
 
-/* needed by tpm2_util and tpm2_option functions */
-bool output_enabled = false;
-
 /* Context struct used to store passed command line parameters */
 static struct cxt {
     bool  overwrite;
@@ -33,7 +30,7 @@ static bool on_option(char key, char *value) {
 }
 
 /* Define possible command line parameters */
-bool tss2_tool_onstart(tpm2_options **opts) {
+static bool tss2_tool_onstart(tpm2_options **opts) {
     struct option topts[] = {
         {"force"   , no_argument      , NULL, 'f'},
         {"searchPath", required_argument, NULL, 'p'},
@@ -44,7 +41,7 @@ bool tss2_tool_onstart(tpm2_options **opts) {
 }
 
 /* Execute specific tool */
-int tss2_tool_onrun (FAPI_CONTEXT *fctx) {
+static int tss2_tool_onrun (FAPI_CONTEXT *fctx) {
     (void) fctx;
     /* Execute FAPI command with passed arguments */
     char *pathList = NULL;
@@ -66,3 +63,5 @@ int tss2_tool_onrun (FAPI_CONTEXT *fctx) {
     Fapi_Free (pathList);
     return 0;
 }
+
+TSS2_TOOL_REGISTER("list", tss2_tool_onstart, tss2_tool_onrun, NULL)

--- a/tools/fapi/tss2_nvextend.c
+++ b/tools/fapi/tss2_nvextend.c
@@ -6,9 +6,6 @@
 #include <string.h>
 #include "tools/fapi/tss2_template.h"
 
-/* needed by tpm2_util and tpm2_option functions */
-bool output_enabled = false;
-
 /* Context struct used to store passed command line parameters */
 static struct cxt {
     char   const *nvPath;
@@ -33,7 +30,7 @@ static bool on_option(char key, char *value) {
 }
 
 /* Define possible command line parameters */
-bool tss2_tool_onstart(tpm2_options **opts) {
+static bool tss2_tool_onstart(tpm2_options **opts) {
     struct option topts[] = {
         {"data"  , required_argument, NULL, 'i'},
         {"nvPath"  , required_argument, NULL, 'p'},
@@ -44,7 +41,7 @@ bool tss2_tool_onstart(tpm2_options **opts) {
 }
 
 /* Execute specific tool */
-int tss2_tool_onrun (FAPI_CONTEXT *fctx) {
+static int tss2_tool_onrun (FAPI_CONTEXT *fctx) {
     /* Check availability of required parameters */
     if (!ctx.nvPath) {
         fprintf (stderr, "No NV path provided, use --nvPath\n");
@@ -95,3 +92,5 @@ int tss2_tool_onrun (FAPI_CONTEXT *fctx) {
 
     return 0;
 }
+
+TSS2_TOOL_REGISTER("nvextend", tss2_tool_onstart, tss2_tool_onrun, NULL)

--- a/tools/fapi/tss2_nvincrement.c
+++ b/tools/fapi/tss2_nvincrement.c
@@ -4,9 +4,6 @@
 
 #include "tools/fapi/tss2_template.h"
 
-/* needed by tpm2_util and tpm2_option functions */
-bool output_enabled = false;
-
 /* Variable used to store passed command line parameter */
 static char const *nvPath;
 
@@ -21,7 +18,7 @@ static bool on_option(char key, char *value) {
 }
 
 /* Define possible command line parameters */
-bool tss2_tool_onstart(tpm2_options **opts) {
+static bool tss2_tool_onstart(tpm2_options **opts) {
     struct option topts[] = {
         {"nvPath", required_argument, NULL, 'p'}
     };
@@ -30,7 +27,7 @@ bool tss2_tool_onstart(tpm2_options **opts) {
 }
 
 /* Execute specific tool */
-int tss2_tool_onrun (FAPI_CONTEXT *fctx) {
+static int tss2_tool_onrun (FAPI_CONTEXT *fctx) {
     /* Check availability of required parameters */
     if (!nvPath) {
         fprintf (stderr, "No path to the NV provided, use --nvPath\n");
@@ -46,3 +43,5 @@ int tss2_tool_onrun (FAPI_CONTEXT *fctx) {
 
     return 0;
 }
+
+TSS2_TOOL_REGISTER("nvincrement", tss2_tool_onstart, tss2_tool_onrun, NULL)

--- a/tools/fapi/tss2_nvread.c
+++ b/tools/fapi/tss2_nvread.c
@@ -7,9 +7,6 @@
 
 #include "tools/fapi/tss2_template.h"
 
-/* needed by tpm2_util and tpm2_option functions */
-bool output_enabled = false;
-
 /* Context struct used to store passed command line parameters */
 static struct cxt {
     char const *nvPath;
@@ -38,7 +35,7 @@ static bool on_option(char key, char *value) {
 }
 
 /* Define possible command line parameters */
-bool tss2_tool_onstart(tpm2_options **opts) {
+static bool tss2_tool_onstart(tpm2_options **opts) {
     struct option topts[] = {
         {"nvPath"  , required_argument, NULL, 'p'},
         {"force" , no_argument      , NULL, 'f'},
@@ -50,7 +47,7 @@ bool tss2_tool_onstart(tpm2_options **opts) {
 }
 
 /* Execute specific tool */
-int tss2_tool_onrun (FAPI_CONTEXT *fctx) {
+static int tss2_tool_onrun (FAPI_CONTEXT *fctx) {
     /* Check availability of required parameters */
     if (!ctx.nvPath) {
         fprintf (stderr, "No NV path provided, use --nvPath\n");
@@ -101,3 +98,5 @@ int tss2_tool_onrun (FAPI_CONTEXT *fctx) {
 
     return 0;
 }
+
+TSS2_TOOL_REGISTER("nvread", tss2_tool_onstart, tss2_tool_onrun, NULL)

--- a/tools/fapi/tss2_nvsetbits.c
+++ b/tools/fapi/tss2_nvsetbits.c
@@ -4,9 +4,6 @@
 #include <stdio.h>
 #include "tools/fapi/tss2_template.h"
 
-/* needed by tpm2_util and tpm2_option functions */
-bool output_enabled = false;
-
 /* Context struct used to store passed command line parameters */
 static struct cxt {
     char     const *path;
@@ -34,7 +31,7 @@ static bool on_option(char key, char *value) {
 }
 
 /* Define possible command line parameters */
-bool tss2_tool_onstart(tpm2_options **opts) {
+static bool tss2_tool_onstart(tpm2_options **opts) {
     struct option topts[] = {
         {"bitmap", required_argument, NULL, 'i'},
         {"nvPath"    , required_argument, NULL, 'p'}
@@ -44,7 +41,7 @@ bool tss2_tool_onstart(tpm2_options **opts) {
 }
 
 /* Execute specific tool */
-int tss2_tool_onrun (FAPI_CONTEXT *fctx) {
+static int tss2_tool_onrun (FAPI_CONTEXT *fctx) {
     /* Check availability of required parameters */
     if (!ctx.path) {
         fprintf (stderr, "No path to the NV provided, use --nvPath\n");
@@ -64,3 +61,5 @@ int tss2_tool_onrun (FAPI_CONTEXT *fctx) {
 
     return 0;
 }
+
+TSS2_TOOL_REGISTER("nvsetbits", tss2_tool_onstart, tss2_tool_onrun, NULL)

--- a/tools/fapi/tss2_nvwrite.c
+++ b/tools/fapi/tss2_nvwrite.c
@@ -6,9 +6,6 @@
 
 #include "tools/fapi/tss2_template.h"
 
-/* needed by tpm2_util and tpm2_option functions */
-bool output_enabled = false;
-
 /* Context struct used to store passed command line parameters */
 static struct cxt {
     char   const *nvPath;
@@ -29,7 +26,7 @@ static bool on_option(char key, char *value) {
 }
 
 /* Define possible command line parameters */
-bool tss2_tool_onstart(tpm2_options **opts) {
+static bool tss2_tool_onstart(tpm2_options **opts) {
     struct option topts[] = {
         {"data"  , required_argument, NULL, 'i'},
         {"nvPath"  , required_argument, NULL, 'p'}
@@ -39,7 +36,7 @@ bool tss2_tool_onstart(tpm2_options **opts) {
 }
 
 /* Execute specific tool */
-int tss2_tool_onrun (FAPI_CONTEXT *fctx) {
+static int tss2_tool_onrun (FAPI_CONTEXT *fctx) {
     /* Check availability of required parameters */
     if (!ctx.nvPath) {
         fprintf (stderr, "No NV path provided, use --nvPath\n");
@@ -68,3 +65,5 @@ int tss2_tool_onrun (FAPI_CONTEXT *fctx) {
     free (data);
     return 0;
 }
+
+TSS2_TOOL_REGISTER("nvwrite", tss2_tool_onstart, tss2_tool_onrun, NULL)

--- a/tools/fapi/tss2_pcrextend.c
+++ b/tools/fapi/tss2_pcrextend.c
@@ -6,9 +6,6 @@
 #include <string.h>
 #include "tools/fapi/tss2_template.h"
 
-/* needed by tpm2_util and tpm2_option functions */
-bool output_enabled = false;
-
 /* Context struct used to store passed command line parameters */
 static struct cxt {
     uint32_t        pcr;
@@ -37,7 +34,7 @@ static bool on_option(char key, char *value) {
 }
 
 /* Define possible command line parameters */
-bool tss2_tool_onstart(tpm2_options **opts) {
+static bool tss2_tool_onstart(tpm2_options **opts) {
     struct option topts[] = {
         {"pcr"       , required_argument, NULL, 'x'},
         {"data", required_argument, NULL, 'i'},
@@ -48,7 +45,7 @@ bool tss2_tool_onstart(tpm2_options **opts) {
 }
 
 /* Execute specific tool */
-int tss2_tool_onrun (FAPI_CONTEXT *fctx) {
+static int tss2_tool_onrun (FAPI_CONTEXT *fctx) {
     /* Check availability of required parameters */
     if (!ctx.pcr) {
         fprintf (stderr, "No pcr provided, use --pcr\n");
@@ -101,3 +98,5 @@ int tss2_tool_onrun (FAPI_CONTEXT *fctx) {
 
     return 0;
 }
+
+TSS2_TOOL_REGISTER("pcrextend", tss2_tool_onstart, tss2_tool_onrun, NULL)

--- a/tools/fapi/tss2_pcrread.c
+++ b/tools/fapi/tss2_pcrread.c
@@ -6,9 +6,6 @@
 #include <string.h>
 #include "tools/fapi/tss2_template.h"
 
-/* needed by tpm2_util and tpm2_option functions */
-bool output_enabled = false;
-
 /* Context struct used to store passed command line parameters */
 static struct cxt {
     uint32_t        pcrIndex;
@@ -41,7 +38,7 @@ static bool on_option(char key, char *value) {
 }
 
 /* Define possible command line parameters */
-bool tss2_tool_onstart(tpm2_options **opts) {
+static bool tss2_tool_onstart(tpm2_options **opts) {
     struct option topts[] = {
         {"pcrIndex"     , required_argument, NULL, 'x'},
         {"pcrValue"     , required_argument, NULL, 'o'},
@@ -53,7 +50,7 @@ bool tss2_tool_onstart(tpm2_options **opts) {
 }
 
 /* Execute specific tool */
-int tss2_tool_onrun (FAPI_CONTEXT *fctx) {
+static int tss2_tool_onrun (FAPI_CONTEXT *fctx) {
     /* Check availability of required parameters */
     if (!ctx.pcrIndex) {
         fprintf (stderr, "No PCR index provided, use --pcrIndex\n");
@@ -104,3 +101,5 @@ int tss2_tool_onrun (FAPI_CONTEXT *fctx) {
 
     return r;
 }
+
+TSS2_TOOL_REGISTER("pcrread", tss2_tool_onstart, tss2_tool_onrun, NULL)

--- a/tools/fapi/tss2_provision.c
+++ b/tools/fapi/tss2_provision.c
@@ -3,9 +3,6 @@
 #include <stdio.h>
 #include "tools/fapi/tss2_template.h"
 
-/* needed by tpm2_util and tpm2_option functions */
-bool output_enabled = false;
-
 /* Context struct used to store passed commandline parameters */
 static struct cxt {
     char *authValueEh;
@@ -30,7 +27,7 @@ static bool on_option(char key, char *value) {
 }
 
 /* Define possible commandline parameters */
-bool tss2_tool_onstart(tpm2_options **opts) {
+static bool tss2_tool_onstart(tpm2_options **opts) {
     struct option topts[] = {
         {"authValueEh",         required_argument, NULL, 'E'},
         {"authValueSh",         required_argument, NULL, 'S'},
@@ -41,7 +38,7 @@ bool tss2_tool_onstart(tpm2_options **opts) {
 }
 
 /* Execute specific tool */
-int tss2_tool_onrun (FAPI_CONTEXT *fctx) {
+static int tss2_tool_onrun (FAPI_CONTEXT *fctx) {
 
     /* Execute FAPI command with passed arguments */
     TSS2_RC r = Fapi_Provision (fctx, ctx.authValueEh, ctx.authValueSh,
@@ -53,3 +50,5 @@ int tss2_tool_onrun (FAPI_CONTEXT *fctx) {
 
     return 0;
 }
+
+TSS2_TOOL_REGISTER("provision", tss2_tool_onstart, tss2_tool_onrun, NULL)

--- a/tools/fapi/tss2_quote.c
+++ b/tools/fapi/tss2_quote.c
@@ -6,9 +6,6 @@
 #include <string.h>
 #include "tools/fapi/tss2_template.h"
 
-/* needed by tpm2_util and tpm2_option functions */
-bool output_enabled = false;
-
 /* Context struct used to store passed command line parameters */
 static struct cxt {
     uint32_t   *pcrList;
@@ -88,7 +85,7 @@ static bool on_option(char key, char *value) {
 }
 
 /* Define possible command line parameters */
-bool tss2_tool_onstart(tpm2_options **opts) {
+static bool tss2_tool_onstart(tpm2_options **opts) {
     struct option topts[] = {
         {"pcrList"       , required_argument, NULL, 'x'},
         {"keyPath"        , required_argument, NULL, 'p'},
@@ -104,7 +101,7 @@ bool tss2_tool_onstart(tpm2_options **opts) {
 }
 
 /* Execute specific tool */
-int tss2_tool_onrun (FAPI_CONTEXT *fctx) {
+static int tss2_tool_onrun (FAPI_CONTEXT *fctx) {
     /* Check availability of required parameters */
     if (!ctx.pcrList) {
         fprintf (stderr, "No PCRs were chosen, use --pcrList\n");
@@ -217,3 +214,5 @@ int tss2_tool_onrun (FAPI_CONTEXT *fctx) {
 
     return 0;
 }
+
+TSS2_TOOL_REGISTER("quote", tss2_tool_onstart, tss2_tool_onrun, NULL)

--- a/tools/fapi/tss2_setappdata.c
+++ b/tools/fapi/tss2_setappdata.c
@@ -7,9 +7,6 @@
 
 #include "tools/fapi/tss2_template.h"
 
-/* needed by tpm2_util and tpm2_option functions */
-bool output_enabled = false;
-
 /* Context struct used to store passed commandline parameters */
 static struct cxt {
     char const *appData;
@@ -30,7 +27,7 @@ static bool on_option(char key, char *value) {
 }
 
 /* Define possible commandline parameters */
-bool tss2_tool_onstart(tpm2_options **opts) {
+static bool tss2_tool_onstart(tpm2_options **opts) {
     struct option topts[] = {
         {"appData", required_argument, NULL, 'i'},
         {"path", required_argument, NULL, 'p'},
@@ -40,7 +37,7 @@ bool tss2_tool_onstart(tpm2_options **opts) {
 }
 
 /* Execute specific tool */
-int tss2_tool_onrun (FAPI_CONTEXT *fctx) {
+static int tss2_tool_onrun (FAPI_CONTEXT *fctx) {
     /* Check availability of required parameters */
     if (!ctx.path) {
         fprintf (stderr, "path is missing, use --path\n");
@@ -69,3 +66,5 @@ int tss2_tool_onrun (FAPI_CONTEXT *fctx) {
     free(appData);
     return 0;
 }
+
+TSS2_TOOL_REGISTER("setappdata", tss2_tool_onstart, tss2_tool_onrun, NULL)

--- a/tools/fapi/tss2_setcertificate.c
+++ b/tools/fapi/tss2_setcertificate.c
@@ -4,9 +4,6 @@
 #include <stdlib.h>
 #include "tools/fapi/tss2_template.h"
 
-/* needed by tpm2_util and tpm2_option functions */
-bool output_enabled = false;
-
 /* Context struct used to store passed command line parameters */
 static struct cxt {
     char const *path;
@@ -27,7 +24,7 @@ static bool on_option(char key, char *value) {
 }
 
 /* Define possible command line parameters */
-bool tss2_tool_onstart(tpm2_options **opts) {
+static bool tss2_tool_onstart(tpm2_options **opts) {
     struct option topts[] = {
         {"path"    , required_argument, NULL, 'p'},
         {"x509certData", required_argument, NULL, 'i'}
@@ -37,7 +34,7 @@ bool tss2_tool_onstart(tpm2_options **opts) {
 }
 
 /* Execute specific tool */
-int tss2_tool_onrun (FAPI_CONTEXT *fctx) {
+static int tss2_tool_onrun (FAPI_CONTEXT *fctx) {
     /* Check availability of required parameters */
     if (!ctx.path) {
         fprintf (stderr, "path missing, use --path\n");
@@ -66,3 +63,5 @@ int tss2_tool_onrun (FAPI_CONTEXT *fctx) {
     free (x509certData);
     return 0;
 }
+
+TSS2_TOOL_REGISTER("setcertificate", tss2_tool_onstart, tss2_tool_onrun, NULL)

--- a/tools/fapi/tss2_setdescription.c
+++ b/tools/fapi/tss2_setdescription.c
@@ -4,9 +4,6 @@
 #include <string.h>
 #include "tools/fapi/tss2_template.h"
 
-/* needed by tpm2_util and tpm2_option functions */
-bool output_enabled = false;
-
 /* Context struct used to store passed command line parameters */
 static struct cxt {
     char const *path;
@@ -31,7 +28,7 @@ static bool on_option(char key, char *value) {
 }
 
 /* Define possible command line parameters */
-bool tss2_tool_onstart(tpm2_options **opts) {
+static bool tss2_tool_onstart(tpm2_options **opts) {
     struct option topts[] = {
         {"description", required_argument, NULL, 'i'},
         {"path"       , required_argument, NULL, 'p'}
@@ -41,7 +38,7 @@ bool tss2_tool_onstart(tpm2_options **opts) {
 }
 
 /* Execute specific tool */
-int tss2_tool_onrun (FAPI_CONTEXT *fctx) {
+static int tss2_tool_onrun (FAPI_CONTEXT *fctx) {
     /* Check availability of required parameters */
     if (!ctx.path) {
         fprintf (stderr, "path is missing, use --path\n");
@@ -56,3 +53,5 @@ int tss2_tool_onrun (FAPI_CONTEXT *fctx) {
     }
     return 0;
 }
+
+TSS2_TOOL_REGISTER("setdescription", tss2_tool_onstart, tss2_tool_onrun, NULL)

--- a/tools/fapi/tss2_sign.c
+++ b/tools/fapi/tss2_sign.c
@@ -7,9 +7,6 @@
 
 #include "tools/fapi/tss2_template.h"
 
-/* needed by tpm2_util and tpm2_option functions */
-bool output_enabled = false;
-
 /* Context struct used to store passed commandline parameters */
 static struct cxt {
     char const *keyPath;
@@ -50,7 +47,7 @@ static bool on_option(char key, char *value) {
 }
 
 /* Define possible command line parameters */
-bool tss2_tool_onstart(tpm2_options **opts) {
+static bool tss2_tool_onstart(tpm2_options **opts) {
     struct option topts[] = {
         {"keyPath",     required_argument, NULL, 'p'},
         {"padding",     required_argument, NULL, 's'},
@@ -66,7 +63,7 @@ bool tss2_tool_onstart(tpm2_options **opts) {
 }
 
 /* Execute specific tool */
-int tss2_tool_onrun (FAPI_CONTEXT *fctx) {
+static int tss2_tool_onrun (FAPI_CONTEXT *fctx) {
 
     /* Check availability of required parameters */
     if (!ctx.digest) {
@@ -148,3 +145,5 @@ int tss2_tool_onrun (FAPI_CONTEXT *fctx) {
 
     return 0;
 }
+
+TSS2_TOOL_REGISTER("sign", tss2_tool_onstart, tss2_tool_onrun, NULL)

--- a/tools/fapi/tss2_unseal.c
+++ b/tools/fapi/tss2_unseal.c
@@ -5,9 +5,6 @@
 #include <string.h>
 #include "tools/fapi/tss2_template.h"
 
-/* needed by tpm2_util and tpm2_option functions */
-bool output_enabled = false;
-
 /* Context struct used to store passed command line parameters */
 static struct cxt {
     char const *path;
@@ -32,7 +29,7 @@ static bool on_option(char key, char *value) {
 }
 
 /* Define possible command line parameters */
-bool tss2_tool_onstart(tpm2_options **opts) {
+static bool tss2_tool_onstart(tpm2_options **opts) {
     struct option topts[] = {
         {"path",    required_argument, NULL, 'p'},
         {"data",    required_argument, NULL, 'o'},
@@ -43,7 +40,7 @@ bool tss2_tool_onstart(tpm2_options **opts) {
 }
 
 /* Execute specific tool */
-int tss2_tool_onrun (FAPI_CONTEXT *fctx) {
+static int tss2_tool_onrun (FAPI_CONTEXT *fctx) {
     /* Check availability of required parameters */
     if (!ctx.path) {
         fprintf (stderr, "path to the sealed data missing, use --path\n");
@@ -71,3 +68,5 @@ int tss2_tool_onrun (FAPI_CONTEXT *fctx) {
 
     return 0;
 }
+
+TSS2_TOOL_REGISTER("unseal", tss2_tool_onstart, tss2_tool_onrun, NULL)

--- a/tools/fapi/tss2_verifyquote.c
+++ b/tools/fapi/tss2_verifyquote.c
@@ -5,9 +5,6 @@
 #include <string.h>
 #include "tools/fapi/tss2_template.h"
 
-/* needed by tpm2_util and tpm2_option functions */
-bool output_enabled = false;
-
 /* Context struct used to store passed command line parameters */
 static struct cxt {
     char *publicKeyPath;
@@ -40,7 +37,7 @@ static bool on_option(char key, char *value) {
 }
 
 /* Define possible command line parameters */
-bool tss2_tool_onstart(tpm2_options **opts) {
+static bool tss2_tool_onstart(tpm2_options **opts) {
     struct option topts[] = {
         {"publicKeyPath",   required_argument, NULL, 'k'},
         {"qualifyingData",  required_argument, NULL, 'Q'},
@@ -53,7 +50,7 @@ bool tss2_tool_onstart(tpm2_options **opts) {
 }
 
 /* Execute specific tool */
-int tss2_tool_onrun (FAPI_CONTEXT *fctx) {
+static int tss2_tool_onrun (FAPI_CONTEXT *fctx) {
     /* Check availability of required parameters */
     if (!ctx.quoteInfo) {
         fprintf (stderr, "quote info parameter not provided, use "\
@@ -146,3 +143,5 @@ int tss2_tool_onrun (FAPI_CONTEXT *fctx) {
 
     return 0;
 }
+
+TSS2_TOOL_REGISTER("verifyquote", tss2_tool_onstart, tss2_tool_onrun, NULL)

--- a/tools/fapi/tss2_verifysignature.c
+++ b/tools/fapi/tss2_verifysignature.c
@@ -6,9 +6,6 @@
 
 #include "tools/fapi/tss2_template.h"
 
-/* needed by tpm2_util and tpm2_option functions */
-bool output_enabled = false;
-
 /* Context struct used to store passed commandline parameters */
 static struct cxt {
     char const *digest;
@@ -33,7 +30,7 @@ static bool on_option(char key, char *value) {
 }
 
 /* Define possible command line parameters */
-bool tss2_tool_onstart(tpm2_options **opts) {
+static bool tss2_tool_onstart(tpm2_options **opts) {
     struct option topts[] = {
         {"keyPath",     required_argument, NULL, 'p'},
         {"digest",      required_argument, NULL, 'd'},
@@ -44,7 +41,7 @@ bool tss2_tool_onstart(tpm2_options **opts) {
 }
 
 /* Execute specific tool */
-int tss2_tool_onrun (FAPI_CONTEXT *fctx) {
+static int tss2_tool_onrun (FAPI_CONTEXT *fctx) {
     /* Check availability of required parameters */
     if (!ctx.publicKeyPath) {
         fprintf (stderr, "public key path parameter not provided, use " \
@@ -97,3 +94,5 @@ int tss2_tool_onrun (FAPI_CONTEXT *fctx) {
     free (signature);
     return 0;
 }
+
+TSS2_TOOL_REGISTER("verifysignature", tss2_tool_onstart, tss2_tool_onrun, NULL)

--- a/tools/fapi/tss2_writeauthorizenv.c
+++ b/tools/fapi/tss2_writeauthorizenv.c
@@ -6,9 +6,6 @@
 
 #include "tools/fapi/tss2_template.h"
 
-/* needed by tpm2_util and tpm2_option functions */
-bool output_enabled = false;
-
 /* Context struct used to store passed command line parameters */
 static struct cxt {
     char const *nvPath;
@@ -29,7 +26,7 @@ static bool on_option(char key, char *value) {
 }
 
 /* Define possible command line parameters */
-bool tss2_tool_onstart(tpm2_options **opts) {
+static bool tss2_tool_onstart(tpm2_options **opts) {
     struct option topts[] = {
         {"nvPath"  , required_argument, NULL, 'p'},
         {"policyPath"  , required_argument, NULL, 'P'}
@@ -39,7 +36,7 @@ bool tss2_tool_onstart(tpm2_options **opts) {
 }
 
 /* Execute specific tool */
-int tss2_tool_onrun (FAPI_CONTEXT *fctx) {
+static int tss2_tool_onrun (FAPI_CONTEXT *fctx) {
     /* Check availability of required parameters */
     if (!ctx.nvPath) {
         fprintf (stderr, "No NV path provided, use --nvPath\n");
@@ -59,3 +56,5 @@ int tss2_tool_onrun (FAPI_CONTEXT *fctx) {
 
     return 0;
 }
+
+TSS2_TOOL_REGISTER("writeauthorizenv", tss2_tool_onstart, tss2_tool_onrun, NULL)


### PR DESCRIPTION
Reuses the same name registration and lookup functions as #2077 for the programs in `tools/fapi/tss2_*`.