### PR TITLE
tss2_*: Fix a memory leak caused by empty output (for master)

### DIFF
--- a/doc/CHANGELOG.md
+++ b/doc/CHANGELOG.md
@@ -72,6 +72,7 @@
     - Fix autocompletion issue
     - Switch tss2\_\* to with-"="-style
     - Add size parameter to tss2_createseal
+    - Memory leaks are fixed in cases when a returned empty non-char output value was passed to file output
 
 ### 4.2 2020-04-08
 

--- a/tools/fapi/tss2_decrypt.c
+++ b/tools/fapi/tss2_decrypt.c
@@ -85,6 +85,7 @@ static int tss2_tool_onrun (FAPI_CONTEXT *fctx) {
     r = open_write_and_close (ctx.plainText, ctx.overwrite, plainText,
         plainTextSize);
     if (r){
+        Fapi_Free (plainText);
         return r;
     }
 

--- a/tools/fapi/tss2_encrypt.c
+++ b/tools/fapi/tss2_encrypt.c
@@ -85,6 +85,7 @@ static int tss2_tool_onrun (FAPI_CONTEXT *fctx) {
     r = open_write_and_close (ctx.cipherText, ctx.overwrite, cipherText,
         cipherTextSize);
     if (r) {
+        Fapi_Free (cipherText);
         return 1;
     }
 

--- a/tools/fapi/tss2_exportpolicy.c
+++ b/tools/fapi/tss2_exportpolicy.c
@@ -3,6 +3,7 @@
 #include <stdbool.h>
 #include <stdio.h>
 #include <stdlib.h>
+#include <string.h>
 #include "tools/fapi/tss2_template.h"
 
 /* Context struct used to store passed command line parameters */
@@ -61,8 +62,10 @@ static int tss2_tool_onrun (FAPI_CONTEXT *fctx) {
     }
 
     /* Write returned data to file(s) */
-    r = open_write_and_close (ctx.jsonPolicy, ctx.overwrite, jsonPolicy, 0);
+    r = open_write_and_close (ctx.jsonPolicy, ctx.overwrite, jsonPolicy,
+        strlen(jsonPolicy));
     if (r){
+        Fapi_Free (jsonPolicy);
         return 1;
     }
 

--- a/tools/fapi/tss2_getinfo.c
+++ b/tools/fapi/tss2_getinfo.c
@@ -3,6 +3,7 @@
 #include <stdbool.h>
 #include <stdio.h>
 #include <stdlib.h>
+#include <string.h>
 #include "tools/fapi/tss2_template.h"
 
 /* Context struct used to store passed commandline parameters */
@@ -52,7 +53,7 @@ static int tss2_tool_onrun (FAPI_CONTEXT *fctx) {
     }
 
     /* Write returned data to file(s) */
-    r = open_write_and_close (ctx.info, ctx.overwrite, info, 0);
+    r = open_write_and_close (ctx.info, ctx.overwrite, info, strlen(info));
     if (r) {
         Fapi_Free (info);
         return 1;

--- a/tools/fapi/tss2_getrandom.c
+++ b/tools/fapi/tss2_getrandom.c
@@ -3,6 +3,7 @@
 #include <stdbool.h>
 #include <stdio.h>
 #include <stdlib.h>
+#include <string.h>
 
 #include "tools/fapi/tss2_template.h"
 
@@ -77,11 +78,16 @@ static int tss2_tool_onrun (FAPI_CONTEXT *fctx) {
 
     if (ctx.hex) {
         char* str = malloc (ctx.numBytes*2 + 1);
+        if (!str) {
+            Fapi_Free (data);
+            LOG_ERR ("malloc(2) failed: %m\n");
+            return 1;
+        }
         for (size_t i = 0; i<ctx.numBytes; i++) {
             sprintf(str+i*2,"%02x",data[i]);
         }
         /* Write returned data to file(s) */
-        r = open_write_and_close (ctx.filename, ctx.overwrite, str, 0);
+        r = open_write_and_close (ctx.filename, ctx.overwrite, str, strlen(str));
         free(str);
     }
     else {

--- a/tools/fapi/tss2_gettpmblobs.c
+++ b/tools/fapi/tss2_gettpmblobs.c
@@ -87,6 +87,7 @@ static int tss2_tool_onrun (FAPI_CONTEXT *fctx) {
         r = open_write_and_close (ctx.tpm2bPublic, ctx.overwrite, tpm2bPublic,
             tpm2bPublicSize);
         if (r) {
+            Fapi_Free (tpm2bPublic);
             return 1;
         }
     }
@@ -96,6 +97,7 @@ static int tss2_tool_onrun (FAPI_CONTEXT *fctx) {
             tpm2bPrivateSize);
         if (r) {
             Fapi_Free (tpm2bPublic);
+            Fapi_Free (tpm2bPrivate);
             return 1;
         }
     }
@@ -106,13 +108,14 @@ static int tss2_tool_onrun (FAPI_CONTEXT *fctx) {
         if (r) {
             Fapi_Free (tpm2bPublic);
             Fapi_Free (tpm2bPrivate);
+            Fapi_Free (policy);
             return 1;
         }
     }
 
-    Fapi_Free (policy);
     Fapi_Free (tpm2bPublic);
     Fapi_Free (tpm2bPrivate);
+    Fapi_Free (policy);
 
     return 0;
 }

--- a/tools/fapi/tss2_nvread.c
+++ b/tools/fapi/tss2_nvread.c
@@ -81,6 +81,7 @@ static int tss2_tool_onrun (FAPI_CONTEXT *fctx) {
     /* Write returned data to file(s) */
     r = open_write_and_close (ctx.data, ctx.overwrite, data, data_len);
     if (r) {
+        Fapi_Free (data);
         return 1;
     }
 
@@ -89,12 +90,13 @@ static int tss2_tool_onrun (FAPI_CONTEXT *fctx) {
             strlen(logData));
         if (r) {
             Fapi_Free (data);
+            Fapi_Free (logData);
             return 1;
         }
     }
 
-    Fapi_Free (logData);
     Fapi_Free (data);
+    Fapi_Free (logData);
 
     return 0;
 }

--- a/tools/fapi/tss2_pcrread.c
+++ b/tools/fapi/tss2_pcrread.c
@@ -84,20 +84,23 @@ static int tss2_tool_onrun (FAPI_CONTEXT *fctx) {
             pcrValueSize);
         if (r) {
             Fapi_Free (pcrLog);
-            return 1;
-        }
-    }
-
-    if (ctx.pcrLog) {
-        r =  open_write_and_close (ctx.pcrLog, ctx.overwrite, pcrLog, 0);
-        if (r) {
             Fapi_Free (pcrValue);
             return 1;
         }
     }
 
-    Fapi_Free (pcrValue);
+    if (ctx.pcrLog) {
+        r =  open_write_and_close (ctx.pcrLog, ctx.overwrite, pcrLog,
+            strlen(pcrLog));
+        if (r) {
+            Fapi_Free (pcrLog);
+            Fapi_Free (pcrValue);
+            return 1;
+        }
+    }
+
     Fapi_Free (pcrLog);
+    Fapi_Free (pcrValue);
 
     return r;
 }

