### PR TITLE
tpm2-checkqoute: fix wrong format specifier

### DIFF
--- a/tools/misc/tpm2_checkquote.c
+++ b/tools/misc/tpm2_checkquote.c
@@ -267,7 +267,7 @@ static bool parse_selection_data_from_file(FILE *pcr_input,
     }
 
     if (le64toh(pcrs->count) > ARRAY_LEN(pcrs->pcr_values)) {
-        LOG_ERR("Malformed PCR file, pcr count cannot be greater than %zu, got: %zu",
+        LOG_ERR("Malformed PCR file, pcr count cannot be greater than %zu, got: %" PRIu64 " ",
                 ARRAY_LEN(pcrs->pcr_values), le64toh(pcrs->count));
         return false;
     }


### PR DESCRIPTION
Fixes this compilation error:
```In file included from tools/misc/tpm2_checkquote.c:12:0:
tools/misc/tpm2_checkquote.c: In function ‘parse_selection_data_from_file’:
tools/misc/tpm2_checkquote.c:270:17: error: format ‘%zu’ expects
argument of type ‘size_t’, but argument 6 has type ‘__uint64_t {aka long
long unsigned int}’ [-Werror=format=]
         LOG_ERR("Malformed PCR file, pcr count cannot be greater than
%zu, got: %zu",
```
`le64toh `always returns an `uint64_t`, thus `%PRIu64`

Signed-off-by: Peter Huewe <peter.huewe@infineon.com>