### PR TITLE
tss2_*: Reference cryptographic profile from relevant tss2_* man pages

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -518,6 +518,8 @@ man/man1/%.1 : man/%.1.md $(MARKDOWN_COMMON_DEPS)
 	    -e '/\[common tcti options\]/d' \
 	    -e '/\[common tss2 options\]/r $(top_srcdir)/man/common/tss2-options.md' \
 	    -e '/\[common tss2 options\]/d' \
+	    -e '/\[common fapi references\]/r $(top_srcdir)/man/common/tss2-fapi-references.md' \
+	    -e '/\[common fapi references\]/d' \
 	    -e '/\[authorization formatting\]/r $(top_srcdir)/man/common/authorizations.md' \
 	    -e '/\[authorization formatting\]/d' \
 	    -e '/\[context object format\]/r $(top_srcdir)/man/common/ctxobj.md' \

--- a/doc/CHANGELOG.md
+++ b/doc/CHANGELOG.md
@@ -72,6 +72,7 @@
     - Fix autocompletion issue
     - Switch tss2\_\* to with-"="-style
     - Add size parameter to tss2_createseal
+    - References to the cryptographic profile (fapi-profile(5)) and config file (fapi-config(5)) man pages from all relevant tss2\_\* man pages
 
 ### 4.2 2020-04-08
 

--- a/man/common/tss2-fapi-references.md
+++ b/man/common/tss2-fapi-references.md
@@ -1,0 +1,9 @@
+# SEE ALSO
+
+**fapi-config(5)** to adjust Fapi parameters like the used cryptographic profile
+and TCTI or directories for the Fapi metadata storages.
+
+**fapi-profile(5)** to determine the cryptographic algorithms and parameters for
+all keys and operations of a specific TPM interaction like the name hash
+algorithm, the asymmetric signature algorithm, scheme and parameters and PCR
+bank selection.

--- a/man/tss2_authorizepolicy.1.md
+++ b/man/tss2_authorizepolicy.1.md
@@ -10,9 +10,11 @@
 
 **tss2_authorizepolicy** [*OPTIONS*]
 
+[common fapi references](common/tss2-fapi-references.md)
+
 # DESCRIPTION
 
-**tss2_authorizepolicy**(1) - This command signs a given policy with a given key such that the policy can be referenced from other policies that contain a corresponding PolicyAuthorize elements.
+**tss2_authorizepolicy**(1) - This command signs a given policy with a given key such that the policy can be referenced from other policies that contain a corresponding PolicyAuthorize elements. The signature is done using the TPM signing schemes as specified in the cryptographic profile (cf., **fapi-profile(5)**).
 
 # OPTIONS
 

--- a/man/tss2_changeauth.1.md
+++ b/man/tss2_changeauth.1.md
@@ -6,11 +6,11 @@
 
 **tss2_changeauth**(1) - This command changes the authorization data of an entity referred to by the path.
 
-The authValue is a UTF-8 password.
-
 # SYNOPSIS
 
 **tss2_changeauth** [*OPTIONS*]
+
+[common fapi references](common/tss2-fapi-references.md)
 
 # DESCRIPTION
 
@@ -24,7 +24,11 @@ These are the available options:
 
     The new UTF-8 password. Optional parameter. If it is neglected then the user
     is queried interactively for a password. To set no password, this option
-    should be used with the empty string ("").
+    should be used with the empty string ("").  The maximum password size is
+    determined by the digest size of the chosen name hash algorithm in the
+    cryptographic profile (cf., **fapi-profile(5)**). For example, choosing
+    SHA256 as hash algorithm, allows passwords of a maximum size of 32
+    characters.
 
   * **-p**, **\--entityPath**=_STRING_:
 

--- a/man/tss2_createkey.1.md
+++ b/man/tss2_createkey.1.md
@@ -10,9 +10,15 @@
 
 **tss2_createkey** [*OPTIONS*]
 
