### PR TITLE
Fix Build on CentOS 7

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -287,8 +287,8 @@ AC_DEFUN([add_c_flag], [
 # -D_GNU_SOURCE is required for execvpe() in options.c
 add_c_flag([-D_GNU_SOURCE], [AC_MSG_ERROR([Cannot enable -D_GNU_SOURCE])])
 
-# Enable C99 mode, since we use some of these features.
-add_c_flag([-std=c99], [AC_MSG_ERROR([Cannot enable -std=c99])])
+# Enable gnu99 mode, since we use some of these features.
+add_c_flag([-std=gnu99], [AC_MSG_ERROR([Cannot enable -std=gnu99])])
 
 # Best attempt compiler options that are on newer versions of GCC that
 # we can't widely enforce without killing other peoples builds.

--- a/configure.ac
+++ b/configure.ac
@@ -295,7 +295,7 @@ AS_IF([test "$HOSTOS" = "Linux"],
        add_c_flag([-Wstringop-truncation])
        add_c_flag([-Wduplicated-branches])
        add_c_flag([-Wduplicated-cond])
-       add_hardened_c_flag([-Wbool-compare])],[])
+       add_c_flag([-Wbool-compare])],[])
 
 # Best attempt, strip unused stuff from the binary to reduce size.
 # Rather than nesting these and making them ugly just use a counter.

--- a/configure.ac
+++ b/configure.ac
@@ -287,6 +287,9 @@ AC_DEFUN([add_c_flag], [
 # -D_GNU_SOURCE is required for execvpe() in options.c
 add_c_flag([-D_GNU_SOURCE], [AC_MSG_ERROR([Cannot enable -D_GNU_SOURCE])])
 
+# Enable C99 mode, since we use some of these features.
+add_c_flag([-std=c99], [AC_MSG_ERROR([Cannot enable -std=c99])])
+
 # Best attempt compiler options that are on newer versions of GCC that
 # we can't widely enforce without killing other peoples builds.
 # Works with gcc only. Needs to be disabled on BSD and clang

--- a/lib/tpm2_convert.c
+++ b/lib/tpm2_convert.c
@@ -647,7 +647,6 @@ out:
 }
 
 bool tpm2_base64_encode(BYTE *buffer, size_t buffer_length, char *base64) {
-    int rc;
 
     unsigned char out[1024];
     int outl;
@@ -655,12 +654,16 @@ bool tpm2_base64_encode(BYTE *buffer, size_t buffer_length, char *base64) {
     EVP_ENCODE_CTX *ctx = EVP_ENCODE_CTX_new();
     EVP_EncodeInit(ctx);
 
-    rc = EVP_EncodeUpdate(ctx, out, &outl, buffer, buffer_length);
+#if defined(LIB_TPM2_OPENSSL_OPENSSL_PRE11)
+    EVP_EncodeUpdate(ctx, out, &outl, buffer, buffer_length);
+#else
+    int rc = EVP_EncodeUpdate(ctx, out, &outl, buffer, buffer_length);
     if(rc < 0) {
         LOG_ERR("EVP_DecodeUpdate failed with %d\n", rc);
         EVP_ENCODE_CTX_free(ctx);
         return false;
     }
+#endif
 
     EVP_EncodeFinal(ctx, out, &outl); // no return value
 

--- a/lib/tpm2_convert.c
+++ b/lib/tpm2_convert.c
@@ -8,6 +8,7 @@
 
 #include <openssl/bio.h>
 #include <openssl/err.h>
+#include <openssl/evp.h>
 #include <openssl/pem.h>
 
 #include "files.h"

--- a/lib/tpm2_openssl.c
+++ b/lib/tpm2_openssl.c
@@ -122,6 +122,18 @@ int ECDSA_SIG_set0(ECDSA_SIG *sig, BIGNUM *r, BIGNUM *s) {
     return 1;
 }
 
+EVP_ENCODE_CTX *EVP_ENCODE_CTX_new(void) {
+	EVP_ENCODE_CTX *ctx = OPENSSL_malloc(sizeof(EVP_ENCODE_CTX));
+	if (ctx) {
+		memset(ctx, 0, sizeof(*ctx));
+	}
+	return ctx;
+}
+
+void EVP_ENCODE_CTX_free(EVP_ENCODE_CTX *ctx) {
+    OPENSSL_free(ctx);
+}
+
 #endif
 
 bool tpm2_openssl_hash_compute_data(TPMI_ALG_HASH halg, BYTE *buffer,

--- a/lib/tpm2_openssl.h
+++ b/lib/tpm2_openssl.h
@@ -36,6 +36,8 @@
 int RSA_set0_key(RSA *r, BIGNUM *n, BIGNUM *e, BIGNUM *d);
 void RSA_get0_factors(const RSA *r, const BIGNUM **p, const BIGNUM **q);
 int ECDSA_SIG_set0(ECDSA_SIG *sig, BIGNUM *r, BIGNUM *s);
+EVP_ENCODE_CTX *EVP_ENCODE_CTX_new(void);
+void EVP_ENCODE_CTX_free(EVP_ENCODE_CTX *ctx);
 #endif
 
 /**

--- a/tools/misc/tpm2_checkquote.c
+++ b/tools/misc/tpm2_checkquote.c
@@ -463,7 +463,7 @@ static tool_rc init(void) {
         if (pcr_select.count > TPM2_NUM_PCR_BANKS)
             goto err;
 
-        tpm2_eventlog_context eventlog_ctx = {};
+        tpm2_eventlog_context eventlog_ctx = { 0 };
         bool rc = eventlog_from_file(&eventlog_ctx, ctx.eventlog_path);
         if (!rc) {
             LOG_ERR("Failed to process eventlog");


### PR DESCRIPTION
Fixes builds on CentOS 7 which notably has:
1. An ancient version of GCC: 4.8.5
2. An older version of OSSL, 1.0.2k

Patches in the series:
- tools/tpm2_checkquote: fix missing initializer
- tpm2_convert: fix EVP_EncodeUpdate usage for OSSL < 1.1.0
- openssl: fix EVP_ENCODE_CTX_(new|free)
- configure: make build gnu99
- configure: make -Wbool-compare non fatal
