### PR TITLE
Don't assume end of argv is NULL

### DIFF
--- a/lib/tpm2_options.c
+++ b/lib/tpm2_options.c
@@ -300,7 +300,7 @@ tpm2_option_code tpm2_handle_options(int argc, char **argv,
             if (argv[optind - 1]) {
                 if (!strcmp(argv[optind - 1], "--help=no-man") ||
                     !strcmp(argv[optind - 1], "-h=no-man") ||
-                    (argv[optind] && !strcmp(argv[optind], "no-man"))) {
+                    (argc < optind && !strcmp(argv[optind], "no-man"))) {
                     manpager = false;
                     optind++;
                 /*
@@ -309,7 +309,7 @@ tpm2_option_code tpm2_handle_options(int argc, char **argv,
                  */
                 } else if (!strcmp(argv[optind - 1], "--help=man") ||
                            !strcmp(argv[optind - 1], "-h=man") ||
-                           (argv[optind] && !strcmp(argv[optind], "man"))) {
+                           (argc < optind && !strcmp(argv[optind], "man"))) {
                     manpager = true;
                     explicit_manpager = true;
                     optind++;
@@ -318,7 +318,7 @@ tpm2_option_code tpm2_handle_options(int argc, char **argv,
                      * argv[0] = "tool name"
                      * argv[1] = "--help" argv[2] = 0
                      */
-                    if (!argv[optind] && argc == 2) {
+                    if (optind >= argc && argc == 2) {
                         manpager = false;
                     } else {
                         /*


### PR DESCRIPTION
On a musl based system argv[optind] && strcmp(...) where optind > argc might read random memory and segfault.

