### PR TITLE
tss2 *: Enhance Fapi Tools integration tests with ECC profile

### DIFF
--- a/bootstrap
+++ b/bootstrap
@@ -14,6 +14,18 @@ src_listvar () {
     echo ""
 }
 
+# duplicate fapi tests with ecc
+duplicate () {
+    basedir=$1
+    suffix=$2
+
+    find "${basedir}" \( -iname "${suffix}" ! -iname "*ecc.sh" \) | while read fname; do
+      cp $fname ${fname%.sh}_ecc.sh
+      sed -i -e 's/CRYPTO_PROFILE="RSA"/CRYPTO_PROFILE="ECC"/g' ${fname%.sh}_ecc.sh
+    done
+}
+
+
 VARS_FILE=src_vars.mk
 AUTORECONF=${AUTORECONF:-autoreconf}
 
@@ -25,6 +37,8 @@ echo "Generating file lists: ${VARS_FILE}"
 
   src_listvar "test/integration/tests" "*.sh" "SYSTEM_TESTS"
   printf "ALL_SYSTEM_TESTS = \$(SYSTEM_TESTS)\n"
+
+  duplicate "test/integration/fapi" "*.sh"
 
   src_listvar "test/integration/fapi" "*.sh" "FAPI_TESTS"
   printf "ALL_FAPI_TESTS = \$(FAPI_TESTS)\n"

--- a/test/integration/fapi/fapi-authorize-policy.sh
+++ b/test/integration/fapi/fapi-authorize-policy.sh
@@ -4,7 +4,8 @@ source helpers.sh
 
 start_up
 