+[common fapi references](common/tss2-fapi-references.md)
+
 # DESCRIPTION
 
-**tss2_createkey**(1) - This commands creates a key inside the TPM and stores it in the FAPI metadata store and if requested persistently inside the TPM.
+**tss2_createkey**(1) - This commands creates a key inside the TPM and stores it
+in the FAPI metadata store and if requested
+persistently inside the TPM. Depending on the  specified key type, cryptographic
+algorithms and parameters for the created key are determined by the
+corresponding cryptographic profile (cf., **fapi-profile(5)**).
 
 # OPTIONS
 
@@ -53,7 +59,11 @@ These are the available options:
 
     The new UTF-8 password. Optional parameter. If it is neglected then the user
     is queried interactively for a password. To set no password, this option
-    should be used with the empty string ("").
+    should be used with the empty string (""). The maximum password size is
+    determined by the digest size of the chosen name hash algorithm in the
+    cryptographic profile (cf., **fapi-profile(5)**). For example, choosing
+    SHA256 as hash algorithm, allows passwords of a maximum size of 32
+    characters.
 
 [common tss2 options](common/tss2-options.md)
 

--- a/man/tss2_createnv.1.md
+++ b/man/tss2_createnv.1.md
@@ -10,6 +10,8 @@
 
 **tss2_createnv** [*OPTIONS*]
 
+[common fapi references](common/tss2-fapi-references.md)
+
 # DESCRIPTION
 
 **tss2_createnv**(1) - This command creates an NV index in the TPM.
@@ -62,7 +64,10 @@ These are the available options:
 
     The new UTF-8 password. Optional parameter. If it is neglected then the user
     is queried interactively for a password. To set no password, this option
-    should be used with the empty string ("").
+    should be used with the empty string (""). The maximum password size is
+    determined by the digest size of the chosen name hash algorithm in the
+    cryptographic profile (cf., **fapi-profile(5)**). For example, choosing
+    SHA256 as hash algorithm, allows passwords of a maximum size of 32 characters.
 
 [common tss2 options](common/tss2-options.md)
 

--- a/man/tss2_createseal.1.md
+++ b/man/tss2_createseal.1.md
@@ -10,9 +10,12 @@
 
 **tss2_createseal** [*OPTIONS*]
 
+[common fapi references](common/tss2-fapi-references.md)
+
 # DESCRIPTION
 
-**tss2_createseal**(1) - This command creates a sealed object and stores it in the FAPI metadata store. If no data is provided (i.e. a NULL-pointer) then the TPM generates random data and fills the sealed object.
+**tss2_createseal**(1) - This command creates a sealed object and stores it in the FAPI metadata store. If no data is provided (i.e. a NULL-pointer) then the TPM generates random data and fills the sealed object. TPM signing schemes are used as specified in
+the cryptographic profile (cf., **fapi-profile(5)**).
 
 # OPTIONS
 
@@ -48,7 +51,11 @@ These are the available options:
 
     The new UTF-8 password. Optional parameter. If it is neglected then the user
     is queried interactively for a password. To set no password, this option
-    should be used with the empty string ("").
+    should be used with the empty string (""). The maximum password size is
+    determined by the digest size of the chosen name hash algorithm in the
+    cryptographic profile (cf., **fapi-profile(5)**). For example, choosing
+    SHA256 as hash algorithm, allows passwords of a maximum size of 32
+    characters.
 
   * **-i**, **\--data**=_FILENAME_ or _-_ (for stdin):
 

--- a/man/tss2_decrypt.1.md
+++ b/man/tss2_decrypt.1.md
@@ -10,9 +10,13 @@
 
 **tss2_decrypt** [*OPTIONS*]
 
+[common fapi references](common/tss2-fapi-references.md)
+
 # DESCRIPTION
 
-**tss2_decrypt**(1) - This command decrypts data that was encrypted using tss2_encrypt.
+**tss2_decrypt**(1) - This command decrypts data that was encrypted using tss2_encrypt
+using the TPM decryption schemes as specified in the cryptographic profile
+(cf., **fapi-profile(5)**).
 
 
 # OPTIONS

