### PR TITLE
lib/tpm2_eventlog_yaml.c: fix buffer overflow in bytes_to_str()

### DIFF
--- a/lib/tpm2_eventlog_yaml.c
+++ b/lib/tpm2_eventlog_yaml.c
@@ -84,7 +84,7 @@ void bytes_to_str(uint8_t const *buf, size_t size, char *dest, size_t dest_size)
 
     size_t i, j;
 
-    for(i = 0, j = 0; i < size && j < dest_size - 1; ++i, j+=2) {
+    for(i = 0, j = 0; i < size && j < dest_size - 2; ++i, j+=2) {
         sprintf(&dest[j], "%02x", buf[i]);
     }
     dest[j] = '\0';
@@ -340,8 +340,8 @@ bool yaml_sha1_log_eventhdr_callback(TCG_EVENT const *eventhdr, size_t size,
 
     yaml_sha1_log_eventhdr(eventhdr, size);
 
-    char hexstr[20 * 2] = { 0, };
-    bytes_to_str(eventhdr->digest, 20, hexstr, sizeof(hexstr));
+    char hexstr[BYTES_TO_HEX_STRING_SIZE(sizeof(eventhdr->digest))] = { 0, };
+    bytes_to_str(eventhdr->digest, sizeof(eventhdr->digest), hexstr, sizeof(hexstr));
 
     tpm2_tool_output("    DigestCount: 1\n"
                      "    Digests:\n"


### PR DESCRIPTION
The output buffer `dest` should usually have an odd length (two characters per byte in hexadecimal representation, plus one for the null terminator). If the buffer had an even `dest_size` <= 2*`size`, the null terminator was written out of bounds to `dest[dest_size]`. Ensure that the null terminator is stored within the array bounds by omitting the last byte from the hex representation if necessary.

This issue was triggered by the recent commit 46942ef1731f36ca862067130c211854368aef67, leading to the compiler warning/error
```
In function ‘bytes_to_str’,
    inlined from ‘yaml_sha1_log_eventhdr_callback’ at lib/tpm2_eventlog_yaml.c:344:5:
lib/tpm2_eventlog_yaml.c:90:13: error: writing 1 byte into a region of size 0 [-Werror=stringop-overflow=]
   90 |     dest[j] = '\0';
      |     ~~~~~~~~^~~~~~
lib/tpm2_eventlog_yaml.c: In function ‘yaml_sha1_log_eventhdr_callback’:
lib/tpm2_eventlog_yaml.c:343:10: note: at offset 40 to object ‘hexstr’ with size 40 declared here
  343 |     char hexstr[20 * 2] = { 0, };
      |          ^~~~~~
cc1: all warnings being treated as errors
```
Fix this instance by using the existing macro `BYTES_TO_HEX_STRING_SIZE` to calculate the correct buffer length.