### PR TITLE
tss2 *: Enhance Fapi Tools integration tests

### DIFF
--- a/.ci/download-deps.sh
+++ b/.ci/download-deps.sh
@@ -3,7 +3,7 @@
 
 function get_deps() {
 
-	TSS_VERSION=${TPM2_TSS_VERSION:-2.4.0}
+	TSS_VERSION=${TPM2_TSS_VERSION:-2.4.2}
 	ABRMD_VERSION=2.3.1
 
 	echo "pwd starting: `pwd`"

--- a/bootstrap
+++ b/bootstrap
@@ -14,6 +14,18 @@ src_listvar () {
     echo ""
 }
 
+# duplicate fapi tests with ecc
+duplicate () {
+    basedir=$1
+    suffix=$2
+
+    find "${basedir}" \( -iname "${suffix}" ! -iname "*ecc.sh" \) | while read fname; do
+      cp $fname ${fname%.sh}_ecc.sh
+      sed -i -e 's/CRYPTO_PROFILE="RSA"/CRYPTO_PROFILE="ECC"/g' ${fname%.sh}_ecc.sh
+    done
+}
+
+
 VARS_FILE=src_vars.mk
 AUTORECONF=${AUTORECONF:-autoreconf}
 
@@ -25,6 +37,8 @@ echo "Generating file lists: ${VARS_FILE}"
 
   src_listvar "test/integration/tests" "*.sh" "SYSTEM_TESTS"
   printf "ALL_SYSTEM_TESTS = \$(SYSTEM_TESTS)\n"
+
+  duplicate "test/integration/fapi" "*.sh"
 
   src_listvar "test/integration/fapi" "*.sh" "FAPI_TESTS"
   printf "ALL_FAPI_TESTS = \$(FAPI_TESTS)\n"

--- a/test/integration/fapi/fapi-authorize-policy.sh
+++ b/test/integration/fapi/fapi-authorize-policy.sh
@@ -4,7 +4,8 @@ source helpers.sh
 
 start_up
 
-setup_fapi
+CRYPTO_PROFILE="RSA"
+setup_fapi $CRYPTO_PROFILE
 
 function cleanup {
     tss2 delete --path=/
@@ -41,9 +42,13 @@ tss2 authorizepolicy --keyPath=$POLICY_SIGN_KEY_PATH --policyPath=$POLICY_PCR \
 tss2 createkey --path=$KEY_PATH --type="noDa, sign" \
     --policyPath=$POLICY_AUTHORIZE --authValue=""
 
-tss2 sign --keyPath=$KEY_PATH --padding="RSA_PSS" --digest=$DIGEST_FILE \
-    --signature=$SIGNATURE_FILE --publicKey=$PUBLIC_KEY_FILE
-
+if [ "$CRYPTO_PROFILE" = "RSA" ]; then
+    tss2 sign --keyPath=$KEY_PATH --padding="RSA_PSS" --digest=$DIGEST_FILE \
+        --signature=$SIGNATURE_FILE --publicKey=$PUBLIC_KEY_FILE
+else
+    tss2 sign --keyPath=$KEY_PATH --digest=$DIGEST_FILE \
+        --signature=$SIGNATURE_FILE --publicKey=$PUBLIC_KEY_FILE
+fi
 
 expect <<EOF
 # Try with missing policyPath

--- a/test/integration/fapi/fapi-authorize-policy.sh
+++ b/test/integration/fapi/fapi-authorize-policy.sh
@@ -24,6 +24,12 @@ POLICY_REF=$TEMP_DIR/policy_ref.file
 SIGNATURE_FILE=$TEMP_DIR/signature.file
 PUBLIC_KEY_FILE=$TEMP_DIR/public_key.file
 DIGEST_FILE=$TEMP_DIR/digest.file
+LOG_FILE=$TEMP_DIR/log.file
+
+touch $LOG_FILE
+
+EMPTY_FILE=$TEMP_DIR/empty.file
+BIG_FILE=$TEMP_DIR/big_file.file
 
 echo -n 01234567890123456789012345678901 > $DIGEST_FILE
 echo 'f0f1f2f3f4f5f6f7f8f9' | xxd -r -p > $POLICY_REF
@@ -33,6 +39,44 @@ tss2 provision
 tss2 import --path=$POLICY_PCR --importData=$PCR_POLICY_DATA
 
 tss2 import --path=$POLICY_AUTHORIZE --importData=$AUTHORIZE_POLICY_DATA
+
+echo "tss2 import with EMPTY_FILE" # Expected to fail
+expect <<EOF
+spawn sh -c "tss2 import --path=$POLICY_AUTHORIZE --importData=$EMPTY_FILE 2> $LOG_FILE"
+set ret [wait]
+if {[lindex \$ret 2] || [lindex \$ret 3] != 1} {
+    set file [open $LOG_FILE r]
+    set log [read \$file]
+    close $file
+    send_user "[lindex \$log]\n"
+    exit 1
+}
+EOF
+
+if [[ "`cat $LOG_FILE`" == $SANITIZER_FILTER ]]; then
+  echo "Error: AddressSanitizer triggered."
+  cat $LOG_FILE
+  exit 1
+fi
+
+echo "tss2 import with BIG_FILE" # Expected to fail
+expect <<EOF
+spawn sh -c "tss2 import --path=$POLICY_AUTHORIZE --importData=$BIG_FILE 2> $LOG_FILE"
+set ret [wait]
+if {[lindex \$ret 2] || [lindex \$ret 3] != 1} {
+    set file [open $LOG_FILE r]
+    set log [read \$file]
+    close $file
+    send_user "[lindex \$log]\n"
+    exit 1
+}
+EOF
+
+if [[ "`cat $LOG_FILE`" == $SANITIZER_FILTER ]]; then
+  echo "Error: AddressSanitizer triggered."
+  cat $LOG_FILE
+  exit 1
+fi
 
 tss2 createkey --path=$POLICY_SIGN_KEY_PATH --type="noDa, sign" --authValue=""
 
@@ -49,6 +93,27 @@ else
     tss2 sign --keyPath=$KEY_PATH --digest=$DIGEST_FILE \
         --signature=$SIGNATURE_FILE --publicKey=$PUBLIC_KEY_FILE
 fi
+
+echo "tss2 sign with BIG_FILE" # Expected to fail
+expect <<EOF
+spawn sh -c "tss2 sign --keyPath=$KEY_PATH --padding=RSA_PSS --digest=$BIG_FILE \
+    --signature=$SIGNATURE_FILE --publicKey=$PUBLIC_KEY_FILE 2> $LOG_FILE"
+set ret [wait]
+if {[lindex \$ret 2] || [lindex \$ret 3] != 1} {
+    set file [open $LOG_FILE r]
+    set log [read \$file]
+    close $file
+    send_user "[lindex \$log]\n"
+    exit 1
+}
+EOF
+
+if [[ "`cat $LOG_FILE`" == $SANITIZER_FILTER ]]; then
+  echo "Error: AddressSanitizer triggered."
+  cat $LOG_FILE
+  exit 1
+fi
+
 
 expect <<EOF
 # Try with missing policyPath
@@ -71,5 +136,29 @@ if {[lindex \$ret 2] || [lindex \$ret 3] != 1} {
     exit 1
 }
 EOF
+
+echo "tss2 authorizepolicy with EMPTY_FILE" # Expected to succeed
+tss2 authorizepolicy --keyPath=$POLICY_SIGN_KEY_PATH --policyPath=$POLICY_PCR \
+  --policyRef=$EMPTY_FILE
+
+echo "tss2 authorizepolicy with BIG_FILE" # Expected to fail
+expect <<EOF
+spawn sh -c "tss2 authorizepolicy --keyPath=$POLICY_SIGN_KEY_PATH \
+    --policyPath=$POLICY_PCR --policyRef=$BIG_FILE 2> $LOG_FILE"
+set ret [wait]
+if {[lindex \$ret 2] || [lindex \$ret 3] != 1} {
+    set file [open $LOG_FILE r]
+    set log [read \$file]
+    close $file
+    send_user "[lindex \$log]\n"
+    exit 1
+}
+EOF
+
+if [[ "`cat $LOG_FILE`" == $SANITIZER_FILTER ]]; then
+  echo "Error: AddressSanitizer triggered."
+  cat $LOG_FILE
+  exit 1
+fi
 
 exit 0

--- a/test/integration/fapi/fapi-branch-select.sh
+++ b/test/integration/fapi/fapi-branch-select.sh
@@ -4,7 +4,8 @@ source helpers.sh
 
 start_up
 
-setup_fapi
+CRYPTO_PROFILE="RSA"
+setup_fapi $CRYPTO_PROFILE
 
 function cleanup {
     tss2 delete --path=/

--- a/test/integration/fapi/fapi-encrypt-decrypt.sh
+++ b/test/integration/fapi/fapi-encrypt-decrypt.sh
@@ -3,10 +3,14 @@ source helpers.sh
 
 start_up
 
-setup_fapi
+CRYPTO_PROFILE="RSA"
+setup_fapi $CRYPTO_PROFILE
 
 function cleanup {
-    tss2 delete --path=/
+    # In case the test is skipped no key is created and a
+    # failure is expected here. Therefore, we need to pass a successful
+    # execution in any case
+    tss2 delete --path=/ && true
     shut_down
 }
 
@@ -23,6 +27,11 @@ TYPES="noDa,decrypt"
 echo -n "Secret Text!" > $PLAIN_TEXT
 
 set -x
+
+if [ "$CRYPTO_PROFILE" = "ECC" ]; then
+echo ECC currently not supported for encryption. Skipping test.
+exit 077
+fi
 
 tss2 provision
 

--- a/test/integration/fapi/fapi-export-key.sh
+++ b/test/integration/fapi/fapi-export-key.sh
@@ -4,7 +4,8 @@ source helpers.sh
 
 start_up
 
-setup_fapi
+CRYPTO_PROFILE="RSA"
+setup_fapi $CRYPTO_PROFILE
 
 function cleanup {
     tss2 delete --path=/

--- a/test/integration/fapi/fapi-export-policy.sh
+++ b/test/integration/fapi/fapi-export-policy.sh
@@ -4,7 +4,8 @@ source helpers.sh
 
 start_up
 
-setup_fapi
+CRYPTO_PROFILE="RSA"
+setup_fapi $CRYPTO_PROFILE
 
 function cleanup {
     tss2 delete --path=/

--- a/test/integration/fapi/fapi-get-info.sh
+++ b/test/integration/fapi/fapi-get-info.sh
@@ -4,7 +4,8 @@ source helpers.sh
 
 start_up
 
-setup_fapi
+CRYPTO_PROFILE="RSA"
+setup_fapi $CRYPTO_PROFILE
 
 function cleanup {
     tss2 delete --path=/

--- a/test/integration/fapi/fapi-get-platform-certificates.sh
+++ b/test/integration/fapi/fapi-get-platform-certificates.sh
@@ -4,7 +4,8 @@ source helpers.sh
 
 start_up
 
-setup_fapi
+CRYPTO_PROFILE="RSA"
+setup_fapi $CRYPTO_PROFILE
 
 PATH=${BUILDDIR}/tools/fapi:$PATH
 

--- a/test/integration/fapi/fapi-get-random.sh
+++ b/test/integration/fapi/fapi-get-random.sh
@@ -4,7 +4,8 @@ source helpers.sh
 
 start_up
 
-setup_fapi
+CRYPTO_PROFILE="RSA"
+setup_fapi $CRYPTO_PROFILE
 
 PATH=${BUILDDIR}/tools/fapi:$PATH
 

--- a/test/integration/fapi/fapi-get-tpm-blobs.sh
+++ b/test/integration/fapi/fapi-get-tpm-blobs.sh
@@ -4,7 +4,8 @@ source helpers.sh
 
 start_up
 
-setup_fapi
+CRYPTO_PROFILE="RSA"
+setup_fapi $CRYPTO_PROFILE
 
 function cleanup {
     tss2 delete --path=/

--- a/test/integration/fapi/fapi-list.sh
+++ b/test/integration/fapi/fapi-list.sh
@@ -4,7 +4,8 @@ source helpers.sh
 
 start_up
 
-setup_fapi
+CRYPTO_PROFILE="RSA"
+setup_fapi $CRYPTO_PROFILE
 
 function cleanup {
     tss2 delete --path=/

--- a/test/integration/fapi/fapi-nv-extend.sh
+++ b/test/integration/fapi/fapi-nv-extend.sh
@@ -4,7 +4,8 @@ source helpers.sh
 
 start_up
 
-setup_fapi
+CRYPTO_PROFILE="RSA"
+setup_fapi $CRYPTO_PROFILE
 
 function cleanup {
     tss2 delete --path=/

--- a/test/integration/fapi/fapi-nv-extend.sh
+++ b/test/integration/fapi/fapi-nv-extend.sh
@@ -19,6 +19,11 @@ DATA_EXTEND_FILE=$TEMP_DIR/nv_extend.data
 DATA_READ_FILE=$TEMP_DIR/nv_read.data
 LOG_DATA=$TEMP_DIR/log.data
 READ_LOG_DATA=$TEMP_DIR/read_log.data
+EMPTY_FILE=$TEMP_DIR/empty.file
+BIG_FILE=$TEMP_DIR/big_file.file
+
+LOG_FILE=$TEMP_DIR/log.file
+touch $LOG_FILE
 
 echo -n 01234567890123456789 > $DATA_EXTEND_FILE
 echo -n 01234567890123456789 > $LOG_DATA
@@ -28,6 +33,69 @@ tss2 provision
 tss2 createnv --path=$NV_PATH --type="noDa, pcr" --size=0 --authValue=""
 
 tss2 nvextend --nvPath=$NV_PATH --data=$DATA_EXTEND_FILE --logData=$LOG_DATA
+
+echo "tss2 nvextend with EMPTY_FILE data" # Expected to succeed
+tss2 nvextend --nvPath=$NV_PATH --data=$EMPTY_FILE --logData=$LOG_DATA
+
+echo "tss2 nvextend with BIG_FILE data" # Expected to fail
+expect <<EOF
+spawn sh -c "tss2 nvextend --nvPath=$NV_PATH --data=$BIG_FILE \
+  --logData=$LOG_DATA 2> $LOG_FILE"
+set ret [wait]
+if {[lindex \$ret 2] || [lindex \$ret 3] != 1} {
+    set file [open $LOG_FILE r]
+    set log [read \$file]
+    close $file
+    send_user "[lindex \$log]\n"
+    exit 1
+}
+EOF
+
+if [[ "`cat $LOG_FILE`" == $SANITIZER_FILTER ]]; then
+  echo "Error: AddressSanitizer triggered."
+  cat $LOG_FILE
+  exit 1
+fi
+
+echo "tss2 nvextend with EMPTY_FILE logData" # Expected to fail
+expect <<EOF
+spawn sh -c "tss2 nvextend --nvPath=$NV_PATH --data=$DATA_EXTEND_FILE \
+    --logData=$EMPTY_FILE 2> $LOG_FILE"
+set ret [wait]
+if {[lindex \$ret 2] || [lindex \$ret 3] != 1} {
+    set file [open $LOG_FILE r]
+    set log [read \$file]
+    close $file
+    send_user "[lindex \$log]\n"
+    exit 1
+}
+EOF
+
+if [[ "`cat $LOG_FILE`" == $SANITIZER_FILTER ]]; then
+  echo "Error: AddressSanitizer triggered."
+  cat $LOG_FILE
+  exit 1
+fi
+
+echo "tss2 nvextend with BIG_FILE logData" # Expected to fail
+expect <<EOF
+spawn sh -c "tss2 nvextend --nvPath=$NV_PATH --data=$DATA_EXTEND_FILE0 \
+    --logData=$BIG_FILE 2> $LOG_FILE"
+set ret [wait]
+if {[lindex \$ret 2] || [lindex \$ret 3] != 1} {
+    set file [open $LOG_FILE r]
+    set log [read \$file]
+    close $file
+    send_user "[lindex \$log]\n"
+    exit 1
+}
+EOF
+
+if [[ "`cat $LOG_FILE`" == $SANITIZER_FILTER ]]; then
+  echo "Error: AddressSanitizer triggered."
+  cat $LOG_FILE
+  exit 1
+fi
 
 tss2 nvread --nvPath=$NV_PATH --data=$DATA_READ_FILE --logData=$READ_LOG_DATA
 

--- a/test/integration/fapi/fapi-nv-increment.sh
+++ b/test/integration/fapi/fapi-nv-increment.sh
@@ -4,7 +4,8 @@ source helpers.sh
 
 start_up
 
-setup_fapi
+CRYPTO_PROFILE="RSA"
+setup_fapi $CRYPTO_PROFILE
 
 function cleanup {
     tss2 delete --path=/

--- a/test/integration/fapi/fapi-nv-set-bits.sh
+++ b/test/integration/fapi/fapi-nv-set-bits.sh
@@ -4,7 +4,8 @@ source helpers.sh
 
 start_up
 
-setup_fapi
+CRYPTO_PROFILE="RSA"
+setup_fapi $CRYPTO_PROFILE
 
 function cleanup {
     tss2 delete --path=/

--- a/test/integration/fapi/fapi-nv-write-authorize.sh
+++ b/test/integration/fapi/fapi-nv-write-authorize.sh
@@ -4,7 +4,8 @@ source helpers.sh
 
 start_up
 
-setup_fapi
+CRYPTO_PROFILE="RSA"
+setup_fapi $CRYPTO_PROFILE
 
 function cleanup {
     tss2 delete --path=/
@@ -49,8 +50,13 @@ tss2 createkey --path=$POLICY_SIGN_KEY_PATH --type="noDa, sign" --authValue=""
 tss2 createkey --path=$SIGN_KEY_PATH --type="noDa, sign" \
     --policyPath=$AUTHORIZE_NV_POLICY  --authValue=""
 
+if [ "$CRYPTO_PROFILE" = "RSA" ]; then
 tss2 sign --keyPath=$SIGN_KEY_PATH --padding="RSA_PSS" --digest=$DIGEST_FILE \
     --signature=$SIGNATURE_FILE --publicKey=$PUBLIC_KEY_FILE
+else
+tss2 sign --keyPath=$SIGN_KEY_PATH --digest=$DIGEST_FILE \
+    --signature=$SIGNATURE_FILE --publicKey=$PUBLIC_KEY_FILE
+fi
 
 expect <<EOF
 # Try with missing nvPath

--- a/test/integration/fapi/fapi-nv-write-read.sh
+++ b/test/integration/fapi/fapi-nv-write-read.sh
@@ -4,7 +4,8 @@ source helpers.sh
 
 start_up
 
-setup_fapi
+CRYPTO_PROFILE="RSA"
+setup_fapi $CRYPTO_PROFILE
 
 function cleanup {
     tss2 delete --path=/

--- a/test/integration/fapi/fapi-pcr-extend-read.sh
+++ b/test/integration/fapi/fapi-pcr-extend-read.sh
@@ -4,7 +4,8 @@ source helpers.sh
 
 start_up
 
-setup_fapi
+CRYPTO_PROFILE="RSA"
+setup_fapi $CRYPTO_PROFILE
 
 function cleanup {
     tss2 delete --path=/

--- a/test/integration/fapi/fapi-provision.sh
+++ b/test/integration/fapi/fapi-provision.sh
@@ -4,7 +4,8 @@ source helpers.sh
 
 start_up
 
-setup_fapi
+CRYPTO_PROFILE="RSA"
+setup_fapi $CRYPTO_PROFILE
 
 function cleanup {
     # Since clean up should already been done during normal run of the test, a

--- a/test/integration/fapi/fapi-quote-verify.sh
+++ b/test/integration/fapi/fapi-quote-verify.sh
@@ -4,7 +4,8 @@ source helpers.sh
 
 start_up
 
-setup_fapi
+CRYPTO_PROFILE="RSA"
+setup_fapi $CRYPTO_PROFILE
 
 function cleanup {
     tss2 delete --path=/

--- a/test/integration/fapi/fapi-seal-unseal.sh
+++ b/test/integration/fapi/fapi-seal-unseal.sh
@@ -4,7 +4,8 @@ source helpers.sh
 
 start_up
 
-setup_fapi
+CRYPTO_PROFILE="RSA"
+setup_fapi $CRYPTO_PROFILE
 
 function cleanup {
     tss2 delete --path=/

--- a/test/integration/fapi/fapi-set-get-app-data.sh
+++ b/test/integration/fapi/fapi-set-get-app-data.sh
@@ -4,7 +4,8 @@ source helpers.sh
 
 start_up
 
-setup_fapi
+CRYPTO_PROFILE="RSA"
+setup_fapi $CRYPTO_PROFILE
 
 function cleanup {
     tss2 delete --path=/

--- a/test/integration/fapi/fapi-set-get-app-data.sh
+++ b/test/integration/fapi/fapi-set-get-app-data.sh
@@ -20,10 +20,19 @@ APP_DATA_FILE=$TEMP_DIR/app_data.file
 
 echo -n "abcdef" > $APP_DATA_SET
 
+EMPTY_FILE=$TEMP_DIR/empty.file
+BIG_FILE=$TEMP_DIR/big_file.file
+
 tss2 provision
 
 tss2 createkey --path=$KEY_PATH --type="noDa, restricted, decrypt" \
     --authValue=""
+
+echo "tss2 setappdata with EMPTY_FILE" # Expected to succeed
+tss2 setappdata --path=$KEY_PATH --appData=$EMPTY_FILE
+
+echo "tss2 setappdata with BIG_FILE" # Expected to succeed
+tss2 setappdata --path=$KEY_PATH --appData=$BIG_FILE
 
 tss2 setappdata --path=$KEY_PATH --appData=$APP_DATA_SET
 

--- a/test/integration/fapi/fapi-set-get-certificate.sh
+++ b/test/integration/fapi/fapi-set-get-certificate.sh
@@ -40,10 +40,19 @@ cat > $WRITE_CERTIFICATE_FILE <<EOF
     -----END CERTIFICATE-----\n"
 EOF
 
+EMPTY_FILE=$TEMP_DIR/empty.file
+BIG_FILE=$TEMP_DIR/big_file.file
+
 tss2 provision
 
 tss2 createkey --path=$KEY_PATH --type="noDa, restricted, decrypt" \
     --authValue=""
+
+echo "tss2 setcertificate with EMPTY_FILE" # Expected to succeed
+tss2 setcertificate --path=$KEY_PATH --x509certData=$EMPTY_FILE
+
+echo "tss2 setcertificate with BIG_FILE" # Expected to succeed
+tss2 setcertificate --path=$KEY_PATH --x509certData=$BIG_FILE
 
 tss2 setcertificate --path=$KEY_PATH --x509certData=$WRITE_CERTIFICATE_FILE
 

--- a/test/integration/fapi/fapi-set-get-certificate.sh
+++ b/test/integration/fapi/fapi-set-get-certificate.sh
@@ -4,7 +4,8 @@ source helpers.sh
 
 start_up
 
-setup_fapi
+CRYPTO_PROFILE="RSA"
+setup_fapi $CRYPTO_PROFILE
 
 function cleanup {
     tss2 delete --path=/

--- a/test/integration/fapi/fapi-set-get-description.sh
+++ b/test/integration/fapi/fapi-set-get-description.sh
@@ -4,7 +4,8 @@ source helpers.sh
 
 start_up
 
-setup_fapi
+CRYPTO_PROFILE="RSA"
+setup_fapi $CRYPTO_PROFILE
 
 function cleanup {
     tss2 delete --path=/

--- a/test/integration/fapi/fapi-sign-verify.sh
+++ b/test/integration/fapi/fapi-sign-verify.sh
@@ -4,7 +4,8 @@ source helpers.sh
 
 start_up
 
-setup_fapi
+CRYPTO_PROFILE="RSA"
+setup_fapi $CRYPTO_PROFILE
 
 function cleanup {
     tss2 delete --path=/
@@ -23,21 +24,38 @@ PUB_KEY_DIR="ext"
 tss2 provision
 echo -n "01234567890123456789" > $DIGEST_FILE
 tss2 createkey --path=$KEY_PATH --type="noDa, sign" --authValue=""
+
+if [ "$CRYPTO_PROFILE" = "RSA" ]; then
 echo -n `cat $DIGEST_FILE` | tss2 sign --digest=- --keyPath=$KEY_PATH \
     --padding="RSA_PSS" --signature=$SIGNATURE_FILE --publicKey=$PUBLIC_KEY_FILE
+else
+echo -n `cat $DIGEST_FILE` | tss2 sign --digest=- --keyPath=$KEY_PATH \
+    --signature=$SIGNATURE_FILE --publicKey=$PUBLIC_KEY_FILE
+fi
 
 tss2 import --path=$IMPORTED_KEY_NAME --importData=$PUBLIC_KEY_FILE
 tss2 verifysignature --keyPath=$PUB_KEY_DIR/$IMPORTED_KEY_NAME \
     --digest=$DIGEST_FILE --signature=$SIGNATURE_FILE
 
 # Try without certificate
+if [ "$CRYPTO_PROFILE" = "RSA" ]; then
 tss2 sign --keyPath=$KEY_PATH --padding="RSA_PSS" --digest=$DIGEST_FILE \
     --signature=$SIGNATURE_FILE --publicKey=$PUBLIC_KEY_FILE --force
+else
+tss2 sign --keyPath=$KEY_PATH --digest=$DIGEST_FILE \
+    --signature=$SIGNATURE_FILE --publicKey=$PUBLIC_KEY_FILE --force
+fi
 
 # Try without public key
+if [ "$CRYPTO_PROFILE" = "RSA" ]; then
 tss2 sign --keyPath=$KEY_PATH --padding="RSA_PSS" --digest=$DIGEST_FILE \
     --signature=$SIGNATURE_FILE --force
+else
+tss2 sign --keyPath=$KEY_PATH --digest=$DIGEST_FILE \
+    --signature=$SIGNATURE_FILE --force
+fi
 
+if [ "$CRYPTO_PROFILE" = "RSA" ]; then
 expect <<EOF
 # Try with missing keyPath
 spawn tss2 sign --padding="RSA_PSS" --digest=$DIGEST_FILE \
@@ -48,7 +66,20 @@ if {[lindex \$ret 2] || [lindex \$ret 3] != 1} {
     exit 1
 }
 EOF
+else
+expect <<EOF
+# Try with missing keyPath
+spawn tss2 sign --digest=$DIGEST_FILE \
+    --signature=$SIGNATURE_FILE --publicKey=$PUBLIC_KEY_FILE
+set ret [wait]
+if {[lindex \$ret 2] || [lindex \$ret 3] != 1} {
+    Command has not failed as expected\n"
+    exit 1
+}
+EOF
+fi
 
+if [ "$CRYPTO_PROFILE" = "RSA" ]; then
 expect <<EOF
 # Try with missing digest
 spawn tss2 sign --keyPath=$KEY_PATH --padding="RSA_PSS" \
@@ -59,7 +90,20 @@ if {[lindex \$ret 2] || [lindex \$ret 3] != 1} {
     exit 1
 }
 EOF
+else
+expect <<EOF
+# Try with missing digest
+spawn tss2 sign --keyPath=$KEY_PATH \
+    --signature=$SIGNATURE_FILE --publicKey=$PUBLIC_KEY_FILE
+set ret [wait]
+if {[lindex \$ret 2] || [lindex \$ret 3] != 1} {
+    Command has not failed as expected\n"
+    exit 1
+}
+EOF
+fi
 
+if [ "$CRYPTO_PROFILE" = "RSA" ]; then
 expect <<EOF
 # Try with missing signature
 spawn tss2 sign --keyPath=$KEY_PATH --padding="RSA_PSS" --digest=$DIGEST_FILE \
@@ -70,7 +114,21 @@ if {[lindex \$ret 2] || [lindex \$ret 3] != 1} {
     exit 1
 }
 EOF
+else
+expect <<EOF
+# Try with missing signature
+spawn tss2 sign --keyPath=$KEY_PATH --digest=$DIGEST_FILE \
+    --publicKey=$PUBLIC_KEY_FILE
+set ret [wait]
+if {[lindex \$ret 2] || [lindex \$ret 3] != 1} {
+    Command has not failed as expected\n"
+    exit 1
+}
+EOF
+fi
 
+
+if [ "$CRYPTO_PROFILE" = "RSA" ]; then
 expect <<EOF
 # Try with multiple stdins with publicKey and with certificate
 spawn tss2 sign --keyPath=$KEY_PATH --padding="RSA_PSS" --digest=$DIGEST_FILE \
@@ -81,7 +139,20 @@ if {[lindex \$ret 2] || [lindex \$ret 3] != 1} {
     exit 1
 }
 EOF
+else
+expect <<EOF
+# Try with multiple stdins with publicKey and with certificate
+spawn tss2 sign --keyPath=$KEY_PATH --digest=$DIGEST_FILE \
+    --signature=- --publicKey=- --certificate -
+set ret [wait]
+if {[lindex \$ret 2] || [lindex \$ret 3] != 1} {
+    Command has not failed as expected\n"
+    exit 1
+}
+EOF
+fi
 
+if [ "$CRYPTO_PROFILE" = "RSA" ]; then
 expect <<EOF
 # Try with multiple stdins without publicKey and with certificate
 spawn tss2 sign --keyPath=$KEY_PATH --padding="RSA_PSS" --digest=$DIGEST_FILE \
@@ -92,7 +163,20 @@ if {[lindex \$ret 2] || [lindex \$ret 3] != 1} {
     exit 1
 }
 EOF
+else
+expect <<EOF
+# Try with multiple stdins without publicKey and with certificate
+spawn tss2 sign --keyPath=$KEY_PATH --digest=$DIGEST_FILE \
+    --signature=- --certificate=-
+set ret [wait]
+if {[lindex \$ret 2] || [lindex \$ret 3] != 1} {
+    Command has not failed as expected\n"
+    exit 1
+}
+EOF
+fi
 
+if [ "$CRYPTO_PROFILE" = "RSA" ]; then
 expect <<EOF
 # Try with missing digest file
 spawn tss2 sign --keyPath=$KEY_PATH --padding="RSA_PSS" --digest=abc \
@@ -103,6 +187,18 @@ if {[lindex \$ret 2] || [lindex \$ret 3] != 1} {
     exit 1
 }
 EOF
+else
+expect <<EOF
+# Try with missing digest file
+spawn tss2 sign --keyPath=$KEY_PATH --digest=abc \
+    --signature=$SIGNATURE_FILE --publicKey=$PUBLIC_KEY_FILE
+set ret [wait]
+if {[lindex \$ret 2] || [lindex \$ret 3] != 1} {
+    Command has not failed as expected\n"
+    exit 1
+}
+EOF
+fi
 
 expect <<EOF
 # Try with missing keyPath

--- a/test/integration/fapi/fapi-testing-template.sh
+++ b/test/integration/fapi/fapi-testing-template.sh
@@ -4,7 +4,8 @@ source helpers.sh
 
 start_up
 
-setup_fapi
+CRYPTO_PROFILE="RSA"
+setup_fapi $CRYPTO_PROFILE
 
 function cleanup {
     # If this test is successful, no keys are created. Thus, command below will

--- a/test/integration/helpers.sh
+++ b/test/integration/helpers.sh
@@ -531,6 +531,10 @@ EOF
 
     export TSS2_FAPICONF=$tempdir/fapi_config.json
     export TEMP_DIR=$tempdir
+    dd if=/dev/zero of=$tempdir/big_file.file bs=1M count=10
+    touch $tempdir/empty.file
+
+    SANITIZER_FILTER="*"AddressSanitizer"*"
 
     PATH=${BUILDDIR}/tools/fapi:$PATH
 

--- a/tools/fapi/tss2_authorizepolicy.c
+++ b/tools/fapi/tss2_authorizepolicy.c
@@ -61,7 +61,7 @@ static int tss2_tool_onrun (FAPI_CONTEXT *fctx) {
         r = open_read_and_close (ctx.policyRef, (void**)&policyRef,
             &policyRefSize);
         if (r){
-            return r;
+            return 1;
         }
     }
 
@@ -71,12 +71,12 @@ static int tss2_tool_onrun (FAPI_CONTEXT *fctx) {
     if (r != TSS2_RC_SUCCESS){
         LOG_PERR ("Fapi_AuthorizePolicy", r);
         free (policyRef);
-        return r;
+        return 1;
     }
 
     free (policyRef);
 
-    return r;
+    return 0;
 }
 
 TSS2_TOOL_REGISTER("authorizepolicy", tss2_tool_onstart, tss2_tool_onrun, NULL)

--- a/tools/fapi/tss2_createkey.c
+++ b/tools/fapi/tss2_createkey.c
@@ -73,14 +73,14 @@ static int tss2_tool_onrun (FAPI_CONTEXT *fctx) {
             free (ctx.authValue);
         }
         LOG_PERR ("Fapi_CreateKey", r);
-        return r;
+        return 1;
     }
 
     if(has_asked_for_password){
         free (ctx.authValue);
     }
 
-    return r;
+    return 0;
 }
 
 TSS2_TOOL_REGISTER("createkey", tss2_tool_onstart, tss2_tool_onrun, NULL)

--- a/tools/fapi/tss2_createnv.c
+++ b/tools/fapi/tss2_createnv.c
@@ -107,7 +107,7 @@ static int tss2_tool_onrun (FAPI_CONTEXT *fctx) {
         free (ctx.authValue);
     }
 
-    return r;
+    return 0;
 }
 
 TSS2_TOOL_REGISTER("createnv", tss2_tool_onstart, tss2_tool_onrun, NULL)

--- a/tools/fapi/tss2_createseal.c
+++ b/tools/fapi/tss2_createseal.c
@@ -102,7 +102,7 @@ static int tss2_tool_onrun (FAPI_CONTEXT *fctx) {
     if (ctx.data) {
         r = open_read_and_close (ctx.data, (void**)&data, &dataSize);
         if (r) {
-            return r;
+            return 1;
         }
     }
     else {

--- a/tools/fapi/tss2_decrypt.c
+++ b/tools/fapi/tss2_decrypt.c
@@ -66,7 +66,7 @@ static int tss2_tool_onrun (FAPI_CONTEXT *fctx) {
     TSS2_RC r = open_read_and_close (ctx.cipherText, (void**)&cipherText,
         &cipherTextSize);
     if (r){
-        return r;
+        return 1;
     }
 
     /* Execute FAPI command with passed arguments */
@@ -86,11 +86,11 @@ static int tss2_tool_onrun (FAPI_CONTEXT *fctx) {
         plainTextSize);
     if (r){
         Fapi_Free (plainText);
-        return r;
+        return 1;
     }
 
     Fapi_Free (plainText);
-    return r;
+    return 0;
 }
 
 TSS2_TOOL_REGISTER("decrypt", tss2_tool_onstart, tss2_tool_onrun, NULL)

--- a/tools/fapi/tss2_getrandom.c
+++ b/tools/fapi/tss2_getrandom.c
@@ -101,7 +101,7 @@ static int tss2_tool_onrun (FAPI_CONTEXT *fctx) {
     }
 
     Fapi_Free (data);
-    return r;
+    return 0;
 }
 
 TSS2_TOOL_REGISTER("getrandom", tss2_tool_onstart, tss2_tool_onrun, NULL)

--- a/tools/fapi/tss2_pcrread.c
+++ b/tools/fapi/tss2_pcrread.c
@@ -102,7 +102,7 @@ static int tss2_tool_onrun (FAPI_CONTEXT *fctx) {
     Fapi_Free (pcrLog);
     Fapi_Free (pcrValue);
 
-    return r;
+    return 0;
 }
 
 TSS2_TOOL_REGISTER("pcrread", tss2_tool_onstart, tss2_tool_onrun, NULL)


### PR DESCRIPTION
This PR enhances the tss2 tools integration tests. Enhancements are:
1. The tests now additionally run with the ECC default profile.
2. The tests now test input boundaries with empty and big input files. Because of this, the TSS version in the CI needs to be updated to include latest fixes so that tests do not fail.