### PR TITLE
tpm2_eventlog: parse EV_EFI_VARIABLE_AUTHORITY

### DIFF
--- a/lib/tpm2_eventlog_yaml.c
+++ b/lib/tpm2_eventlog_yaml.c
@@ -363,7 +363,29 @@ static bool yaml_uefi_var(UEFI_VARIABLE_DATA *data, size_t size, UINT32 type,
                 }
                 return true;
             }
+            /* Other variables will be printed as a hex string */
+        } else if (type == EV_EFI_VARIABLE_AUTHORITY) {
+            free(ret);
+            tpm2_tool_output("      VariableData:\n");
+            
+            EFI_SIGNATURE_DATA *s= (EFI_SIGNATURE_DATA *)&data->UnicodeName[
+                data->UnicodeNameLength];
+            char *sdata = calloc (1,
+                BYTES_TO_HEX_STRING_SIZE(data->VariableDataLength-16));
+            if (sdata == NULL) {
+                LOG_ERR("Failled to allocate data: %s\n", strerror(errno));
+                return false;
+            }
+            bytes_to_str(s->SignatureData, data->VariableDataLength-16,
+                sdata, BYTES_TO_HEX_STRING_SIZE(data->VariableDataLength-16));
+            uuid_unparse_lower(s->SignatureOwner, uuidstr);
+            tpm2_tool_output("      - SignatureOwner: %s\n"
+                             "        SignatureData: %s\n",
+                             uuidstr, sdata);
+            free(sdata);
+            return true;
         }
+        /* Other event types will be printed as a hex string */
     }
 
     free(ret);


### PR DESCRIPTION
This PR parses the event type EV_EFI_VARIABLE_AUTHORITY using the data structure previously defined. To avoid backward compatibility issue, it will only be parsed with `--eventlog-version=2` flag