### PR TITLE
tss2_pcrextend: fix extending PCR 0

### DIFF
--- a/tools/fapi/tss2_pcrextend.c
+++ b/tools/fapi/tss2_pcrextend.c
@@ -11,6 +11,7 @@ bool output_enabled = false;
 
 /* Context struct used to store passed command line parameters */
 static struct cxt {
+    bool            pcr_set;
     uint32_t        pcr;
     char     const *data;
     char     const *logData;
@@ -25,6 +26,7 @@ static bool on_option(char key, char *value) {
                 "larger than 2**32 - 1\n", value);
             return false;
         }
+	ctx.pcr_set = true;
         break;
     case 'i':
         ctx.data = value;
@@ -50,7 +52,7 @@ bool tss2_tool_onstart(tpm2_options **opts) {
 /* Execute specific tool */
 int tss2_tool_onrun (FAPI_CONTEXT *fctx) {
     /* Check availability of required parameters */
-    if (!ctx.pcr) {
+    if (!ctx.pcr_set) {
         fprintf (stderr, "No pcr provided, use --pcr\n");
         return -1;
     }


### PR DESCRIPTION
The check if a PCR is set requires that the PCR value be greater than 0.
However, PCR index 0 is valid, so use another variable to track if the
PCR index is specified.

Fixes Error:
tss2_pcrextend --pcr=0
No pcr provided, use --pcr
Usage: tss2_pcrextend [<options>]
Where <options> are:
    [ -x | --pcr=<value>] [ -i | --data=<value>] [ -l | --logData=<value>] [ -h | --help=<value>]
    [ -v | --version]

Fixes: #2167

Signed-off-by: William Roberts <william.c.roberts@intel.com>