### PR TITLE
tpm2_getekcertificate: Add capability to scan NV indices for EK cert

### DIFF
--- a/doc/CHANGELOG.md
+++ b/doc/CHANGELOG.md
@@ -18,6 +18,16 @@
 
     - umask set to 0117 for all tools.
 
+    - tpm2\_getekcertificate now outputs the INTC EK certificates in PEM format
+      by default. In order to output the URL safe variant of base64 encoded
+      output of the INTC EK certificate use the added option **--raw**.
+
+ * tpm2_getekcertificate:
+   - Add option **--raw** to output EK certificate in URL safe variant base64
+     encoded format. By default it outputs a PEM formatted certificate.
+   - The tool can now output INTC and non INTC EK certificates from NV indices
+     specified by the TCG EK profile specification.
+
  * tpm2_activatecredential:
    - The secret data input can now be specified as stdin with **-s -** option.
 

--- a/man/tpm2_getekcertificate.1.md
+++ b/man/tpm2_getekcertificate.1.md
@@ -79,6 +79,11 @@ conditions dictating the certificate location lookup.
     mode. This forces the tool to not look for the EK certificates on the NV
     indices.
 
+  * **--raw**:
+
+    This flags the tool to output the EK certificate as is received from the
+    source: NV/ Web-Hosting.
+
   * **ARGUMENT** the command line argument specifies the URL address for the EK
     certificate portal. This forces the tool to not look for the EK certificates
     on the NV indices.

--- a/test/integration/tests/getekcertificate.sh
+++ b/test/integration/tests/getekcertificate.sh
@@ -92,30 +92,48 @@ define_ek_cert_nv_index() {
     tpm2 nvwrite -C p -i $1 $2
 }
 
-## ECC only
+## ECC only INTC certificate from NV index
 define_ek_cert_nv_index ecc_ek_cert.bin $ECC_EK_CERT_NV_INDEX
 
-tpm2 getekcertificate -o nv_ecc_ek_cert.bin
+tpm2 getekcertificate -o nv_ecc_ek_cert.pem
 
-diff nv_ecc_ek_cert.bin ecc_ek_cert.bin
+sed 's/-/+/g;s/_/\//g;s/%3D/=/g;s/^{.*certificate":"//g;s/"}$//g;' \
+ecc_ek_cert.bin | base64 --decode > ecc_test.der
 
-## RSA only
+openssl x509 -inform PEM -outform DER  -in nv_ecc_ek_cert.pem \
+-out nv_ecc_ek_cert.der
+
+diff nv_ecc_ek_cert.der ecc_test.der
+
+## RSA only INTC certificate from NV index
 tpm2 nvundefine -C p $ECC_EK_CERT_NV_INDEX
 
 define_ek_cert_nv_index rsa_ek_cert.bin $RSA_EK_CERT_NV_INDEX
 
-tpm2 getekcertificate -o nv_rsa_ek_cert.bin
+tpm2 getekcertificate -o nv_rsa_ek_cert.pem
 
-diff nv_rsa_ek_cert.bin rsa_ek_cert.bin
+sed 's/-/+/g;s/_/\//g;s/%3D/=/g;s/^{.*certificate":"//g;s/"}$//g;' \
+rsa_ek_cert.bin | base64 --decode > rsa_test.der
 
-## RSA & ECC
+openssl x509 -inform PEM -outform DER  -in nv_rsa_ek_cert.pem \
+-out nv_rsa_ek_cert.der
+
+diff nv_rsa_ek_cert.der rsa_test.der
+
+## RSA & ECC INTC certificates from NV index
 
 define_ek_cert_nv_index ecc_ek_cert.bin $ECC_EK_CERT_NV_INDEX
 
-tpm2 getekcertificate -o nv_rsa_ek_cert.bin -o nv_ecc_ek_cert.bin
+tpm2 getekcertificate -o nv_rsa_ek_cert.pem -o nv_ecc_ek_cert.pem
 
-diff nv_ecc_ek_cert.bin ecc_ek_cert.bin
+openssl x509 -inform PEM -outform DER  -in nv_ecc_ek_cert.pem \
+-out nv_ecc_ek_cert.der
 
