### PR TITLE
tss2_pcrread: fix reading PCR 0

### DIFF
--- a/tools/fapi/tss2_pcrread.c
+++ b/tools/fapi/tss2_pcrread.c
@@ -8,6 +8,7 @@
 
 /* Context struct used to store passed command line parameters */
 static struct cxt {
+    bool            pcr_set;
     uint32_t        pcrIndex;
     char     const *pcrValue;
     char     const *pcrLog;
@@ -26,6 +27,7 @@ static bool on_option(char key, char *value) {
                 "2**32-1\n");
             return false;
         }
+	ctx.pcr_set = true;
         break;
     case 'f':
         ctx.overwrite = true;
@@ -52,7 +54,7 @@ static bool tss2_tool_onstart(tpm2_options **opts) {
 /* Execute specific tool */
 static int tss2_tool_onrun (FAPI_CONTEXT *fctx) {
     /* Check availability of required parameters */
-    if (!ctx.pcrIndex) {
+    if (!ctx.pcr_set) {
         fprintf (stderr, "No PCR index provided, use --pcrIndex\n");
         return -1;
     }


### PR DESCRIPTION
The check if a PCR is set requires that the PCR value be greater than 0.
However, PCR index 0 is valid, so use another variable to track if the
PCR index is specified.
Similar to #2168

Fixes Error:
$ tss2_pcrread -x 0 -o -
No PCR index provided, use --pcrIndex
Usage: tss2_pcrread [<options>]

Fixes: #2167

Signed-off-by: Peter Huewe <peter.huewe@infineon.com>