### PR TITLE
ci: disable doxygen for tpm2-tss

### DIFF
--- a/.ci/download-deps.sh
+++ b/.ci/download-deps.sh
@@ -24,7 +24,7 @@ function get_deps() {
 		pushd tpm2-tss
 		echo "pwd build tss: `pwd`"
 		./bootstrap
-		./configure CFLAGS=-g
+		./configure --disable-doxygen-doc CFLAGS=-g
 		make -j4
 		make install
 		popd


### PR DESCRIPTION
Theirs no need to build the doxygen docs, so avoid it and pick up some
CI time.

Signed-off-by: William Roberts <william.c.roberts@intel.com>