-diff nv_rsa_ek_cert.bin rsa_ek_cert.bin
+openssl x509 -inform PEM -outform DER  -in nv_rsa_ek_cert.pem \
+-out nv_rsa_ek_cert.der
+
+diff nv_ecc_ek_cert.der ecc_test.der
+
+diff nv_rsa_ek_cert.der rsa_test.der
 
 exit 0

--- a/tools/tpm2_getekcertificate.c
+++ b/tools/tpm2_getekcertificate.c
@@ -12,27 +12,46 @@
 
 #include "files.h"
 #include "log.h"
+#include "object.h"
 #include "tpm2.h"
 #include "tpm2_alg_util.h"
 #include "tpm2_auth_util.h"
 #include "tpm2_capability.h"
+#include "tpm2_nv_util.h"
 #include "tpm2_tool.h"
 
 typedef struct tpm_getekcertificate_ctx tpm_getekcertificate_ctx;
 struct tpm_getekcertificate_ctx {
-    char *ec_cert_path;
-    FILE *ec_cert_file_handle;
+    // TPM Device properties
+    bool is_tpm2_device_active;
+    bool is_cert_on_nv;
+    bool is_intc_cert;
+    bool is_rsa_ek_cert_nv_location_defined;
+    bool is_ecc_ek_cert_nv_location_defined;
+    bool is_tpmgeneratedeps;
+    // Certficate data handling
+    uint8_t cert_count;
+    char *ec_cert_path_1;
+    FILE *ec_cert_file_handle_1;
+    char *ec_cert_path_2;
+    FILE *ec_cert_file_handle_2;
+    unsigned char *rsa_cert_buffer;
+    uint16_t rsa_cert_buffer_size;
+    unsigned char *ecc_cert_buffer;
+    uint16_t ecc_cert_buffer_size;
+    // EK certificate hosting particulars
     char *ek_server_addr;
     unsigned int SSL_NO_VERIFY;
     char *ek_path;
     bool verbose;
-    bool is_tpm2_device_active;
     TPM2B_PUBLIC *out_public;
 };
 
 static tpm_getekcertificate_ctx ctx = {
     .is_tpm2_device_active = true,
     .ek_server_addr = "https://ekop.intel.com/ekcertservice/",
+    .is_cert_on_nv = true,
+    .cert_count = 0,
 };
 
 static unsigned char *hash_ek_public(void) {
@@ -117,7 +136,7 @@ err:
     return NULL;
 }
 
-char *base64_encode(const unsigned char* buffer)
+static char *base64_encode(const unsigned char* buffer)
 {
     BIO *bio, *b64;
     BUF_MEM *buffer_pointer;
@@ -170,27 +189,27 @@ char *base64_encode(const unsigned char* buffer)
     return final_string;
 }
 
