### PR TITLE
Fix compiler and packaging warnings

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -45,7 +45,7 @@ lib_libcommon_a_SOURCES = $(LIB_SRC)
 lib_libcommon_a_CFLAGS = -fPIC $(AM_CFLAGS)
 
 tools_fapi_tss2_CFLAGS = $(FAPI_CFLAGS) -DTSS2_TOOLS_MAX="$(words $(tss2_tools))"
-tools_fapi_tss2_LDFLAGS = $(TSS2_FAPI_LIBS)
+tools_fapi_tss2_LDFLAGS = $(EXTRA_LDFLAGS) $(TSS2_FAPI_LIBS)
 tools_fapi_tss2_SOURCES = \
 	tools/fapi/tss2_template.c \
 	tools/fapi/tss2_template.h \

--- a/lib/tpm2_util.c
+++ b/lib/tpm2_util.c
@@ -47,11 +47,7 @@ bool tpm2_util_concat_buffer(TPM2B_MAX_BUFFER *result, TPM2B *append) {
         return false;
     }
 
-    if ((result->size + append->size) < result->size) {
-        return false;
-    }
-
-    if ((result->size + append->size) > TPM2_MAX_DIGEST_BUFFER) {
+    if (((UINT32)result->size + append->size) > TPM2_MAX_DIGEST_BUFFER) {
         return false;
     }
 

--- a/tools/tpm2_getekcertificate.c
+++ b/tools/tpm2_getekcertificate.c
@@ -190,8 +190,8 @@ static char *base64_encode(const unsigned char* buffer)
     return final_string;
 }
 
-static size_t writecallback(void *contents, size_t size, size_t nitems,
-    char *CERT_BUFFER) {
+static size_t writecallback(char *contents, size_t size, size_t nitems,
+    void *CERT_BUFFER) {
 
     strncpy(CERT_BUFFER, (const char *)contents, nitems * size);
     ctx.rsa_cert_buffer_size = nitems * size;


### PR DESCRIPTION
This addresses some issues I encountered while trying to package the 5.0 release for openSUSE.