--- a/tools/fapi/tss2_quote.c
+++ b/tools/fapi/tss2_quote.c
@@ -168,7 +168,8 @@ static int tss2_tool_onrun (FAPI_CONTEXT *fctx) {
 
     /* Write returned data to file(s) */
     if (ctx.quoteInfo && quoteInfo) {
-        r = open_write_and_close (ctx.quoteInfo, ctx.overwrite, quoteInfo, 0);
+        r = open_write_and_close (ctx.quoteInfo, ctx.overwrite, quoteInfo,
+            strlen(quoteInfo));
         if (r) {
             Fapi_Free (quoteInfo);
             Fapi_Free (pcrLog);
@@ -181,7 +182,8 @@ static int tss2_tool_onrun (FAPI_CONTEXT *fctx) {
     Fapi_Free (quoteInfo);
 
     if (ctx.pcrLog && pcrLog) {
-        r = open_write_and_close (ctx.pcrLog, ctx.overwrite, pcrLog, 0);
+        r = open_write_and_close (ctx.pcrLog, ctx.overwrite, pcrLog,
+            strlen(pcrLog));
         if (r) {
             Fapi_Free (pcrLog);
             Fapi_Free (signature);

--- a/tools/fapi/tss2_template.c
+++ b/tools/fapi/tss2_template.c
@@ -456,7 +456,13 @@ free_opts:
 
 int open_write_and_close(const char* path, bool overwrite, const void *output,
     size_t output_len) {
-    size_t length = output_len ? output_len : strlen (output);
+
+    size_t length = 0;
+
+    if (output_len){
+        length = output_len;
+    }
+
     if (!path || !strcmp(path, "-")) {
         if (-1 == write (STDOUT_FILENO, output, length)) {
             fprintf (stderr, "write(2) to stdout failed: %m\n");


### PR DESCRIPTION
This commit fixes a memory leak in cases when an returned empty non-char
output value was passed to file output.

Signed-off-by: Christian Plappert <christian.plappert@sit.fraunhofer.de>