### PR TITLE
Including inttypes.h on tpm2_checkquote

### DIFF
--- a/tools/misc/tpm2_checkquote.c
+++ b/tools/misc/tpm2_checkquote.c
@@ -1,11 +1,12 @@
 /* SPDX-License-Identifier: BSD-3-Clause */
 
+#include <inttypes.h>
 #include <stdbool.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
 
- #include <openssl/pem.h>
+#include <openssl/pem.h>
 #include <openssl/err.h>
 
 #include "files.h"


### PR DESCRIPTION
I had this error when i tried to install:

> In file included from tools/misc/tpm2_checkquote.c:12:0:
> tools/misc/tpm2_checkquote.c: In function 'parse_selection_data_from_file':
> tools/misc/tpm2_checkquote.c:270:84: error: expected ')' before 'PRIu64'
>          LOG_ERR("Malformed PCR file, pcr count cannot be greater than %zu, got: %" PRIu64 " ",
>                                                                                     ^
> ./lib/log.h:29:69: note: in definition of macro 'LOG_ERR'
>  #define LOG_ERR(fmt, ...) _log(log_level_error, __FILE__, __LINE__, fmt, ##__VA_ARGS__)
>                                                                      ^
> tools/misc/tpm2_checkquote.c:270:17: error: format '%zu' expects a matching 'size_t' argument [-Werror=format=]
>          LOG_ERR("Malformed PCR file, pcr count cannot be greater than %zu, got: %" PRIu64 " ",
>                  ^
> ./lib/log.h:29:69: note: in definition of macro 'LOG_ERR'
>  #define LOG_ERR(fmt, ...) _log(log_level_error, __FILE__, __LINE__, fmt, ##__VA_ARGS__)
>                                                                      ^
> tools/misc/tpm2_checkquote.c:270:17: error: spurious trailing '%' in format [-Werror=format=]
>          LOG_ERR("Malformed PCR file, pcr count cannot be greater than %zu, got: %" PRIu64 " ",
>                  ^
> ./lib/log.h:29:69: note: in definition of macro 'LOG_ERR'
>  #define LOG_ERR(fmt, ...) _log(log_level_error, __FILE__, __LINE__, fmt, ##__VA_ARGS__)
>                                                                      ^
> cc1: all warnings being treated as errors
> Makefile:3588: recipe for target 'tools/misc/tools_tpm2-tpm2_checkquote.o' failed
> make: *** [tools/misc/tools_tpm2-tpm2_checkquote.o] Error 1

I supose it was caused by #2238 and i managed to solve this by including inttypes.h on tpm2_checkquote.