### PR TITLE
Add changes to make credential tool to simplify/ reduce options.

### DIFF
--- a/doc/CHANGELOG.md
+++ b/doc/CHANGELOG.md
@@ -21,6 +21,10 @@
  * tpm2_activatecredential:
    - The secret data input can now be specified as stdin with **-s -** option.
 
+   - The public key used for encryption can be specified as **-u** to make it
+     similar to rest of the tools specifying a public key. The old **-e** option
+     is retained for backwards compatibility.
+
  * tpm2_tools (all):
    - Set stdin/stdout to non-buffering.
 

--- a/doc/CHANGELOG.md
+++ b/doc/CHANGELOG.md
@@ -25,6 +25,11 @@
      similar to rest of the tools specifying a public key. The old **-e** option
      is retained for backwards compatibility.
 
+   - Add option to specify the key algorithm when the input public key is in PEM
+     format using the new option **-G**, **--key-algorithm**. Can specify either
+     RSA/ECC. When this option is used, input public key is expected to be in
+     PEM format and the default TCG EK template is used for the key properties.
+
  * tpm2_tools (all):
    - Set stdin/stdout to non-buffering.
 

--- a/doc/CHANGELOG.md
+++ b/doc/CHANGELOG.md
@@ -18,6 +18,9 @@
 
     - umask set to 0117 for all tools.
 
+ * tpm2_activatecredential:
+   - The secret data input can now be specified as stdin with **-s -** option.
+
  * tpm2_tools (all):
    - Set stdin/stdout to non-buffering.
 

--- a/man/tpm2_makecredential.1.md
+++ b/man/tpm2_makecredential.1.md
@@ -21,9 +21,9 @@ by using the **none** TCTI option.
 
     A TPM public key which was used to wrap the seed.
 
-  * **-s**, **\--secret**=_FILE_:
+  * **-s**, **\--secret**=_FILE_ or _STDIN_:
 
-    The secret which will be protected by the key derived from the random seed.
+    The secret which will be protected by the key derived from the random seed. It can be specified as a file or passed from stdin.
 
   * **-n**, **\--name**=_FILE_:
 

--- a/man/tpm2_makecredential.1.md
+++ b/man/tpm2_makecredential.1.md
@@ -19,7 +19,14 @@ by using the **none** TCTI option.
 
   * **-e**, **\--encryption-key**=_FILE_:
 
+    **DEPRECATED**, use **-u** or **--public** instead.
+
+  * **-u**, **\--public**=_FILE_:
+
     A TPM public key which was used to wrap the seed.
+    NOTE: This option is same as **-e** and is added to make it similar with
+    other tools specifying the public key. The old option is retained for
+    backwards compatibility.
 
   * **-s**, **\--secret**=_FILE_ or _STDIN_:
 

--- a/man/tpm2_makecredential.1.md
+++ b/man/tpm2_makecredential.1.md
@@ -2,8 +2,9 @@
 
 # NAME
 
-**tpm2_makecredential**(1) - Load an object that is not a Protected Object into
-the TPM.
+**tpm2_makecredential**(1) - Generate the encrypted-user-chosen-data and the
+wrapped-secret-data-encryption-key for the privacy-sensitive credentialing
+process of a TPM object.
 
 # SYNOPSIS
 
@@ -11,9 +12,25 @@ the TPM.
 
 # DESCRIPTION
 
-**tpm2_makecredential**(1) - Use a TPM public key to protect a secret that is
-used to encrypt the attestation key certificate. This can be used without a TPM
-by using the **none** TCTI option.
+**tpm2_makecredential**(1) - The TPM supports a privacy preserving protocol for
+distributing credentials for keys on a TPM. The process guarantees that the
+credentialed-TPM-object(AIK) is loaded on the same TPM as a well-known
+public-key-object(EK) without knowledge of the specific public properties of the
+credentialed-TPM-object(AIK). The privacy is guaranteed due to the fact that
+only the name of the credentialed-TPM-object(AIK) is shared and not the
+credentialed-TPM-object's public key itself.
+
+Make-credential is the first step in this process where in after receiving the
+public-key-object(EK) public key of the TPM and the name of the
+credentialed-TPM-object(AIK), an encrypted-user-chosen-data is generated and the
+secret-data-encryption-key is generated and wrapped using cryptographic
+processes specific to credential activation that guarantees that the
+credentialed-TPM-object(AIK) is loaded on the TPM with the well-known
+public-key-object(EK).
+
+**tpm2_makecredential** can be used to generate the encrypted-user-chosen-data
+and the wrapped secret-data-encryption-key without a TPM by using the **none**
+TCTI option.
 
 # OPTIONS
 
