### PR TITLE
tpm2_nvdefine: Add support for specifying aux sessions for audit/enc

### DIFF
--- a/doc/CHANGELOG.md
+++ b/doc/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ### next
 
+  * tpm2_nvdefine:
+      - Added option **-S**, **--session** to specify auxiliary sessions for
+        audit and encryption.
+
   * tpm2_nvextend:
       - Added option **-S**, **--session** to specify auxilary sessions for
         audit and encryption.

--- a/lib/tpm2.c
+++ b/lib/tpm2.c
@@ -2505,7 +2505,8 @@ tpm2_import_skip_esapi_call:
 
 tool_rc tpm2_nv_definespace(ESYS_CONTEXT *esys_context,
         tpm2_loaded_object *auth_hierarchy_obj, const TPM2B_AUTH *auth,
-        const TPM2B_NV_PUBLIC *public_info, TPM2B_DIGEST *cp_hash) {
+        const TPM2B_NV_PUBLIC *public_info, TPM2B_DIGEST *cp_hash,
+        ESYS_TR shandle2, ESYS_TR shandle3) {
 
     ESYS_TR shandle1 = ESYS_TR_NONE;
     tool_rc rc = tpm2_auth_util_get_shandle(esys_context,
@@ -2557,8 +2558,8 @@ tpm2_nvdefinespace_free_name1:
     }
 
     TSS2_RC rval = Esys_NV_DefineSpace(esys_context,
-            auth_hierarchy_obj->tr_handle, shandle1, ESYS_TR_NONE, ESYS_TR_NONE,
-            auth, public_info, &nvHandle);
+    auth_hierarchy_obj->tr_handle, shandle1, shandle2, shandle3, auth,
+    public_info, &nvHandle);
     if (rval != TPM2_RC_SUCCESS) {
         LOG_ERR("Failed to define NV area at index 0x%X",
                 public_info->nvPublic.nvIndex);

--- a/lib/tpm2.h
+++ b/lib/tpm2.h
@@ -289,7 +289,8 @@ tool_rc tpm2_import(ESYS_CONTEXT *esys_context, tpm2_loaded_object *parent_obj,
 
 tool_rc tpm2_nv_definespace(ESYS_CONTEXT *esys_context,
         tpm2_loaded_object *auth_hierarchy_obj, const TPM2B_AUTH *auth,
-        const TPM2B_NV_PUBLIC *public_info, TPM2B_DIGEST *cp_hash);
+        const TPM2B_NV_PUBLIC *public_info, TPM2B_DIGEST *cp_hash,
+        ESYS_TR shandle2, ESYS_TR shandle3);
 
 tool_rc tpm2_nvextend(ESYS_CONTEXT *esys_context,
         tpm2_loaded_object *auth_hierarchy_obj, TPM2_HANDLE nv_index,

--- a/man/tpm2_nvdefine.1.md
+++ b/man/tpm2_nvdefine.1.md
@@ -76,6 +76,12 @@ uses the first free index. The tool outputs the nv index defined on success.
     termed as cpHash. NOTE: When this option is selected, The tool will not
     actually execute the command, it simply returns a cpHash.
 
+  * **-S**, **\--session**=_FILE_:
+
+    The session created using **tpm2_startauthsession**. Multiple of these can
+    be specified. For example, you can have one session for auditing and another
+    for encryption/decryption of the parameters.
+
   * **ARGUMENT** the command line argument specifies the NV index or offset
     number.
 


### PR DESCRIPTION
Signed-off-by: Imran Desai <imran.desai@intel.com>