-setup_fapi
+CRYPTO_PROFILE="RSA"
+setup_fapi $CRYPTO_PROFILE
 
 function cleanup {
     tss2 delete --path=/
@@ -41,9 +42,13 @@ tss2 authorizepolicy --keyPath=$POLICY_SIGN_KEY_PATH --policyPath=$POLICY_PCR \
 tss2 createkey --path=$KEY_PATH --type="noDa, sign" \
     --policyPath=$POLICY_AUTHORIZE --authValue=""
 
-tss2 sign --keyPath=$KEY_PATH --padding="RSA_PSS" --digest=$DIGEST_FILE \
-    --signature=$SIGNATURE_FILE --publicKey=$PUBLIC_KEY_FILE
-
+if [ "$CRYPTO_PROFILE" = "RSA" ]; then
+    tss2 sign --keyPath=$KEY_PATH --padding="RSA_PSS" --digest=$DIGEST_FILE \
+        --signature=$SIGNATURE_FILE --publicKey=$PUBLIC_KEY_FILE
+else
+    tss2 sign --keyPath=$KEY_PATH --digest=$DIGEST_FILE \
+        --signature=$SIGNATURE_FILE --publicKey=$PUBLIC_KEY_FILE
+fi
 
 expect <<EOF
 # Try with missing policyPath

--- a/test/integration/fapi/fapi-branch-select.sh
+++ b/test/integration/fapi/fapi-branch-select.sh
@@ -4,7 +4,8 @@ source helpers.sh
 
 start_up
 
-setup_fapi
+CRYPTO_PROFILE="RSA"
+setup_fapi $CRYPTO_PROFILE
 
 function cleanup {
     tss2 delete --path=/

--- a/test/integration/fapi/fapi-encrypt-decrypt.sh
+++ b/test/integration/fapi/fapi-encrypt-decrypt.sh
@@ -3,10 +3,14 @@ source helpers.sh
 
 start_up
 
-setup_fapi
+CRYPTO_PROFILE="RSA"
+setup_fapi $CRYPTO_PROFILE
 
 function cleanup {
-    tss2 delete --path=/
+    # In case the test is skipped no key is created and a
+    # failure is expected here. Therefore, we need to pass a successful
+    # execution in any case
+    tss2 delete --path=/ && true
     shut_down
 }
 
@@ -23,6 +27,11 @@ TYPES="noDa,decrypt"
 echo -n "Secret Text!" > $PLAIN_TEXT
 
 set -x
+
+if [ "$CRYPTO_PROFILE" = "ECC" ]; then
+echo ECC currently not supported for encryption. Skipping test.
+exit 077
+fi
 
 tss2 provision
 

--- a/test/integration/fapi/fapi-export-key.sh
+++ b/test/integration/fapi/fapi-export-key.sh
@@ -4,7 +4,8 @@ source helpers.sh
 
 start_up
 
-setup_fapi
+CRYPTO_PROFILE="RSA"
+setup_fapi $CRYPTO_PROFILE
 
 function cleanup {
     tss2 delete --path=/

--- a/test/integration/fapi/fapi-export-policy.sh
+++ b/test/integration/fapi/fapi-export-policy.sh
@@ -4,7 +4,8 @@ source helpers.sh
 
 start_up
 
-setup_fapi
+CRYPTO_PROFILE="RSA"
+setup_fapi $CRYPTO_PROFILE
 
 function cleanup {
     tss2 delete --path=/

--- a/test/integration/fapi/fapi-get-info.sh
+++ b/test/integration/fapi/fapi-get-info.sh
@@ -4,7 +4,8 @@ source helpers.sh
 
 start_up
 
-setup_fapi
+CRYPTO_PROFILE="RSA"
+setup_fapi $CRYPTO_PROFILE
 
 function cleanup {
     tss2 delete --path=/

--- a/test/integration/fapi/fapi-get-platform-certificates.sh
+++ b/test/integration/fapi/fapi-get-platform-certificates.sh
@@ -4,7 +4,8 @@ source helpers.sh
 
 start_up
 
-setup_fapi
+CRYPTO_PROFILE="RSA"
+setup_fapi $CRYPTO_PROFILE
 
 PATH=${BUILDDIR}/tools/fapi:$PATH
 

--- a/test/integration/fapi/fapi-get-random.sh
+++ b/test/integration/fapi/fapi-get-random.sh
@@ -4,7 +4,8 @@ source helpers.sh
 
 start_up
 
-setup_fapi
+CRYPTO_PROFILE="RSA"
+setup_fapi $CRYPTO_PROFILE
 
 PATH=${BUILDDIR}/tools/fapi:$PATH
 

--- a/test/integration/fapi/fapi-get-tpm-blobs.sh
+++ b/test/integration/fapi/fapi-get-tpm-blobs.sh
@@ -4,7 +4,8 @@ source helpers.sh
 
 start_up
 
-setup_fapi
+CRYPTO_PROFILE="RSA"
+setup_fapi $CRYPTO_PROFILE
 
 function cleanup {
     tss2 delete --path=/

--- a/test/integration/fapi/fapi-list.sh
+++ b/test/integration/fapi/fapi-list.sh
@@ -4,7 +4,8 @@ source helpers.sh
 
 start_up
 
-setup_fapi
+CRYPTO_PROFILE="RSA"
+setup_fapi $CRYPTO_PROFILE
 
 function cleanup {
     tss2 delete --path=/

--- a/test/integration/fapi/fapi-nv-extend.sh
+++ b/test/integration/fapi/fapi-nv-extend.sh
@@ -4,7 +4,8 @@ source helpers.sh
 
 start_up
 
-setup_fapi
+CRYPTO_PROFILE="RSA"
+setup_fapi $CRYPTO_PROFILE
 
 function cleanup {
     tss2 delete --path=/

--- a/test/integration/fapi/fapi-nv-increment.sh
+++ b/test/integration/fapi/fapi-nv-increment.sh
@@ -4,7 +4,8 @@ source helpers.sh
 
 start_up
 
-setup_fapi
+CRYPTO_PROFILE="RSA"
+setup_fapi $CRYPTO_PROFILE
 
 function cleanup {
     tss2 delete --path=/

--- a/test/integration/fapi/fapi-nv-set-bits.sh
+++ b/test/integration/fapi/fapi-nv-set-bits.sh
@@ -4,7 +4,8 @@ source helpers.sh
 
 start_up
 
-setup_fapi
+CRYPTO_PROFILE="RSA"
+setup_fapi $CRYPTO_PROFILE
 
 function cleanup {
     tss2 delete --path=/

--- a/test/integration/fapi/fapi-nv-write-authorize.sh
+++ b/test/integration/fapi/fapi-nv-write-authorize.sh
@@ -4,7 +4,8 @@ source helpers.sh
 
 start_up
 
-setup_fapi
+CRYPTO_PROFILE="RSA"
+setup_fapi $CRYPTO_PROFILE
 
 function cleanup {
     tss2 delete --path=/
@@ -49,8 +50,13 @@ tss2 createkey --path=$POLICY_SIGN_KEY_PATH --type="noDa, sign" --authValue=""
 tss2 createkey --path=$SIGN_KEY_PATH --type="noDa, sign" \
     --policyPath=$AUTHORIZE_NV_POLICY  --authValue=""
 
+if [ "$CRYPTO_PROFILE" = "RSA" ]; then
 tss2 sign --keyPath=$SIGN_KEY_PATH --padding="RSA_PSS" --digest=$DIGEST_FILE \
     --signature=$SIGNATURE_FILE --publicKey=$PUBLIC_KEY_FILE
+else
+tss2 sign --keyPath=$SIGN_KEY_PATH --digest=$DIGEST_FILE \
+    --signature=$SIGNATURE_FILE --publicKey=$PUBLIC_KEY_FILE
+fi
 
 expect <<EOF
 # Try with missing nvPath

--- a/test/integration/fapi/fapi-nv-write-read.sh
+++ b/test/integration/fapi/fapi-nv-write-read.sh
@@ -4,7 +4,8 @@ source helpers.sh
 
 start_up
 
-setup_fapi
+CRYPTO_PROFILE="RSA"
+setup_fapi $CRYPTO_PROFILE
 
 function cleanup {
     tss2 delete --path=/

--- a/test/integration/fapi/fapi-pcr-extend-read.sh
+++ b/test/integration/fapi/fapi-pcr-extend-read.sh
@@ -4,7 +4,8 @@ source helpers.sh
 
 start_up
 
-setup_fapi
+CRYPTO_PROFILE="RSA"
+setup_fapi $CRYPTO_PROFILE
 
 function cleanup {
     tss2 delete --path=/

--- a/test/integration/fapi/fapi-provision.sh
+++ b/test/integration/fapi/fapi-provision.sh
@@ -4,7 +4,8 @@ source helpers.sh
 
 start_up
 
-setup_fapi
+CRYPTO_PROFILE="RSA"
+setup_fapi $CRYPTO_PROFILE
 
 function cleanup {
     # Since clean up should already been done during normal run of the test, a

--- a/test/integration/fapi/fapi-quote-verify.sh
+++ b/test/integration/fapi/fapi-quote-verify.sh
@@ -4,7 +4,8 @@ source helpers.sh
 
 start_up
 
-setup_fapi
+CRYPTO_PROFILE="RSA"
+setup_fapi $CRYPTO_PROFILE
 
 function cleanup {
     tss2 delete --path=/

--- a/test/integration/fapi/fapi-seal-unseal.sh
+++ b/test/integration/fapi/fapi-seal-unseal.sh
@@ -4,7 +4,8 @@ source helpers.sh
 
 start_up
 
-setup_fapi
+CRYPTO_PROFILE="RSA"
+setup_fapi $CRYPTO_PROFILE
 
 function cleanup {
     tss2 delete --path=/

--- a/test/integration/fapi/fapi-set-get-app-data.sh
+++ b/test/integration/fapi/fapi-set-get-app-data.sh
@@ -4,7 +4,8 @@ source helpers.sh
 
 start_up
 
-setup_fapi
+CRYPTO_PROFILE="RSA"
+setup_fapi $CRYPTO_PROFILE
 
 function cleanup {
     tss2 delete --path=/

--- a/test/integration/fapi/fapi-set-get-certificate.sh
+++ b/test/integration/fapi/fapi-set-get-certificate.sh
@@ -4,7 +4,8 @@ source helpers.sh
 
 start_up
 
-setup_fapi
+CRYPTO_PROFILE="RSA"
+setup_fapi $CRYPTO_PROFILE
 
 function cleanup {
     tss2 delete --path=/

--- a/test/integration/fapi/fapi-set-get-description.sh
+++ b/test/integration/fapi/fapi-set-get-description.sh
@@ -4,7 +4,8 @@ source helpers.sh
 
 start_up
 
-setup_fapi
+CRYPTO_PROFILE="RSA"
+setup_fapi $CRYPTO_PROFILE
 
 function cleanup {
     tss2 delete --path=/

--- a/test/integration/fapi/fapi-sign-verify.sh
+++ b/test/integration/fapi/fapi-sign-verify.sh
@@ -4,7 +4,8 @@ source helpers.sh
 
 start_up
 
-setup_fapi
+CRYPTO_PROFILE="RSA"
+setup_fapi $CRYPTO_PROFILE
 
 function cleanup {
     tss2 delete --path=/
@@ -23,21 +24,38 @@ PUB_KEY_DIR="ext"
 tss2 provision
 echo -n "01234567890123456789" > $DIGEST_FILE
 tss2 createkey --path=$KEY_PATH --type="noDa, sign" --authValue=""
+
+if [ "$CRYPTO_PROFILE" = "RSA" ]; then
 echo -n `cat $DIGEST_FILE` | tss2 sign --digest=- --keyPath=$KEY_PATH \
     --padding="RSA_PSS" --signature=$SIGNATURE_FILE --publicKey=$PUBLIC_KEY_FILE
+else
+echo -n `cat $DIGEST_FILE` | tss2 sign --digest=- --keyPath=$KEY_PATH \
+    --signature=$SIGNATURE_FILE --publicKey=$PUBLIC_KEY_FILE
+fi
 
 tss2 import --path=$IMPORTED_KEY_NAME --importData=$PUBLIC_KEY_FILE
 tss2 verifysignature --keyPath=$PUB_KEY_DIR/$IMPORTED_KEY_NAME \
     --digest=$DIGEST_FILE --signature=$SIGNATURE_FILE
 
 # Try without certificate
+if [ "$CRYPTO_PROFILE" = "RSA" ]; then
 tss2 sign --keyPath=$KEY_PATH --padding="RSA_PSS" --digest=$DIGEST_FILE \
     --signature=$SIGNATURE_FILE --publicKey=$PUBLIC_KEY_FILE --force
+else
+tss2 sign --keyPath=$KEY_PATH --digest=$DIGEST_FILE \
+    --signature=$SIGNATURE_FILE --publicKey=$PUBLIC_KEY_FILE --force
+fi
 
 # Try without public key
+if [ "$CRYPTO_PROFILE" = "RSA" ]; then
 tss2 sign --keyPath=$KEY_PATH --padding="RSA_PSS" --digest=$DIGEST_FILE \
     --signature=$SIGNATURE_FILE --force
+else
+tss2 sign --keyPath=$KEY_PATH --digest=$DIGEST_FILE \
+    --signature=$SIGNATURE_FILE --force
+fi
 
+if [ "$CRYPTO_PROFILE" = "RSA" ]; then
 expect <<EOF
 # Try with missing keyPath
 spawn tss2 sign --padding="RSA_PSS" --digest=$DIGEST_FILE \
@@ -48,7 +66,20 @@ if {[lindex \$ret 2] || [lindex \$ret 3] != 1} {
     exit 1
 }
 EOF
+else
+expect <<EOF
+# Try with missing keyPath
+spawn tss2 sign --digest=$DIGEST_FILE \
+    --signature=$SIGNATURE_FILE --publicKey=$PUBLIC_KEY_FILE
+set ret [wait]
+if {[lindex \$ret 2] || [lindex \$ret 3] != 1} {
+    Command has not failed as expected\n"
+    exit 1
+}
+EOF
+fi
 
+if [ "$CRYPTO_PROFILE" = "RSA" ]; then
 expect <<EOF
 # Try with missing digest
 spawn tss2 sign --keyPath=$KEY_PATH --padding="RSA_PSS" \
@@ -59,7 +90,20 @@ if {[lindex \$ret 2] || [lindex \$ret 3] != 1} {
     exit 1
 }
 EOF
+else
+expect <<EOF
+# Try with missing digest
+spawn tss2 sign --keyPath=$KEY_PATH \
+    --signature=$SIGNATURE_FILE --publicKey=$PUBLIC_KEY_FILE
+set ret [wait]
+if {[lindex \$ret 2] || [lindex \$ret 3] != 1} {
+    Command has not failed as expected\n"
+    exit 1
+}
+EOF
+fi
 
+if [ "$CRYPTO_PROFILE" = "RSA" ]; then
 expect <<EOF
 # Try with missing signature
 spawn tss2 sign --keyPath=$KEY_PATH --padding="RSA_PSS" --digest=$DIGEST_FILE \
@@ -70,7 +114,21 @@ if {[lindex \$ret 2] || [lindex \$ret 3] != 1} {
     exit 1
 }
 EOF
+else
+expect <<EOF
+# Try with missing signature
+spawn tss2 sign --keyPath=$KEY_PATH --digest=$DIGEST_FILE \
+    --publicKey=$PUBLIC_KEY_FILE
+set ret [wait]
+if {[lindex \$ret 2] || [lindex \$ret 3] != 1} {
+    Command has not failed as expected\n"
+    exit 1
+}
+EOF
+fi
 
+
+if [ "$CRYPTO_PROFILE" = "RSA" ]; then
 expect <<EOF
 # Try with multiple stdins with publicKey and with certificate
 spawn tss2 sign --keyPath=$KEY_PATH --padding="RSA_PSS" --digest=$DIGEST_FILE \
@@ -81,7 +139,20 @@ if {[lindex \$ret 2] || [lindex \$ret 3] != 1} {
     exit 1
 }
 EOF
+else
+expect <<EOF
+# Try with multiple stdins with publicKey and with certificate
+spawn tss2 sign --keyPath=$KEY_PATH --digest=$DIGEST_FILE \
+    --signature=- --publicKey=- --certificate -
+set ret [wait]
+if {[lindex \$ret 2] || [lindex \$ret 3] != 1} {
+    Command has not failed as expected\n"
+    exit 1
+}
+EOF
+fi
 
+if [ "$CRYPTO_PROFILE" = "RSA" ]; then
 expect <<EOF
 # Try with multiple stdins without publicKey and with certificate
 spawn tss2 sign --keyPath=$KEY_PATH --padding="RSA_PSS" --digest=$DIGEST_FILE \
@@ -92,7 +163,20 @@ if {[lindex \$ret 2] || [lindex \$ret 3] != 1} {
     exit 1
 }
 EOF
+else
+expect <<EOF
+# Try with multiple stdins without publicKey and with certificate
+spawn tss2 sign --keyPath=$KEY_PATH --digest=$DIGEST_FILE \
+    --signature=- --certificate=-
+set ret [wait]
+if {[lindex \$ret 2] || [lindex \$ret 3] != 1} {
+    Command has not failed as expected\n"
+    exit 1
+}
+EOF
+fi
 
+if [ "$CRYPTO_PROFILE" = "RSA" ]; then
 expect <<EOF
 # Try with missing digest file
 spawn tss2 sign --keyPath=$KEY_PATH --padding="RSA_PSS" --digest=abc \
@@ -103,6 +187,18 @@ if {[lindex \$ret 2] || [lindex \$ret 3] != 1} {
     exit 1
 }
 EOF
+else
+expect <<EOF
+# Try with missing digest file
+spawn tss2 sign --keyPath=$KEY_PATH --digest=abc \
+    --signature=$SIGNATURE_FILE --publicKey=$PUBLIC_KEY_FILE
+set ret [wait]
+if {[lindex \$ret 2] || [lindex \$ret 3] != 1} {
+    Command has not failed as expected\n"
+    exit 1
+}
+EOF
+fi
 
 expect <<EOF
 # Try with missing keyPath

--- a/test/integration/fapi/fapi-testing-template.sh
+++ b/test/integration/fapi/fapi-testing-template.sh
@@ -4,7 +4,8 @@ source helpers.sh
 
 start_up
 
-setup_fapi
+CRYPTO_PROFILE="RSA"
+setup_fapi $CRYPTO_PROFILE
 
 function cleanup {
     # If this test is successful, no keys are created. Thus, command below will


### PR DESCRIPTION
The Fapi Tools integration tests now additionally run with the ECC
default profile.

Signed-off-by: Christian Plappert <christian.plappert@sit.fraunhofer.de>