--- a/man/tss2_delete.1.md
+++ b/man/tss2_delete.1.md
@@ -4,25 +4,27 @@
 
 # NAME
 
-**tss2_delete**(1) - This command deletes the given key, policy or NV from the
-FAPI keystore and the TPM. Depending on the entity type, one of the following
-actions are taken:
-
-    - Non-persistent key: Flush from TPM (if loaded) and delete public and private blobs from keystore.
-    - Persistent keys: Evict from TPM and delete public and private blobs from keystore
-    - Primary keys: Flush from TPM and delete public blob from keystore
-    - NV index: Undefine NV index from TPM and delete public blob from metadata store
-    - Policies: Delete entry from policy store
-    - Hierarchy, PCR: These are not deletable
-    - Special keys ek, srk: These are not deletable
+**tss2_delete**(1) -
 
 # SYNOPSIS
 
 **tss2_delete** [*OPTIONS*]
 
+[common fapi references](common/tss2-fapi-references.md)
+
 # DESCRIPTION
 
-**tss2_delete**(1) -
+**tss2_delete**(1) - This command deletes the given key, policy or NV from the
+FAPI metadata store and the TPM. Depending on the entity type, one of the following
+actions are taken:
+
+    - Non-persistent key: Flush from TPM (if loaded) and delete public and private blobs from keystore.
+    - Persistent keys: Evict from TPM and delete public and private blobs from keystore
+    - Primary keys: Flush from TPM and delete public blob from keystore
+    - NV index: Undefine NV index from TPM and delete public blob from FAPI metadata store
+    - Policies: Delete entry from policy store
+    - Hierarchy, PCR: These are not deletable
+    - Special keys ek, srk: These are not deletable
 
 # OPTIONS
 

--- a/man/tss2_encrypt.1.md
+++ b/man/tss2_encrypt.1.md
@@ -10,10 +10,13 @@
 
 **tss2_encrypt** [*OPTIONS*]
 
+[common fapi references](common/tss2-fapi-references.md)
+
 # DESCRIPTION
 
 **tss2_encrypt**(1) - This command encrypts the provided data for a target key
-using the TPM encryption schemes as specified in the crypto profile.
+using the TPM encryption schemes as specified in the cryptographic profile
+(cf., **fapi-profile(5)**).
 
 # OPTIONS
 

--- a/man/tss2_exportkey.1.md
+++ b/man/tss2_exportkey.1.md
@@ -10,10 +10,13 @@
 
 **tss2_exportkey** [*OPTIONS*]
 
+[common fapi references](common/tss2-fapi-references.md)
+
 # DESCRIPTION
 
 **tss2_exportkey**(1) - This command will duplicate a key and encrypt it using the public key of a new parent. The
-exported data will contain the re-wrapped key pointed to by the pathOfKeyToDuplicate and then the JSON encoded policy.
+exported data will contain the re-wrapped key pointed to by the pathOfKeyToDuplicate and then the JSON encoded policy. Encryption is done according to TPM encryption
+schemes specified in the cryptographic profile (cf., **fapi-profile(5)**).
 
 # OPTIONS
 

--- a/man/tss2_exportpolicy.1.md
+++ b/man/tss2_exportpolicy.1.md
@@ -10,6 +10,8 @@
 
 **tss2_policyexport** [*OPTIONS*]
 
+[common fapi references](common/tss2-fapi-references.md)
+
 # DESCRIPTION
 
 **tss2_policyexport**(1) - This commands exports a policy associated with a key

--- a/man/tss2_getappdata.1.md
+++ b/man/tss2_getappdata.1.md
@@ -10,6 +10,8 @@
 
 **tss2_getappdata** [*OPTIONS*]
 
