### PR TITLE
getcap/ readpublic equivalent for displayin and configuring session info from a session context

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -198,7 +198,8 @@ tpm2_tools = \
     tools/tpm2_commit.c \
     tools/tpm2_ecdhkeygen.c \
     tools/tpm2_ecdhzgen.c \
-    tools/tpm2_zgen2phase.c
+    tools/tpm2_zgen2phase.c \
+    tools/tpm2_sessionconfig.c
 
 # Create the symlinks for each tool to the tpm2 and optional tss2 bundled executables
 install-exec-hook:
@@ -452,6 +453,7 @@ if HAVE_MAN_PAGES
     man/man1/tpm2_ecdhkeygen.1 \
     man/man1/tpm2_ecdhzgen.1 \
     man/man1/tpm2_zgen2phase.1 \
+    man/man1/tpm2_sessionconfig.1 \
     man/man1/tpm2.1
 
 if HAVE_FAPI

--- a/man/tpm2_sessionconfig.1.md
+++ b/man/tpm2_sessionconfig.1.md
@@ -1,0 +1,103 @@
+% tpm2_sessionconfig(1) tpm2-tools | General Commands Manual
+
+# NAME
+
+**tpm2_sessionconfig**(1) - Configure session attributes and print session info
+from a session file.
+
+# SYNOPSIS
+
+**tpm2_sessionconfig** [*OPTIONS*] [*ARGUMENT*]
+
+# DESCRIPTION
+
+**tpm2_sessionconfig**(1) - Configure session attributes and print session info
+from a session file. The session file used in the tpm2-tools has useful info
+about the session in addition to the encrypted-session-blob created by the TPM.
+This meta-information is added by esys library and the tpm2_session lib.
+
+The tool operates in one of two modes:
+1. Configure/ modify the session attributes.
+2. Print the session information. This is the default behavior.
+
+# OPTIONS
+
+  * **\--enable-continuesession**:
+
+    Enable continueSession in the session-attributes.
+
+  * **\--disable-continuesession**
+
+    Disable continuesession in the session-attributes.
+
+  * **\--enable-auditexclusive**
+
+    Enable auditexclusive in the session-attributes.
+
+  * **\--disable-auditexclusive**
+
+    Disable auditexclusive in the session-attributes.
+
+  * **\--enable-auditreset**
+
+    Enable  auditreset in the session-attributes.
+
+  * **\--disable-auditreset**
+
+    Disable auditreset in the session-attributes.
+
+  * **\--enable-decrypt**
+
+    Enable  decrypt in the session-attributes.
+
+  * **\--disable-decrypt**
+
+    Disable decrypt in the session-attributes.
+
+  * **\--enable-encrypt**
+
+    Enable  encrypt in the session-attributes.
+
+  * **\--disable-encrypt**
+
+    Disable encrypt in the session-attributes.
+
+  * **\--enable-audit**
+
+    Enable  audit in the session-attributes.
+
+  * **\--disable-audit**
+
+    Disable audit in the session-attributes.
+
+* **ARGUMENT** the session context file.
+
+## References
+
+[common options](common/options.md) collection of common options that provide
+information many users may expect.
+
+[common tcti options](common/tcti.md) collection of options used to configure
+the various known TCTI modules.
+
+# EXAMPLES
+
+## Start a bounded & salted session, disable continuesession and display session
+
+```bash
+
+tpm2 createprimary -c prim.ctx
+tpm2 startauthsession -S session.ctx --policy-session -c prim.ctx
+
+### Session info before changing attributes
+tpm2 sessionconfig session.ctx
+
+### Session info after changing attributes
+tpm2 sessionconfig --disable-continuesession
+tpm2 sessionconfig session.ctx
+
+```
+
+[returns](common/returns.md)
+
+[footer](common/footer.md)