-int retrieve_endorsement_certificate(char *b64h) {
-    int ret = -1;
+static bool retrieve_web_endorsement_certificate(char *b64h) {
 
     size_t len = 1 + strlen(b64h) + strlen(ctx.ek_server_addr);
     char *weblink = (char *) malloc(len);
     if (!weblink) {
         LOG_ERR("oom");
-        return ret;
+        return false;
     }
 
-    snprintf(weblink, len, "%s%s", ctx.ek_server_addr, b64h);
-
+    bool ret = true;
     CURLcode rc = curl_global_init(CURL_GLOBAL_DEFAULT);
     if (rc != CURLE_OK) {
         LOG_ERR("curl_global_init failed: %s", curl_easy_strerror(rc));
+        ret = false;
         goto out_memory;
     }
 
     CURL *curl = curl_easy_init();
     if (!curl) {
         LOG_ERR("curl_easy_init failed");
+        ret = false;
         goto out_global_cleanup;
     }
 
@@ -202,14 +221,17 @@ int retrieve_endorsement_certificate(char *b64h) {
         if (rc != CURLE_OK) {
             LOG_ERR("curl_easy_setopt for CURLOPT_SSL_VERIFYPEER failed: %s",
                     curl_easy_strerror(rc));
+            ret = false;
             goto out_easy_cleanup;
         }
     }
 
+    snprintf(weblink, len, "%s%s", ctx.ek_server_addr, b64h);
     rc = curl_easy_setopt(curl, CURLOPT_URL, weblink);
     if (rc != CURLE_OK) {
         LOG_ERR("curl_easy_setopt for CURLOPT_URL failed: %s",
                 curl_easy_strerror(rc));
+        ret = false;
         goto out_easy_cleanup;
     }
 
@@ -221,6 +243,7 @@ int retrieve_endorsement_certificate(char *b64h) {
     if (rc != CURLE_OK) {
         LOG_ERR("curl_easy_setopt for CURLOPT_VERBOSE failed: %s",
                 curl_easy_strerror(rc));
+        ret = false;
         goto out_easy_cleanup;
     }
 
@@ -228,11 +251,12 @@ int retrieve_endorsement_certificate(char *b64h) {
      * If an output file is specified, write to the file, else curl will use stdout:
      * https://curl.haxx.se/libcurl/c/CURLOPT_WRITEDATA.html
      */
-    if (ctx.ec_cert_file_handle) {
-        rc = curl_easy_setopt(curl, CURLOPT_WRITEDATA, ctx.ec_cert_file_handle);
+    if (ctx.ec_cert_file_handle_1) {
+        rc = curl_easy_setopt(curl, CURLOPT_WRITEDATA, ctx.ec_cert_file_handle_1);
         if (rc != CURLE_OK) {
             LOG_ERR("curl_easy_setopt for CURLOPT_WRITEDATA failed: %s",
                     curl_easy_strerror(rc));
+            ret = false;
             goto out_easy_cleanup;
         }
     }
@@ -240,10 +264,9 @@ int retrieve_endorsement_certificate(char *b64h) {
     rc = curl_easy_perform(curl);
     if (rc != CURLE_OK) {
         LOG_ERR("curl_easy_perform() failed: %s", curl_easy_strerror(rc));
+        ret = false;
         goto out_easy_cleanup;
     }
-
-    ret = 0;
 
 out_easy_cleanup:
     curl_easy_cleanup(curl);
@@ -255,44 +278,317 @@ out_memory:
     return ret;
 }
 
-int get_ek_certificate(void) {
-    int rc = 1;
+static bool get_web_ek_certificate(void) {
+
+    if (ctx.SSL_NO_VERIFY) {
+        LOG_WARN("TLS communication with the said TPM manufacturer server setup"
+                 " with SSL_NO_VERIFY!");
+    }
+
+    bool ret = true;
     unsigned char *hash = hash_ek_public();
     char *b64 = base64_encode(hash);
     if (!b64) {
         LOG_ERR("base64_encode returned null");
+        ret = false;
         goto out;
     }
 
     LOG_INFO("%s", b64);
 
-    rc = retrieve_endorsement_certificate(b64);
+    ret = retrieve_web_endorsement_certificate(b64);
 
     free(b64);
 out:
     free(hash);
+    return ret;
+}
+
+#define INTC 0x494E5443
+#define IBM  0x49424D20
+#define RSA_EK_CERT_NV_INDEX 0x01C00002
+#define ECC_EK_CERT_NV_INDEX 0x01C0000A
+tool_rc get_tpm_properties(ESYS_CONTEXT *ectx) {
+
+    TPMI_YES_NO more_data;
+    TPMS_CAPABILITY_DATA *capability_data;
+    tool_rc rc = tool_rc_success;
+    rc = tpm2_getcap(ectx, TPM2_CAP_TPM_PROPERTIES, TPM2_PT_MANUFACTURER,
+            1, &more_data, &capability_data);
+    if (rc != tool_rc_success) {
+        LOG_ERR("TPM property read failure.");
+        goto get_tpm_properties_out;
+    }
+
+    if (capability_data->data.tpmProperties.tpmProperty[0].value == IBM) {
+        LOG_WARN("The TPM device is a simulator —— Inspect the certficate chain and root certificate");
+    }
+
+    if (capability_data->data.tpmProperties.tpmProperty[0].value == INTC) {
+        ctx.is_intc_cert = true;
+    }
+
+    free(capability_data);
+    rc = tpm2_getcap(ectx, TPM2_CAP_TPM_PROPERTIES, TPM2_PT_PERMANENT,
+            1, &more_data, &capability_data);
+    if (rc != tool_rc_success) {
+        LOG_ERR("TPM property read failure.");
+        goto get_tpm_properties_out;
+    }
+
+    if (capability_data->data.tpmProperties.tpmProperty[0].value &
+        TPMA_PERMANENT_TPMGENERATEDEPS) {
+            ctx.is_tpmgeneratedeps = true;
+    }
+
+    free(capability_data);
+    rc = tpm2_getcap(ectx, TPM2_CAP_HANDLES,
+        tpm2_util_hton_32(TPM2_HT_NV_INDEX), TPM2_PT_NV_INDEX_MAX, NULL,
+        &capability_data);
+    if (rc != tool_rc_success) {
+        LOG_ERR("Failed to read capability data for NV indices.");
+        ctx.is_cert_on_nv = false;
+        goto get_tpm_properties_out;
+    }
+
+    if (capability_data->data.handles.count == 0) {
+        ctx.is_cert_on_nv = false;
+        goto get_tpm_properties_out;
+    }
+
+    UINT32 i;
+    for (i = 0; i < capability_data->data.handles.count; i++) {
+        TPMI_RH_NV_INDEX index = capability_data->data.handles.handle[i];
+        if (index == RSA_EK_CERT_NV_INDEX) {
+            ctx.is_rsa_ek_cert_nv_location_defined = true;
+        }
+        if (index == ECC_EK_CERT_NV_INDEX) {
+            ctx.is_ecc_ek_cert_nv_location_defined = true;
+        }
+    }
+
+    if (!ctx.is_rsa_ek_cert_nv_location_defined &&
+    !ctx.is_ecc_ek_cert_nv_location_defined) {
+        ctx.is_cert_on_nv = false;
+    }
+
+get_tpm_properties_out:
+    free(capability_data);
     return rc;
 }
 
-static bool on_option(char key, char *value) {
+static tool_rc nv_read(ESYS_CONTEXT *ectx, TPMI_RH_NV_INDEX nv_index) {
 
-    switch (key) {
-    case 'o':
-        ctx.ec_cert_path = value;
-        break;
-    case 'X':
-        ctx.SSL_NO_VERIFY = 1;
-        LOG_WARN("TLS communication with the said TPM manufacturer server setup"
-                 " with SSL_NO_VERIFY!");
-        break;
-    case 'u':
-        ctx.ek_path = value;
-        break;
-    case 'x':
-        ctx.is_tpm2_device_active = false;
-        break;
+    /*
+     * Typical NV Index holding EK certificate has an empty auth
+     * with attributes:
+     * ppwrite|ppread|ownerread|authread|no_da|written|platformcreate
+     */
+    char index_string[11];
+    if (nv_index == RSA_EK_CERT_NV_INDEX) {
+        strcpy(index_string, "0x01C00002");
+    } else {
+        strcpy(index_string, "0x01C0000A");
     }
-    return true;
+    tpm2_loaded_object object;
+    tool_rc tmp_rc = tool_rc_success;
+    tool_rc rc = tpm2_util_object_load_auth(ectx, index_string, NULL, &object,
+        false, TPM2_HANDLE_FLAGS_NV);
+    if (rc != tool_rc_success) {
+        goto nv_read_out;
+    }
+
+    rc = nv_index == RSA_EK_CERT_NV_INDEX ?
+         tpm2_util_nv_read(ectx, nv_index, 0, 0, &object, &ctx.rsa_cert_buffer,
+         &ctx.rsa_cert_buffer_size, 0) :
+         tpm2_util_nv_read(ectx, nv_index, 0, 0, &object, &ctx.ecc_cert_buffer,
+         &ctx.ecc_cert_buffer_size, 0);
+
+nv_read_out:
+    tmp_rc = tpm2_session_close(&object.session);
+    if (rc != tool_rc_success) {
+        return tmp_rc;
+    }
+
+    return rc;
+}
+
+static tool_rc get_nv_ek_certificate(ESYS_CONTEXT *ectx) {
+
+    if (!ctx.is_cert_on_nv) {
+        LOG_ERR("TCG specified location for EK certs aren't defined.");
+        return tool_rc_general_error;
+    }
+
+    if (ctx.SSL_NO_VERIFY) {
+        LOG_WARN("Ignoring -X or --allow-unverified if EK certificate found on NV");
+    }
+
+    if (ctx.ek_path) {
+        LOG_WARN("Ignoring -u or --ek-public option if EK certificate found on NV");
+        return tool_rc_option_error;
+    }
+
+    if (ctx.is_rsa_ek_cert_nv_location_defined &&
+    ctx.is_ecc_ek_cert_nv_location_defined && ctx.cert_count == 1) {
+        LOG_WARN("Found 2 certficates on NV. Add another -o to save the ECC cert");
+    }
+
+    if ((!ctx.is_rsa_ek_cert_nv_location_defined ||
+    !ctx.is_ecc_ek_cert_nv_location_defined) && ctx.cert_count == 2) {
+        LOG_WARN("Ignoring the additional output file since only 1 cert found on NV");
+    }
+
+    tool_rc rc = tool_rc_success;
+    if (ctx.is_rsa_ek_cert_nv_location_defined) {
+        rc = nv_read(ectx, RSA_EK_CERT_NV_INDEX);
+        if (rc != tool_rc_success) {
+            return rc;
+        }
+    }
+
+    if (ctx.is_ecc_ek_cert_nv_location_defined) {
+        rc = nv_read(ectx, ECC_EK_CERT_NV_INDEX);
+    }
+
+    return rc;
+}
+
+static tool_rc print_intel_ek_certificate_warning(void) {
+
+    if (ctx.is_intc_cert && ctx.is_tpmgeneratedeps && !ctx.is_cert_on_nv) {
+
+        LOG_ERR("Cannot proceed. For further information please refer to: "
+                "https://www.intel.com/content/www/us/en/security-center/"
+                "advisory/intel-sa-00086.html. Recovery tools are located here:"
+                "https://github.com/intel/INTEL-SA-00086-Linux-Recovery-Tools");
+
+        return tool_rc_general_error;
+    }
+
+    return tool_rc_success;
+}
+
+static tool_rc get_ek_certificates(ESYS_CONTEXT *ectx) {
+
+    tool_rc rc = tool_rc_success;
+    if (ctx.is_cert_on_nv) {
+        rc = get_nv_ek_certificate(ectx);
+        if (rc == tool_rc_success) {
+            return rc;
+        } else {
+            LOG_WARN("EK certificate not found on NV");
+            ctx.is_cert_on_nv = false;
+        }
+    }
+
+    /*
+     * Following is everything applicable to ctx.is_cert_on_nv = false.
+     */
+
+    rc = print_intel_ek_certificate_warning();
+    if (rc != tool_rc_success) {
+        return rc;
+    }
+
+    if (!ctx.ek_path) {
+        LOG_ERR("Must specify the EK public key path");
+        return tool_rc_option_error;
+    }
+
+    if (ctx.cert_count > 1) {
+        LOG_ERR("Specify one output path for EK cert file per EK public key");
+        return tool_rc_option_error;
+    }
+
+    bool retval = get_web_ek_certificate();
+    if (!retval) {
+        return tool_rc_general_error;
+    }
+
+    return tool_rc_success;
+}
+
+static tool_rc process_input(ESYS_CONTEXT *ectx) {
+
+    if (ctx.ek_path) {
+        ctx.out_public = malloc(sizeof(*ctx.out_public));
+        ctx.out_public->size = 0;
+        bool res = files_load_public(ctx.ek_path, ctx.out_public);
+        if (!res) {
+            LOG_ERR("Could not load EK public from file");
+            return tool_rc_general_error;
+        }
+    }
+
+    tool_rc rc = tool_rc_success;
+    if (ctx.is_tpm2_device_active) {
+        rc = get_tpm_properties(ectx);
+        if (rc != tool_rc_success) {
+            return rc;
+        }
+    }
+
+    return print_intel_ek_certificate_warning();
+}
+
+static tool_rc process_output(void) {
+
+    bool retval = true;
+
+    if (ctx.rsa_cert_buffer) {
+        retval = files_write_bytes(
+            ctx.ec_cert_file_handle_1 ? ctx.ec_cert_file_handle_1 : stdout,
+            ctx.rsa_cert_buffer, ctx.rsa_cert_buffer_size);
+        if (!retval) {
+            return tool_rc_general_error;
+        }
+    }
+
+    if (ctx.ecc_cert_buffer) {
+        retval = files_write_bytes(
+            ctx.ec_cert_file_handle_2 ? ctx.ec_cert_file_handle_2 :
+            ctx.rsa_cert_buffer ? stdout : ctx.ec_cert_file_handle_1,
+            ctx.ecc_cert_buffer, ctx.ecc_cert_buffer_size);
+        if (!retval) {
+            return tool_rc_general_error;
+        }
+    }
+
+    return tool_rc_success;
+}
+
+static tool_rc check_input_options(void) {
+
+    if (!ctx.ek_path && !ctx.is_cert_on_nv) {
+        LOG_ERR("Must specify the EK public key path");
+        return tool_rc_option_error;
+    }
+
+    if (!ctx.ek_server_addr && !ctx.is_cert_on_nv) {
+        LOG_ERR("Must specify a valid remote server url!");
+        return tool_rc_option_error;
+    }
+
+    if (ctx.ec_cert_path_1) {
+        ctx.ec_cert_file_handle_1 = fopen(ctx.ec_cert_path_1, "wb");
+        if (!ctx.ec_cert_file_handle_1) {
+            LOG_ERR("Could not open file for writing: \"%s\"",
+                ctx.ec_cert_path_1);
+            return tool_rc_general_error;
+        }
+    }
+
+    if (ctx.ec_cert_path_2) {
+        ctx.ec_cert_file_handle_2 = fopen(ctx.ec_cert_path_2, "wb");
+        if (!ctx.ec_cert_file_handle_2) {
+            LOG_ERR("Could not open file for writing: \"%s\"",
+                ctx.ec_cert_path_2);
+            return tool_rc_general_error;
+        }
+    }
+
+    return tool_rc_success;
 }
 
 static bool on_args(int argc, char **argv) {
@@ -303,7 +599,39 @@ static bool on_args(int argc, char **argv) {
     }
 
     ctx.ek_server_addr = argv[0];
+    ctx.is_cert_on_nv = false;
 
+    return true;
+}
+
+static bool on_option(char key, char *value) {
+
+    switch (key) {
+    case 'o':
+        if (ctx.cert_count < 2) {
+            ctx.cert_count++;
+        } else {
+            LOG_ERR("Specify only 2 outputs for RSA/ ECC certificates");
+            return false;
+        }
+        if (ctx.cert_count == 1) {
+            ctx.ec_cert_path_1 = value;
+        }
+        if (ctx.cert_count == 2) {
+            ctx.ec_cert_path_2 = value;
+        }
+        break;
+    case 'X':
+        ctx.SSL_NO_VERIFY = 1;
+        break;
+    case 'u':
+        ctx.ek_path = value;
+        break;
+    case 'x':
+        ctx.is_tpm2_device_active = false;
+        ctx.is_cert_on_nv = false;
+        break;
+    }
     return true;
 }
 
@@ -323,103 +651,48 @@ static bool tpm2_tool_onstart(tpm2_options **opts) {
     return *opts != NULL;
 }
 
-#define INTC 0x494E5443
-#define IBM  0x49424D20
-bool is_getekcertificate_feasible(ESYS_CONTEXT *ectx) {
-
-    TPMI_YES_NO more_data;
-    TPMS_CAPABILITY_DATA *capability_data;
-
-    tool_rc rc = tpm2_getcap(ectx, TPM2_CAP_TPM_PROPERTIES, TPM2_PT_MANUFACTURER,
-            1, &more_data, &capability_data);
-    if (rc != tool_rc_success) {
-        LOG_ERR("TPM property read failure.");
-        return false;
-    }
-
-    if (capability_data->data.tpmProperties.tpmProperty[0].value == IBM) {
-        LOG_ERR("Simulator endorsement keys aren't certified");
-        return false;
-    }
-
-    if (capability_data->data.tpmProperties.tpmProperty[0].value != INTC) {
-        return true;
-    }
-
-    rc = tpm2_getcap(ectx, TPM2_CAP_TPM_PROPERTIES, TPM2_PT_PERMANENT,
-            1, &more_data, &capability_data);
-    if (rc != tool_rc_success) {
-        LOG_ERR("TPM property read failure.");
-        return false;
-    }
-
-    if (capability_data->data.tpmProperties.tpmProperty[0].value &
-        TPMA_PERMANENT_TPMGENERATEDEPS) {
-        LOG_ERR("Cannot proceed. For further information please refer to: "
-                "https://www.intel.com/content/www/us/en/security-center/"
-                "advisory/intel-sa-00086.html. Recovery tools are located here:"
-                "https://github.com/intel/INTEL-SA-00086-Linux-Recovery-Tools");
-        return false;
-    }
-
-    return true;
-}
-
 static tool_rc tpm2_tool_onrun(ESYS_CONTEXT *ectx, tpm2_option_flags flags) {
 
     UNUSED(ectx);
 
-    bool is_getekcert_feasible;
-    if (ctx.is_tpm2_device_active) {
-        is_getekcert_feasible = is_getekcertificate_feasible(ectx);
-        if (!is_getekcert_feasible) {
-            return tool_rc_general_error;
-        }
+    tool_rc rc = check_input_options();
+    if (rc != tool_rc_success) {
+        return rc;
     }
 
-    if (!ctx.ek_path) {
-        LOG_ERR("Must specify the ek public key path");
-        return tool_rc_general_error;
-    }
-
-    if (!ctx.ek_server_addr) {
-        LOG_ERR("Must specify a remote server url!");
-        return tool_rc_option_error;
-    }
-
-    if (ctx.ec_cert_path) {
-        ctx.ec_cert_file_handle = fopen(ctx.ec_cert_path, "wb");
-        if (!ctx.ec_cert_file_handle) {
-            LOG_ERR("Could not open file for writing: \"%s\"",
-                ctx.ec_cert_path);
-            return tool_rc_general_error;
-        }
-    }
-
-    ctx.out_public = malloc(sizeof(*ctx.out_public));
-    ctx.out_public->size = 0;
-    bool res = files_load_public(ctx.ek_path, ctx.out_public);
-    if (!res) {
-        LOG_ERR("Could not load EK public from file");
-        return tool_rc_general_error;
+    rc = process_input(ectx);
+    if (rc != tool_rc_success) {
+        return rc;
     }
 
     ctx.verbose = flags.verbose;
 
-    int ret = get_ek_certificate();
-    if (ret) {
-        return tool_rc_general_error;
+    rc = get_ek_certificates(ectx);
+    if (rc != tool_rc_success) {
+        return rc;
     }
 
-    return tool_rc_success;
+    return process_output();
 }
 
 static tool_rc tpm2_tool_onstop(ESYS_CONTEXT *ectx) {
 
     UNUSED(ectx);
 
-    if (ctx.ec_cert_file_handle) {
-        fclose(ctx.ec_cert_file_handle);
+    if (ctx.ec_cert_file_handle_1) {
+        fclose(ctx.ec_cert_file_handle_1);
+    }
+
+    if (ctx.ec_cert_file_handle_2) {
+        fclose(ctx.ec_cert_file_handle_2);
+    }
+
+    if (ctx.rsa_cert_buffer) {
+        free(ctx.rsa_cert_buffer);
+    }
+
+    if (ctx.ecc_cert_buffer) {
+        free(ctx.ecc_cert_buffer);
     }
 
     return tool_rc_success;


### PR DESCRIPTION
Fixes #1885

- [x] Add capability to scan NV indices for EK certificates per TCG specification for RSA and ECC certificates
- [x] Scan for NV indices first prior to looking for EK certificates on web hosting.
- [x] Default for Intel EK certificates found on NV to be converted to standard PEM format.
- [x] Add option to output both RSA and ECC certificates to file/stdout simultaneously when reading from NV indices.
- [x] Option to dump the Intel EK certificates as received in the URL safe variant of Base 64: https://tools.ietf.org/html/rfc4648#section-5
- [x] Fix an error where in a message to download EK certificate for Intel backend existed for non-Intel TPM.
- [x] Default for Intel EK certificates found on web hosting to be converted to standard PEM format.

Signed-off-by: Imran Desai <imran.desai@intel.com>