+[common fapi references](common/tss2-fapi-references.md)
+
 # DESCRIPTION
 
 **tss2_getappdata**(1) - This command returns the previously stored application data for an object.
@@ -24,7 +26,7 @@ These are the available options:
 
   * **-p**, **\--path**=_STRING_:
 
-    Path of the object for which the appData will be loaded.
+    Path of the object for which the application data will be loaded.
 
   * **-o**, **\--appData**=_FILENAME_ or _-_ (for stdout):
 

--- a/man/tss2_getcertificate.1.md
+++ b/man/tss2_getcertificate.1.md
@@ -10,6 +10,8 @@
 
 **tss2_getcertificate** [*OPTIONS*]
 
+[common fapi references](common/tss2-fapi-references.md)
+
 # DESCRIPTION
 
 **tss2_getcertificate**(1) - This command returns the PEM encoded X.509 certificate associated with the key at path.

--- a/man/tss2_getdescription.1.md
+++ b/man/tss2_getdescription.1.md
@@ -10,6 +10,8 @@
 
 **tss2_getdescription** [*OPTIONS*]
 
+[common fapi references](common/tss2-fapi-references.md)
+
 # DESCRIPTION
 
 **tss2_getdescription**(1) - This command returns the previously stored application data for an object. If no

--- a/man/tss2_getinfo.1.md
+++ b/man/tss2_getinfo.1.md
@@ -10,6 +10,8 @@
 
 **tss2_getinfo** [*OPTIONS*]
 
+[common fapi references](common/tss2-fapi-references.md)
+
 # DESCRIPTION
 
 **tss2_getinfo**(1) - This command returns a UTF-8 string identifying the version of the FAPI, the TPM, configurations and other relevant information in a human readable format.

--- a/man/tss2_getplatformcertificates.1.md
+++ b/man/tss2_getplatformcertificates.1.md
@@ -10,6 +10,8 @@
 
 **tss2_getplatformcertificates** [*OPTIONS*]
 
+[common fapi references](common/tss2-fapi-references.md)
+
 # DESCRIPTION
 
 **tss2_getplatformcertificates**(1) - This command returns the set of platform certificates concatenated in a continuous buffer if the platform provides platform certificates. Platform certificates for TPM 2.0 can consist not only of a single certificate but also a series of so-called delta certificates.

--- a/man/tss2_getrandom.1.md
+++ b/man/tss2_getrandom.1.md
@@ -9,6 +9,8 @@
 
 **tss2_getrandom** [*OPTIONS*]
 
+[common fapi references](common/tss2-fapi-references.md)
+
 # DESCRIPTION
 
 **tss2_getrandom**(1) - This command uses the TPM to create an array of random bytes.

--- a/man/tss2_gettpmblobs.1.md
+++ b/man/tss2_gettpmblobs.1.md
@@ -10,6 +10,8 @@
 
 **tss2_gettpmblobs** [*OPTIONS*]
 
+[common fapi references](common/tss2-fapi-references.md)
+
 # DESCRIPTION
 
 **tss2_gettpmblobs**(1) - This command returns the public and private blobs of an object, such that they could be loaded by a low-level API (e.g. ESAPI). It also returns the policy associated with these blobs in JSON format.

--- a/man/tss2_import.1.md
+++ b/man/tss2_import.1.md
@@ -10,6 +10,8 @@
 
 **tss2_import** [*OPTIONS*]
 
+[common fapi references](common/tss2-fapi-references.md)
+
 # DESCRIPTION
 
 **tss2_import**(1) - This command imports a JSON encoded policy or policy

--- a/man/tss2_list.1.md
+++ b/man/tss2_list.1.md
@@ -10,9 +10,11 @@
 
 **tss2_list** [*OPTIONS*]
 
+[common fapi references](common/tss2-fapi-references.md)
+
 # DESCRIPTION
 
-**tss2_list**(1) - This command enumerates all objects in the metadata store in a given a path.
+**tss2_list**(1) - This command enumerates all objects in the FAPI metadata store in a given a path.
 
 # OPTIONS
 