@@ -28,6 +45,12 @@ by using the **none** TCTI option.
     other tools specifying the public key. The old option is retained for
     backwards compatibility.
 
+  * **-G**, **\--key-algorithm**=_ALGORITHM_:
+
+    The key algorithm associated with TPM public key. Specify either RSA/ ECC.
+    When this option is used, input public key is expected to be in PEM format
+    and the default TCG EK template is used for the key properties.
+
   * **-s**, **\--secret**=_FILE_ or _STDIN_:
 
     The secret which will be protected by the key derived from the random seed. It can be specified as a file or passed from stdin.
@@ -38,14 +61,8 @@ by using the **none** TCTI option.
 
   * **-o**, **\--credential-blob**=_FILE_:
 
-    The output file path, recording the two structures output by
-    tpm2_makecredential function.
-
-  * **-G**, **\--key-algorithm**=_ALGORITHM_:
-
-    The key algorithm associated with TPM public key. Specify either RSA/ ECC.
-    When this option is used, input public key is expected to be in PEM format
-    and the default TCG EK template is used for the key properties.
+    The output file path, recording the encrypted-user-chosen-data and the
+    wrapped secret-data-encryption-key.
 
 [common options](common/options.md)
 
@@ -54,7 +71,18 @@ by using the **none** TCTI option.
 # EXAMPLES
 
 ```bash
-tpm2_makecredential -e <keyFile> -s <secFile> -n <hexString> -o <outFile>
+tpm2 createek -Q -c 0x81010009 -G rsa -u ek.pub
+
+tpm2 createak -C 0x81010009 -c ak.ctx -G rsa -g sha256 -s rsassa -u ak.pub \
+-n ak.name -p akpass> ak.out
+
+file_size=`ls -l ak.name | awk {'print $5'}`
+loaded_key_name=`cat ak.name | xxd -p -c $file_size`
+
+tpm2 readpublic -c 0x81010009 -o ek.pem -f pem -Q
+
+echo "12345678" | tpm2 makecredential -Q -u ek.pem -s - -n $loaded_key_name \
+-o mkcred.out -G rsa
 ```
 
 [returns](common/returns.md)

--- a/man/tpm2_makecredential.1.md
+++ b/man/tpm2_makecredential.1.md
@@ -41,6 +41,12 @@ by using the **none** TCTI option.
     The output file path, recording the two structures output by
     tpm2_makecredential function.
 
+  * **-G**, **\--key-algorithm**=_ALGORITHM_:
+
+    The key algorithm associated with TPM public key. Specify either RSA/ ECC.
+    When this option is used, input public key is expected to be in PEM format
+    and the default TCG EK template is used for the key properties.
+
 [common options](common/options.md)
 
 [common tcti options](common/tcti.md)

--- a/test/integration/tests/abrmd_policycphash.sh
+++ b/test/integration/tests/abrmd_policycphash.sh
@@ -327,7 +327,7 @@ tpm2 readpublic -c prim.ctx -o prim.pub
 tpm2 create -C prim.ctx -u key.pub -r key.priv -c key.ctx -L authorized.policy
 tpm2 readpublic -c key.ctx -n key.name
 echo "plaintext" > plain.txt
-tpm2 makecredential -e prim.pub  -s plain.txt -n `xxd -p -c 34 key.name` \
+tpm2 makecredential -u prim.pub  -s plain.txt -n `xxd -p -c 34 key.name` \
 -o cred.secret
 tpm2 activatecredential -c key.ctx -C prim.ctx -i cred.secret -o act_cred.secret \
 --cphash cp.hash

