### PR TITLE
tss2_*: Fix a memory leak caused by empty output (for 4.2.x)

### DIFF
--- a/doc/CHANGELOG.md
+++ b/doc/CHANGELOG.md
@@ -23,6 +23,8 @@
 
  * tss2_*: tss2_setappdata now reads from file or stdin allowing to store also binary data
 
+ * tss2_*: Memory leaks are fixed in cases when a returned empty non-char output value was passed to file output
+
 ### 4.2.1 - 2020-05-25
 
 * Fix missing handle maps for ESY3 handle breaks. See #1994.

--- a/tools/fapi/tss2_decrypt.c
+++ b/tools/fapi/tss2_decrypt.c
@@ -79,6 +79,7 @@ int tss2_tool_onrun (FAPI_CONTEXT *fctx) {
     r = Fapi_Decrypt (fctx, ctx.keyPath, cipherText, cipherTextSize,
         &plainText, &plainTextSize);
     if (r != TSS2_RC_SUCCESS) {
+        free(cipherText);
         LOG_PERR ("Fapi_Decrypt", r);
         return 1;
     }
@@ -89,6 +90,7 @@ int tss2_tool_onrun (FAPI_CONTEXT *fctx) {
         plainTextSize);
     if (r){
         LOG_PERR ("open_write_and_close plainText", r);
+        Fapi_Free (plainText);
         return r;
     }
 

--- a/tools/fapi/tss2_encrypt.c
+++ b/tools/fapi/tss2_encrypt.c
@@ -90,6 +90,7 @@ int tss2_tool_onrun (FAPI_CONTEXT *fctx) {
         cipherTextSize);
     if (r) {
         LOG_PERR ("open_write_and_close cipherText", r);
+        Fapi_Free (cipherText);
         return 1;
     }
 

--- a/tools/fapi/tss2_exportpolicy.c
+++ b/tools/fapi/tss2_exportpolicy.c
@@ -3,6 +3,7 @@
 #include <stdbool.h>
 #include <stdio.h>
 #include <stdlib.h>
+#include <string.h>
 #include "tools/fapi/tss2_template.h"
 
 /* needed by tpm2_util and tpm2_option functions */
@@ -64,9 +65,11 @@ int tss2_tool_onrun (FAPI_CONTEXT *fctx) {
     }
 
     /* Write returned data to file(s) */
-    r = open_write_and_close (ctx.jsonPolicy, ctx.overwrite, jsonPolicy, 0);
+    r = open_write_and_close (ctx.jsonPolicy, ctx.overwrite, jsonPolicy,
+        strlen(jsonPolicy));
     if (r){
         LOG_PERR ("open_write_and_close buffer", r);
+        Fapi_Free (jsonPolicy);
         return 1;
     }
 

--- a/tools/fapi/tss2_getinfo.c
+++ b/tools/fapi/tss2_getinfo.c
@@ -3,6 +3,7 @@
 #include <stdbool.h>
 #include <stdio.h>
 #include <stdlib.h>
+#include <string.h>
 #include "tools/fapi/tss2_template.h"
 
 /* needed by tpm2_util and tpm2_option functions */
@@ -55,7 +56,7 @@ int tss2_tool_onrun (FAPI_CONTEXT *fctx) {
     }
 
     /* Write returned data to file(s) */
-    r = open_write_and_close (ctx.info, ctx.overwrite, info, 0);
+    r = open_write_and_close (ctx.info, ctx.overwrite, info, strlen(info));
     if (r) {
         LOG_PERR ("open_write_and_close", r);
         Fapi_Free (info);

--- a/tools/fapi/tss2_gettpmblobs.c
+++ b/tools/fapi/tss2_gettpmblobs.c
@@ -91,6 +91,7 @@ int tss2_tool_onrun (FAPI_CONTEXT *fctx) {
             tpm2bPublicSize);
         if (r) {
             LOG_PERR ("open_write_and_close tpm2bPublic", r);
+            Fapi_Free (tpm2bPublic);
             return 1;
         }
     }
@@ -101,6 +102,7 @@ int tss2_tool_onrun (FAPI_CONTEXT *fctx) {
         if (r) {
             LOG_PERR ("open_write_and_close tpm2bPrivate", r);
             Fapi_Free (tpm2bPublic);
+            Fapi_Free (tpm2bPrivate);
             return 1;
         }
     }
@@ -112,6 +114,7 @@ int tss2_tool_onrun (FAPI_CONTEXT *fctx) {
             LOG_PERR ("open_write_and_close policy", r);
             Fapi_Free (tpm2bPublic);
             Fapi_Free (tpm2bPrivate);
+            Fapi_Free (policy);
             return 1;
         }
     }

