### PR TITLE
tss2-tools: retain executable permission for user and group in umask

### DIFF
--- a/tools/fapi/tss2_template.c
+++ b/tools/fapi/tss2_template.c
@@ -402,11 +402,9 @@ static const tss2_tool *tss2_tool_lookup(int *argc, char ***argv)
 int main(int argc, char *argv[]) {
 
     /* get rid of:
-     *   owner execute (1)
-     *   group execute (1)
      *   other write + read + execute (7)
      */
-    umask(0117);
+    umask(0007);
 
     const tss2_tool * const tool = tss2_tool_lookup(&argc, &argv);
     if (!tool) {


### PR DESCRIPTION
The umask affects files and directories alike, see [man umask(2)](https://man7.org/linux/man-pages/man2/umask.2.html). Creating FAPI objects entails creating new directories as well, which will not be searchable, leading to failures like
```
ERROR:fapi:src/tss2-fapi/ifapi_helpers.c:986:create_dirs() mkdir not possible: -1 /tmp/tpm2_test_umRcf1/tss2_fapi.6tZ4O8/keystore_system/P_RSA/HE/
ERROR:fapi:src/tss2-fapi/ifapi_helpers.c:1013:ifapi_create_dirs() ErrorCode (0x0006000b) Create directories for /P_RSA/HE/EK
ERROR:fapi:src/tss2-fapi/ifapi_keystore.c:710:ifapi_keystore_store_async() ErrorCode (0x0006000b) Directory /P_RSA/HE/EK could not be created.
ERROR:fapi:src/tss2-fapi/api/Fapi_Provision.c:835:Fapi_Provision_Finish() ErrorCode (0x0006000b) Could not open: HE/EK
ERROR:fapi:src/tss2-fapi/api/Fapi_Provision.c:168:Fapi_Provision() ErrorCode (0x0006000b) Provision
Fapi_Provision(0x6000B) - fapi:A parameter has a bad value
```
To avoid this issue, the umask needs to retain the executable permission for user and group. This has no implications for files created by the FAPI since [these are created using `fopen()`](https://github.com/tpm2-software/tpm2-tss/blob/0eee5c42fd06bfb36d351cb9f13c1c06a59d678b/src/tss2-fapi/ifapi_io.c#L179), which uses mode 0666 (so no executable permission), see [man fopen(3)](https://man7.org/linux/man-pages/man3/fopen.3.html).

I am not sure why this does not lead to test failures in the CI, on my local system all FAPI integration tests fail because of this. I suspect the umask might not be respected at all in a container?