--- a/test/integration/tests/activecredential.sh
+++ b/test/integration/tests/activecredential.sh
@@ -27,6 +27,23 @@ tpm2 createek -Q -c 0x81010009 -G rsa -u ek.pub
 tpm2 createak -C 0x81010009 -c ak.ctx -G rsa -g sha256 -s rsassa -u ak.pub \
 -n ak.name -p akpass> ak.out
 
+file_size=`ls -l ak.name | awk {'print $5'}`
+loaded_key_name=`cat ak.name | xxd -p -c $file_size` # Use -c in xxd so there is no line wrapping
+
+tpm2 readpublic -c 0x81010009 -o ek.pem -f pem -Q
+
+echo "12345678" | tpm2 makecredential -Q -u ek.pem -s - -n $loaded_key_name \
+-o mkcred.out -G rsa
+
+# Test the secret data matches after credential activation process
+tpm2 startauthsession --policy-session -S session.ctx
+tpm2 policysecret -S session.ctx -c e
+tpm2 activatecredential -Q -c ak.ctx -C 0x81010009 -i mkcred.out \
+-o actcred.out -p akpass -P"session:session.ctx"
+tpm2 flushcontext session.ctx
+
+diff actcred.out secret.data
+
 # Capture the yaml output and verify that its the same as the name output
 loaded_key_name_yaml=`python << pyscript
 from __future__ import print_function
@@ -38,23 +55,6 @@ with open('ak.out', 'r') as f:
     print(doc['loaded-key']['name'])
 pyscript`
 
-# Use -c in xxd so there is no line wrapping
-file_size=`ls -l ak.name | awk {'print $5'}`
-loaded_key_name=`cat ak.name | xxd -p -c $file_size`
-
 test "$loaded_key_name_yaml" == "$loaded_key_name"
-
-tpm2 readpublic -c 0x81010009 -o ek.pem -f pem -Q
-
-echo "12345678" | tpm2 makecredential -Q -u ek.pem -s - -n $loaded_key_name \
--o mkcred.out -G rsa
-
-tpm2 startauthsession --policy-session -S session.ctx
-tpm2 policysecret -S session.ctx -c e
-tpm2 activatecredential -Q -c ak.ctx -C 0x81010009 -i mkcred.out \
--o actcred.out -p akpass -P"session:session.ctx"
-tpm2 flushcontext session.ctx
-
-diff actcred.out secret.data
 
 exit 0

--- a/test/integration/tests/activecredential.sh
+++ b/test/integration/tests/activecredential.sh
@@ -44,8 +44,10 @@ loaded_key_name=`cat ak.name | xxd -p -c $file_size`
 
 test "$loaded_key_name_yaml" == "$loaded_key_name"
 
-echo "12345678" | tpm2 makecredential -Q -u ek.pub -s - -n $loaded_key_name \
--o mkcred.out
+tpm2 readpublic -c 0x81010009 -o ek.pem -f pem -Q
+
+echo "12345678" | tpm2 makecredential -Q -u ek.pem -s - -n $loaded_key_name \
+-o mkcred.out -G rsa
 
 tpm2 startauthsession --policy-session -S session.ctx
 tpm2 policysecret -S session.ctx -c e

--- a/test/integration/tests/activecredential.sh
+++ b/test/integration/tests/activecredential.sh
@@ -53,4 +53,6 @@ tpm2 activatecredential -Q -c ak.ctx -C 0x81010009 -i mkcred.out \
 -o actcred.out -p akpass -P"session:session.ctx"
 tpm2 flushcontext session.ctx
 
+diff actcred.out secret.data
+
 exit 0

--- a/test/integration/tests/activecredential.sh
+++ b/test/integration/tests/activecredential.sh
@@ -44,7 +44,7 @@ loaded_key_name=`cat ak.name | xxd -p -c $file_size`
 
 test "$loaded_key_name_yaml" == "$loaded_key_name"
 
