### PR TITLE
tpm2_eventlog differentiate parsed events vs. unparsed and better handle parsed strings that could consistent multiple lines

### DIFF
--- a/lib/tpm2_eventlog_yaml.c
+++ b/lib/tpm2_eventlog_yaml.c
@@ -210,9 +210,8 @@ static bool yaml_uefi_post_code(const TCG_EVENT2* const event) {
                          blob->BlobLength);
     } else { // otherwise, we treat it as an ASCII string
         const char* const data = (const char *) event->Event;
-        tpm2_tool_output("    Event:\n"
-                         "      Action: |-\n"
-                         "        %.*s\n", (int) len, data);
+        tpm2_tool_output("    Event: |-\n"
+                         "      %.*s\n", (int) len, data);
 
     }
     return true;
@@ -256,9 +255,8 @@ bool yaml_uefi_platfwblob(UEFI_PLATFORM_FIRMWARE_BLOB *data) {
 /* TCG PC Client PFP section 9.4.4 */
 bool yaml_uefi_action(UINT8 const *action, size_t size) {
 
-    tpm2_tool_output("    Event:\n"
-                     "      Action: |-\n"
-                     "        %.*s\n", (int) size, action);
+    tpm2_tool_output("    Event: |-\n"
+                     "      %.*s\n", (int) size, action);
 
     return true;
 }

--- a/lib/tpm2_eventlog_yaml.c
+++ b/lib/tpm2_eventlog_yaml.c
@@ -210,7 +210,10 @@ static bool yaml_uefi_post_code(const TCG_EVENT2* const event) {
                          blob->BlobLength);
     } else { // otherwise, we treat it as an ASCII string
         const char* const data = (const char *) event->Event;
-        tpm2_tool_output("    Event: '%.*s'\n", (int) len, data);
+        tpm2_tool_output("    Event:\n"
+                         "      Action: |-\n"
+                         "        %.*s\n", (int) len, data);
+
     }
     return true;
 }
@@ -253,7 +256,9 @@ bool yaml_uefi_platfwblob(UEFI_PLATFORM_FIRMWARE_BLOB *data) {
 /* TCG PC Client PFP section 9.4.4 */
 bool yaml_uefi_action(UINT8 const *action, size_t size) {
 
-    tpm2_tool_output("    Event: '%.*s'\n", (int) size, action);
+    tpm2_tool_output("    Event:\n"
+                     "      Action: |-\n"
+                     "        %.*s\n", (int) size, action);
 
     return true;
 }
@@ -266,7 +271,7 @@ bool yaml_uefi_action(UINT8 const *action, size_t size) {
 bool yaml_ipl(UINT8 const *description, size_t size) {
 
     tpm2_tool_output("    Event:\n"
-                     "      String: |\n");
+                     "      String: |-\n");
 
     /* We need to handle when description contains multiple lines. */
     size_t i, j;


### PR DESCRIPTION
Now that more types of events are parsed, it would be nice to be able to differentiate (by a human or by a script) eventlog entries that are parsed vs. unparsed. One possible way is to look at the the data type of what is after `Event: `. If it's a string, then it's unparsed. Otherwise, it's parsed.

Additionally, added yaml annotation to handle parsed strings that could consist multiple lines. 