### PR TITLE
tpm2_policysigned: add cpHashA support

### DIFF
--- a/lib/tpm2.c
+++ b/lib/tpm2.c
@@ -454,11 +454,12 @@ tool_rc tpm2_policy_signed(ESYS_CONTEXT *esys_context,
         tpm2_loaded_object *auth_entity_obj, ESYS_TR policy_session,
         const TPMT_SIGNATURE *signature, INT32 expiration,
         TPM2B_TIMEOUT **timeout, TPMT_TK_AUTH **policy_ticket,
-        TPM2B_NONCE *policy_qualifier, TPM2B_NONCE *nonce_tpm) {
+        TPM2B_NONCE *policy_qualifier, TPM2B_NONCE *nonce_tpm,
+        TPM2B_DIGEST *cphash) {
 
     TSS2_RC rval = Esys_PolicySigned(esys_context, auth_entity_obj->tr_handle,
         policy_session, ESYS_TR_NONE, ESYS_TR_NONE, ESYS_TR_NONE, nonce_tpm,
-        NULL, policy_qualifier, expiration, signature, timeout, policy_ticket);
+        cphash, policy_qualifier, expiration, signature, timeout, policy_ticket);
     if (rval != TSS2_RC_SUCCESS) {
         LOG_PERR(Esys_PolicySigned, rval);
         return tool_rc_from_tpm(rval);
@@ -691,7 +692,7 @@ tool_rc tpm2_policy_secret(ESYS_CONTEXT *esys_context,
         TPM2B_TIMEOUT **timeout, TPM2B_NONCE *nonce_tpm,
         TPM2B_NONCE *policy_qualifier, TPM2B_DIGEST *cp_hash) {
 
-    const TPM2B_DIGEST *cp_hash_a = NULL;
+    const TPM2B_DIGEST *cphash = NULL;
 
     ESYS_TR auth_entity_obj_session_handle = ESYS_TR_NONE;
     tool_rc rc = tpm2_auth_util_get_shandle(esys_context,
@@ -714,7 +715,7 @@ tool_rc tpm2_policy_secret(ESYS_CONTEXT *esys_context,
         }
 
         TSS2_RC rval = Tss2_Sys_PolicySecret_Prepare(sys_context,
-            auth_entity_obj->handle, policy_session, nonce_tpm, cp_hash_a,
+            auth_entity_obj->handle, policy_session, nonce_tpm, cphash,
             policy_qualifier, expiration);
         if (rval != TPM2_RC_SUCCESS) {
             LOG_PERR(Tss2_Sys_PolicySecret_Prepare, rval);
@@ -751,7 +752,7 @@ tpm2_policysecret_free_name1:
 
     TSS2_RC rval = Esys_PolicySecret(esys_context, auth_entity_obj->tr_handle,
             policy_session, auth_entity_obj_session_handle, ESYS_TR_NONE,
-            ESYS_TR_NONE, nonce_tpm, cp_hash_a, policy_qualifier, expiration, timeout,
+            ESYS_TR_NONE, nonce_tpm, cphash, policy_qualifier, expiration, timeout,
             policy_ticket);
     if (rval != TSS2_RC_SUCCESS) {
         LOG_PERR(Esys_PolicySecret, rval);

--- a/lib/tpm2.h
+++ b/lib/tpm2.h
@@ -108,7 +108,8 @@ tool_rc tpm2_policy_signed(ESYS_CONTEXT *esys_context,
         tpm2_loaded_object *auth_entity_obj, ESYS_TR policy_session,
         const TPMT_SIGNATURE *signature, INT32 expiration,
         TPM2B_TIMEOUT **timeout, TPMT_TK_AUTH **policy_ticket,
-        TPM2B_NONCE *policy_qualifier, TPM2B_NONCE *nonce_tpm);
+        TPM2B_NONCE *policy_qualifier, TPM2B_NONCE *nonce_tpm,
+        TPM2B_DIGEST *cphash);
 
 tool_rc tpm2_policy_ticket(ESYS_CONTEXT *esys_context, ESYS_TR policy_session,
     const TPM2B_TIMEOUT *timeout, const TPM2B_NONCE *policyref,

--- a/lib/tpm2_policy.h
+++ b/lib/tpm2_policy.h
@@ -195,7 +195,8 @@ tool_rc tpm2_policy_build_policysigned(ESYS_CONTEXT *ectx,
         tpm2_session *policy_session, tpm2_loaded_object *auth_entity_obj,
         TPMT_SIGNATURE *signature, INT32 expiration, TPM2B_TIMEOUT **timeout,
         TPMT_TK_AUTH **policy_ticket, const char *policy_qualifier_path,
-        bool is_nonce_tpm, const char *raw_data_path);
+        bool is_nonce_tpm, const char *raw_data_path,
+        const char *cphash_path);
 
 /**
  * PolicyTicket assertion enables proxy authentication for either PolicySecret

--- a/man/tpm2_policysigned.1.md
+++ b/man/tpm2_policysigned.1.md
@@ -53,6 +53,11 @@ The optional TPM2 parameters being cpHashA, nonceTPM, policyRef and expiration.
     value an authorization ticket is additionally returned. If expiration value
     is 0 then the policy does not have a time limit on the authorization.
 
+  * **\--cphash**=_FILE_:
+
+    The command parameter hash (cpHash), enforcing the TPM command to be
+    authorized as well as its handle and parameter values.
+
   * **\--ticket**=_FILE_:
 
     The ticket file to record the authorization ticket structure.

--- a/test/integration/tests/abrmd_policysigned.sh
+++ b/test/integration/tests/abrmd_policysigned.sh
@@ -102,4 +102,37 @@ tpm2 flushcontext session.ctx
 diff secret.dat unsealed.dat
 rm -f unsealed.dat
 
+#
+# Test with cpHashA with ECDSA signature
+#
+openssl ecparam -name prime256v1 -genkey -noout -out signing_key.priv
+openssl ec -in signing_key.priv -outform PEM -pubout -out signing_key.pub
+tpm2 loadexternal -C o -G ecc -u signing_key.pub -c signing_key_pub.ctx
+
+## Create cpHash and policy digest
+tpm2 dictionarylockout -c --cphash cphash.bin
+tpm2 startauthsession -S session.ctx
+tpm2 policysigned -S session.ctx -c signing_key_pub.ctx -L policy.signed \
+--cphash cphash.bin
+tpm2 flushcontext session.ctx
+
+## Set lockout hierarchy authValue and policyAuth
+tpm2 changeauth -c l "password"
+tpm2 setprimarypolicy -C l -P "password" -L policy.signed -g sha256
+
+tpm2 startauthsession -S session.ctx --policy-session
+### Generate signature with cpHashA
+tpm2 policysigned -S session.ctx -c signing_key_pub.ctx --raw-data to_sign.bin \
+--cphash cphash.bin
+openssl dgst -sha256 -sign signing_key.priv -out signature.dat to_sign.bin
+### Satisfy policy
+tpm2 policysigned -S session.ctx -g sha256 -s signature.dat -f ecdsa \
+-c signing_key_pub.ctx --cphash cphash.bin
+### Authorize
+tpm2 dictionarylockout -c session:session.ctx
+
+tpm2 flushcontext session.ctx
+rm -f signing_key.priv signing_key.pub signing_key_pub.ctx cphash.bin \
+      session.ctx policy.signed to_sign.bin signature.dat
+
 exit 0

--- a/tools/tpm2_policysigned.c
+++ b/tools/tpm2_policysigned.c
@@ -35,6 +35,8 @@ struct tpm2_policysigned_ctx {
 
     const char *raw_data_path;
 
+    const char *cphash_path;
+
     const char *policy_qualifier_data;
 
     union {
@@ -100,6 +102,9 @@ static bool on_option(char key, char *value) {
     case 2:
         ctx.raw_data_path = value;
         break;
+    case 3:
+        ctx.cphash_path = value;
+        break;
     case 'x':
         ctx.is_nonce_tpm = true;
         break;
@@ -130,6 +135,7 @@ static bool tpm2_tool_onstart(tpm2_options **opts) {
         { "ticket",         required_argument, NULL,  0  },
         { "timeout",        required_argument, NULL,  1  },
         { "raw-data",       required_argument, NULL,  2  },
+        { "cphash",         required_argument, NULL,  3  },
     };
 
     *opts = tpm2_options_new("L:S:g:s:f:c:t:q:x", ARRAY_LEN(topts), topts, on_option,
@@ -202,7 +208,7 @@ static tool_rc tpm2_tool_onrun(ESYS_CONTEXT *ectx, tpm2_option_flags flags) {
     rc = tpm2_policy_build_policysigned(ectx, ctx.session,
         &ctx.key_context_object, &ctx.signature, ctx.expiration, &timeout,
         &policy_ticket, ctx.policy_qualifier_data, ctx.is_nonce_tpm,
-        ctx.raw_data_path);
+        ctx.raw_data_path, ctx.cphash_path);
     if (rc != tool_rc_success) {
         LOG_ERR("Could not build policysigned TPM");
         goto tpm2_tool_onrun_out;


### PR DESCRIPTION
The signature used for PolicySigned includes `nonceTPM`, `expiration`, `cpHash` and `policyRef`. Add support for `cpHash` by adding the parameter `--cpHash` to `tpm2_policysigned`.