### PR TITLE
Use correct index for policy branch selection

### DIFF
--- a/tools/fapi/tss2_template.c
+++ b/tools/fapi/tss2_template.c
@@ -302,12 +302,12 @@ TSS2_RC branch_callback(
     while (1) {
         printf ("Your choice: ");
         if (scanf ("%zu", selectedBranch) != EOF) {
-            while (getchar () != '\n'); /* Consume all remainign input */
+            while (getchar () != '\n'); /* Consume all remaining input */
             if (*selectedBranch > numBranches || *selectedBranch < 1) {
                 fprintf (stderr, "The entered integer must be positive and "\
                     "less than %zu.\n", numBranches + 1);
             } else {
-                numBranches--;
+                (*selectedBranch)--; /* the user display/choice is always +1 */
                 return TSS2_RC_SUCCESS;
             }
         } else {


### PR DESCRIPTION
The user is presented a menu starting from 1, while internally we are
zero based, thus the correct variable has to be decremented in order to
chose the right branch.

Signed-off-by: Peter Huewe <peter.huewe@infineon.com>