--- a/test/integration/tests/sessionconfig.sh
+++ b/test/integration/tests/sessionconfig.sh
@@ -1,0 +1,40 @@
+# SPDX-License-Identifier: BSD-3-Clause
+
+source helpers.sh
+
+cleanup() {
+    rm -f session.ctx
+
+    if [ "$1" != "no-shut-down" ]; then
+        shut_down
+    fi
+}
+trap cleanup EXIT
+
+start_up
+
+cleanup "no-shut-down"
+
+# Start a session and test if session attributes can be modified
+tpm2 startauthsession -S session.ctx --policy-session
+
+## Check default session attribute has continuesession set
+DEFAULT_SESSION_ATTRIBUTE=01
+tpm2 sessionconfig session.ctx | grep sessionAttributes | awk {'print $2'} |\
+grep $DEFAULT_SESSION_ATTRIBUTE
+
+# Check if session can be marked for encryption
+SESSION_ENCRYPT_SET=41
+tpm2 sessionconfig session.ctx --enable-encrypt
+tpm2 sessionconfig session.ctx | grep sessionAttributes | awk {'print $2'} |\
+grep $SESSION_ENCRYPT_SET
+
+# Check if session can be marked for decryption
+SESSION_DECRYPT_SET=61
+tpm2 sessionconfig session.ctx --enable-decrypt
+tpm2 sessionconfig session.ctx | grep sessionAttributes | awk {'print $2'} |\
+grep $SESSION_DECRYPT_SET
+
+tpm2 flushcontext session.ctx
+
+exit 0

