### PR TITLE
Fix tpm2_checkquote when run on a big endian system

### DIFF
--- a/lib/pcr.h
+++ b/lib/pcr.h
@@ -33,6 +33,18 @@ struct tpm2_pcrs {
 bool pcr_print_pcr_struct(TPML_PCR_SELECTION *pcrSelect, tpm2_pcrs *pcrs);
 
 /**
+ * Echo out all PCR banks according to g_pcrSelection & g_pcrs->.
+ * Assume that data structures are all little endian.
+ * @param pcrSelect
+ *  Description of which PCR registers are selected.
+ * @param pcrs
+ *  Struct containing PCR digests.
+ * @return
+ *  True on success, false otherwise.
+ */
+bool pcr_print_pcr_struct_le(TPML_PCR_SELECTION *pcrSelect, tpm2_pcrs *pcrs);
+
+/**
  * Set the PCR value into pcrId if string in arg is a valid PCR index.
  * @param arg
  *  PCR index as string

--- a/lib/tpm2_openssl.c
+++ b/lib/tpm2_openssl.c
@@ -12,6 +12,7 @@
 #include "log.h"
 #include "tpm2_alg_util.h"
 #include "tpm2_openssl.h"
+#include "tpm2_systemdeps.h"
 
 /* compatibility function for OpenSSL versions < 1.1.0 */
 #if OPENSSL_VERSION_NUMBER < 0x10100000L
@@ -327,6 +328,82 @@ bool tpm2_openssl_hash_pcr_banks(TPMI_ALG_HASH hash_alg,
     }
 
     // Finalize running digest
+    unsigned size = EVP_MD_size(md);
+    rc = EVP_DigestFinal_ex(mdctx, digest->buffer, &size);
+    if (!rc) {
+        LOG_ERR("%s", tpm2_openssl_get_err());
+        goto out;
+    }
+
+    digest->size = size;
+
+    result = true;
+
+out:
+    EVP_MD_CTX_destroy(mdctx);
+    return result;
+}
+
+/* show all PCR banks according to g_pcrSelection & g_pcrs-> */
+bool tpm2_openssl_hash_pcr_banks_le(TPMI_ALG_HASH hash_alg,
+        TPML_PCR_SELECTION *pcr_select, tpm2_pcrs *pcrs, TPM2B_DIGEST *digest) {
+
+    UINT32 vi = 0, di = 0, i;
+    bool result = false;
+
+    const EVP_MD *md = tpm2_openssl_halg_from_tpmhalg(hash_alg);
+    if (!md) {
+        return false;
+    }
+
+    EVP_MD_CTX *mdctx = EVP_MD_CTX_create();
+    if (!mdctx) {
+        LOG_ERR("%s", tpm2_openssl_get_err());
+        return false;
+    }
+
+    int rc = EVP_DigestInit_ex(mdctx, md, NULL);
+    if (!rc) {
+        LOG_ERR("%s", tpm2_openssl_get_err());
+        goto out;
+    }
+
+    /* Loop through all PCR/hash banks */
+    for (i = 0; i < le32toh(pcr_select->count); i++) {
+
+        /* Loop through all PCRs in this bank */
+        unsigned int pcr_id;
+        for (pcr_id = 0; pcr_id < pcr_select->pcrSelections[i].sizeofSelect * 8u;
+                pcr_id++) {
+            if (!tpm2_util_is_pcr_select_bit_set(&pcr_select->pcrSelections[i],
+                    pcr_id)) {
+                continue; // skip non-selected banks
+            }
+            if (vi >= le64toh(pcrs->count) || di >= le32toh(pcrs->pcr_values[vi].count)) {
+                LOG_ERR("Something wrong, trying to print but nothing more");
+                goto out;
+            }
+
+            /* Update running digest (to compare with quote) */
+            TPM2B_DIGEST *b = &pcrs->pcr_values[vi].digests[di];
+            rc = EVP_DigestUpdate(mdctx, b->buffer, le16toh(b->size));
+            if (!rc) {
+                LOG_ERR("%s", tpm2_openssl_get_err());
+                goto out;
+            }
+
+            if (++di < le32toh(pcrs->pcr_values[vi].count)) {
+                continue;
+            }
+
+            di = 0;
+            if (++vi < le64toh(pcrs->count)) {
+                continue;
+            }
+        }
+    }
+
+    /* Finalize running digest */
     unsigned size = EVP_MD_size(md);
     rc = EVP_DigestFinal_ex(mdctx, digest->buffer, &size);
     if (!rc) {

--- a/lib/tpm2_openssl.h
+++ b/lib/tpm2_openssl.h
@@ -137,6 +137,24 @@ bool tpm2_openssl_hash_pcr_values(TPMI_ALG_HASH halg, TPML_DIGEST *digests,
 bool tpm2_openssl_hash_pcr_banks(TPMI_ALG_HASH hashAlg,
         TPML_PCR_SELECTION *pcr_select, tpm2_pcrs *pcrs, TPM2B_DIGEST *digest);
 
+/*
+ * Hash a list of PCR digests, supporting multiple banks.
+ * The data in TPML_PCR_SELECTION and tpm2_pcrs is in little endian format.
+ *
+ * @param halg
+ *  The hashing algorithm to use.
+ * @param pcr_select
+ *  The list that specifies which PCRs are selected.
+ * @param pcrs
+ *  The list of PCR banks, each containing a list of PCR digests to hash.
+ ^ * @param digest
+ ^ *  The result of hashing digests with halg.
+ * @return
+ *  true on success, false on error.
+ */
+bool tpm2_openssl_hash_pcr_banks_le(TPMI_ALG_HASH hashAlg,
+        TPML_PCR_SELECTION *pcr_select, tpm2_pcrs *pcrs, TPM2B_DIGEST *digest);
+
 /**
  * Extend a PCR with a new digest.
  * @param halg

--- a/lib/tpm2_systemdeps.h
+++ b/lib/tpm2_systemdeps.h
@@ -1,0 +1,12 @@
+/* SPDX-License-Identifier: BSD-3-Clause */
+
+#ifndef SYSTEM_H
+#define SYSTEM_H
+
+#if defined __FreeBSD__ || defined __DragonFly__
+# include <sys/endian.h>
+#else
+# include <endian.h>
+#endif
+
+#endif

--- a/tools/misc/tpm2_checkquote.c
+++ b/tools/misc/tpm2_checkquote.c
@@ -15,6 +15,7 @@
 #include "tpm2_convert.h"
 #include "tpm2_openssl.h"
 #include "tpm2_options.h"
+#include "tpm2_systemdeps.h"
 #include "tpm2_tool.h"
 #include "tpm2_eventlog.h"
 
@@ -265,14 +266,14 @@ static bool parse_selection_data_from_file(FILE *pcr_input,
         return false;
     }
 
-    if (pcrs->count > ARRAY_LEN(pcrs->pcr_values)) {
+    if (le64toh(pcrs->count) > ARRAY_LEN(pcrs->pcr_values)) {
         LOG_ERR("Malformed PCR file, pcr count cannot be greater than %zu, got: %zu",
-                ARRAY_LEN(pcrs->pcr_values), pcrs->count);
+                ARRAY_LEN(pcrs->pcr_values), le64toh(pcrs->count));
         return false;
     }
 
     UINT32 j;
-    for (j = 0; j < pcrs->count; j++) {
+    for (j = 0; j < le64toh(pcrs->count); j++) {
         if (fread(&pcrs->pcr_values[j], sizeof(TPML_DIGEST), 1, pcr_input)
                 != 1) {
             LOG_ERR("Failed to read PCR digest from file");
@@ -431,20 +432,20 @@ static tool_rc init(void) {
             goto err;
         }
 
-        if (pcr_select.count > TPM2_NUM_PCR_BANKS)
+        if (le32toh(pcr_select.count) > TPM2_NUM_PCR_BANKS)
             goto err;
 
         UINT32 i;
-        for (i = 0; i < pcr_select.count; i++)
-            if (pcr_select.pcrSelections[i].hash == TPM2_ALG_ERROR)
+        for (i = 0; i < le32toh(pcr_select.count); i++)
+            if (le16toh(pcr_select.pcrSelections[i].hash) == TPM2_ALG_ERROR)
             goto err;
 
-        if (!tpm2_openssl_hash_pcr_banks(ctx.halg, &pcr_select, pcrs,
+        if (!tpm2_openssl_hash_pcr_banks_le(ctx.halg, &pcr_select, pcrs,
                 &ctx.pcr_hash)) {
             LOG_ERR("Failed to hash PCR values related to quote!");
             goto err;
         }
-        if (!pcr_print_pcr_struct(&pcr_select, pcrs)) {
+        if (!pcr_print_pcr_struct_le(&pcr_select, pcrs)) {
             LOG_ERR("Failed to print PCR values related to quote!");
             goto err;
         }


### PR DESCRIPTION
Various PCR related structures read by tpm2_checkquote are written
in little endian format, which needs to be taken into account when
run on a big endian system. Although little endian is unusual for
TPM, it is better to leave these data structures in little endian
format to not disrupt existing systems.

Signed-off-by: Stefan Berger <stefanb@linux.ibm.com>