### PR TITLE
tpm2_eventlog.c: Fix for possible bad bit shift operation

### DIFF
--- a/lib/files.c
+++ b/lib/files.c
@@ -129,6 +129,7 @@ bool files_get_file_size(FILE *fp, unsigned long *file_size, const char *path) {
 
 bool file_read_bytes_from_file(FILE *f, UINT8 *buf, UINT16 *size,
         const char *path) {
+
     unsigned long file_size;
     bool result = files_get_file_size(f, &file_size, path);
     if (!result) {
@@ -163,6 +164,7 @@ bool file_read_bytes_from_file(FILE *f, UINT8 *buf, UINT16 *size,
 }
 
 bool files_load_bytes_from_path(const char *path, UINT8 *buf, UINT16 *size) {
+
     if (!buf || !size || !path) {
         return false;
     }

--- a/lib/tpm2_eventlog.c
+++ b/lib/tpm2_eventlog.c
@@ -35,8 +35,15 @@ bool foreach_digest2(tpm2_eventlog_context *ctx, unsigned pcr_index, TCG_DIGEST2
         return false;
     }
 
-    bool ret = true;
+    /* Because pcr_index is used for array indexing and bit-shift operations it
+       is 1 less than the max value */
+    if (pcr_index > (TPM2_MAX_PCRS - 1)) {
+        LOG_ERR("PCR Index %d is out of bounds for max available PCRS %d",
+        pcr_index, TPM2_MAX_PCRS);
+        return false;
+    }
 
+    bool ret = true;
     size_t i;
     for (i = 0; i < count; ++i) {
         if (size < sizeof(*digest)) {
@@ -52,9 +59,7 @@ bool foreach_digest2(tpm2_eventlog_context *ctx, unsigned pcr_index, TCG_DIGEST2
         }
 
         uint8_t *pcr = NULL;
-        if (pcr_index > TPM2_MAX_PCRS) {
-            LOG_ERR("PCR%d > max %d", pcr_index, TPM2_MAX_PCRS);
-        } else if (alg == TPM2_ALG_SHA1) {
+        if (alg == TPM2_ALG_SHA1) {
             pcr = ctx->sha1_pcrs[pcr_index];
             ctx->sha1_used |= (1 << pcr_index);
         } else if (alg == TPM2_ALG_SHA256) {

--- a/lib/tpm2_eventlog.c
+++ b/lib/tpm2_eventlog.c
@@ -421,16 +421,14 @@ bool specid_event(TCG_EVENT const *event, size_t size,
 
 bool parse_eventlog(tpm2_eventlog_context *ctx, BYTE const *eventlog, size_t size) {
 
-    TCG_EVENT_HEADER2 *next;
-    TCG_EVENT *event = (TCG_EVENT*)eventlog;
-    bool ret;
-
-    if (!event) {
+    if(!eventlog || (size < sizeof(TCG_EVENT))) {
         return false;
     }
 
+    TCG_EVENT *event = (TCG_EVENT*)eventlog;
     if (event->eventType == EV_NO_ACTION) {
-        ret = specid_event(event, size, &next);
+        TCG_EVENT_HEADER2 *next;
+        bool ret = specid_event(event, size, &next);
         if (!ret) {
             return false;
         }
@@ -443,9 +441,10 @@ bool parse_eventlog(tpm2_eventlog_context *ctx, BYTE const *eventlog, size_t siz
                 return false;
             }
         }
+
         return foreach_event2(ctx, next, size);
-    } else {
-        /* No specid event found. sha1 log format will be parsed. */
-        return foreach_sha1_log_event(ctx, event, size);
     }
+
+    /* No specid event found. sha1 log format will be parsed. */
+    return foreach_sha1_log_event(ctx, event, size);
 }


### PR DESCRIPTION
Because pcr_index is used for array indexing and bit-shift
operations it is 1 less than the max value.

Also moving the check to the top to fail fast/ early.

Signed-off-by: Imran Desai <imran.desai@intel.com>