@@ -30,7 +32,7 @@ These are the available options:
   * **-o**, **\--pathList**=_FILENAME_ or _-_ (for stdout):
 
     Returns the colon-separated list of paths. Optional parameter. If omitted,
-    results will be printed to _STDOUT_.
+    results will be printed to _-_ (stdout).
 
 [common tss2 options](common/tss2-options.md)
 

--- a/man/tss2_nvextend.1.md
+++ b/man/tss2_nvextend.1.md
@@ -10,6 +10,8 @@
 
 **tss2_nvextend** [*OPTIONS*]
 
+[common fapi references](common/tss2-fapi-references.md)
+
 # DESCRIPTION
 
 **tss2_nvextend**(1) - This command performs an extend operation on an NV index

--- a/man/tss2_nvincrement.1.md
+++ b/man/tss2_nvincrement.1.md
@@ -10,6 +10,8 @@
 
 **tss2_nvincrement** [*OPTIONS*]
 
+[common fapi references](common/tss2-fapi-references.md)
+
 # DESCRIPTION
 
 **tss2_nvincrement**(1) - This command increments by 1 an NV index that is of type counter.

--- a/man/tss2_nvread.1.md
+++ b/man/tss2_nvread.1.md
@@ -10,6 +10,8 @@
 
 **tss2_nvread** [*OPTIONS*]
 
+[common fapi references](common/tss2-fapi-references.md)
+
 # DESCRIPTION
 
 **tss2_nvread**(1) - This command reads the entire data from an NV index of the TPM.

--- a/man/tss2_nvsetbits.1.md
+++ b/man/tss2_nvsetbits.1.md
@@ -10,9 +10,11 @@
 
 **tss2_nvsetbits** [*OPTIONS*]
 
+[common fapi references](common/tss2-fapi-references.md)
+
 # DESCRIPTION
 
-**tss2_nvsetbits**(1) - This command sets bits in an NV Index that was created as a bit field. Any number of bits from 0 to 64 may be SET. The contents of bitmap are ORed with the current contents of the NV Index.
+**tss2_nvsetbits**(1) - This command sets bits in an NV Index that was created as a bit field. Any number of bits from 0 to 64 may be set. The contents of bitmap are ORed with the current contents of the NV Index.
 
 # OPTIONS
 

--- a/man/tss2_nvwrite.1.md
+++ b/man/tss2_nvwrite.1.md
@@ -10,6 +10,8 @@
 
 **tss2_nvwrite** [*OPTIONS*]
 
+[common fapi references](common/tss2-fapi-references.md)
+
 # DESCRIPTION
 
 **tss2_nvwrite**(1) - This command writes data to a "regular" (not pin, extend or counter) NV index. Only the full index can be written, partial writes are not allowed. If the provided data is smaller than the NV index's size, then it is padded up with zero bytes at the end.

--- a/man/tss2_pcrextend.1.md
+++ b/man/tss2_pcrextend.1.md
@@ -10,6 +10,8 @@
 
 **tss2_pcrextend** [*OPTIONS*]
 
+[common fapi references](common/tss2-fapi-references.md)
+
 # DESCRIPTION
 
 **tss2_pcrextend**(1) - This command extends the data into the PCR listed. The parameter logData is extended into the PCR log. If the logData is NULL, only the PCR extend takes place. All PCRs currently active in the TPM are extended.

--- a/man/tss2_pcrread.1.md
+++ b/man/tss2_pcrread.1.md
@@ -10,9 +10,13 @@
 
 **tss2_pcrread** [*OPTIONS*]
 
+[common fapi references](common/tss2-fapi-references.md)
+
 # DESCRIPTION
 
-**tss2_pcrread**(1) - This command provides a PCRs value and corresponding Event log. The PCR bank to be used per PCR is defined in the cryptographic profile.
+**tss2_pcrread**(1) - This command provides a PCRs value and corresponding event
+log. The PCR bank to be used per PCR is defined in the cryptographic profile
+(cf., **fapi-profile(5)**).
 
 # OPTIONS
 

