### PR TITLE
Refactor handling of unique data in object creation commands.

### DIFF
--- a/lib/tpm2_alg_util.c
+++ b/lib/tpm2_alg_util.c
@@ -936,8 +936,7 @@ tool_rc tpm2_alg_util_get_signature_scheme(ESYS_CONTEXT *ectx,
 }
 
 tool_rc tpm2_alg_util_public_init(char *alg_details, char *name_halg, char *attrs,
-        char *auth_policy, char *unique_file, TPMA_OBJECT def_attrs,
-        TPM2B_PUBLIC *public) {
+        char *auth_policy,  TPMA_OBJECT def_attrs, TPM2B_PUBLIC *public) {
 
     memset(public, 0, sizeof(*public));
 
@@ -948,19 +947,6 @@ tool_rc tpm2_alg_util_public_init(char *alg_details, char *name_halg, char *attr
         bool res = files_load_bytes_from_path(auth_policy,
             public->publicArea.authPolicy.buffer,
                 &public->publicArea.authPolicy.size);
-        if (!res) {
-            return tool_rc_general_error;
-        }
-    }
-
-    /* load the unique portion of TPMT_PUBLIC from a path if present */
-    if (unique_file) {
-        UINT16 unique_size = sizeof(public->publicArea.unique);
-        /* loaded size may be <= unique_size; user is responsible
-         * for ensuring that that this buffer is formatted as a
-         * TPMU_PUBLIC_ID union. unique_size is max size of the union */
-        bool res = files_load_bytes_from_path(unique_file,
-                (UINT8*) &public->publicArea.unique, &unique_size);
         if (!res) {
             return tool_rc_general_error;
         }

--- a/lib/tpm2_alg_util.h
+++ b/lib/tpm2_alg_util.h
@@ -174,8 +174,7 @@ bool tpm2_alg_util_handle_ext_alg(const char *alg_spec, TPM2B_PUBLIC *public);
  * @return
  */
 tool_rc tpm2_alg_util_public_init(char *alg_details, char *name_halg, char *attrs,
-        char *auth_policy, char *unique_file, TPMA_OBJECT def_attrs,
-        TPM2B_PUBLIC *public);
+        char *auth_policy,  TPMA_OBJECT def_attrs, TPM2B_PUBLIC *public);
 
 /**
  * Returns an ECC curve as a friendly name.

--- a/tools/tpm2_create.c
+++ b/tools/tpm2_create.c
@@ -400,8 +400,7 @@ static tool_rc tpm2_tool_onrun(ESYS_CONTEXT *ectx, tpm2_option_flags flags) {
     }
 
     rc = tpm2_alg_util_public_init(ctx.object.alg, ctx.object.name_alg,
-            ctx.object.attrs, ctx.object.policy, NULL, attrs,
-            &ctx.object.public);
+            ctx.object.attrs, ctx.object.policy, attrs, &ctx.object.public);
     if (rc != tool_rc_success) {
         return rc;
     }


### PR DESCRIPTION
Handle the loading of the unique data upfront in the create object
    tool. This will make it flexible for at least two reasons, namely:
    1. Option to input data from stdin.
    2. Anticipate the key type and process stdin data so as to remove
       end user overhead to format data as TPMU_PUBLIC_ID.

Look at issue #2091 for more details.