-echo "12345678" | tpm2 makecredential -Q -e ek.pub -s - -n $loaded_key_name \
+echo "12345678" | tpm2 makecredential -Q -u ek.pub -s - -n $loaded_key_name \
 -o mkcred.out
 
 tpm2 startauthsession --policy-session -S session.ctx

--- a/test/integration/tests/activecredential.sh
+++ b/test/integration/tests/activecredential.sh
@@ -44,7 +44,7 @@ loaded_key_name=`cat ak.name | xxd -p -c $file_size`
 
 test "$loaded_key_name_yaml" == "$loaded_key_name"
 
-tpm2 makecredential -Q -e ek.pub -s secret.data -n $loaded_key_name \
+echo "12345678" | tpm2 makecredential -Q -e ek.pub -s - -n $loaded_key_name \
 -o mkcred.out
 
 tpm2 startauthsession --policy-session -S session.ctx

--- a/test/integration/tests/attestation.sh
+++ b/test/integration/tests/attestation.sh
@@ -75,7 +75,7 @@ tpm2 readpublic -Q -c $context_ak -o $output_ak_pub
 # Validate keys (registrar)
 file_size=`ls -l $output_ak_pub_name | awk {'print $5'}`
 loaded_key_name=`cat $output_ak_pub_name | xxd -p -c $file_size`
-tpm2 makecredential -Q -T none -e $output_ek_pub -s $file_input_data \
+tpm2 makecredential -Q -T none -u $output_ek_pub -s $file_input_data \
 -n $loaded_key_name -o $output_mkcredential
 
 tpm2 startauthsession --policy-session -S session.ctx

--- a/test/integration/tests/makecredential.sh
+++ b/test/integration/tests/makecredential.sh
@@ -49,4 +49,10 @@ tpm2 makecredential -Q -u $output_ek_pub -s $file_input_data -n $Loadkeyname \
 tpm2 makecredential -T none -Q -u $output_ek_pub -s $file_input_data \
 -n $Loadkeyname -o $output_mkcredential
 
+# use no tpm backend and EK in PEM format
+tpm2 readpublic -c $handle_ek -o ek.pem -f pem -Q
+
+tpm2 makecredential -T none -Q -u ek.pem -G rsa -s $file_input_data \
+-n $Loadkeyname -o $output_mkcredential
+
 exit 0

--- a/test/integration/tests/makecredential.sh
+++ b/test/integration/tests/makecredential.sh
@@ -42,11 +42,11 @@ tpm2 createak -Q -C $handle_ek -c $ak_ctx -G $ak_alg -g $digestAlg -s $signAlg \
 file_size=`ls -l $output_ak_pub_name | awk {'print $5'}`
 Loadkeyname=`cat $output_ak_pub_name | xxd -p -c $file_size`
 
-tpm2 makecredential -Q -e $output_ek_pub -s $file_input_data -n $Loadkeyname \
+tpm2 makecredential -Q -u $output_ek_pub -s $file_input_data -n $Loadkeyname \
 -o $output_mkcredential
 
 # use no tpm backend
-tpm2 makecredential -T none -Q -e $output_ek_pub -s $file_input_data \
+tpm2 makecredential -T none -Q -u $output_ek_pub -s $file_input_data \
 -n $Loadkeyname -o $output_mkcredential
 
 exit 0


### PR DESCRIPTION
Fixes #2054
Fixes #2055
Fixes #2051

~- [ ] Make name optional if public key for encryption is provided in tss format~ This is invalid since we need the name of the AIK which is not the public encryption-key. The public encryption-key is the EK.
- [x] Add option to specify the secret from stdin.
- [x] Add **-u**, **--public** as an alternative to **-e**, **--encryption-key** for specifying the public key
- [x] Add PEM loading support for EK and assume TCG EK template. Add **-G** option to know the key type: RSA/ ECC.
~- [ ] Add **-c**, **--context** option to use key handles loaded by loadexternal~ This is invalid since we can now load public encryption key in directly in both PEM and TSS format.
- [x] Add clarifying information in the **tpm2_makecredential** man page.