--- a/tools/tpm2_sessionconfig.c
+++ b/tools/tpm2_sessionconfig.c
@@ -1,0 +1,650 @@
+/* SPDX-License-Identifier: BSD-3-Clause */
+
+#include <errno.h>
+#include <inttypes.h>
+#include <stdbool.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include <tss2/tss2_mu.h>
+#include <tss2/tss2_esys.h>
+
+#include "files.h"
+#include "log.h"
+#include "tpm2.h"
+#include "tpm2_tool.h"
+
+typedef struct tpm_sessionconfig_ctx tpm_sessionconfig_ctx;
+struct tpm_sessionconfig_ctx {
+    tpm2_session *session;
+    const char *session_path;
+    TPMA_SESSION bmask;
+    TPMA_SESSION flags;
+    bool session_describe;
+};
+
+static tpm_sessionconfig_ctx ctx;
+
+/*
+ * IESYS_METADATA structures copied from esys_types.h since these are not
+ * accessible through esys header/ library.
+ */
+typedef UINT32 IESYSC_RESOURCE_TYPE_CONSTANT;
+typedef UINT32 IESYSC_PARAM_ENCRYPT;
+typedef UINT32 IESYSC_PARAM_DECRYPT;
+typedef UINT32 IESYSC_TYPE_POLICY_AUTH;
+typedef struct {
+    TPM2B_NAME                             bound_entity;
+    TPM2B_ENCRYPTED_SECRET                encryptedSalt;
+    TPM2B_DATA                                     salt;
+    TPMT_SYM_DEF                              symmetric;
+    TPMI_ALG_HASH                              authHash;
+    TPM2B_DIGEST                             sessionKey;
+    TPM2_SE                                 sessionType;
+    TPMA_SESSION                      sessionAttributes;
+    TPMA_SESSION                  origSessionAttributes;
+    TPM2B_NONCE                             nonceCaller;
+    TPM2B_NONCE                                nonceTPM;
+    IESYSC_PARAM_ENCRYPT                        encrypt;
+    IESYSC_PARAM_DECRYPT                        decrypt;
+    IESYSC_TYPE_POLICY_AUTH         type_policy_session;
+    UINT16                             sizeSessionValue;
+    BYTE                 sessionValue [2*sizeof(TPMU_HA)];
+    UINT16                                sizeHmacValue;
+} IESYS_SESSION;
+
+typedef UINT32                  IESYSC_RESOURCE_TYPE;
+typedef union {
+    TPM2B_PUBLIC                           rsrc_key_pub;
+    TPM2B_NV_PUBLIC                         rsrc_nv_pub;
+    IESYS_SESSION                          rsrc_session;
+    TPMS_EMPTY                               rsrc_empty;
+} IESYS_RSRC_UNION;
+typedef struct {
+    TPM2_HANDLE                                  handle;
+    TPM2B_NAME                                     name;
+    IESYSC_RESOURCE_TYPE                       rsrcType;
+    IESYS_RSRC_UNION                               misc;
+} IESYS_RESOURCE;
+typedef struct {
+    UINT16                                         size;
+    IESYS_RESOURCE                                 data;
+} IESYS_METADATA;
+
+#define FORMAT_NEWLINE(SZ, BUF, OFFST) \
+do { \
+    for(i = 0; i < SZ; i++) { \
+        if (i && !(i % 32)) { \
+            tpm2_tool_output("\n\t\t\t"); \
+        } \
+        tpm2_tool_output("%02x", BUF[i + OFFST]); \
+    } \
+    tpm2_tool_output("\n"); \
+} while(false)
+
+static void print_session_info(    UINT32 session_version, TPM2_SE session_type,
+TPMI_ALG_HASH session_hash_algorithm, UINT32 context_version,
+TPMS_CONTEXT context, const char *hierarchy, UINT32 iesys_reserved,
+UINT16 tpm2context_size, TPM2B_DIGEST tpm2bcontext_integrity_data,
+UINT8 *tpm2context_data_buffer, IESYS_METADATA iesys_metadata) {
+
+    tpm2_tool_output("session-version:\t%d\n", session_version);
+
+    tpm2_tool_output("session-type:\t\t%d\n", session_type);
+
+    tpm2_tool_output("session_hash_algorithm:\t%04x\n", session_hash_algorithm);
+
+    tpm2_tool_output("context-version:\t%d\n", context_version);
+    tpm2_tool_output("hierarchy:\t\t%s\n", hierarchy);
+
+    tpm2_tool_output("handle:\t\t\t%x\n", context.savedHandle);
+
+    tpm2_tool_output("sequence:\t\t%"PRIu64"\n", context.sequence);
+
+    //tpm2_tool_output("size: %d\n", context.contextBlob.size);
+    tpm2_tool_output("iesys-reserved:\t\t%08x\n", iesys_reserved);
+
+    //tpm2_tool_output("size: %d\n", tpm2context_size);
+    tpm2_tool_output("integrity-size:\t\t%d\n",
+    tpm2bcontext_integrity_data.size);
+    tpm2_tool_output("integrity-buffer:\t");
+    UINT16 i;
+    FORMAT_NEWLINE(tpm2bcontext_integrity_data.size,
+    tpm2bcontext_integrity_data.buffer, 0);
+
+    UINT16 tpm2bcontext_encrypted_data_size =
+    tpm2context_size - tpm2bcontext_integrity_data.size;
+    tpm2_tool_output("encrypted-session-data-size: %d\n",
+    tpm2bcontext_encrypted_data_size);
+
+    tpm2_tool_output("encrypted-session-data: ");
+    FORMAT_NEWLINE(tpm2bcontext_encrypted_data_size, tpm2context_data_buffer,
+    tpm2bcontext_integrity_data.size);
+
+    tpm2_tool_output("iesys-resource-handle:\t%08x\n",
+    iesys_metadata.data.handle);
+
+    tpm2_tool_output("iesys-resource-name:\t");
+    FORMAT_NEWLINE(iesys_metadata.data.name.size,
+    iesys_metadata.data.name.name, 0);
+
+    tpm2_tool_output("iesys-resource-type:\t%d\n", iesys_metadata.data.rsrcType);
+
+    tpm2_tool_output("bound_entity:\t\t");
+    FORMAT_NEWLINE(iesys_metadata.data.misc.rsrc_session.bound_entity.size,
+    iesys_metadata.data.misc.rsrc_session.bound_entity.name, 0);
+
+    tpm2_tool_output("encryptedSalt:\t");
+    FORMAT_NEWLINE(iesys_metadata.data.misc.rsrc_session.encryptedSalt.size,
+    iesys_metadata.data.misc.rsrc_session.encryptedSalt.secret, 0);
+
+    tpm2_tool_output("salt:\t");
+    FORMAT_NEWLINE(iesys_metadata.data.misc.rsrc_session.salt.size,
+    iesys_metadata.data.misc.rsrc_session.salt.buffer, 0);
+
+    tpm2_tool_output("symmetric-algorithm:\t%02x\n",
+        iesys_metadata.data.misc.rsrc_session.symmetric.algorithm);
+    tpm2_tool_output("symmetric-keybits:\t%02x\n",
+        iesys_metadata.data.misc.rsrc_session.symmetric.keyBits.sym);
+    tpm2_tool_output("symmetric-mode:\t\t%02x\n",
+        iesys_metadata.data.misc.rsrc_session.symmetric.mode.sym);
+
+    tpm2_tool_output("authHash:\t\t%02x\n",
+    iesys_metadata.data.misc.rsrc_session.authHash);
+
+    tpm2_tool_output("sessionKey:\t\t");
+    FORMAT_NEWLINE(iesys_metadata.data.misc.rsrc_session.sessionKey.size,
+    iesys_metadata.data.misc.rsrc_session.sessionKey.buffer, 0);
+
+    tpm2_tool_output("sessionType:\t\t%02x\n",
+    iesys_metadata.data.misc.rsrc_session.sessionType);
+
+    tpm2_tool_output("sessionAttributes:\t%02x\n",
+    iesys_metadata.data.misc.rsrc_session.sessionAttributes);
+
+    /*
+     * It appears origSessionAttributes was not marshalled.
+     *
+     * tpm2_tool_output("origSessionAttributes:\t%02x\n",
+     * iesys_metadata.data.misc.rsrc_session.origSessionAttributes);
+     */
+
+    tpm2_tool_output("nonceCaller:\t\t");
+    FORMAT_NEWLINE(iesys_metadata.data.misc.rsrc_session.nonceCaller.size,
+    iesys_metadata.data.misc.rsrc_session.nonceCaller.buffer, 0);
+
+    tpm2_tool_output("nonceTPM:\t\t");
+    FORMAT_NEWLINE(iesys_metadata.data.misc.rsrc_session.nonceTPM.size,
+    iesys_metadata.data.misc.rsrc_session.nonceTPM.buffer, 0);
+
+    tpm2_tool_output("encrypt:\t\t%d\n",
+    iesys_metadata.data.misc.rsrc_session.encrypt);
+
+    tpm2_tool_output("decrypt:\t\t%d\n",
+    iesys_metadata.data.misc.rsrc_session.decrypt);
+
+    tpm2_tool_output("type_policy_session:\t%d\n",
+    iesys_metadata.data.misc.rsrc_session.type_policy_session);
+
+    tpm2_tool_output("sizeSessionValue:\t%04x\n",
+    iesys_metadata.data.misc.rsrc_session.sizeSessionValue);
+
+    tpm2_tool_output("sessionValue:\t\t");
+    FORMAT_NEWLINE(iesys_metadata.data.misc.rsrc_session.sizeSessionValue,
+    iesys_metadata.data.misc.rsrc_session.sessionValue, 0);
+
+    tpm2_tool_output("sizeHmacValue:\t\t%04x\n",
+    iesys_metadata.data.misc.rsrc_session.sizeHmacValue);
+}
+
+#define ERRCHK_IESYS_UNMARSHAL(rval, result, type, buffer, size, offset, name) \
+do { \
+    rval = Tss2_MU_##type##_Unmarshal(buffer, size, &offset, &name); \
+    if (rval != TSS2_RC_SUCCESS) { \
+        LOG_ERR("Failed unmarshalling iesys metadata."); \
+        result = false; \
+        goto out; \
+    } \
+} while(false)
+
+static bool populate_iesys_session_info(FILE *fstream,
+IESYS_METADATA *iesys_metadata) {
+
+    /*
+     * Since we are reading the file stream at an offset, existing file read
+     * functions cannot return actual bytes read.
+     */
+    bool result = true;
+    uint8_t buffer[sizeof(IESYS_METADATA)] = { 0 };
+    uint16_t size = fread(buffer, 1, sizeof(IESYS_METADATA), fstream);
+    if (!size) {
+        LOG_ERR("Cannot read iesys_metadata from file.");
+        goto out;
+    }
+
+    size_t offset = 0;
+    TSS2_RC rval = TSS2_RC_SUCCESS;
+    ERRCHK_IESYS_UNMARSHAL(rval, result, UINT16, buffer, size, offset,
+    iesys_metadata->size);
+
+    ERRCHK_IESYS_UNMARSHAL(rval, result, TPM2_HANDLE, buffer, size, offset,
+    iesys_metadata->data.handle);
+
+    ERRCHK_IESYS_UNMARSHAL(rval, result, TPM2B_NAME, buffer, size, offset,
+    iesys_metadata->data.name);
+
+    ERRCHK_IESYS_UNMARSHAL(rval, result, UINT32, buffer, size, offset,
+    iesys_metadata->data.rsrcType);
+
+    ERRCHK_IESYS_UNMARSHAL(rval, result, TPM2B_NAME, buffer, size, offset,
+    iesys_metadata->data.misc.rsrc_session.bound_entity);
+
+    ERRCHK_IESYS_UNMARSHAL(rval, result, TPM2B_ENCRYPTED_SECRET, buffer, size,
+    offset, iesys_metadata->data.misc.rsrc_session.encryptedSalt);
+
+    ERRCHK_IESYS_UNMARSHAL(rval, result, TPM2B_DATA, buffer, size, offset,
+    iesys_metadata->data.misc.rsrc_session.salt);
+
+    ERRCHK_IESYS_UNMARSHAL(rval, result, TPMT_SYM_DEF, buffer, size, offset,
+    iesys_metadata->data.misc.rsrc_session.symmetric);
+
+    ERRCHK_IESYS_UNMARSHAL(rval, result, TPMI_ALG_HASH, buffer, size, offset,
+    iesys_metadata->data.misc.rsrc_session.authHash);
+
+    ERRCHK_IESYS_UNMARSHAL(rval, result, TPM2B_DIGEST, buffer, size, offset,
+    iesys_metadata->data.misc.rsrc_session.sessionKey);
+
+    ERRCHK_IESYS_UNMARSHAL(rval, result, TPM2_SE, buffer, size, offset,
+    iesys_metadata->data.misc.rsrc_session.sessionType);
+
+    ERRCHK_IESYS_UNMARSHAL(rval, result, TPMA_SESSION, buffer, size, offset,
+    iesys_metadata->data.misc.rsrc_session.sessionAttributes);
+
+    /*
+     * It appears that origSessionAttributes is not marshalled
+     *
+     * ERRCHK_IESYS_UNMARSHAL(rval, result, TPMA_SESSION, buffer, size, offset,
+       iesys_metadata->data.misc.rsrc_session.origSessionAttributes);
+    */
+
+    ERRCHK_IESYS_UNMARSHAL(rval, result, TPM2B_NONCE, buffer, size, offset,
+    iesys_metadata->data.misc.rsrc_session.nonceCaller);
+
+    ERRCHK_IESYS_UNMARSHAL(rval, result, TPM2B_NONCE, buffer, size, offset,
+    iesys_metadata->data.misc.rsrc_session.nonceTPM);
+
+    ERRCHK_IESYS_UNMARSHAL(rval, result, UINT32, buffer, size, offset,
+    iesys_metadata->data.misc.rsrc_session.encrypt);
+
+    ERRCHK_IESYS_UNMARSHAL(rval, result, UINT32, buffer, size, offset,
+    iesys_metadata->data.misc.rsrc_session.decrypt);
+
+    ERRCHK_IESYS_UNMARSHAL(rval, result, UINT32, buffer, size, offset,
+    iesys_metadata->data.misc.rsrc_session.type_policy_session);
+
+    ERRCHK_IESYS_UNMARSHAL(rval, result, UINT16, buffer, size, offset,
+    iesys_metadata->data.misc.rsrc_session.sizeSessionValue);
+
+    size_t sessionval_size =
+    iesys_metadata->data.misc.rsrc_session.sizeSessionValue;
+    memcpy(&iesys_metadata->data.misc.rsrc_session.sessionValue[0],
+    buffer + offset, sessionval_size);
+    offset += sessionval_size;
+
+    ERRCHK_IESYS_UNMARSHAL(rval, result, UINT16, buffer, size, offset,
+    iesys_metadata->data.misc.rsrc_session.sizeHmacValue);
+
+out:
+    return result;
+}
+
+static tool_rc populate_tpm2_session_info(FILE *fstream,
+UINT16 *tpm2context_size, TPM2B_DIGEST *tpm2bcontext_integrity_data,
+UINT8 **tpm2context_data_buffer) {
+
+    bool result = files_read_16(fstream, tpm2context_size);
+    if (!result) {
+        LOG_ERR("Error reading tpm2 context size!");
+        return false;
+    }
+
+    *tpm2context_data_buffer = malloc(*tpm2context_size + sizeof(UINT16));
+    result = files_read_bytes(fstream, *tpm2context_data_buffer,
+    *tpm2context_size);
+    if (!result) {
+        LOG_ERR("Error reading tpm2 context data!");
+        return false;
+    }
+
+    /*
+     * Cannot use Tss2_MU_TPMS_CONTEXT_DATA_Unmarshal because SESSION structure
+     * created by the TPM does not give the size of the encrypted member of the
+     * TPMS_CONTEXT_DATA
+     */
+    size_t offset = 0;
+    TSS2_RC rval = Tss2_MU_TPM2B_DIGEST_Unmarshal(*tpm2context_data_buffer,
+    *tpm2context_size, &offset, tpm2bcontext_integrity_data);
+    if (rval != TSS2_RC_SUCCESS) {
+        LOG_ERR("Error reading TPMS_CONTEXT_DATA.");
+        LOG_PERR(Tss2_MU_TPM2B_DIGEST_Unmarshal, rval);
+        return false;
+    }
+
+    return true;
+}
+
+static bool populate_tpm2_tools_session_info(FILE *fstream,
+UINT32 *session_version, TPM2_SE *session_type,
+TPMI_ALG_HASH *session_hash_algorithm, UINT32 *context_version,
+TPMS_CONTEXT *context, const char *hierarchy, UINT32 *iesys_reserved) {
+
+    bool result = files_read_header(fstream, session_version);
+    if (!result) {
+        LOG_ERR("Session data does not have a proper header.");
+        return false;
+    }
+
+    result = files_read_bytes(fstream, session_type, sizeof(TPM2_SE));
+    if (!result) {
+        LOG_ERR("Session type information not available.");
+        return false;
+    }
+
+    result = files_read_16(fstream, session_hash_algorithm);
+    if (!result) {
+        LOG_ERR("Session hash algorithm information not available.");
+        return false;
+    }
+
+    result = files_read_header(fstream, context_version);
+    if (!result) {
+        /* Only latest version of session context format supported */
+        LOG_ERR("Session data does not have a proper header.");
+        return false;
+    }
+
+    result = files_read_32(fstream, &context->hierarchy);
+    if (!result) {
+        LOG_ERR("Error reading hierarchy!");
+        return false;
+    }
+    switch (context->hierarchy) {
+    case TPM2_RH_OWNER:
+        hierarchy = "owner";
+        break;
+    case TPM2_RH_PLATFORM:
+        hierarchy = "platform";
+        break;
+    case TPM2_RH_ENDORSEMENT:
+        hierarchy = "endorsement";
+        break;
+    case TPM2_RH_NULL:
+    default:
+        hierarchy = "null";
+        break;
+    }
+    /*
+     * The assignment of a string to hierarchy is complete with the switch above
+     * and it is being referenced in the final step of printing out the session
+     * information. However, clang assumes that the value assigned to hierarchy
+     * is never used; hence the redundant check below.
+     */
+    if (!hierarchy) {
+        return false;
+    }
+
+    result = files_read_32(fstream, &context->savedHandle);
+    if (!result) {
+        LOG_ERR("Error reading savedHandle!");
+        return false;
+    }
+
+    result = files_read_64(fstream, &context->sequence);
+    if (!result) {
+        LOG_ERR("Error reading sequence!");
+        return false;
+    }
+
+    result = files_read_16(fstream, &context->contextBlob.size);
+    if (!result) {
+        LOG_ERR("Error reading contextBlob.size!");
+        return false;
+    }
+
+    if (context->contextBlob.size > sizeof(context->contextBlob.buffer)) {
+        LOG_ERR("Size mismatch found on contextBlob, got %"PRIu16" expected "
+                "less than or equal to %zu", context->contextBlob.size,
+                sizeof(context->contextBlob.buffer));
+        return false;
+    }
+
+    result = files_read_32(fstream, iesys_reserved);
+    if (!result) {
+        LOG_ERR("Error reading iesys reserved area!");
+        return false;
+    }
+
+    return true;
+}
+
+/*
+ * Note:
+ *
+ * esys adds meta information to the context blob in addition to what
+ * the TPM already specifies.
+ *
+ * esys data from file has been deserialized @ tpm2_session_restore
+ * But we will parse the file to evaluate the session structure in the file.
+ *
+ * Only latest version of session/ context format supported
+ */
+static tool_rc describe_session(void) {
+
+    FILE *fstream = fopen(ctx.session_path, "rb");
+    if (!fstream) {
+        LOG_ERR("Couldn't open session file.");
+        return tool_rc_general_error;
+    }
+
+    /* Populate session info from tpm2-tools */
+    UINT32 session_version;
+    TPM2_SE session_type;
+    TPMI_ALG_HASH session_hash_algorithm;
+    UINT32 context_version;
+    TPMS_CONTEXT context;
+    const char *hierarchy = "null";
+    UINT32 iesys_reserved;
+    bool result = populate_tpm2_tools_session_info(fstream, &session_version,
+    &session_type, &session_hash_algorithm, &context_version, &context,
+    hierarchy, &iesys_reserved);
+    if (!result) {
+        goto out2;
+    }
+
+    /* Populate session info from tpm2-sim */
+    UINT16 tpm2context_size;
+    TPM2B_DIGEST tpm2bcontext_integrity_data = {0};
+    UINT8 *tpm2context_data_buffer = 0;
+    result = populate_tpm2_session_info(fstream, &tpm2context_size,
+    &tpm2bcontext_integrity_data, &tpm2context_data_buffer);
+    if (!result) {
+        goto out1;
+    }
+
+    /* Populate session info from iesys */
+    IESYS_METADATA iesys_metadata = { 0 };
+    result = populate_iesys_session_info(fstream, &iesys_metadata);
+    if (!result) {
+        goto out1;
+    }
+
+    print_session_info(session_version, session_type, session_hash_algorithm,
+    context_version, context, hierarchy, iesys_reserved, tpm2context_size,
+    tpm2bcontext_integrity_data, tpm2context_data_buffer, iesys_metadata);
+
+out1:
+    free(tpm2context_data_buffer);
+out2:
+    fclose(fstream);
+    return result ? tool_rc_success : tool_rc_general_error;
+}
+
+static tool_rc process_output(ESYS_CONTEXT *esys_context) {
+
+    /* bmask is set when modifying session attributes */
+    if (ctx.bmask) {
+        ESYS_TR sessionhandle = tpm2_session_get_handle(ctx.session);
+        if (!sessionhandle) {
+            LOG_ERR("Session handle cannot be null");
+            return tool_rc_general_error;
+        }
+
+        return Esys_TRSess_SetAttributes(esys_context, sessionhandle, ctx.flags,
+        ctx.bmask);
+    }
+
+    return describe_session();
+}
+
+static tool_rc process_input(ESYS_CONTEXT *esys_context) {
+
+    /*
+     * Inferring session info before/ after changing the attributes can be a
+     * subjective choice. So allowing only one operation at a time.
+     */
+    if (ctx.bmask && ctx.session_describe) {
+        LOG_ERR("Specify option to describe session or modify it, not both.");
+        return tool_rc_option_error;
+    }
+
+    /* If no options are specified default to describing the session */
+    if (!ctx.bmask && !ctx.session_describe) {
+        ctx.session_describe = true;
+    }
+
+    tool_rc rc = tpm2_session_restore(esys_context, ctx.session_path, false,
+    &ctx.session);
+    if (rc != tool_rc_success) {
+        LOG_ERR("Could not restore session from the specified file");
+        return rc;
+    }
+
+    return tool_rc_success;
+}
+
+static bool on_option(char key, char *value) {
+
+    UNUSED(value);
+
+    switch (key) {
+        case 0:
+            ctx.bmask |= TPMA_SESSION_CONTINUESESSION;
+            ctx.flags |= TPMA_SESSION_CONTINUESESSION;
+            break;
+        case 1:
+            ctx.bmask |= TPMA_SESSION_CONTINUESESSION;
+            break;
+        case 2:
+            ctx.bmask |= TPMA_SESSION_AUDITEXCLUSIVE;
+            ctx.flags |= TPMA_SESSION_AUDITEXCLUSIVE;
+            break;
+        case 3:
+            ctx.bmask |= TPMA_SESSION_AUDITEXCLUSIVE;
+            break;
+        case 4:
+            ctx.bmask |= TPMA_SESSION_AUDITRESET;
+            ctx.flags |= TPMA_SESSION_AUDITRESET;
+            break;
+        case 5:
+            ctx.bmask |= TPMA_SESSION_AUDITRESET;
+            break;
+        case 6:
+            ctx.bmask |= TPMA_SESSION_DECRYPT;
+            ctx.flags |= TPMA_SESSION_DECRYPT;
+            break;
+        case 7:
+            ctx.bmask |= TPMA_SESSION_DECRYPT;
+            break;
+        case 8:
+            ctx.bmask |= TPMA_SESSION_ENCRYPT;
+            ctx.flags |= TPMA_SESSION_ENCRYPT;
+            break;
+        case 9:
+            ctx.bmask |= TPMA_SESSION_ENCRYPT;
+            break;
+        case 10:
+            ctx.bmask |= TPMA_SESSION_AUDIT;
+            ctx.flags |= TPMA_SESSION_AUDIT;
+            break;
+        case 11:
+            ctx.bmask |= TPMA_SESSION_AUDIT;
+            break;
+        case 12:
+            ctx.session_describe = true;
+            break;
+    }
+
+    return true;
+}
+
+static bool on_args(int argc, char **argv) {
+
+    if (argc > 1 || !argc) {
+        LOG_ERR("Argument takes one file name for session data");
+        return false;
+    }
+
+    ctx.session_path = argv[0];
+
+    return true;
+}
+
+static bool tpm2_tool_onstart(tpm2_options **opts) {
+
+    const struct option topts[] = {
+        { "enable-continuesession",  no_argument, NULL, 0  },
+        { "disable-continuesession", no_argument, NULL, 1  },
+        { "enable-auditexclusive",   no_argument, NULL, 2  },
+        { "disable-auditexclusive",  no_argument, NULL, 3  },
+        { "enable-auditreset",       no_argument, NULL, 4  },
+        { "disable-auditreset",      no_argument, NULL, 5  },
+        { "enable-decrypt",          no_argument, NULL, 6  },
+        { "disable-decrypt",         no_argument, NULL, 7  },
+        { "enable-encrypt",          no_argument, NULL, 8  },
+        { "disable-encrypt",         no_argument, NULL, 9  },
+        { "enable-audit",            no_argument, NULL, 10 },
+        { "disable-audit",           no_argument, NULL, 11 },
+    };
+
+    *opts = tpm2_options_new(NULL, ARRAY_LEN(topts), topts, on_option, on_args,
+    0);
+
+    return *opts != NULL;
+}
+
+static tool_rc tpm2_tool_onrun(ESYS_CONTEXT *esys_context,
+tpm2_option_flags flags) {
+
+    UNUSED(flags);
+
+    tool_rc rc = process_input(esys_context);
+    if(rc != tool_rc_success) {
+        return rc;
+    }
+
+    return process_output(esys_context);
+    /*
+     * Disabling continuesession should flush the session after use.
+     */
+}
+
+static tool_rc tpm2_tool_onstop(ESYS_CONTEXT *esys_context) {
+
+    UNUSED(esys_context);
+    return tpm2_session_close(&ctx.session);
+}
+
+// Register this tool with tpm2_tool.c
+TPM2_TOOL_REGISTER("sessionconfig", tpm2_tool_onstart, tpm2_tool_onrun,
+tpm2_tool_onstop, NULL)


