### PR TITLE
lib/tpm2_options.c: Fix MAN pages were not displayed for tpm2<spc>toolname

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -451,7 +451,8 @@ if HAVE_MAN_PAGES
     man/man1/tpm2_commit.1 \
     man/man1/tpm2_ecdhkeygen.1 \
     man/man1/tpm2_ecdhzgen.1 \
-    man/man1/tpm2_zgen2phase.1
+    man/man1/tpm2_zgen2phase.1 \
+    man/man1/tpm2.1
 
 if HAVE_FAPI
 dist_man1_MANS += \

--- a/lib/tpm2_options.c
+++ b/lib/tpm2_options.c
@@ -273,22 +273,13 @@ tpm2_option_code tpm2_handle_options(int argc, char **argv,
             break;
         case 'h':
             show_help = true;
-            /*
-             * argv[0] = "tool name"
-             * AND
-             * argv[1] = "--help=no/man" argv[2] = 0
-             * OR
-             * argv[1] = "--help" argv[2] = "no/man"
-             */
-            if (argv[optind - 1]) {
-                if (strstr(argv[optind - 1], "no-man") ||
-                    (argv[optind] && strstr(argv[optind], "no-man"))) {
-                    manpager = false;
-                    optind++;
-                } else if (strstr(argv[optind - 1], "man") ||
-                            (argv[optind] && strstr(argv[optind], "man"))) {
+            if (argv[optind]) {
+                if (!strcmp(argv[optind], "man")) {
                     manpager = true;
                     explicit_manpager = true;
+                    optind++;
+                } else if (!strcmp(argv[optind], "no-man")) {
+                    manpager = false;
                     optind++;
                 } else {
                     show_help = false;

--- a/man/tpm2.1.md
+++ b/man/tpm2.1.md
@@ -1,0 +1,253 @@
+% tpm2(1) tpm2-tools | General Commands Manual
+
+# NAME
+
+**tpm2**(1) - A single small executable that combines the various tpm2-tools
+much like a BusyBox that provides a fairly complete environment for any small or
+embedded system.
+
+# SYNOPSIS
+
+**tpm2** [*OPTIONS*] [*ARGUMENTS*]
+
+# DESCRIPTION
+
+**tpm2**(1) - To ease installation of tpm2-tools in initrd or embedded systems
+where size-optimization and limited resources are important, it is convenient to
+have a single executable that can dispatch the various TPM2 functionalities
+specified by the argument which is one of the available tool names.
+
+The options and arguments that follow are either the **common options** or those
+specific to the **tool name**.
+
+It is important to note that individual tools with prefix **tpm2_** can still be
+invoked, however, they are now soft-linked to this **tpm2** executable. And so
+unlike BusyBox, full functionality of the individual tools is available in the
+executable. For example: **tpm2_getrandom 8** can alternatively be specified as
+**tpm2 getrandom 8**.
+
+
+# ARGUMENTS
+
+List of possible tool names. NOTE: Specify only one of these. Look at examples.
+
+**certifyX509certutil**
+
+**checkquote**
+
+**eventlog**
+
+**print**
+
+**rc_decode**
+
+**activatecredential**
+
+**certify**
+
+**changeauth**
+
+**changeeps**
+
+**changepps**
+
+**clear**
+
+**clearcontrol**
+
+**clockrateadjust**
+
+**create**
+
+**createak**
+
+**createek**
+
+**createpolicy**
+
+**setprimarypolicy**
+
+**createprimary**
+
+**dictionarylockout**
+
+**duplicate**
+
+**getcap**
+
+**gettestresult**
+
+**encryptdecrypt**
+
+**evictcontrol**
+
+**flushcontext**
+
+**getekcertificate**
+
+**getrandom**
+
+**gettime**
+
+**hash**
+
+**hierarchycontrol**
+
+**hmac**
+
+**import**
+
+**incrementalselftest**
+
+**load**
+
+**loadexternal**
+
+**makecredential**
+
+**nvdefine**
+
+**nvextend**
+
+**nvincrement**
+
+**nvreadpublic**
+
+**nvread**
+
+**nvreadlock**
+
+**nvundefine**
+
+**nvwrite**
+
+**nvwritelock**
+
+**nvsetbits**
+
+**pcrallocate**
+
+**pcrevent**
+
+**pcrextend**
+
+**pcrread**
+
+**pcrreset**
+
+**policypcr**
+
+**policyauthorize**
+
+**policyauthorizenv**
+
+**policynv**
+
+**policycountertimer**
+
+**policyor**
+
+**policynamehash**
+
+**policytemplate**
+
+**policycphash**
+
+**policypassword**
+
+**policysigned**
+
+**policyticket**
+
+**policyauthvalue**
+
+**policysecret**
+
+**policyrestart**
+
+**policycommandcode**
+
+**policynvwritten**
+
+**policyduplicationselect**
+
+**policylocality**
+
+**quote**
+
+**readclock**
+
+**readpublic**
+
+**rsadecrypt**
+
+**rsaencrypt**
+
+**send**
+
+**selftest**
+
+**setclock**
+
+**shutdown**
+
+**sign**
+
+**certifycreation**
+
+**nvcertify**
+
+**startauthsession**
+
+**startup**
+
+**stirrandom**
+
+**testparms**
+
+**unseal**
+
+**verifysignature**
+
+**setcommandauditstatus**
+
+**getcommandauditdigest**
+
+**getsessionauditdigest**
+
+**geteccparameters**
+
+**ecephermal**
+
+**commit**
+
+**ecdhkeygen**
+
+**ecdhzgen**
+
+**zgen2phase**
+
+
+## References
+
+[common options](common/options.md) collection of common options that provide
+information many users may expect.
+
+[common tcti options](common/tcti.md) collection of options used to configure
+the various known TCTI modules.
+
+# EXAMPLES
+
+## Get 8 rand bytes from the TPM
+```bash
+tpm2 getrandom 8 | xxd -p
+```
+
+## Send a TPM Startup Command with flags TPM2\_SU\_CLEAR
+```bash
+tpm2 startup -c
+```
+
+[returns](common/returns.md)
+
+[footer](common/footer.md)


### PR DESCRIPTION
Progresses #2111

- [x] Fix an issue where man pages were not displayed when specifying tpm2--space--toolname.
- [x] Fix an issue where --help man and --help yielded the same unexpected result of providing no-man help.
- [x] Fix an issue where --help=no-man and --help no-man provided the same unexpected result of providing man help.
- [x] Fix an issue where tpm2 did not have a bash completion via #2182
- [x] Add tpm2 man page