### PR TITLE
Fix tpm2_checkquote build on 32b little-endian platforms

### DIFF
--- a/tools/misc/tpm2_checkquote.c
+++ b/tools/misc/tpm2_checkquote.c
@@ -269,7 +269,7 @@ static bool parse_selection_data_from_file(FILE *pcr_input,
 
     if (le64toh(pcrs->count) > ARRAY_LEN(pcrs->pcr_values)) {
         LOG_ERR("Malformed PCR file, pcr count cannot be greater than %zu, got: %" PRIu64 " ",
-                ARRAY_LEN(pcrs->pcr_values), le64toh(pcrs->count));
+                ARRAY_LEN(pcrs->pcr_values), le64toh((UINT64)pcrs->count));
         return false;
     }
 


### PR DESCRIPTION
The build fails for example on the RaspberryPI.
tools/misc/tpm2_checkquote.c:271:17: error: format ‘%llu’ expects argument of type
‘long long unsigned int’, but argument 6 has type ‘size_t {aka unsigned int}’

When size_t is 32-bit and when le64toh() is just a fall-through with no
type change, we need an explicit cast to match the PRIu64 specifier.