### PR TITLE
tss2: fix symlink to wrong toolbox

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -200,17 +200,19 @@ tpm2_tools = \
     tools/tpm2_zgen2phase.c
 
 # Create the symlinks for each tool to the tpm2 and optional tss2 bundled executables
-all_tools = $(tpm2_tools)
-if HAVE_FAPI
-all_tools += $(tss2_tools)
-endif
-
 install-exec-hook:
-	for tool in $(notdir $(basename $(all_tools))) ; do \
+	for tool in $(notdir $(basename $(tpm2_tools))) ; do \
 		$(LN_S) -f \
 		"tpm2$(EXEEXT)" \
 		"$(DESTDIR)$(bindir)/$$tool$(EXEEXT)" ; \
 	done
+if HAVE_FAPI
+	for tool in $(notdir $(basename $(tss2_tools))) ; do \
+		$(LN_S) -f \
+		"tss2$(EXEEXT)" \
+		"$(DESTDIR)$(bindir)/$$tool$(EXEEXT)" ; \
+	done
+endif
 
 if UNIT
 TESTS += $(check_PROGRAMS)


### PR DESCRIPTION
The tss2 tools were getting symlinked to the tpm2 tools execitable,
correct this by linking tss2_<tool> to the tss2 executable.

Signed-off-by: William Roberts <william.c.roberts@intel.com>