### PR DESCRIPTION
tools/tpm2_sessionconfig: Add tool to display and configure session
Signed-off-by: Imran Desai <imran.desai@intel.com>

```bash

tpm2_createprimary -c prim.ctx -p "primepass"
tpm2_startauthsession -S session.ctx --policy-session -c prim.ctx

tpm2_sessionconfig session.ctx

session-version:        2
session-type:           1
session_hash_algorithm: 000b
context-version:        1
hierarchy:              null
handle:                 0x3000000
sequence:               55
iesys-reserved:         00000000
integrity-size:         64
integrity-buffer:       8CA5368AD816EF4E95D65B43D0CA0A426A7B9E6A6558DFB373B1A1C98460CBFA
                        C2BD8B0D770742ECC05B4955324C43E6DA5F31E52F9C37B5208ADF8E7AD4B28F
encrypted-session-data-size: 322
encrypted-session-data: B28F137B5A4040A225D69877DF70555143AA29FEF700E8B9E3A2AE572103525F
                        9EC1595D7ECDA171D117C52F89BB12E7F1C72F544AA953F89E62A705B751307A
                        A59AFC2F707B1EF54EB2714F3488790A42B5B60885E0126F1B0F4B1F85F74418
                        FB296BF5A024BCC84AABDC7E8EBB7D599624F5BEF94268BE5084B29A37B67E10
                        9EFD9AFECE363D5C33AB252265F7FE8DC7C6A582A30ABED3516D4CDB4E19DBAC
                        4A92128C37859F40391D63EB5F0835419C7752BB1E3E4953E84442F165C20529
                        DAC58A113002C34B96FEDD1D4E207F9264167C7FE1BE441123CA2ABD7CE54A5C
                        694490B7820857E7D4ADA8F583D1383C78CC19B90441FDD23D159A074929A7FD
                        A93977A9DDE99F8DFC176A329C0303E8081FD4CF696FA51795F3E782025D9AEA
                        16350D0686638D040486F1BE1322C4AC838396C9B98D7976A0C89EE946B84530
                        525D
iesys-resource-handle:  03000000
iesys-resource-name:    03000000
iesys-resource-type:    3
bound_entity:           000B856BE6266FA3176C9190C4160020CFD6C7F175B20D34DEE1F139A28D3E36
                        AF1F000000000000000000000000000000000000000000000000000000000000
                        00000000
encryptedSalt:
salt:
symmetric-algorithm:    06
symmetric-keybits:      80
symmetric-mode:         43
authHash:               0B
sessionKey:             614A850E4C054CDF0EDFB16ABFD06CBAD3E24B2FB6D9BE6C493B7DA9D751F4EA
sessionType:            01
sessionAttributes:      61
nonceCaller:            107EB4C679229945D6B4C01BFAF2C50DF5C0205C2957DCB8943BCC1BF9A88F58
nonceTPM:               898BB009301B41FB0AEDEFBF8FAC194F35BE8E4746F1B5ADFA9C1E40DC162620
encrypt:                0
decrypt:                0
type_policy_session:    0
sizeSessionValue:       0000
sessionValue:
sizeHmacValue:          0000
```