--- a/man/tss2_provision.1.md
+++ b/man/tss2_provision.1.md
@@ -10,17 +10,22 @@
 
 **tss2_provision** [*OPTIONS*]
 
+[common fapi references](common/tss2-fapi-references.md)
+
 # DESCRIPTION
 
 **tss2_provision**(1) - This command provisions a FAPI instance and its associated TPM. The steps taken are:
 
   * Retrieve the EK template, nonce and certificate, verify that they match the TPM's EK and store them in the key store.
   * Set the authValues and policies for the Owner (Storage Hierarchy), the Privacy Administrator (Endorsement Hierarchy) and the lockout authority.
-  * Scan the TPM's nv indices and create entries in the metadata store. This operation MAY use a heuristic to guess the originating programs for nv indices found and name the entries accordingly.
-  * Create the SRK (storage primary key) inside the TPM and make it persistent if required by the FAPI configuration and stored its metadata in the system-wide metadata store. Note that the SRK will not have an authorization value associated.
+  * Scan the TPM's nv indices and create entries in the FAPI metadata store. This operation MAY use a heuristic to guess the originating programs for nv indices found and name the entries accordingly.
+  * Create the SRK (storage primary key) inside the TPM and make it persistent if required by the cryptographic profile (cf., **fapi-profile(5)**) and store its metadata in the system-wide FAPI metadata store. Note that the SRK will not have an authorization value associated.
 
-If an authorization value is associated with the storage hierarchy, it is highly RECOMMENDED that the SRK
+If an authorization value is associated with the storage hierarchy, it is highly recommended that the SRK
 without authorization value is made persistent.
+
+The paths of the different metadata storages for keys and nv indices are configured
+in the FAPI configuration file (cf., **fapi-config(5)**).
 
 # OPTIONS
 

--- a/man/tss2_quote.1.md
+++ b/man/tss2_quote.1.md
@@ -10,9 +10,12 @@
 
 **tss2_quote** [*OPTIONS*]
 
+[common fapi references](common/tss2-fapi-references.md)
+
 # DESCRIPTION
 
-**tss2_quote**(1) - This command performs an attestation using the TPM. The PCR bank for each provided PCR index is set in the cryptographic profile.
+**tss2_quote**(1) - This command performs an attestation using the TPM. The PCR bank for each provided PCR index and signing scheme are set in the cryptographic profile
+(cf., **fapi-profile(5)**).
 
 # OPTIONS
 

--- a/man/tss2_setappdata.1.md
+++ b/man/tss2_setappdata.1.md
@@ -10,6 +10,8 @@
 
 **tss2_setappdata** [*OPTIONS*]
 
+[common fapi references](common/tss2-fapi-references.md)
+
 # DESCRIPTION
 
 **tss2_setappdata**(1) - This command allows an application to associate an arbitrary data blob with a given object. The data is stored and can be returned with tss2_getappdata. Previously stored data is overwritten by this function. If empty data is passed in, the stored data is deleted.

--- a/man/tss2_setcertificate.1.md
+++ b/man/tss2_setcertificate.1.md
@@ -10,6 +10,8 @@
 
 **tss2_setcertificate** [*OPTIONS*]
 
+[common fapi references](common/tss2-fapi-references.md)
+
 # DESCRIPTION
 
 **tss2_setcertificate**(1) - This command associates an x509 certificate in PEM encoding into the path of a key.

--- a/man/tss2_setdescription.1.md
+++ b/man/tss2_setdescription.1.md
@@ -10,9 +10,11 @@
 
 **tss2_setdescription** [*OPTIONS*]
 
+[common fapi references](common/tss2-fapi-references.md)
+
 # DESCRIPTION
 