--- a/tools/fapi/tss2_nvread.c
+++ b/tools/fapi/tss2_nvread.c
@@ -85,6 +85,7 @@ int tss2_tool_onrun (FAPI_CONTEXT *fctx) {
     r = open_write_and_close (ctx.data, ctx.overwrite, data, data_len);
     if (r) {
         LOG_PERR ("open_write_and_close data", r);
+        Fapi_Free (data);
         return 1;
     }
 
@@ -93,6 +94,7 @@ int tss2_tool_onrun (FAPI_CONTEXT *fctx) {
             strlen(logData));
         if (r) {
             Fapi_Free (data);
+            Fapi_Free (logData);
             LOG_PERR ("open_write_and_close logData", r);
             return 1;
         }

--- a/tools/fapi/tss2_pcrread.c
+++ b/tools/fapi/tss2_pcrread.c
@@ -87,14 +87,17 @@ int tss2_tool_onrun (FAPI_CONTEXT *fctx) {
             pcrValueSize);
         if (r) {
             Fapi_Free (pcrLog);
+            Fapi_Free (pcrValue);
             LOG_PERR ("open_write_and_close pcrValue", r);
             return 1;
         }
     }
 
     if (ctx.pcrLog) {
-        r =  open_write_and_close (ctx.pcrLog, ctx.overwrite, pcrLog, 0);
+        r =  open_write_and_close (ctx.pcrLog, ctx.overwrite, pcrLog,
+            strlen(pcrLog));
         if (r) {
+            Fapi_Free (pcrLog);
             Fapi_Free (pcrValue);
             LOG_PERR ("open_write_and_close pcrLog", r);
             return 1;

--- a/tools/fapi/tss2_quote.c
+++ b/tools/fapi/tss2_quote.c
@@ -172,7 +172,8 @@ int tss2_tool_onrun (FAPI_CONTEXT *fctx) {
 
     /* Write returned data to file(s) */
     if (ctx.quoteInfo && quoteInfo) {
-        r = open_write_and_close (ctx.quoteInfo, ctx.overwrite, quoteInfo, 0);
+        r = open_write_and_close (ctx.quoteInfo, ctx.overwrite, quoteInfo,
+            strlen(quoteInfo));
         if (r) {
             LOG_PERR ("open_write_and_close quoteInfo", r);
             Fapi_Free (quoteInfo);
@@ -186,7 +187,8 @@ int tss2_tool_onrun (FAPI_CONTEXT *fctx) {
     Fapi_Free (quoteInfo);
 
     if (ctx.pcrLog && pcrLog) {
-        r = open_write_and_close (ctx.pcrLog, ctx.overwrite, pcrLog, 0);
+        r = open_write_and_close (ctx.pcrLog, ctx.overwrite, pcrLog,
+            strlen(pcrLog));
         if (r) {
             LOG_PERR ("open_write_and_close pcrLog", r);
             Fapi_Free (pcrLog);

--- a/tools/fapi/tss2_template.c
+++ b/tools/fapi/tss2_template.c
@@ -374,7 +374,13 @@ free_opts:
 
 int open_write_and_close(const char* path, bool overwrite, const void *output,
     size_t output_len) {
-    size_t length = output_len ? output_len : strlen (output);
+
+    size_t length = 0;
+
+    if (output_len) {
+        length = output_len;
+    }
+
     if (!path || !strcmp(path, "-")) {
         if (-1 == write (STDOUT_FILENO, output, length)) {
             fprintf (stderr, "write(2) to stdout failed: %m\n");


### PR DESCRIPTION
This commit fixes a memory leak in cases when an returned empty non-char
output value was passed to file output.

Signed-off-by: Christian Plappert <christian.plappert@sit.fraunhofer.de>