### PR TITLE
test: add support for swtpm simulator

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -311,7 +311,7 @@ test_unit_test_tpm2_eventlog_yaml_LDADD = $(CMOCKA_LIBS) $(LDADD)
 
 AM_TESTS_ENVIRONMENT =	\
 	TPM2_ABRMD=tpm2-abrmd; export TPM2_ABRMD; \
-	TPM2_SIM=tpm_server; export TPM2_SIM; \
+	TPM2_SIM=$(TPM2_SIM); export TPM2_SIM; \
 	PATH=$(abs_builddir)/tools:$(abs_builddir)/tools/misc:$(abs_top_srcdir)/test/integration:$(PATH); \
 	TPM2_TOOLS_TEST_FIXTURES=$(abs_top_srcdir)/test/integration/fixtures; \
 	SRCDIR=$(abs_srcdir); export SRCDIR; BUILDDIR=$(abs_builddir); export BUILDDIR; \

--- a/configure.ac
+++ b/configure.ac
@@ -140,9 +140,12 @@ AS_IF([test "x$enable_unit" != xno], [
     AS_IF([test $tpm2_abrmd = no],
           [AC_MSG_ERROR([Required executable tpm2_abrmd not found, try setting PATH])])
 
+    AC_CHECK_PROG([swtpm], [swtpm], yes, no)
     AC_CHECK_PROG([tpm_server], [tpm_server], yes, no)
-    AS_IF([test $tpm_server = no],
-          [AC_MSG_ERROR([Required executable tpm_server not found, try setting PATH])])
+    AS_IF([test $swtpm = yes], [TPM2_SIM=swtpm],
+          [AS_IF([test $tpm_server = yes], [TPM2_SIM=tpm_server],
+                 [AC_MSG_ERROR([Required executables swtpm or tpm_server not found, try setting PATH])])])
+    AC_SUBST([TPM2_SIM])
 
     AC_CHECK_PROG([BASH_SHELL], [bash], yes, no)
     AS_IF([test $BASH_SHELL = no],
@@ -180,7 +183,7 @@ AS_IF([test "x$enable_unit" != xno], [
           [AC_MSG_ERROR([Required executable openssl not found, some system tests will fail!])])
 
     unit_test_tool_report="- tpm2_abrmd: $tpm2_abrmd
-    - tpm_server: $tpm_server
+    - TPM simulator: $TPM2_SIM
     - bash: $BASH_SHELL
     - python: $PYTHON
     - xxd: $XXD

--- a/lib/tpm2_alg_util.c
+++ b/lib/tpm2_alg_util.c
@@ -47,6 +47,7 @@ static void tpm2_alg_util_for_each_alg(alg_iter iterator, void *userdata) {
         { .name = "ecc", .id = TPM2_ALG_ECC, .flags = tpm2_alg_util_flags_asymmetric|tpm2_alg_util_flags_base },
 
         // Symmetric
+        { .name = "tdes", .id = TPM2_ALG_TDES, .flags = tpm2_alg_util_flags_symmetric },
         { .name = "aes", .id = TPM2_ALG_AES, .flags = tpm2_alg_util_flags_symmetric },
         { .name = "camellia", .id = TPM2_ALG_CAMELLIA, .flags = tpm2_alg_util_flags_symmetric },
 

--- a/test/integration/tests/testparms.sh
+++ b/test/integration/tests/testparms.sh
@@ -63,7 +63,7 @@ else
 fi
 
 # Attempt to specify a suite that is not supported (error from TPM)
-if tpm2 testparms "ecc521:ecdsa:aes256cbc" &>/dev/null; then
+if tpm2 testparms "ecc521:ecdsa:camellia" &>/dev/null; then
     echo "tpm2 testparms succeeded while it shouldn't or TPM failed"
     exit 1
 else


### PR DESCRIPTION
tpm2-tss supports the [swtpm](https://github.com/stefanberger/swtpm) TPM simulator since version 3.0.0. Two small changes (adding Triple DES to the algorithm list, choosing a different unsupported algorithm for negative testing in [`testparms.sh`](https://github.com/tpm2-software/tpm2-tools/blob/26f60611a045320ceb2554b6929a54bb3e3de06b/test/integration/tests/testparms.sh#L66)) were necessary, other than that everything works out of the box after adapting [`test/integration/helpers.sh`](https://github.com/tpm2-software/tpm2-tools/compare/master...diabonas:add-swtpm?expand=1#diff-7e13f2fcb4dce9b9de0bb58c89995153).

Support for ibmswtpm (aka `tpm_server`) is kept for backwards compatibility, but swtpm is preferred if it is available. Since the Docker images come with swtpm preinstalled, this means that this PR [switches CI testing from ibmswtpm to swtpm](https://travis-ci.org/github/tpm2-software/tpm2-tools/jobs/732035679#L2286) as well.