### PR TITLE
tss2 *: Implement callback function Fapi_SetSignCB

### DIFF
--- a/.ci/download-deps.sh
+++ b/.ci/download-deps.sh
@@ -3,7 +3,7 @@
 
 function get_deps() {
 
-	TSS_VERSION=${TPM2_TSS_VERSION:-3.0.1}
+	TSS_VERSION=${TPM2_TSS_VERSION:-3.0.2}
 	ABRMD_VERSION=2.3.3
 
 	echo "pwd starting: `pwd`"

--- a/.ci/download-deps.sh
+++ b/.ci/download-deps.sh
@@ -3,7 +3,7 @@
 
 function get_deps() {
 
-	TSS_VERSION=${TPM2_TSS_VERSION:-3.0.2}
+	export TSS_VERSION=${TPM2_TSS_VERSION:-3.0.2}
 	ABRMD_VERSION=2.3.3
 
 	echo "pwd starting: `pwd`"

--- a/lib/tpm2_convert.h
+++ b/lib/tpm2_convert.h
@@ -117,4 +117,30 @@ bool tpm2_convert_sig_load_plain(const char *path,
 
 bool tpm2_public_load_pkey(const char *path, EVP_PKEY **pkey);
 
+/**
+ * Encode a binary buffer to a Base64-encoded String.
+ * @param buffer
+ *  The binary buffer.
+ * @param buffer_length:
+ *  The length of the binary buffer.
+ * @param base64
+ *  The resulting Base64-encoded String.
+ * @return
+ *  true on success, false on error.
+ */
+bool tpm2_base64_encode(BYTE *buffer, size_t buffer_length, char *base64);
+
+/**
+ * Decode a Base64-encoded String to a binary buffer.
+ * @param base64
+ *  The Base64-encoded String.
+ * @param buffer
+ *  The resulting binary buffer, valid on success.
+ * @param buffer_length:
+ *  The length of the resulting binary buffer, valid on success.
+ * @return
+ *  true on success, false on error.
+ */
+bool tpm2_base64_decode(char *base64, BYTE *buffer, size_t *buffer_length);
+
 #endif /* CONVERSION_H */

--- a/lib/tpm2_util.h
+++ b/lib/tpm2_util.h
@@ -456,4 +456,35 @@ void tpm2_util_print_time(const TPMS_TIME_INFO *current_time);
 bool tpm2_calq_qname(TPM2B_NAME *pqname,
         TPMI_ALG_HASH halg, TPM2B_NAME *name, TPM2B_NAME *qname);
 
+/**
+ * Reads safely from stdin.
+ *
+ * @param length
+ *  Maximum length to read.
+ * @param data
+ *  The output data that was read, valid on success.
+ * @return
+ *  True on success, false otherwise.
+ */
+bool tpm2_safe_read_from_stdin(int length, char *data);
+
+
+/**
+ * Converts a PEM-encoded public key to its sha256 representation (fingerprint).
+ * The resulting Base64-encoded fingerprint format is based on the SSH:
+ * '''
+ *      ssh-keygen -lf id_ecdsa.pub
+ *          256 SHA256:wTUOtZnoSGKwq36mPIN20rCK0Fc1y0zCvHxI2eAvVxU
+ * '''
+ *
+ * @param pem_encoded_key
+ *  The PEM-encoded public key.
+ * @param fingerprint
+ *  The resulting fingerprint, valid on success.
+ * @return
+ *  True on success, false otherwise.
+ */
+bool tpm2_pem_encoded_key_to_fingerprint(const char* pem_encoded_key, char*
+    fingerprint);
+
 #endif /* STRING_BYTES_H */

--- a/test/integration/fapi/fapi-policy_signed.sh
+++ b/test/integration/fapi/fapi-policy_signed.sh
@@ -1,0 +1,204 @@
+
+# set -e
+source helpers.sh
+
+start_up
+
+CRYPTO_PROFILE="RSA"
+setup_fapi $CRYPTO_PROFILE
+
+function cleanup {
+    tss2 delete --path=/
+    shut_down
+}
+
+trap cleanup EXIT
+
+# openssl ecparam -name secp256r1 -genkey -noout -out key_priv.pem
+# openssl ec -in key_priv.pem -pubout -out key_pub.pem
+
+# -----BEGIN PUBLIC KEY-----
+# MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEAw+PKFksCw+ikD76l6BMeXfebcZx
+# Gf8QGWT2MOy8tOfpe6m+6MUUm2GUijGPkvCTjtJPOJz//XMom+k+7OaWmA==
+# -----END PUBLIC KEY-----
+
+# -----BEGIN EC PRIVATE KEY-----
+# MHcCAQEEICf0OXKKsPkEVR1jsPOKSQQJnJVimamLYwLDZwJDj7etoAoGCCqGSM49
+# AwEHoUQDQgAEAw+PKFksCw+ikD76l6BMeXfebcZxGf8QGWT2MOy8tOfpe6m+6MUU
+# m2GUijGPkvCTjtJPOJz//XMom+k+7OaWmA==
+# -----END EC PRIVATE KEY-----
+
+
+KEY_PATH_1=HS/SRK/mySignKey1
+KEY_PATH_2=HS/SRK/mySignKey2
+SIGN_POLICY_DATA=pol_signed.json
+SIGN_POLICY_DATA_KEY_HINT=pol_signed_key_hint.json
+POLICY_SIGNED=policy/policy-signed
+POLICY_SIGNED_KEY_HINT=policy/policy-signed_key_hint
+TEST_SIGNATURE_FILE=test_signature.file
+SIGNATURE_FILE=signature.file
+DIGEST_FILE=digest.file
+PRIV_KEY_FILE=priv_key.file
+
+LOG_FILE=$TEMP_DIR/log.file
+touch $LOG_FILE
+
+EMPTY_FILE=$TEMP_DIR/empty.file
+BIG_FILE=$TEMP_DIR/big_file.file
+
+# Setup Policy Signed
+cat > $SIGN_POLICY_DATA_KEY_HINT <<EOF
+{
+    "description":"Description pol_signed",
+    "policy":[
+        {
+            "type": "POLICYSIGNED",
+            "keyPEM": "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEAw+PKFksCw+ikD76l6BMeXfebcZx\nGf8QGWT2MOy8tOfpe6m+6MUUm2GUijGPkvCTjtJPOJz//XMom+k+7OaWmA==\n-----END PUBLIC KEY-----",
+            "keyPEMhashAlg": "SHA1",
+            "publicKeyHint": "My Signature Key"
+        }
+    ]
+}
+EOF
+
+cat > $SIGN_POLICY_DATA <<EOF
+{
+    "description":"Description pol_signed",
+    "policy":[
+        {
+            "type": "POLICYSIGNED",
+            "keyPEM": "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEAw+PKFksCw+ikD76l6BMeXfebcZx\nGf8QGWT2MOy8tOfpe6m+6MUUm2GUijGPkvCTjtJPOJz//XMom+k+7OaWmA==\n-----END PUBLIC KEY-----",
+            "keyPEMhashAlg": "SHA1",
+        }
+    ]
+}
+EOF
+
+# Write private pem key to file
+cat > $PRIV_KEY_FILE <<EOF
+-----BEGIN EC PRIVATE KEY-----
+MHcCAQEEICf0OXKKsPkEVR1jsPOKSQQJnJVimamLYwLDZwJDj7etoAoGCCqGSM49
+AwEHoUQDQgAEAw+PKFksCw+ikD76l6BMeXfebcZxGf8QGWT2MOy8tOfpe6m+6MUU
+m2GUijGPkvCTjtJPOJz//XMom+k+7OaWmA==
+-----END EC PRIVATE KEY-----
+EOF
+
+echo -n 01234567890123456789 > $DIGEST_FILE
+
+tss2 provision
+
+tss2 import --path=$POLICY_SIGNED --importData=$SIGN_POLICY_DATA
+
+tss2 import --path=$POLICY_SIGNED_KEY_HINT --importData=$SIGN_POLICY_DATA_KEY_HINT
+
+tss2 createkey --path $KEY_PATH_1 --type="sign, noda" \
+  --policyPath $POLICY_SIGNED --authValue ""
+
+tss2 createkey --path $KEY_PATH_2 --type="sign, noda" \
+  --policyPath $POLICY_SIGNED_KEY_HINT --authValue ""
+
+OUTPUT_FILE=$TEMP_DIR/data2sign.file
+
+expect <<EOF
+    spawn sh -c "tss2 sign --keyPath=$KEY_PATH_1 --digest=$DIGEST_FILE --signature=$TEST_SIGNATURE_FILE --force 2> $LOG_FILE"
+    expect "Filename for nonce output: " {
+        send "$OUTPUT_FILE\r"
+        expect "Filename for signature input: " {
+            exec openssl dgst -sha1 -sign $PRIV_KEY_FILE -out $SIGNATURE_FILE $OUTPUT_FILE
+            send "$SIGNATURE_FILE\r"
+            exp_continue
+        }
+    }
+EOF
+
+if grep "ERROR" $LOG_FILE > /dev/null
+then
+  cat $LOG_FILE
+  exit 1
+fi
+
+expect <<EOF
+    spawn sh -c "tss2 sign --keyPath=$KEY_PATH_2 --digest=$DIGEST_FILE --signature=$TEST_SIGNATURE_FILE --force 2> $LOG_FILE"
+    expect "Filename for nonce output: " {
+        send "$OUTPUT_FILE\r"
+        expect "Filename for signature input: " {
+            exec openssl dgst -sha1 -sign $PRIV_KEY_FILE -out $SIGNATURE_FILE $OUTPUT_FILE
+            send "$SIGNATURE_FILE\r"
+            exp_continue
+        }
+    }
+EOF
+
+if grep "ERROR" $LOG_FILE > /dev/null
+then
+  cat $LOG_FILE
+  exit 1
+fi
+
+echo "sign callback with BIG_FILE" # Expected to fail
+expect <<EOF
+    spawn sh -c "tss2 sign --keyPath=$KEY_PATH_1 --digest=$DIGEST_FILE --signature=$TEST_SIGNATURE_FILE --force 2> $LOG_FILE"
+    expect "Filename for nonce output: " {
+        send "$OUTPUT_FILE\r"
+        expect "Filename for signature input: " {
+            exec openssl dgst -sha1 -sign $PRIV_KEY_FILE -out $SIGNATURE_FILE $OUTPUT_FILE
+            send "$BIG_FILE\r"
+            set ret [wait]
+            if {[lindex \$ret 2] || [lindex \$ret 3] == 0} {
+                send_user "\n[lindex \$ret]\n"
+                send_user "Command not failed as expected\n"
+                exit 1
+            }
+        }
+        set ret [wait]
+        if {[lindex \$ret 2] || [lindex \$ret 3] == 0} {
+            set file [open $LOG_FILE r]
+            set log [read \$file]
+            close $file
+            send_user "\n[lindex \$ret]\n"
+            send_user "Command has not failed as expected\n"
+            exit 1
+        }
+    }          
+EOF
+
+if [[ "`cat $LOG_FILE`" == $SANITIZER_FILTER ]]; then
+  echo "Error: AddressSanitizer triggered."
+  cat $LOG_FILE
+  exit 1
+fi
+
+echo "sign callback with EMPTY_FILE" # Expected to fail
+expect <<EOF  
+    spawn sh -c "tss2 sign --keyPath=$KEY_PATH_1 --digest=$DIGEST_FILE --signature=$TEST_SIGNATURE_FILE --force 2> $LOG_FILE"
+    expect "Filename for nonce output: " {
+        send "$OUTPUT_FILE\r"
+        expect "Filename for signature input: " {
+            exec openssl dgst -sha1 -sign $PRIV_KEY_FILE -out $SIGNATURE_FILE $OUTPUT_FILE
+            send "$EMPTY_FILE\r"
+            set ret [wait]
+            if {[lindex \$ret 2] || [lindex \$ret 3] == 0} {
+                send_user "\n[lindex \$ret]\n"
+                send_user "Command has not failed as expected\n"
+                exit 1
+            }
+        }
+        set ret [wait]
+        if {[lindex \$ret 2] || [lindex \$ret 3] == 0} {
+            set file [open $LOG_FILE r]
+            set log [read \$file]
+            close $file
+            send_user "\n[lindex \$ret]\n"
+            send_user "Command has not failed as expected\n"
+            exit 1
+        }
+    }          
+EOF
+
+if [[ "`cat $LOG_FILE`" == $SANITIZER_FILTER ]]; then
+  echo "Error: AddressSanitizer triggered."
+  cat $LOG_FILE
+  exit 1
+fi
+
+exit 0

--- a/test/integration/fapi/fapi-policy_signed_delegation.sh
+++ b/test/integration/fapi/fapi-policy_signed_delegation.sh
@@ -1,0 +1,366 @@
+# In this test a backend issues two policies to a user "A":
+#   1. A user policy that allows "A" to authorize key usage
+#   2. An offline delegation policy that allows "A" to delegate his access rights
+#      two user "B" without further interaction with the backend. 
+
+# set -e
+source helpers.sh
+
+start_up
+
+CRYPTO_PROFILE="RSA"
+setup_fapi $CRYPTO_PROFILE
+
+# Extract value from JSON file
+function jsonValue {
+    KEY=$1
+    num=$2
+    awk -F"[,:}]" '{for(i=1;i<=NF;i++){if($i~/'$KEY'\042/){print $(i+1)}}}' | tr -d '"' | sed -n ${num}p
+}
+
+function cleanup {
+    # In case the test is skipped, no key is created and a
+    # failure is expected here. Therefore, we need to pass a successful
+    # execution in any case
+    tss2 delete --path=/ && true
+    shut_down
+}
+
+trap cleanup EXIT
+
+# The delegation test needs at least the commit
+# b843960b6e601a786b469832392dc0a12e13cf34 of TSS to be executed successfully.
+# This commit will be introduced in version > 3.0.3. Will skip the test if
+# version is below.
+if [[ "$(echo $TSS_VERSION | sed 's/[^0-9]*//g')" -le "303" && "$TSS_VERSION" != "master" ]]; then
+    echo "TSS version does not support test"
+    exit 077
+fi
+
+PATH_REVOCATION="/nv/Owner/ctr"
+PATH_FEATURE_KEY_SIGN="HS/SRK/signkey"
+
+# Backend Policies
+POLICY_AUTH_BACKEND_PEM="pol_authorize_backend_pem.json"
+PATH_POL_AUTHORIZE="/policy/pol_authorize"
+
+# User Policies
+POLICY_USER="pol_user.json"
+PATH_POL_USER="/policy/pol_user"
+POLICY_TO_BE_SIGNED_USER="pol_to_be_signed_user.json"
+POLICY_AUTHORIZED_USER="pol_authorized_user.json"
+PATH_POL_AUTHORIZED_USER="/policy/pol_authorized_user"
+
+# Offline Delegation Policy
+POLICY_OFFLINE_DELEGATION="pol_offline_delegation.json"
+PATH_POL_OFFLINE_DELEGATION="/policy/pol_offline_delegation"
+POLICY_TO_BE_SIGNED_OFFLINE_DELEGATION="pol_to_be_signed_offline_delegation.json"
+POLICY_AUTHORIZED_OFFLINE_DELEGATION="pol_authorized_offline_delegation.json"
+PATH_POL_AUTHORIZED_OFFLINE_DELEGATION="/policy/pol_authorized_offline_delegation"
+
+# Sub Policy
+POLICY_SUB_POLICY="pol_sub_policy.json"
+PATH_POL_SUB_POLICY="/policy/pol_sub_policy"
+POLICY_TO_BE_SIGNED_SUB_POLICY="pol_to_be_signed_sub_policy.json"
+POLICY_AUTHORIZED_SUB_POLICY="pol_authorized_sub_policy.json"
+PATH_POL_AUTHORIZED_SUB_POLICY="/policy/pol_authorized_sub_policy"
+
+# Data for Authorization
+TEST_SIGNATURE_FILE=$TEMP_DIR/test_signature.file
+OUTPUT_FILE=$TEMP_DIR/data2sign.file
+SIGNATURE_FILE=$TEMP_DIR/signature.file
+
+search_string="\"policy\":["
+
+LOG_FILE=$TEMP_DIR/log.file
+touch $LOG_FILE
+
+EMPTY_FILE=$TEMP_DIR/empty.file
+BIG_FILE=$TEMP_DIR/big_file.file
+
+# 0. Create Keys
+
+openssl ecparam -name secp256r1 -genkey -noout -out $TEMP_DIR/key_backend_priv.pem
+openssl ec -in $TEMP_DIR/key_backend_priv.pem -pubout -out $TEMP_DIR/key_backend_pub.pem
+
+openssl ecparam -name secp256r1 -genkey -noout -out $TEMP_DIR/key_user_priv.pem
+openssl ec -in $TEMP_DIR/key_user_priv.pem -pubout -out $TEMP_DIR/key_user_pub.pem
+
+openssl ecparam -name secp256r1 -genkey -noout -out $TEMP_DIR/key_delegated_priv.pem
+openssl ec -in $TEMP_DIR/key_delegated_priv.pem -pubout -out $TEMP_DIR/key_delegated_pub.pem
+
+# 1. Create necessary policy templates
+
+## Backend Authorization Policy
+cat <<EOF > $TEMP_DIR/$POLICY_AUTH_BACKEND_PEM
+{
+    "description":"Initial Authorization Policy",
+    "policy":[
+        {
+            "type": "POLICYAUTHORIZE",
+            "policyRef": [ 1, 2, 3, 4, 5 ],
+            "keyPEM": "`cat $TEMP_DIR/key_backend_pub.pem`"
+        }
+    ]
+}
+EOF
+
+# USER POLICY
+cat <<EOF > $TEMP_DIR/$POLICY_USER
+{
+  "description": "User Policy",
+  "policy": [
+    {
+      "type": "NV",
+      "nvPath": "`echo $PATH_REVOCATION`",
+      "operandB": "0000000000000002",
+      "operation": "neq"
+    },
+    {
+      "type": "CounterTimer",
+      "operandB": "5000",
+      "operation": "signed_lt"
+    },
+    {
+      "type": "Signed",
+      "keyPEM": "`cat $TEMP_DIR/key_user_pub.pem`",
+      "keyPEMhashAlg": "SHA256"
+    }
+  ]
+}
+EOF
+
+## Offline Delegation Policy
+cat <<EOF > $TEMP_DIR/$POLICY_OFFLINE_DELEGATION
+{
+    "description":"Offline Delegation",
+    "policy":[
+        {
+            "type": "POLICYAUTHORIZE",
+            "policyRef": [ 1, 2, 3, 4, 5 ],
+            "keyPEM": "`cat $TEMP_DIR/key_user_pub.pem`"
+        },
+        {
+          "type": "NV",
+          "nvPath": "`echo $PATH_REVOCATION`",
+          "operandB": "0000000000000002",
+          "operation": "neq"
+        }
+    ]
+}
+EOF
+
+## SUB POLICY (will be signed by user)
+cat <<EOF > $TEMP_DIR/$POLICY_SUB_POLICY
+{
+  "description": "Sub Policy",
+  "policy": [
+    {
+      "type": "CounterTimer",
+      "operandB": "5000",
+      "operation": "signed_lt"
+    },
+    {
+      "type": "Signed",
+      "keyPEM": "`cat $TEMP_DIR/key_delegated_pub.pem`",
+      "keyPEMhashAlg": "SHA256"
+    }
+  ]
+}
+EOF
+
+
+
+# 2. Create Setting
+tss2 provision
+
+## Create feature key with authorize policy
+tss2 import --path $PATH_POL_AUTHORIZE --importData $TEMP_DIR/$POLICY_AUTH_BACKEND_PEM
+tss2 createkey --path $PATH_FEATURE_KEY_SIGN --type="sign, noda, 0x81000002" --policyPath $PATH_POL_AUTHORIZE --authValue ""
+
+## Create revocation counter
+tss2 createnv --path $PATH_REVOCATION --type=counter --authValue ""
+tss2 nvincrement --nvPath $PATH_REVOCATION
+
+# 3. Backend creates User Policy and Offline Delegation Policy
+## 3.1 Get digests of policies and sign for authorization
+
+### Sign digest of User Policy with key_backend_priv
+tss2 import --path $PATH_POL_USER --importData $TEMP_DIR/$POLICY_USER
+tss2 createkey --path HS/SRK/tmpkey --policyPath $PATH_POL_USER --type="sign, noda" --authValue ""
+tss2 exportpolicy --path HS/SRK/tmpkey --jsonPolicy $TEMP_DIR/$POLICY_TO_BE_SIGNED_USER -f
+tss2 delete --path HS/SRK/tmpkey
+tss2 delete --path $PATH_POL_USER
+
+digest_user=`cat $TEMP_DIR/$POLICY_TO_BE_SIGNED_USER | jsonValue "digest" 1` 
+digest_user="$digest_user""0102030405"
+
+echo -n $digest_user | \
+    xxd -r -p | openssl dgst -sha256 -sign $TEMP_DIR/key_backend_priv.pem -hex | \
+    sed 's/^.* //' > signed_user_policy.sig
+
+### Sign digest of Offline Delegation Policy with key_backend_priv
+tss2 import --path $PATH_POL_OFFLINE_DELEGATION --importData $TEMP_DIR/$POLICY_OFFLINE_DELEGATION
+tss2 createkey --path HS/SRK/tmpkey --policyPath $PATH_POL_OFFLINE_DELEGATION --type="sign, noda" --authValue ""
+tss2 exportpolicy --path HS/SRK/tmpkey --jsonPolicy $TEMP_DIR/$POLICY_TO_BE_SIGNED_OFFLINE_DELEGATION -f
+tss2 delete --path HS/SRK/tmpkey
+tss2 delete --path $PATH_POL_OFFLINE_DELEGATION
+
+digest_offline_delegation=`cat $TEMP_DIR/$POLICY_TO_BE_SIGNED_OFFLINE_DELEGATION | jsonValue "digest" 1` 
+digest_offline_delegation="$digest_offline_delegation""0102030405" #"0504030201"
+
+echo -n $digest_offline_delegation | \
+    xxd -r -p | openssl dgst -sha256 -sign $TEMP_DIR/key_backend_priv.pem -hex | \
+    sed 's/^.* //' > signed_policy_offline_delegation.sig
+
+### Sign digest of Sub Policy with key_user_priv
+tss2 import --path $PATH_POL_SUB_POLICY --importData $TEMP_DIR/$POLICY_SUB_POLICY
+tss2 createkey --path HS/SRK/tmpkey --policyPath $PATH_POL_SUB_POLICY --type="sign, noda" --authValue ""
+tss2 exportpolicy --path HS/SRK/tmpkey --jsonPolicy $TEMP_DIR/$POLICY_TO_BE_SIGNED_SUB_POLICY -f
+tss2 delete --path HS/SRK/tmpkey
+tss2 delete --path $PATH_POL_SUB_POLICY
+
+digest_sub_policy=`cat $TEMP_DIR/$POLICY_TO_BE_SIGNED_SUB_POLICY | jsonValue "digest" 1` 
+digest_sub_policy="$digest_sub_policy""0102030405" #"0504030201"
+
+echo -n $digest_sub_policy | \
+    xxd -r -p | openssl dgst -sha256 -sign $TEMP_DIR/key_user_priv.pem -hex | \
+    sed 's/^.* //' > signed_policy_sub_policy.sig
+
+
+## 3.2 Create Authorized Policies from Template
+
+### Create Authorized User Policy
+POLICY_AUTH_TEMPLATE_USER=$(cat <<EOF
+    "policyAuthorizations":[
+        {
+            "type": "pem",
+            "policyRef": [ 1, 2, 3, 4, 5 ],
+            "key": "`cat $TEMP_DIR/key_backend_pub.pem`",
+            "signature": "`cat signed_user_policy.sig`"
+        }
+    ],
+EOF
+)
+
+AUTHORIZED_POLICY_TMP=""
+while read line; do
+    # reading each line
+    if [[ $search_string == $line ]]; then
+        AUTHORIZED_POLICY_TMP="$AUTHORIZED_POLICY_TMP"$'\n'"$POLICY_AUTH_TEMPLATE_USER"
+    fi
+    AUTHORIZED_POLICY_TMP="$AUTHORIZED_POLICY_TMP"$'\n'"$line"
+done < $TEMP_DIR/$POLICY_TO_BE_SIGNED_USER
+AUTHORIZED_POLICY_TMP="$AUTHORIZED_POLICY_TMP"$'\n'"}"
+
+echo "$AUTHORIZED_POLICY_TMP" > $TEMP_DIR/$POLICY_AUTHORIZED_USER
+
+
+### Create Offline Delegation und Sub Policy
+
+POLICY_AUTH_TEMPLATE_OFFLINE_DELEGATION=$(cat <<EOF
+    "policyAuthorizations":[
+        {
+            "type": "pem",
+            "policyRef": [ 1, 2, 3, 4, 5 ],
+            "key": "`cat $TEMP_DIR/key_backend_pub.pem`",
+            "signature": "`cat signed_policy_offline_delegation.sig`"
+        }
+    ],
+EOF
+)
+
+CONCATENATED_POLICY=""
+while read line; do
+    # reading each line
+    if [[ $search_string == $line ]]; then
+        CONCATENATED_POLICY="$CONCATENATED_POLICY"$'\n'"$POLICY_AUTH_TEMPLATE_OFFLINE_DELEGATION"
+    fi
+    CONCATENATED_POLICY="$CONCATENATED_POLICY"$'\n'"$line"
+done < $TEMP_DIR/$POLICY_TO_BE_SIGNED_OFFLINE_DELEGATION
+CONCATENATED_POLICY="$CONCATENATED_POLICY"$'\n'"}"
+
+echo "$CONCATENATED_POLICY" > $TEMP_DIR/$POLICY_AUTHORIZED_OFFLINE_DELEGATION
+
+POLICY_AUTH_TEMPLATE_SUB_POLICY=$(cat <<EOF
+    "policyAuthorizations":[
+        {
+            "type": "pem",
+            "policyRef": [ 1, 2, 3, 4, 5 ],
+            "key": "`cat $TEMP_DIR/key_user_pub.pem`",
+            "signature": "`cat signed_policy_sub_policy.sig`"
+        }
+    ],
+EOF
+)
+
+CONCATENATED_POLICY=""
+while read line; do
+    # reading each line
+    if [[ $search_string == $line ]]; then
+        CONCATENATED_POLICY="$CONCATENATED_POLICY"$'\n'"$POLICY_AUTH_TEMPLATE_SUB_POLICY"
+    fi
+    CONCATENATED_POLICY="$CONCATENATED_POLICY"$'\n'"$line"
+done < $TEMP_DIR/$POLICY_TO_BE_SIGNED_SUB_POLICY
+CONCATENATED_POLICY="$CONCATENATED_POLICY"$'\n'"}"
+
+echo "$CONCATENATED_POLICY" > $TEMP_DIR/$POLICY_AUTHORIZED_SUB_POLICY
+
+## 4. Authorize with authorized policies
+
+### Create some digest data to sign
+DIGEST_FILE=$TEMP_DIR/digest.file
+echo -n 01234567890123456789 > $DIGEST_FILE
+
+### Import the authorized policies
+tss2 import --path $PATH_POL_AUTHORIZED_USER --importData $TEMP_DIR/$POLICY_AUTHORIZED_USER
+tss2 import --path $PATH_POL_AUTHORIZED_OFFLINE_DELEGATION --importData $TEMP_DIR/$POLICY_AUTHORIZED_OFFLINE_DELEGATION
+tss2 import --path $PATH_POL_AUTHORIZED_SUB_POLICY --importData $TEMP_DIR/$POLICY_AUTHORIZED_SUB_POLICY
+
+## 4.1 User authorizes key usage with the user policy
+echo "User authorizes key usage with the user policy"
+
+expect -c "  
+  spawn tss2 sign --keyPath=$PATH_FEATURE_KEY_SIGN --digest=$DIGEST_FILE --signature=$TEST_SIGNATURE_FILE -f
+  expect -re \"Select a branch .*\" {
+    send \"1\r\"
+    expect \"Filename for nonce output: \" {
+      send \"$OUTPUT_FILE\r\"
+      expect \"Filename for signature input: \" {
+        exec openssl dgst -sha256 -sign $TEMP_DIR/key_user_priv.pem -out $SIGNATURE_FILE $OUTPUT_FILE
+        send \"$SIGNATURE_FILE\r\"
+      }
+    }
+    set ret [wait]
+    if {[lindex \$ret 2] || [lindex \$ret 3] != 0} {
+        send_user \"\n[lindex \$ret]\n\"
+        send_user \"Command failed\n\"
+        exit 1
+    }
+  }
+"
+
+## 4.2 Delegated User authorizes key usage with the offline delegation policy
+echo "Delegated User authorizes key usage with the offline delegation policy"
+
+expect -c "  
+    spawn tss2 sign --keyPath=$PATH_FEATURE_KEY_SIGN --digest=$DIGEST_FILE --signature=$TEST_SIGNATURE_FILE -f
+    expect -re \"Select a branch .*\" {
+      send \"2\r\"
+      expect \"Filename for nonce output: \" {
+          send \"$OUTPUT_FILE\r\"
+          expect \"Filename for signature input: \" {
+              exec openssl dgst -sha256 -sign $TEMP_DIR/key_delegated_priv.pem -out $SIGNATURE_FILE $OUTPUT_FILE
+              send \"$SIGNATURE_FILE\r\"
+          }
+      }
+      set ret [wait]
+      if {[lindex \$ret 2] || [lindex \$ret 3] != 0} {
+          send_user \"\n[lindex \$ret]\n\"
+          send_user \"Command failed 2\n\"
+          exit 1
+      }
+  }
+"
+
+exit 0


### PR DESCRIPTION
The callback function Fapi_SetSignCB for the PolicySigned command
and the corresponding integration tests were implemented.

Signed-off-by: Christian Plappert <christian.plappert@sit.fraunhofer.de>