### PR TITLE
Fixes for ECC ecdaa signing scheme

### DIFF
--- a/doc/CHANGELOG.md
+++ b/doc/CHANGELOG.md
@@ -22,6 +22,10 @@
       by default. In order to output the URL safe variant of base64 encoded
       output of the INTC EK certificate use the added option **--raw**.
 
+ * tpm2_sign:
+   - Add option **--commit-index** to specify the commit index to use when
+     performing an ECDAA signature.
+
  * tpm2_getekcertificate:
    - Add option **--raw** to output EK certificate in URL safe variant base64
      encoded format. By default it outputs a PEM formatted certificate.

--- a/lib/tpm2_alg_util.c
+++ b/lib/tpm2_alg_util.c
@@ -204,12 +204,12 @@ static alg_parser_rc handle_scheme_sign(const char *scheme,
         } else if (!strncmp(scheme, "ecdaa", 5)) {
             do_scheme_halg(scheme, 5, TPM2_ALG_ECDAA);
             /*
-             * ECDAA has both a count and hashing algorithm, scheme
-             * could either be pointing to a null byte or a number,
-             * we need a number
+             * ECDAA has both a commit-counter value and hashing algorithm.
+             * The default commit-counter value is set to zero to use the first
+             * commit-id.
              */
             if (scheme[0] == '\0') {
-                scheme = "4";
+                scheme = "0";
             }
 
             TPMS_SIG_SCHEME_ECDAA *e = &s->scheme.details.ecdaa;

--- a/man/tpm2_sign.1.md
+++ b/man/tpm2_sign.1.md
@@ -83,6 +83,11 @@ must be provided via the **-t** input. The ticket indicates that the TPM perform
     termed as cpHash. NOTE: When this option is selected, The tool will not
     actually execute the command, it simply returns a cpHash.
 
+  * **\--commit-index**=_NATURALNUMBER_
+
+    The commit counter value to determine the key index to use in an ECDAA
+    signing scheme. The default counter value is 0.
+
   * **ARGUMENT** the command line argument specifies the file data for sign.
 
 ## References

--- a/test/integration/tests/sign.sh
+++ b/test/integration/tests/sign.sh
@@ -278,6 +278,8 @@ tpm2 create -Q -g sha256 -G ecc256:ecdaa -u key.pub -r key.priv -C prim.ctx
 tpm2 load -C prim.ctx -u key.pub -r key.priv -n key.name -c key.ctx
 tpm2 readpublic -c key.ctx --format=pem -o key.pem
 tpm2 commit -c key.ctx -t commit.ctr --eccpoint-K K.bin --eccpoint-L L.bin -u E.bin
+tpm2 commit -c key.ctx -t commit.ctr --eccpoint-K K.bin --eccpoint-L L.bin -u E.bin
+tpm2 sign -c key.ctx -g sha256 -o test.sig test.rnd -s ecdaa --commit-index 1
 tpm2 sign -c key.ctx -g sha256 -o test.sig test.rnd -s ecdaa
 
 # Test that invalid password returns the proper code

--- a/test/integration/tests/sign.sh
+++ b/test/integration/tests/sign.sh
@@ -270,6 +270,16 @@ do
     )
 done
 
+# Test signing with ecdaa scheme
+head -c30 /dev/urandom | openssl dgst -sha256 -binary > test.rnd
+tpm2 clear
+tpm2 createprimary -Q -C o -c prim.ctx -g sha256 -G rsa
+tpm2 create -Q -g sha256 -G ecc256:ecdaa -u key.pub -r key.priv -C prim.ctx
+tpm2 load -C prim.ctx -u key.pub -r key.priv -n key.name -c key.ctx
+tpm2 readpublic -c key.ctx --format=pem -o key.pem
+tpm2 commit -c key.ctx -t commit.ctr --eccpoint-K K.bin --eccpoint-L L.bin -u E.bin
+tpm2 sign -c key.ctx -g sha256 -o test.sig test.rnd -s ecdaa
+
 # Test that invalid password returns the proper code
 cleanup "no-shut-down"
 

--- a/test/unit/test_tpm2_alg_util.c
+++ b/test/unit/test_tpm2_alg_util.c
@@ -776,7 +776,7 @@ static void test_extended_alg_ecc_ecdsa_restricted(void **state) {
     assert_int_equal(e->kdf.details.mgf1.hashAlg, 0);
 
     TPMS_SIG_SCHEME_ECDAA *a = &e->scheme.details.ecdaa;
-    assert_int_equal(a->count, 4);
+    assert_int_equal(a->count, 0);
     assert_int_equal(a->hashAlg, TPM2_ALG_SHA256);
 }
 

--- a/tools/tpm2_sign.c
+++ b/tools/tpm2_sign.c
@@ -115,6 +115,12 @@ static tool_rc init(ESYS_CONTEXT *ectx) {
         }
     }
 
+    if (ctx.in_scheme.scheme == TPM2_ALG_ECDAA &&
+    ctx.sig_format != signature_format_tss) {
+        LOG_ERR("Only TSS signature format is possible with ECDAA scheme");
+        return tool_rc_option_error;
+    }
+
     if (ctx.cp_hash_path && ctx.output_path) {
         LOG_ERR("Cannot output signature when calculating cpHash");
         return tool_rc_option_error;


### PR DESCRIPTION
Fixes #2071

- [x] Fix the default value for ecdaa commit counter — Should be 0.
- [x] Add a ECC ecdaa signing test
- [x] Add more tests to check signing with commit-counter values other than default 0.
- [x] Sanitize **tpm2_sign** input options — Do not allow -f when ecdaa chosen.
- [x] Sanitize commit-counter value specified as ecdaa# in sign and key creation.
~~- [ ] Add signature verification~~
Signed-off-by: Imran Desai <imran.desai@intel.com>