### PR TITLE
fapi: return error if no number for policy branch selection was entered.

### DIFF
--- a/tools/fapi/tss2_template.c
+++ b/tools/fapi/tss2_template.c
@@ -312,7 +312,7 @@ TSS2_RC branch_callback(
             }
         } else {
             fprintf (stderr, "No number received, but EOF.\n");
-            return TSS2_RC_SUCCESS;
+            return TSS2_FAPI_RC_GENERAL_FAILURE;
         }
     }
 }


### PR DESCRIPTION
If no number was received, but EOF the error TSS2_FAPI_RC_GENERAL_FAILURE will be returned.

Signed-off-by: Juergen Repp <juergen.repp@sit.fraunhofer.de>