### PR TITLE
tss2 *: Fix policy signed delegation test

### DIFF
--- a/test/integration/fapi/fapi-policy_signed_delegation.sh
+++ b/test/integration/fapi/fapi-policy_signed_delegation.sh
@@ -327,7 +327,7 @@ expect -c "
     expect \"Filename for nonce output: \" {
       send \"$OUTPUT_FILE\r\"
       expect \"Filename for signature input: \" {
-        exec openssl dgst -sha256 -sign $TEMP_DIR/key_user_priv.pem -out $SIGNATURE_FILE $OUTPUT_FILE
+        exec openssl dgst -sha256 -sign $TEMP_DIR/key_user_priv.pem $OUTPUT_FILE > $SIGNATURE_FILE
         send \"$SIGNATURE_FILE\r\"
       }
     }
@@ -350,7 +350,7 @@ expect -c "
       expect \"Filename for nonce output: \" {
           send \"$OUTPUT_FILE\r\"
           expect \"Filename for signature input: \" {
-              exec openssl dgst -sha256 -sign $TEMP_DIR/key_delegated_priv.pem -out $SIGNATURE_FILE $OUTPUT_FILE
+              exec openssl dgst -sha256 -sign $TEMP_DIR/key_delegated_priv.pem $OUTPUT_FILE > $SIGNATURE_FILE
               send \"$SIGNATURE_FILE\r\"
           }
       }


### PR DESCRIPTION
The returned digest of the OpenSSL command "openssl dgst" with parameter
"-out" is inconsistent between OpenSSL versions. This causes errors
in test cases with different OpenSSL versions.
For compatibility among versions, the parameter is replaced with ">".

Signed-off-by: Christian Plappert christian.plappert@sit.fraunhofer.de