-**tss2_setdescription**(1) - This command allows an application to assign a human readable description to an object in the metadata store.  The data is stored and can be returned with tss2_getdescription. Previously stored data is overwritten by this function. If an empty description is passed in, the stored data is deleted.
+**tss2_setdescription**(1) - This command allows an application to assign a human readable description to an object in the FAPI metadata store. The stored data can be returned with tss2_getdescription. Previously stored data is overwritten by this function. If an empty description is passed in, the stored data is deleted.
 
 # OPTIONS
 

--- a/man/tss2_sign.1.md
+++ b/man/tss2_sign.1.md
@@ -10,9 +10,13 @@
 
 **tss2_sign** [*OPTIONS*]
 
+[common fapi references](common/tss2-fapi-references.md)
+
 # DESCRIPTION
 
-**tss2_sign**(1) - This command uses a key inside the TPM to sign a digest value.
+**tss2_sign**(1) - This command uses a key inside the TPM to sign a digest value
+using the TPM signing schemes as specified in the cryptographic profile
+(cf., **fapi-profile(5)**).
 
 # OPTIONS
 
@@ -25,7 +29,8 @@ These are the available options:
   * **-s**, **\--padding**=_STRING_:
 
     The padding scheme used. Possible values are "RSA_SSA", "RSA_PSS" (case insensitive). Optional parameter.
-    If omitted, the default padding specified in the crypto profile is used.
+    If omitted, the default padding specified in the cryptographic profile
+    (cf., **fapi-profile(5)**) is used.
 
   * **-c**, **\--certificate**=_FILENAME_ or _-_ (for stdout):
 

--- a/man/tss2_unseal.1.md
+++ b/man/tss2_unseal.1.md
@@ -10,9 +10,12 @@
 
 **tss2_unseal** [*OPTIONS*]
 
+[common fapi references](common/tss2-fapi-references.md)
+
 # DESCRIPTION
 
-**tss2_unseal**(1) - This command unseals data from a seal in the FAPI meta data store.
+**tss2_unseal**(1) - This command unseals data from a seal in the FAPI metadata store.
+The used decryption scheme is specified in the cryptographic profile (cf., **fapi-profile(5)**).
 
 # OPTIONS
 

--- a/man/tss2_verifyquote.1.md
+++ b/man/tss2_verifyquote.1.md
@@ -10,12 +10,16 @@
 
 **tss2_verifyquote** [*OPTIONS*]
 
+[common fapi references](common/tss2-fapi-references.md)
+
 # DESCRIPTION
 
 **tss2_verifyquote**(1) - This command verifies that the data returned by a quote is valid. This includes
 
   * Reconstructing the quoteInfo's PCR values from the eventLog (if an eventLog was provided)
   * Verifying the quoteInfo using the signature and the publicKeyPath
+
+The used signature verification scheme is specified in the cryptographic profile (cf., **fapi-profile(5)**).
 
 An application using tss2_verifyquote() will further have to
 

--- a/man/tss2_verifysignature.1.md
+++ b/man/tss2_verifysignature.1.md
@@ -12,7 +12,7 @@
 
 # DESCRIPTION
 
-**tss2_verifysignature**(1) - This command verifies a signature using a public key found in the passed key path.
+**tss2_verifysignature**(1) - This command verifies a signature using a public key found in the passed key path. The used signature verification scheme is specified in the cryptographic profile (cf., **fapi-profile(5)**).
 
 # OPTIONS
 
@@ -20,7 +20,8 @@ These are the available options:
 
   * **-d**, **\--digest**=_FILENAME_ or _-_ (for stdin):
 
-    The data that was signed, already hashed.
+    The data that was signed, already hashed according to the cryptographic
+    profile (cf., **fapi-profile(5)**).
 
   * **-p**, **\--keyPath**=_STRING_:
 


### PR DESCRIPTION
The man pages of relevant tss2_* tools reference now the cryptographic
profile man page for further information.

Signed-off-by: Christian Plappert <christian.plappert@sit.fraunhofer.de>