### PR TITLE
tpm2_getekcertificate: Fix tool failing to return error/non-zero for HTTP 404

### DIFF
--- a/tools/tpm2_getekcertificate.c
+++ b/tools/tpm2_getekcertificate.c
@@ -237,6 +237,13 @@ int retrieve_endorsement_certificate(char *b64h) {
         }
     }
 
+    rc = curl_easy_setopt(curl, CURLOPT_FAILONERROR, true);
+    if (rc != CURLE_OK) {
+        LOG_ERR("curl_easy_setopt for CURLOPT_FAILONERROR failed: %s",
+                curl_easy_strerror(rc));
+        goto out_easy_cleanup;
+    }
+
     rc = curl_easy_perform(curl);
     if (rc != CURLE_OK) {
         LOG_ERR("curl_easy_perform() failed: %s", curl_easy_strerror(rc));


### PR DESCRIPTION


Signed-off-by: Imran Desai <imran.desai@intel.com>