### PR TITLE
tpm2_eventlog: Parse keys used for secure boot (i.e., PK, KEK, db, dbx)

### DIFF
--- a/lib/efi_event.h
+++ b/lib/efi_event.h
@@ -156,4 +156,24 @@ typedef struct {
     UEFI_PARTITION_ENTRY Partitions[];
 } PACKED UEFI_GPT_DATA;
 
+/*
+ * An UEFI signature database is represented as a concatenated list of
+ * EFI_SIGNATURE_LIST, which contains one or more EFI_SIGNATURE_DATA. These
+ * structs are described in more details in UEFI Spec Section 32.4.1
+ */
+typedef struct {
+    BYTE SignatureType[16];
+    UINT32 SignatureListSize;
+    UINT32 SignatureHeaderSize;
+    UINT32 SignatureSize;
+    // BYTE SignatureHeader[SignatureHeaderSize];
+    // BYTE Signatures[][SignatureSize];
+} PACKED EFI_SIGNATURE_LIST;
+
+typedef struct {
+    BYTE SignatureOwner[16];
+    BYTE SignatureData[];
+} PACKED EFI_SIGNATURE_DATA;
+
+
 #endif

--- a/lib/tpm2_eventlog_yaml.h
+++ b/lib/tpm2_eventlog_yaml.h
@@ -11,7 +11,7 @@
 char const *eventtype_to_string (UINT32 event_type);
 void yaml_event2hdr(TCG_EVENT_HEADER2 const *event_hdr, size_t size);
 bool yaml_digest2(TCG_DIGEST2 const *digest, size_t size);
-bool yaml_uefi_var_unicodename(UEFI_VARIABLE_DATA *data);
+char *yaml_uefi_var_unicodename(UEFI_VARIABLE_DATA *data);
 bool yaml_event2data(TCG_EVENT2 const *event, UINT32 type);
 bool yaml_digest2_callback(TCG_DIGEST2 const *digest, size_t size, void *data);
 bool yaml_event2hdr_callback(TCG_EVENT_HEADER2 const *event_hdr, size_t size,


### PR DESCRIPTION
In the secureboot mode, the eventlog contains various keys (e.g., PK, KEK, db, and dbx) used to perform boot-time verification. For anyone doing attestation of the eventlog, it would be useful to verify that the keys are genuine. In the current state, the keys are part of a blob. This PR allows the keys (and other fields) to be parsed out separately, resulting in something like the following:

```
  - EventNum: 4
    PCRIndex: 7
    EventType: EV_EFI_VARIABLE_DRIVER_CONFIG
    DigestCount: 2
    Digests:
      - AlgorithmId: sha1
        Digest: "74695203091adbb40c8420f1b499a6ac1a723962"
      - AlgorithmId: sha256
        Digest: "b161e0347f5f040997f97ff52642d43b3a87b986dae8d776d6af27e6468675e6"
    EventSize: 1011
    Event:
      VariableName: 61dfe48b-ca93-d211-aa0d-00e098032b8c
      UnicodeNameLength: 2
      VariableDataLength: 975
      UnicodeName: PK
      VariableData:
      - SignatureType: a159c0a5-e494-a74a-87b5-ab155c2bf072
        SignatureListSize: 975
        SignatureHeaderSize: 0
        SignatureSize: 947
        Keys:
        - SignatureOwner: 5148dc26-5f19-e14a-9a19-fbf883bbb35e
          SignatureData: 3082039f30820287a00302010202103b98c74f9010d1a94c4383363dced485300d06092a864886f70d01010b05003072310c300a06035504061303555341310b300906035504080c0243413111300f06035504070c0853616e204a6f736531223020060355040a0c195375706572204d6963726f20436f6d707574657220496e632e311e301c06035504030c1553555045524d4943524f20504b2043412032303138301e170d3138313232303031343630345a170d3333313232303031353630335a3072310c300a06035504061303555341310b300906035504080c0243413111300f06035504070c0853616e204a6f736531223020060355040a0c195375706572204d6963726f20436f6d707574657220496e632e311e301c06035504030c1553555045524d4943524f20504b204341203230313830820122300d06092a864886f70d01010105000382010f003082010a0282010100b398bfed1fc069518e4daa9129ce319e1b628e022a15e4271bdace95eae234b9f35d5f41aef62b1d04655206371b2b10ad6a750efaee87d6785755c579986e3936a4eb1769eee7335bc2f0f9e596fbc7ee21db41f5a48a621983a3cb16ab74142c0b586272d0f9e2c95b3176ea0659ba37e43bca8f58b115f9a6cb718cb92269483f735763d5ca54e9ae894b3c4bb7b81ad666d88eee177cd96826d2b4721ccdcb3abd2e14a1941a0be7543b17eb944be4a23490939e50aa5e4dfb1f3491d4506f13a0a5104980cd9b8e452b7ec1b49285c768b2652f58287ccb95090810370a8cb5b5c41840a7ad87b2efa5c29404858802e7fa2be41707b5557e312a65fbad0203010001a331302f300e0603551d0f0101ff040403020186301d0603551d0e041604142f7f6b38d83ab463442ae8edd4f1ceba35688388300d06092a864886f70d01010b050003820101002ae10c936dc7137242fa482ffaef28320b39dd00e43e962a31fa33561b615bf80c7df84d18dbfacca8726595a214cb906028dc0a5b723a9d0e9c6583482224498930b40bf39eafbd5b938db74dec4ab46fe5a435e1f57841181d600b7dfc79de431bf9e916de1e22cd627781759bc07de67c1fab878cf7b978678697c47e2c32f2a273d650cbc446a93a18aa3a1e61086034c58cebb61ccf2081ab7bfcb0d8a582dda9139765e08e62004caa252afd665dedda4e47c29dd5fc69f1aaa6b32d66e0e70b98621e3f0c8f2c665355a987fbbf5f1c0e474c8af8d13d1e87c0ffc64ef39a03995e519fbd84f0760e1ae0973b8cf010386b4bca17fc1105b3b8b2c305
```

The file `test/integration/fixtures/event-postcode.bin` is used for the example shown above. 