### PR TITLE
tpm2_eventlog: parse secureboot variable

### DIFF
--- a/lib/tpm2_eventlog.c
+++ b/lib/tpm2_eventlog.c
@@ -273,7 +273,8 @@ bool foreach_sha1_log_event(tpm2_eventlog_context *ctx, TCG_EVENT const *eventhd
 
         /* event data callback */
         if (ctx->event2_cb != NULL) {
-            ret = ctx->event2_cb(event, eventhdr->eventType, ctx->data);
+            ret = ctx->event2_cb(event, eventhdr->eventType, ctx->data,
+                                 ctx->yaml_version);
             if (ret != true) {
                 return false;
             }
@@ -443,7 +444,7 @@ bool foreach_event2(tpm2_eventlog_context *ctx, TCG_EVENT_HEADER2 const *eventhd
 
         /* event data callback */
         if (ctx->event2_cb != NULL) {
-            ret = ctx->event2_cb(event, eventhdr->EventType, ctx->data);
+            ret = ctx->event2_cb(event, eventhdr->EventType, ctx->data, ctx->yaml_version);
             if (ret != true) {
                 return false;
             }

--- a/lib/tpm2_eventlog.c
+++ b/lib/tpm2_eventlog.c
@@ -274,7 +274,7 @@ bool foreach_sha1_log_event(tpm2_eventlog_context *ctx, TCG_EVENT const *eventhd
         /* event data callback */
         if (ctx->event2_cb != NULL) {
             ret = ctx->event2_cb(event, eventhdr->eventType, ctx->data,
-                                 ctx->yaml_version);
+                                 ctx->eventlog_version);
             if (ret != true) {
                 return false;
             }
@@ -444,7 +444,7 @@ bool foreach_event2(tpm2_eventlog_context *ctx, TCG_EVENT_HEADER2 const *eventhd
 
         /* event data callback */
         if (ctx->event2_cb != NULL) {
-            ret = ctx->event2_cb(event, eventhdr->EventType, ctx->data, ctx->yaml_version);
+            ret = ctx->event2_cb(event, eventhdr->EventType, ctx->data, ctx->eventlog_version);
             if (ret != true) {
                 return false;
             }

--- a/lib/tpm2_eventlog.h
+++ b/lib/tpm2_eventlog.h
@@ -14,7 +14,7 @@ typedef bool (*DIGEST2_CALLBACK)(TCG_DIGEST2 const *digest, size_t size,
 typedef bool (*EVENT2_CALLBACK)(TCG_EVENT_HEADER2 const *event_hdr, size_t size,
                                 void *data);
 typedef bool (*EVENT2DATA_CALLBACK)(TCG_EVENT2 const *event, UINT32 type,
-                                    void *data);
+                                    void *data, int32_t yaml_version);
 typedef bool (*SPECID_CALLBACK)(TCG_EVENT const *event, void *data);
 typedef bool (*LOG_EVENT_CALLBACK)(TCG_EVENT const *event_hdr, size_t size,
                                    void *data);
@@ -37,6 +37,7 @@ typedef struct {
     uint8_t sha384_pcrs[TPM2_MAX_PCRS][TPM2_SHA384_DIGEST_SIZE];
     uint8_t sha512_pcrs[TPM2_MAX_PCRS][TPM2_SHA512_DIGEST_SIZE];
     uint8_t sm3_256_pcrs[TPM2_MAX_PCRS][TPM2_SM3_256_DIGEST_SIZE];
+    int32_t yaml_version;
 } tpm2_eventlog_context;
 
 bool digest2_accumulator_callback(TCG_DIGEST2 const *digest, size_t size,

--- a/lib/tpm2_eventlog.h
+++ b/lib/tpm2_eventlog.h
@@ -14,7 +14,7 @@ typedef bool (*DIGEST2_CALLBACK)(TCG_DIGEST2 const *digest, size_t size,
 typedef bool (*EVENT2_CALLBACK)(TCG_EVENT_HEADER2 const *event_hdr, size_t size,
                                 void *data);
 typedef bool (*EVENT2DATA_CALLBACK)(TCG_EVENT2 const *event, UINT32 type,
-                                    void *data, int32_t yaml_version);
+                                    void *data, uint32_t eventlog_version);
 typedef bool (*SPECID_CALLBACK)(TCG_EVENT const *event, void *data);
 typedef bool (*LOG_EVENT_CALLBACK)(TCG_EVENT const *event_hdr, size_t size,
                                    void *data);
@@ -37,7 +37,7 @@ typedef struct {
     uint8_t sha384_pcrs[TPM2_MAX_PCRS][TPM2_SHA384_DIGEST_SIZE];
     uint8_t sha512_pcrs[TPM2_MAX_PCRS][TPM2_SHA512_DIGEST_SIZE];
     uint8_t sm3_256_pcrs[TPM2_MAX_PCRS][TPM2_SM3_256_DIGEST_SIZE];
-    int32_t yaml_version;
+    uint32_t eventlog_version;
 } tpm2_eventlog_context;
 
 bool digest2_accumulator_callback(TCG_DIGEST2 const *digest, size_t size,

--- a/lib/tpm2_eventlog_yaml.h
+++ b/lib/tpm2_eventlog_yaml.h
@@ -12,12 +12,13 @@ char const *eventtype_to_string (UINT32 event_type);
 void yaml_event2hdr(TCG_EVENT_HEADER2 const *event_hdr, size_t size);
 bool yaml_digest2(TCG_DIGEST2 const *digest, size_t size);
 char *yaml_uefi_var_unicodename(UEFI_VARIABLE_DATA *data);
-bool yaml_event2data(TCG_EVENT2 const *event, UINT32 type);
+bool yaml_event2data(TCG_EVENT2 const *event, UINT32 type, INT32 yaml_version);
 bool yaml_digest2_callback(TCG_DIGEST2 const *digest, size_t size, void *data);
 bool yaml_event2hdr_callback(TCG_EVENT_HEADER2 const *event_hdr, size_t size,
                              void *data);
-bool yaml_event2data_callback(TCG_EVENT2 const *event, UINT32 type, void *data);
+bool yaml_event2data_callback(TCG_EVENT2 const *event, UINT32 type, void *data,
+                              INT32 yaml_version);
 
-bool yaml_eventlog(UINT8 const *eventlog, size_t size);
+bool yaml_eventlog(UINT8 const *eventlog, size_t size, INT32 yaml_version);
 
 #endif

--- a/lib/tpm2_eventlog_yaml.h
+++ b/lib/tpm2_eventlog_yaml.h
@@ -8,17 +8,20 @@
 #include "efi_event.h"
 #include "tpm2_eventlog.h"
 
+#define MIN_EVLOG_YAML_VERSION 1
+#define MAX_EVLOG_YAML_VERSION 2
+
 char const *eventtype_to_string (UINT32 event_type);
 void yaml_event2hdr(TCG_EVENT_HEADER2 const *event_hdr, size_t size);
 bool yaml_digest2(TCG_DIGEST2 const *digest, size_t size);
 char *yaml_uefi_var_unicodename(UEFI_VARIABLE_DATA *data);
-bool yaml_event2data(TCG_EVENT2 const *event, UINT32 type, INT32 yaml_version);
+bool yaml_event2data(TCG_EVENT2 const *event, UINT32 type, uint32_t eventlog_version);
 bool yaml_digest2_callback(TCG_DIGEST2 const *digest, size_t size, void *data);
 bool yaml_event2hdr_callback(TCG_EVENT_HEADER2 const *event_hdr, size_t size,
                              void *data);
 bool yaml_event2data_callback(TCG_EVENT2 const *event, UINT32 type, void *data,
-                              INT32 yaml_version);
+                              uint32_t eventlog_version);
 
-bool yaml_eventlog(UINT8 const *eventlog, size_t size, INT32 yaml_version);
+bool yaml_eventlog(UINT8 const *eventlog, size_t size, uint32_t eventlog_version);
 
 #endif

--- a/test/unit/test_tpm2_eventlog_yaml.c
+++ b/test/unit/test_tpm2_eventlog_yaml.c
@@ -64,14 +64,23 @@ static void test_yaml_digest2_callback(void **state) {
     digest->AlgorithmId = TPM2_ALG_SHA1;
     assert_true(yaml_digest2_callback(digest, TPM2_SHA1_DIGEST_SIZE, &count));
 }
-static void test_yaml_event2data(void **state) {
+static void test_yaml_event2data_version1(void **state) {
 
     (void)state;
     uint8_t buf [sizeof(TCG_EVENT2) + 6];
     TCG_EVENT2 *event = (TCG_EVENT2*)buf;
 
     event->EventSize = 6;
-    assert_true(yaml_event2data(event, EV_PREBOOT_CERT));
+    assert_true(yaml_event2data(event, EV_PREBOOT_CERT, 1));
+}
+static void test_yaml_event2data_version2(void **state) {
+
+    (void)state;
+    uint8_t buf [sizeof(TCG_EVENT2) + 6];
+    TCG_EVENT2 *event = (TCG_EVENT2*)buf;
+
+    event->EventSize = 6;
+    assert_true(yaml_event2data(event, EV_PREBOOT_CERT, 2));
 }
 static void test_yaml_event2hdr_callback(void **state){
 
@@ -99,7 +108,7 @@ static void test_yaml_eventlog(void **state){
 
     (void)state;
 
-    assert_false(yaml_eventlog(NULL, 0));
+    assert_false(yaml_eventlog(NULL, 0, 1));
 }
 int main(void) {
 
@@ -137,7 +146,8 @@ int main(void) {
         cmocka_unit_test(test_yaml_event2hdr_callback),
         cmocka_unit_test(test_yaml_event2hdr_callback_nulldata),
         cmocka_unit_test(test_yaml_digest2_callback),
-        cmocka_unit_test(test_yaml_event2data),
+        cmocka_unit_test(test_yaml_event2data_version1),
+        cmocka_unit_test(test_yaml_event2data_version2),
         cmocka_unit_test(test_yaml_eventlog),
     };
 


### PR DESCRIPTION
`SecureBoot` is a variable that appears in every eventlog. This PR makes it more "obvious" what various numeric values mean. Instead of 

```
      UnicodeName: SecureBoot
      VariableData: "01"
```

it spells it out as

```
      UnicodeName: SecureBoot
      VariableData:
        Enabled:'Yes'
```