### PR TITLE
Use correct formatspecifier for size_t

### DIFF
--- a/tools/misc/tpm2_certifyX509certutil.c
+++ b/tools/misc/tpm2_certifyX509certutil.c
@@ -107,7 +107,7 @@ static int fixup_cert(const char *cert)
 
     size = fs.st_size;
     if (size < 100 || size > 255) {
-        LOG_ERR("Wrong cert size %ld", size);
+        LOG_ERR("Wrong cert size %zd", size);
         return tool_rc_general_error; /* there is something wrong with this cert */
     }
 


### PR DESCRIPTION
On arm the compilation fails with `tools/misc/tpm2_certifyX509certutil.c:110:17: error: format ‘%ld’ expects argument of type ‘long int’, but argument 5 has type ‘ssize_t {aka int}’`.
This is due to a wrong format specifier.

Signed-off-by: Peter Huewe <peter.huewe@infineon.com>