### PR TITLE
configure: properly fail if required programs are missing

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -137,46 +137,46 @@ AS_IF([test "x$enable_unit" != xno], [
     PKG_CHECK_MODULES([CMOCKA],[cmocka])
 
     AC_CHECK_PROG([tpm2_abrmd], [tpm2-abrmd], yes, no)
-    AS_IF([test $tpm2_abrmd = missing],
+    AS_IF([test $tpm2_abrmd = no],
           [AC_MSG_ERROR([Required executable tpm2_abrmd not found, try setting PATH])])
 
     AC_CHECK_PROG([tpm_server], [tpm_server], yes, no)
-    AS_IF([test $tpm_server = missing],
+    AS_IF([test $tpm_server = no],
           [AC_MSG_ERROR([Required executable tpm_server not found, try setting PATH])])
 
     AC_CHECK_PROG([BASH_SHELL], [bash], yes, no)
-    AS_IF([test $BASH_SHELL = missing],
+    AS_IF([test $BASH_SHELL = no],
           [AC_MSG_ERROR([Required executable bash not found, system tests require a bash shell!])])
 
     AC_CHECK_PROG([PYTHON], [python], yes, no)
-    AS_IF([test $PYTHON = missing],
+    AS_IF([test $PYTHON = no],
           [AC_MSG_ERROR([Required executable python not found, some system tests will fail!])])
 
     AC_PYTHON_MODULE([yaml])
 
     AC_CHECK_PROG([XXD], [xxd], yes, no)
-    AS_IF([test $XXD = missing],
+    AS_IF([test $XXD = no],
           [AC_MSG_ERROR([Required executable xxd not found, some system tests will fail!])])
     AS_IF([test "$HOSTOS" = "Linux"],
            [AC_CHECK_PROG([SS], [ss], [yes], [no])],
            [AC_CHECK_PROG([SS], [sockstat], [yes], [no])])
-    AS_IF([test $SS = missing],
+    AS_IF([test $SS = no],
           [AC_MSG_ERROR([Required executable ss/sockstat not found, some system tests will fail!])])
 
     AC_CHECK_PROG([SHASUM], [shasum], yes, no)
-    AS_IF([test $SHASUM = missing],
+    AS_IF([test $SHASUM = no],
           [AC_MSG_ERROR([Required executable shasum not found, some system tests will fail!])])
 
     AC_CHECK_PROG([MKTEMP], [mktemp], yes, no)
-    AS_IF([test $MKTEMP = missing],
+    AS_IF([test $MKTEMP = no],
           [AC_MSG_ERROR([Required executable mktemp not found, some system tests will fail!])])
 
     AC_CHECK_PROG([EXPECT], [expect], yes, no)
-    AS_IF([test $EXPECT = missing],
+    AS_IF([test $EXPECT = no],
           [AC_MSG_ERROR([Required executable expect not found, some system tests will fail!])])
 
     AC_CHECK_PROG([OPENSSL], [openssl], yes, no)
-    AS_IF([test $OPENSSL = missing],
+    AS_IF([test $OPENSSL = no],
           [AC_MSG_ERROR([Required executable openssl not found, some system tests will fail!])])
 
     unit_test_tool_report="- tpm2_abrmd: $tpm2_abrmd


### PR DESCRIPTION
The `AC_CHECK_PROG` invocations now use "no" instead of "missing" to signal that a required program is not available. Since the `AS_IF` statements were not adapted to match, missing dependencies did not trigger a warning message or error at all.