### PR TITLE
cirrus ci: fix FreeBSD package mismatch

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -8,8 +8,7 @@ task:
     ibmtpm_name: ibmtpm1637
     TSS2_LOG: "all+ERROR;tcti+TRACE"
   freebsd_instance:
-    matrix:
-      image_family: freebsd-12-1
+    image_family: freebsd-12-2
   install_script:
     - pkg update -f
     - pkg upgrade -y


### PR DESCRIPTION
CI is failing, try its suggestion and set environment variable:
IGNORE_OSVERSION=yes

Per the logs:
pkg update -f
Updating FreeBSD repository catalogue...
Fetching meta.txz: . done
Fetching packagesite.txz: .......... done
Processing entries:
Newer FreeBSD version for package webalizer:
To ignore this error set IGNORE_OSVERSION=yes
- package: 1202000
- running kernel: 1201000
Ignore the mismatch and continue? [Y/n]: pkg: repository FreeBSD contains packages for wrong OS version: FreeBSD:12:amd64
Processing entries... done
Unable to update repository FreeBSD
Error updating repositories!

Signed-off-by: William Roberts <william.c.roberts@intel.com>