### PR TITLE
Revert "tpm2_policysigned: add cpHashA support"

### DIFF
--- a/lib/tpm2.c
+++ b/lib/tpm2.c
@@ -454,12 +454,11 @@ tool_rc tpm2_policy_signed(ESYS_CONTEXT *esys_context,
         tpm2_loaded_object *auth_entity_obj, ESYS_TR policy_session,
         const TPMT_SIGNATURE *signature, INT32 expiration,
         TPM2B_TIMEOUT **timeout, TPMT_TK_AUTH **policy_ticket,
-        TPM2B_NONCE *policy_qualifier, TPM2B_NONCE *nonce_tpm,
-        TPM2B_DIGEST *cphash) {
+        TPM2B_NONCE *policy_qualifier, TPM2B_NONCE *nonce_tpm) {
 
     TSS2_RC rval = Esys_PolicySigned(esys_context, auth_entity_obj->tr_handle,
         policy_session, ESYS_TR_NONE, ESYS_TR_NONE, ESYS_TR_NONE, nonce_tpm,
-        cphash, policy_qualifier, expiration, signature, timeout, policy_ticket);
+        NULL, policy_qualifier, expiration, signature, timeout, policy_ticket);
     if (rval != TSS2_RC_SUCCESS) {
         LOG_PERR(Esys_PolicySigned, rval);
         return tool_rc_from_tpm(rval);
@@ -692,7 +691,7 @@ tool_rc tpm2_policy_secret(ESYS_CONTEXT *esys_context,
         TPM2B_TIMEOUT **timeout, TPM2B_NONCE *nonce_tpm,
         TPM2B_NONCE *policy_qualifier, TPM2B_DIGEST *cp_hash) {
 
-    const TPM2B_DIGEST *cphash = NULL;
+    const TPM2B_DIGEST *cp_hash_a = NULL;
 
     ESYS_TR auth_entity_obj_session_handle = ESYS_TR_NONE;
     tool_rc rc = tpm2_auth_util_get_shandle(esys_context,
@@ -715,7 +714,7 @@ tool_rc tpm2_policy_secret(ESYS_CONTEXT *esys_context,
         }
 
         TSS2_RC rval = Tss2_Sys_PolicySecret_Prepare(sys_context,
-            auth_entity_obj->handle, policy_session, nonce_tpm, cphash,
+            auth_entity_obj->handle, policy_session, nonce_tpm, cp_hash_a,
             policy_qualifier, expiration);
         if (rval != TPM2_RC_SUCCESS) {
             LOG_PERR(Tss2_Sys_PolicySecret_Prepare, rval);
@@ -752,7 +751,7 @@ tpm2_policysecret_free_name1:
 
     TSS2_RC rval = Esys_PolicySecret(esys_context, auth_entity_obj->tr_handle,
             policy_session, auth_entity_obj_session_handle, ESYS_TR_NONE,
-            ESYS_TR_NONE, nonce_tpm, cphash, policy_qualifier, expiration, timeout,
+            ESYS_TR_NONE, nonce_tpm, cp_hash_a, policy_qualifier, expiration, timeout,
             policy_ticket);
     if (rval != TSS2_RC_SUCCESS) {
         LOG_PERR(Esys_PolicySecret, rval);

--- a/lib/tpm2.h
+++ b/lib/tpm2.h
@@ -108,8 +108,7 @@ tool_rc tpm2_policy_signed(ESYS_CONTEXT *esys_context,
         tpm2_loaded_object *auth_entity_obj, ESYS_TR policy_session,
         const TPMT_SIGNATURE *signature, INT32 expiration,
         TPM2B_TIMEOUT **timeout, TPMT_TK_AUTH **policy_ticket,
-        TPM2B_NONCE *policy_qualifier, TPM2B_NONCE *nonce_tpm,
-        TPM2B_DIGEST *cphash);
+        TPM2B_NONCE *policy_qualifier, TPM2B_NONCE *nonce_tpm);
 
 tool_rc tpm2_policy_ticket(ESYS_CONTEXT *esys_context, ESYS_TR policy_session,
     const TPM2B_TIMEOUT *timeout, const TPM2B_NONCE *policyref,

--- a/lib/tpm2_policy.c
+++ b/lib/tpm2_policy.c
@@ -391,8 +391,7 @@ tool_rc tpm2_policy_build_policysigned(ESYS_CONTEXT *ectx,
         tpm2_session *policy_session, tpm2_loaded_object *auth_entity_obj,
         TPMT_SIGNATURE *signature, INT32 expiration, TPM2B_TIMEOUT **timeout,
         TPMT_TK_AUTH **policy_ticket, const char *policy_qualifier_data,
-        bool is_nonce_tpm, const char *raw_data_path,
-        const char *cphash_path) {
+        bool is_nonce_tpm, const char *raw_data_path) {
 
     bool result = true;
 
@@ -406,19 +405,6 @@ tool_rc tpm2_policy_build_policysigned(ESYS_CONTEXT *ectx,
         result = tpm2_util_bin_from_hex_or_file(policy_qualifier_data,
                 &policy_qualifier.size,
                 policy_qualifier.buffer);
-        if (!result) {
-            return tool_rc_general_error;
-        }
-    }
-
-    /*
-     * CpHashA (digest of command parameters for approved command) optional.
-     * If not specified default to NULL
-     */
-    TPM2B_DIGEST cphash = TPM2B_EMPTY_INIT;
-
-    if (cphash_path) {
-        bool result = files_load_digest(cphash_path, &cphash);
         if (!result) {
             return tool_rc_general_error;
         }
@@ -441,7 +427,7 @@ tool_rc tpm2_policy_build_policysigned(ESYS_CONTEXT *ectx,
      */
     if (raw_data_path) {
         uint16_t raw_data_len = (nonce_tpm ? nonce_tpm->size : 0) +
-            sizeof(INT32) + cphash.size + policy_qualifier.size;
+            sizeof(INT32) + policy_qualifier.size;
 
         uint8_t *raw_data = malloc(raw_data_len);
         if (!raw_data) {
@@ -449,22 +435,17 @@ tool_rc tpm2_policy_build_policysigned(ESYS_CONTEXT *ectx,
             rc = tool_rc_general_error;
             goto tpm2_policy_build_policysigned_out;
         }
-        /* nonceTPM */
+        //nonceTPM
         uint16_t offset = 0;
         if (nonce_tpm) {
             memcpy(raw_data, nonce_tpm->buffer, nonce_tpm->size);
             offset += nonce_tpm->size;
         }
-        /* expiration */
+        //expiration
         UINT32 endswap_data = tpm2_util_endian_swap_32(expiration);
         memcpy(raw_data + offset, (UINT8 *)&endswap_data, sizeof(INT32));
         offset += sizeof(INT32);
-        /* cpHash */
-        if (cphash_path) {
-            memcpy(raw_data + offset, cphash.buffer, cphash.size);
-            offset += cphash.size;
-        }
-        /* policyRef */
+        //policyRef
         memcpy(raw_data + offset, policy_qualifier.buffer,
             policy_qualifier.size);
 
@@ -482,7 +463,7 @@ tool_rc tpm2_policy_build_policysigned(ESYS_CONTEXT *ectx,
 
     rc = tpm2_policy_signed(ectx, auth_entity_obj, policy_session_handle,
         signature, expiration, timeout, policy_ticket, &policy_qualifier,
-        nonce_tpm, &cphash);
+        nonce_tpm);
 
 tpm2_policy_build_policysigned_out:
     Esys_Free(nonce_tpm);

--- a/lib/tpm2_policy.h
+++ b/lib/tpm2_policy.h
@@ -195,8 +195,7 @@ tool_rc tpm2_policy_build_policysigned(ESYS_CONTEXT *ectx,
         tpm2_session *policy_session, tpm2_loaded_object *auth_entity_obj,
         TPMT_SIGNATURE *signature, INT32 expiration, TPM2B_TIMEOUT **timeout,
         TPMT_TK_AUTH **policy_ticket, const char *policy_qualifier_path,
-        bool is_nonce_tpm, const char *raw_data_path,
-        const char *cphash_path);
+        bool is_nonce_tpm, const char *raw_data_path);
 
 /**
  * PolicyTicket assertion enables proxy authentication for either PolicySecret

--- a/man/tpm2_policysigned.1.md
+++ b/man/tpm2_policysigned.1.md
@@ -53,11 +53,6 @@ The optional TPM2 parameters being cpHashA, nonceTPM, policyRef and expiration.
     value an authorization ticket is additionally returned. If expiration value
     is 0 then the policy does not have a time limit on the authorization.
 
-  * **\--cphash**=_FILE_:
-
-    The command parameter hash (cpHash), enforcing the TPM command to be
-    authorized as well as its handle and parameter values.
-
   * **\--ticket**=_FILE_:
 
     The ticket file to record the authorization ticket structure.

--- a/test/integration/tests/abrmd_policysigned.sh
+++ b/test/integration/tests/abrmd_policysigned.sh
@@ -102,37 +102,4 @@ tpm2 flushcontext session.ctx
 diff secret.dat unsealed.dat
 rm -f unsealed.dat
 
-#
-# Test with cpHashA with ECDSA signature
-#
-openssl ecparam -name prime256v1 -genkey -noout -out signing_key.priv
-openssl ec -in signing_key.priv -outform PEM -pubout -out signing_key.pub
-tpm2 loadexternal -C o -G ecc -u signing_key.pub -c signing_key_pub.ctx
-
-## Create cpHash and policy digest
-tpm2 dictionarylockout -c --cphash cphash.bin
-tpm2 startauthsession -S session.ctx
-tpm2 policysigned -S session.ctx -c signing_key_pub.ctx -L policy.signed \
---cphash cphash.bin
-tpm2 flushcontext session.ctx
-
-## Set lockout hierarchy authValue and policyAuth
-tpm2 changeauth -c l "password"
-tpm2 setprimarypolicy -C l -P "password" -L policy.signed -g sha256
-
-tpm2 startauthsession -S session.ctx --policy-session
-### Generate signature with cpHashA
-tpm2 policysigned -S session.ctx -c signing_key_pub.ctx --raw-data to_sign.bin \
---cphash cphash.bin
-openssl dgst -sha256 -sign signing_key.priv -out signature.dat to_sign.bin
-### Satisfy policy
-tpm2 policysigned -S session.ctx -g sha256 -s signature.dat -f ecdsa \
--c signing_key_pub.ctx --cphash cphash.bin
-### Authorize
-tpm2 dictionarylockout -c session:session.ctx
-
-tpm2 flushcontext session.ctx
-rm -f signing_key.priv signing_key.pub signing_key_pub.ctx cphash.bin \
-      session.ctx policy.signed to_sign.bin signature.dat
-
 exit 0

--- a/tools/tpm2_policysigned.c
+++ b/tools/tpm2_policysigned.c
@@ -35,8 +35,6 @@ struct tpm2_policysigned_ctx {
 
     const char *raw_data_path;
 
-    const char *cphash_path;
-
     const char *policy_qualifier_data;
 
     union {
@@ -102,9 +100,6 @@ static bool on_option(char key, char *value) {
     case 2:
         ctx.raw_data_path = value;
         break;
-    case 3:
-        ctx.cphash_path = value;
-        break;
     case 'x':
         ctx.is_nonce_tpm = true;
         break;
@@ -135,7 +130,6 @@ static bool tpm2_tool_onstart(tpm2_options **opts) {
         { "ticket",         required_argument, NULL,  0  },
         { "timeout",        required_argument, NULL,  1  },
         { "raw-data",       required_argument, NULL,  2  },
-        { "cphash",         required_argument, NULL,  3  },
     };
 
     *opts = tpm2_options_new("L:S:g:s:f:c:t:q:x", ARRAY_LEN(topts), topts, on_option,
@@ -208,7 +202,7 @@ static tool_rc tpm2_tool_onrun(ESYS_CONTEXT *ectx, tpm2_option_flags flags) {
     rc = tpm2_policy_build_policysigned(ectx, ctx.session,
         &ctx.key_context_object, &ctx.signature, ctx.expiration, &timeout,
         &policy_ticket, ctx.policy_qualifier_data, ctx.is_nonce_tpm,
-        ctx.raw_data_path, ctx.cphash_path);
+        ctx.raw_data_path);
     if (rc != tool_rc_success) {
         LOG_ERR("Could not build policysigned TPM");
         goto tpm2_tool_onrun_out;


### PR DESCRIPTION
This reverts commit 5ad61880a65bd208976e6f01ad5ece8def002ace.

Reason: The --cphash option in all other tools is an output to save
the resulting cphash of a command without executing it.

Solution: Rename the --cphash option in context of how it is used
in this change.
