### PR TITLE
tss2 * tools: Fix for fapi-branch-select (Backport for 4.x)

### DIFF
--- a/test/integration/fapi/fapi-branch-select.sh
+++ b/test/integration/fapi/fapi-branch-select.sh
@@ -17,7 +17,7 @@ trap cleanup EXIT
 KEY_PATH="HS/SRK/mySignKey"
 POLICY_SIGN_KEY_PATH="HS/SRK/myPolicySignKey"
 PCR_POLICY_DATA=$TEMP_DIR/pol_pcr16_0.json
-AUTHORIZE_POLICY_DATA=$TEMP_DIR/pol_authorize.json
+AUTHORIZE_POLICY_DATA=$TEMP_DIR/pol_authorize_ref.json
 POLICY_PCR=policy/pcr-policy
 POLICY_PCR2=policy/pcr-policy2
 POLICY_AUTHORIZE=policy/authorize-policy

--- a/test/integration/fapi/fapi-provision.sh
+++ b/test/integration/fapi/fapi-provision.sh
@@ -25,7 +25,7 @@ tss2_delete --path /
 
 expect <<EOF
 # Test if still objects in path
-spawn tss2_list --path
+spawn tss2_list --searchPath /
 set ret [wait]
 if {[lindex \$ret 2] || [lindex \$ret 3] != 1} {
     send_user "Still objects in path\n"


### PR DESCRIPTION
This PR fixes two issues with the tss2 * tools:

1. tss2 *: Fix integration test fapi-branch-select: With the new TSS version also PolicyRef is included into the search for valid policies. Thus, the test is adapted to include PolicyRef in the authorization policy. This should fix the errors in PR tpm2-software#2264.

2. tss2 *: Fix parameter in provision test: The provision test still had an outdated parameter.

Signed-off-by: Christian Plappert <christian.plappert@sit.fraunhofer.de>