### PR TITLE
CommandAudit and SessionAudit support

### DIFF
--- a/doc/CHANGELOG.md
+++ b/doc/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ### next
 
+  * tpm2_changeeps:
+      - Added option **\--cphash**=_FILE_ to specify ile path to record the hash
+        of the command parameters. This is commonly termed as cpHash.
   * tpm2_changeauth:
       - Added option **\--rphash**=_FILE_ to specify ile path to record the hash
         of the response parameters. This is commonly termed as rpHash.

--- a/doc/CHANGELOG.md
+++ b/doc/CHANGELOG.md
@@ -7,6 +7,8 @@
         of the command parameters. This is commonly termed as cpHash.
       - Added option **\--rphash**=_FILE_ to specify ile path to record the hash
         of the response parameters. This is commonly termed as rpHash.
+      - Added option **-S**, **\--session** to specify to specify an auxiliary
+        session for auditing and or encryption/decryption of the parameters.
 
   * tpm2_changeauth:
       - Added option **\--rphash**=_FILE_ to specify ile path to record the hash

--- a/doc/CHANGELOG.md
+++ b/doc/CHANGELOG.md
@@ -5,6 +5,8 @@
   * tpm2_changepps:
       - Added option **\--cphash**=_FILE_ to specify ile path to record the hash
         of the command parameters. This is commonly termed as cpHash.
+      - Added option **\--rphash**=_FILE_ to specify ile path to record the hash
+        of the response parameters. This is commonly termed as rpHash.
 
   * tpm2_changeeps:
       - Added option **\--cphash**=_FILE_ to specify ile path to record the hash

--- a/doc/CHANGELOG.md
+++ b/doc/CHANGELOG.md
@@ -2,9 +2,11 @@
 
 ### next
 
-  * tpm2_certify:
+  * tpm2_changeauth:
       - Added option **\--rphash**=_FILE_ to specify ile path to record the hash
         of the response parameters. This is commonly termed as rpHash.
+      - Added option **-S**, **\--session** to specify to specify an auxiliary
+        session for auditing and or encryption/decryption of the parameters.
 
   * tpm2_certifycreation:
       - Added option **\--rphash**=_FILE_ to specify ile path to record the hash

--- a/doc/CHANGELOG.md
+++ b/doc/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ### next
 
+  * tpm2_activatecredential:
+      - Added option **\--rphash**=_FILE_ to specify ile path to record the hash
+        of the response parameters. This is commonly termed as rpHash.
+
   * tpm2_create:
        - Added option **\--rphash**=_FILE_ to specify ile path to record the hash
          of the response parameters. This is commonly termed as rpHash.

--- a/doc/CHANGELOG.md
+++ b/doc/CHANGELOG.md
@@ -6,7 +6,8 @@
       - Added option **\--cphash**=_FILE_ to specify ile path to record the hash
         of the command parameters. This is commonly termed as cpHash.
       - Added option **\--rphash**=_FILE_ to specify ile path to record the hash
-        of the response parameters. This is commonly termed as rpHash.
+      - Added option **-S**, **\--session** to specify to specify an auxiliary
+        session for auditing and or encryption/decryption of the parameters.
 
   * tpm2_changeeps:
       - Added option **\--cphash**=_FILE_ to specify ile path to record the hash

--- a/doc/CHANGELOG.md
+++ b/doc/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ### next
 
+  * tpm2_changepps:
+      - Added option **\--cphash**=_FILE_ to specify ile path to record the hash
+        of the command parameters. This is commonly termed as cpHash.
+
   * tpm2_changeeps:
       - Added option **\--cphash**=_FILE_ to specify ile path to record the hash
         of the command parameters. This is commonly termed as cpHash.

--- a/doc/CHANGELOG.md
+++ b/doc/CHANGELOG.md
@@ -5,6 +5,8 @@
   * tpm2_certify:
       - Added option **\--rphash**=_FILE_ to specify ile path to record the hash
         of the response parameters. This is commonly termed as rpHash.
+      - Added option **-S**, **\--session** to specify to specify an auxiliary
+        session for auditing and or encryption/decryption of the parameters.
 
 
   * tpm2_activatecredential:

--- a/doc/CHANGELOG.md
+++ b/doc/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ### next
 
+  * tpm2_certify:
+      - Added option **\--rphash**=_FILE_ to specify ile path to record the hash
+        of the response parameters. This is commonly termed as rpHash.
+
+
   * tpm2_activatecredential:
       - Added option **\--rphash**=_FILE_ to specify ile path to record the hash
         of the response parameters. This is commonly termed as rpHash.

--- a/doc/CHANGELOG.md
+++ b/doc/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ### next
 
+  * tpm2_certify:
+      - Added option **\--rphash**=_FILE_ to specify ile path to record the hash
+        of the response parameters. This is commonly termed as rpHash.
+
   * tpm2_certifycreation:
       - Added option **\--rphash**=_FILE_ to specify ile path to record the hash
         of the response parameters. This is commonly termed as rpHash.

--- a/doc/CHANGELOG.md
+++ b/doc/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ### next
 
+  * tpm2_create:
+       - Added option **\--rphash**=_FILE_ to specify ile path to record the hash
+         of the response parameters. This is commonly termed as rpHash.
+
   * tpm2_unseal:
       - Added option **-S**, **--session** to specify auxiliary sessions for
         audit and encryption.

--- a/doc/CHANGELOG.md
+++ b/doc/CHANGELOG.md
@@ -5,6 +5,9 @@
   * tpm2_activatecredential:
       - Added option **\--rphash**=_FILE_ to specify ile path to record the hash
         of the response parameters. This is commonly termed as rpHash.
+      - Added option **-S**, **\--session** to specify to specify an auxiliary
+        session for auditing and or encryption/decryption of the parameters.
+
 
   * tpm2_create:
        - Added option **\--rphash**=_FILE_ to specify ile path to record the hash

--- a/doc/CHANGELOG.md
+++ b/doc/CHANGELOG.md
@@ -5,6 +5,8 @@
   * tpm2_certifycreation:
       - Added option **\--rphash**=_FILE_ to specify ile path to record the hash
         of the response parameters. This is commonly termed as rpHash.
+      - Added option **-S**, **\--session** to specify to specify an auxiliary
+        session for auditing and or encryption/decryption of the parameters.
 
   * tpm2_certify:
       - Added option **\--rphash**=_FILE_ to specify ile path to record the hash

--- a/doc/CHANGELOG.md
+++ b/doc/CHANGELOG.md
@@ -5,6 +5,9 @@
   * tpm2_changeeps:
       - Added option **\--cphash**=_FILE_ to specify ile path to record the hash
         of the command parameters. This is commonly termed as cpHash.
+      - Added option **\--rphash**=_FILE_ to specify ile path to record the hash
+        of the response parameters. This is commonly termed as rpHash.
+
   * tpm2_changeauth:
       - Added option **\--rphash**=_FILE_ to specify ile path to record the hash
         of the response parameters. This is commonly termed as rpHash.

--- a/doc/CHANGELOG.md
+++ b/doc/CHANGELOG.md
@@ -2,19 +2,21 @@
 
 ### next
 
+  * tpm2_certifycreation:
+      - Added option **\--rphash**=_FILE_ to specify ile path to record the hash
+        of the response parameters. This is commonly termed as rpHash.
+
   * tpm2_certify:
       - Added option **\--rphash**=_FILE_ to specify ile path to record the hash
         of the response parameters. This is commonly termed as rpHash.
       - Added option **-S**, **\--session** to specify to specify an auxiliary
         session for auditing and or encryption/decryption of the parameters.
 
-
   * tpm2_activatecredential:
       - Added option **\--rphash**=_FILE_ to specify ile path to record the hash
         of the response parameters. This is commonly termed as rpHash.
       - Added option **-S**, **\--session** to specify to specify an auxiliary
         session for auditing and or encryption/decryption of the parameters.
-
 
   * tpm2_create:
        - Added option **\--rphash**=_FILE_ to specify ile path to record the hash

--- a/lib/tpm2.c
+++ b/lib/tpm2.c
@@ -1294,12 +1294,12 @@ tool_rc tpm2_create(ESYS_CONTEXT *esys_context, tpm2_loaded_object *parent_obj,
         TPM2B_PRIVATE **out_private, TPM2B_PUBLIC **out_public,
         TPM2B_CREATION_DATA **creation_data, TPM2B_DIGEST **creation_hash,
         TPMT_TK_CREATION **creation_ticket, TPM2B_DIGEST *cp_hash,
-        TPMI_ALG_HASH parameter_hash_algorithm, ESYS_TR shandle2,
-        ESYS_TR shandle3) {
+        TPM2B_DIGEST *rp_hash, TPMI_ALG_HASH parameter_hash_algorithm,
+        ESYS_TR shandle2, ESYS_TR shandle3) {
 
     TSS2_SYS_CONTEXT *sys_context = NULL;
     tool_rc rc = tool_rc_success;
-    if (cp_hash->size) {
+    if (cp_hash->size || rp_hash->size) {
         rc = tpm2_getsapicontext(esys_context, &sys_context);
 
         if(rc != tool_rc_success) {
@@ -1326,12 +1326,17 @@ tool_rc tpm2_create(ESYS_CONTEXT *esys_context, tpm2_loaded_object *parent_obj,
         rc = tpm2_sapi_getcphash(sys_context, name1, NULL, NULL,
             parameter_hash_algorithm, cp_hash);
 
+tpm2_create_free_name1:
+        Esys_Free(name1);
+        if (rc != tool_rc_success) {
+            return rc;
+        }
         /*
          * Exit here without making the ESYS call since we just need the cpHash
          */
-tpm2_create_free_name1:
-        Esys_Free(name1);
-        goto tpm2_create_skip_esapi_call;
+        if (!rp_hash->size) {
+            goto tpm2_create_skip_esapi_call;
+        }
     }
 
     ESYS_TR shandle1 = ESYS_TR_NONE;
@@ -1350,6 +1355,11 @@ tpm2_create_free_name1:
         return tool_rc_from_tpm(rval);
     }
 
+    if (rp_hash->size) {
+        rc = tpm2_sapi_getrphash(sys_context, rval, rp_hash,
+            parameter_hash_algorithm);
+    }
+
 tpm2_create_skip_esapi_call:
     return rc;
 }
@@ -1359,12 +1369,13 @@ tool_rc tpm2_create_loaded(ESYS_CONTEXT *esys_context,
         const TPM2B_SENSITIVE_CREATE *in_sensitive,
         const TPM2B_TEMPLATE *in_public, ESYS_TR *object_handle,
         TPM2B_PRIVATE **out_private, TPM2B_PUBLIC **out_public,
-        TPM2B_DIGEST *cp_hash, TPMI_ALG_HASH parameter_hash_algorithm,
-        ESYS_TR shandle2, ESYS_TR shandle3) {
+        TPM2B_DIGEST *cp_hash, TPM2B_DIGEST *rp_hash,
+        TPMI_ALG_HASH parameter_hash_algorithm, ESYS_TR shandle2,
+        ESYS_TR shandle3) {
 
     TSS2_SYS_CONTEXT *sys_context = NULL;
     tool_rc rc = tool_rc_success;
-    if (cp_hash->size) {
+    if (cp_hash->size || rp_hash->size) {
         rc = tpm2_getsapicontext(esys_context, &sys_context);
 
         if(rc != tool_rc_success) {
@@ -1391,12 +1402,17 @@ tool_rc tpm2_create_loaded(ESYS_CONTEXT *esys_context,
         rc = tpm2_sapi_getcphash(sys_context, name1, NULL, NULL,
             parameter_hash_algorithm, cp_hash);
 
+tpm2_createloaded_free_name1:
+        Esys_Free(name1);
+        if (rc != tool_rc_success) {
+            return rc;
+        }
         /*
          * Exit here without making the ESYS call since we just need the cpHash
          */
-tpm2_createloaded_free_name1:
-        Esys_Free(name1);
-        goto tpm2_createloaded_skip_esapi_call;
+        if (!rp_hash->size) {
+            goto tpm2_createloaded_skip_esapi_call;
+        }
     }
 
     ESYS_TR shandle1 = ESYS_TR_NONE;
@@ -1412,6 +1428,11 @@ tpm2_createloaded_free_name1:
     if (rval != TSS2_RC_SUCCESS) {
         LOG_PERR(Esys_CreateLoaded, rval);
         return tool_rc_from_tpm(rval);
+    }
+
+    if (rp_hash->size) {
+        rc = tpm2_sapi_getrphash(sys_context, rval, rp_hash,
+            parameter_hash_algorithm);
     }
 
 tpm2_createloaded_skip_esapi_call:

--- a/lib/tpm2.c
+++ b/lib/tpm2.c
@@ -1210,7 +1210,7 @@ tool_rc tpm2_activatecredential(ESYS_CONTEXT *esys_context,
     tpm2_loaded_object *activatehandleobj, tpm2_loaded_object *keyhandleobj,
     const TPM2B_ID_OBJECT *credential_blob, const TPM2B_ENCRYPTED_SECRET *secret,
     TPM2B_DIGEST **cert_info, TPM2B_DIGEST *cp_hash, TPM2B_DIGEST *rp_hash,
-    TPMI_ALG_HASH parameter_hash_algorithm) {
+    TPMI_ALG_HASH parameter_hash_algorithm, ESYS_TR shandle3) {
 
     TSS2_SYS_CONTEXT *sys_context = NULL;
     tool_rc rc = tool_rc_success;
@@ -1276,9 +1276,9 @@ tpm2_activatecredential_free_name1:
     }
 
     TSS2_RC rval = Esys_ActivateCredential(esys_context,
-            activatehandleobj->tr_handle, keyhandleobj->tr_handle,
-            activateobj_session_handle, keyobj_session_handle, ESYS_TR_NONE,
-            credential_blob, secret, cert_info);
+        activatehandleobj->tr_handle, keyhandleobj->tr_handle,
+        activateobj_session_handle, keyobj_session_handle, shandle3,
+        credential_blob, secret, cert_info);
     if (rval != TPM2_RC_SUCCESS) {
         LOG_PERR(Esys_ActivateCredential, rval);
         rc = tool_rc_from_tpm(rval);

--- a/lib/tpm2.c
+++ b/lib/tpm2.c
@@ -3750,13 +3750,49 @@ tpm2_quote_skip_esapi_call:
 }
 
 tool_rc tpm2_changeeps(ESYS_CONTEXT *ectx,
-    tpm2_session *platform_hierarchy_session) {
+    tpm2_session *platform_hierarchy_session, TPM2B_DIGEST *cp_hash) {
 
     ESYS_TR platform_hierarchy_session_handle = ESYS_TR_NONE;
     tool_rc rc = tpm2_auth_util_get_shandle(ectx, ESYS_TR_RH_PLATFORM,
         platform_hierarchy_session, &platform_hierarchy_session_handle);
     if (rc != tool_rc_success) {
         return rc;
+    }
+
+if (cp_hash) {
+        /*
+         * Need sys_context to be able to calculate CpHash
+         */
+        TSS2_SYS_CONTEXT *sys_context = NULL;
+        rc = tpm2_getsapicontext(ectx, &sys_context);
+        if(rc != tool_rc_success) {
+            LOG_ERR("Failed to acquire SAPI context.");
+            return rc;
+        }
+
+        TSS2_RC rval = Tss2_Sys_ChangeEPS_Prepare(sys_context, TPM2_RH_PLATFORM);
+        if (rval != TPM2_RC_SUCCESS) {
+            LOG_PERR(Tss2_Sys_ObjectChangeAuth_Prepare, rval);
+            return tool_rc_general_error;
+        }
+
+        TPM2B_NAME *name1 = NULL;
+        rc = tpm2_tr_get_name(ectx, ESYS_TR_RH_PLATFORM ,&name1);
+        if (rc != tool_rc_success) {
+            goto tpm2_changeeps_free_name1;
+        }
+
+        cp_hash->size = tpm2_alg_util_get_hash_size(
+            tpm2_session_get_authhash(platform_hierarchy_session));
+        rc = tpm2_sapi_getcphash(sys_context, name1, NULL, NULL,
+            tpm2_session_get_authhash(platform_hierarchy_session), cp_hash);
+
+tpm2_changeeps_free_name1:
+        Esys_Free(name1);
+        /*
+         * Exit here without making the ESYS call since we just need the cpHash
+         */
+        goto tpm2_changeeps_skip_esapi_call;
     }
 
     TSS2_RC rval = Esys_ChangeEPS(ectx, ESYS_TR_RH_PLATFORM,
@@ -3766,7 +3802,8 @@ tool_rc tpm2_changeeps(ESYS_CONTEXT *ectx,
         return tool_rc_from_tpm(rval);
     }
 
-    return tool_rc_success;
+tpm2_changeeps_skip_esapi_call:
+    return rc;
 }
 
 tool_rc tpm2_changepps(ESYS_CONTEXT *ectx,

--- a/lib/tpm2.c
+++ b/lib/tpm2.c
@@ -1449,7 +1449,8 @@ tool_rc tpm2_object_change_auth(ESYS_CONTEXT *esys_context,
     tpm2_loaded_object *parent_object, tpm2_loaded_object *object,
     const TPM2B_AUTH *new_auth, TPM2B_PRIVATE **out_private,
     TPM2B_DIGEST *cp_hash, TPM2B_DIGEST *rp_hash,
-    TPMI_ALG_HASH parameter_hash_algorithm) {
+    TPMI_ALG_HASH parameter_hash_algorithm, ESYS_TR shandle2,
+    ESYS_TR shandle3) {
 
     TSS2_SYS_CONTEXT *sys_context = NULL;
     tool_rc rc = tool_rc_success;
@@ -1506,7 +1507,7 @@ tpm2_objectchangeauth_free_name1:
     }
 
     TSS2_RC rval = Esys_ObjectChangeAuth(esys_context, object->tr_handle,
-            parent_object->tr_handle, shandle1, ESYS_TR_NONE, ESYS_TR_NONE,
+            parent_object->tr_handle, shandle1, shandle2, shandle3,
             new_auth, out_private);
     if (rval != TPM2_RC_SUCCESS) {
         LOG_PERR(Esys_ObjectChangeAuth, rval);
@@ -1524,7 +1525,8 @@ tpm2_objectchangeauth_skip_esapi_call:
 
 tool_rc tpm2_nv_change_auth(ESYS_CONTEXT *esys_context, tpm2_loaded_object *nv,
     const TPM2B_AUTH *new_auth, TPM2B_DIGEST *cp_hash, TPM2B_DIGEST *rp_hash,
-    TPMI_ALG_HASH parameter_hash_algorithm) {
+    TPMI_ALG_HASH parameter_hash_algorithm, ESYS_TR shandle2,
+    ESYS_TR shandle3) {
 
     TSS2_SYS_CONTEXT *sys_context = NULL;
     tool_rc rc = (cp_hash->size || rp_hash->size) ?
@@ -1569,7 +1571,7 @@ tpm2_nvchangeauth_free_name1:
     }
 
     TSS2_RC rval = Esys_NV_ChangeAuth(esys_context, nv->tr_handle, shandle1,
-            ESYS_TR_NONE, ESYS_TR_NONE, new_auth);
+            shandle2, shandle3, new_auth);
     if (rval != TPM2_RC_SUCCESS) {
         LOG_PERR(Esys_NV_ChangeAuth, rval);
         return tool_rc_from_tpm(rval);
@@ -1587,7 +1589,8 @@ tpm2_nvchangeauth_skip_esapi_call:
 tool_rc tpm2_hierarchy_change_auth(ESYS_CONTEXT *esys_context,
     tpm2_loaded_object *hierarchy, const TPM2B_AUTH *new_auth,
     TPM2B_DIGEST *cp_hash, TPM2B_DIGEST *rp_hash,
-    TPMI_ALG_HASH parameter_hash_algorithm) {
+    TPMI_ALG_HASH parameter_hash_algorithm, ESYS_TR shandle2,
+    ESYS_TR shandle3) {
 
     TSS2_SYS_CONTEXT *sys_context = NULL;
     tool_rc rc = (cp_hash->size || rp_hash->size) ?
@@ -1632,7 +1635,7 @@ tpm2_hierarchychangeauth_free_name1:
     }
 
     TSS2_RC rval = Esys_HierarchyChangeAuth(esys_context, hierarchy->tr_handle,
-            shandle1, ESYS_TR_NONE, ESYS_TR_NONE, new_auth);
+            shandle1, shandle2, shandle3, new_auth);
     if (rval != TPM2_RC_SUCCESS) {
         LOG_PERR(Esys_HierarchyChangeAuth, rval);
         return tool_rc_from_tpm(rval);

--- a/lib/tpm2.c
+++ b/lib/tpm2.c
@@ -3816,7 +3816,8 @@ tpm2_changeeps_skip_esapi_call:
 
 tool_rc tpm2_changepps(ESYS_CONTEXT *ectx,
     tpm2_session *platform_hierarchy_session, TPM2B_DIGEST *cp_hash,
-    TPM2B_DIGEST *rp_hash, TPMI_ALG_HASH parameter_hash_algorithm) {
+    TPM2B_DIGEST *rp_hash, TPMI_ALG_HASH parameter_hash_algorithm,
+    ESYS_TR shandle2, ESYS_TR shandle3) {
 
     TSS2_SYS_CONTEXT *sys_context = NULL;
     tool_rc rc = (cp_hash->size || rp_hash->size) ?
@@ -3861,7 +3862,7 @@ tpm2_changepps_free_name1:
     }
 
     TSS2_RC rval = Esys_ChangePPS(ectx, ESYS_TR_RH_PLATFORM,
-        platform_hierarchy_session_handle, ESYS_TR_NONE, ESYS_TR_NONE);
+        platform_hierarchy_session_handle, shandle2, shandle3);
     if (rval != TPM2_RC_SUCCESS) {
         LOG_PERR(Esys_ChangePPS, rval);
         return tool_rc_from_tpm(rval);

--- a/lib/tpm2.c
+++ b/lib/tpm2.c
@@ -3751,20 +3751,20 @@ tpm2_quote_skip_esapi_call:
 
 tool_rc tpm2_changeeps(ESYS_CONTEXT *ectx,
     tpm2_session *platform_hierarchy_session, TPM2B_DIGEST *cp_hash,
-    TPMI_ALG_HASH parameter_hash_algorithm) {
+    TPM2B_DIGEST *rp_hash, TPMI_ALG_HASH parameter_hash_algorithm) {
 
+    TSS2_SYS_CONTEXT *sys_context = NULL;
     tool_rc rc = tool_rc_success;
-    if (cp_hash->size) {
-        /*
-         * Need sys_context to be able to calculate CpHash
-         */
-        TSS2_SYS_CONTEXT *sys_context = NULL;
+    if (cp_hash->size || rp_hash->size) {
         rc = tpm2_getsapicontext(ectx, &sys_context);
+
         if(rc != tool_rc_success) {
             LOG_ERR("Failed to acquire SAPI context.");
             return rc;
         }
+    }
 
+    if (cp_hash->size) {
         TSS2_RC rval = Tss2_Sys_ChangeEPS_Prepare(sys_context, TPM2_RH_PLATFORM);
         if (rval != TPM2_RC_SUCCESS) {
             LOG_PERR(Tss2_Sys_ObjectChangeAuth_Prepare, rval);
@@ -3785,7 +3785,9 @@ tpm2_changeeps_free_name1:
         /*
          * Exit here without making the ESYS call since we just need the cpHash
          */
-        goto tpm2_changeeps_skip_esapi_call;
+        if (!rp_hash->size || rc != tool_rc_success) {
+            goto tpm2_changeeps_skip_esapi_call;
+        }
     }
 
     ESYS_TR platform_hierarchy_session_handle = ESYS_TR_NONE;
@@ -3800,6 +3802,11 @@ tpm2_changeeps_free_name1:
     if (rval != TPM2_RC_SUCCESS) {
         LOG_PERR(Esys_ChangeEPS, rval);
         return tool_rc_from_tpm(rval);
+    }
+
+    if (rp_hash->size) {
+        rc = tpm2_sapi_getrphash(sys_context, rval, rp_hash,
+            parameter_hash_algorithm);
     }
 
 tpm2_changeeps_skip_esapi_call:

--- a/lib/tpm2.c
+++ b/lib/tpm2.c
@@ -1636,7 +1636,7 @@ tool_rc tpm2_certify(ESYS_CONTEXT *ectx, tpm2_loaded_object *certifiedkey_obj,
     tpm2_loaded_object *signingkey_obj, TPM2B_DATA *qualifying_data,
     TPMT_SIG_SCHEME *scheme, TPM2B_ATTEST **certify_info,
     TPMT_SIGNATURE **signature, TPM2B_DIGEST *cp_hash, TPM2B_DIGEST *rp_hash,
-    TPMI_ALG_HASH parameter_hash_algorithm) {
+    TPMI_ALG_HASH parameter_hash_algorithm, ESYS_TR shandle3) {
 
     TSS2_SYS_CONTEXT *sys_context = NULL;
     tool_rc rc = tool_rc_success;
@@ -1703,7 +1703,7 @@ tpm2_certify_free_name1:
 
     TSS2_RC rval = Esys_Certify(ectx, certifiedkey_obj->tr_handle,
             signingkey_obj->tr_handle, certifiedkey_session_handle,
-            signingkey_session_handle, ESYS_TR_NONE, qualifying_data, scheme,
+            signingkey_session_handle, shandle3, qualifying_data, scheme,
             certify_info, signature);
     if (rval != TPM2_RC_SUCCESS) {
         LOG_PERR(Eys_Certify, rval);

--- a/lib/tpm2.c
+++ b/lib/tpm2.c
@@ -3750,16 +3750,11 @@ tpm2_quote_skip_esapi_call:
 }
 
 tool_rc tpm2_changeeps(ESYS_CONTEXT *ectx,
-    tpm2_session *platform_hierarchy_session, TPM2B_DIGEST *cp_hash) {
+    tpm2_session *platform_hierarchy_session, TPM2B_DIGEST *cp_hash,
+    TPMI_ALG_HASH parameter_hash_algorithm) {
 
-    ESYS_TR platform_hierarchy_session_handle = ESYS_TR_NONE;
-    tool_rc rc = tpm2_auth_util_get_shandle(ectx, ESYS_TR_RH_PLATFORM,
-        platform_hierarchy_session, &platform_hierarchy_session_handle);
-    if (rc != tool_rc_success) {
-        return rc;
-    }
-
-if (cp_hash) {
+    tool_rc rc = tool_rc_success;
+    if (cp_hash->size) {
         /*
          * Need sys_context to be able to calculate CpHash
          */
@@ -3782,10 +3777,8 @@ if (cp_hash) {
             goto tpm2_changeeps_free_name1;
         }
 
-        cp_hash->size = tpm2_alg_util_get_hash_size(
-            tpm2_session_get_authhash(platform_hierarchy_session));
         rc = tpm2_sapi_getcphash(sys_context, name1, NULL, NULL,
-            tpm2_session_get_authhash(platform_hierarchy_session), cp_hash);
+            parameter_hash_algorithm, cp_hash);
 
 tpm2_changeeps_free_name1:
         Esys_Free(name1);
@@ -3793,6 +3786,13 @@ tpm2_changeeps_free_name1:
          * Exit here without making the ESYS call since we just need the cpHash
          */
         goto tpm2_changeeps_skip_esapi_call;
+    }
+
+    ESYS_TR platform_hierarchy_session_handle = ESYS_TR_NONE;
+    rc = tpm2_auth_util_get_shandle(ectx, ESYS_TR_RH_PLATFORM,
+        platform_hierarchy_session, &platform_hierarchy_session_handle);
+    if (rc != tool_rc_success) {
+        return rc;
     }
 
     TSS2_RC rval = Esys_ChangeEPS(ectx, ESYS_TR_RH_PLATFORM,

--- a/lib/tpm2.c
+++ b/lib/tpm2.c
@@ -1294,26 +1294,21 @@ tool_rc tpm2_create(ESYS_CONTEXT *esys_context, tpm2_loaded_object *parent_obj,
         TPM2B_PRIVATE **out_private, TPM2B_PUBLIC **out_public,
         TPM2B_CREATION_DATA **creation_data, TPM2B_DIGEST **creation_hash,
         TPMT_TK_CREATION **creation_ticket, TPM2B_DIGEST *cp_hash,
-        ESYS_TR shandle2, ESYS_TR shandle3) {
+        TPMI_ALG_HASH parameter_hash_algorithm, ESYS_TR shandle2,
+        ESYS_TR shandle3) {
 
-    ESYS_TR shandle1 = ESYS_TR_NONE;
-    tool_rc rc = tpm2_auth_util_get_shandle(esys_context, parent_obj->tr_handle,
-            parent_obj->session, &shandle1);
-    if (rc != tool_rc_success) {
-        return rc;
-    }
-
-    if (cp_hash) {
-        /*
-         * Need sys_context to be able to calculate CpHash
-         */
-        TSS2_SYS_CONTEXT *sys_context = NULL;
+    TSS2_SYS_CONTEXT *sys_context = NULL;
+    tool_rc rc = tool_rc_success;
+    if (cp_hash->size) {
         rc = tpm2_getsapicontext(esys_context, &sys_context);
+
         if(rc != tool_rc_success) {
             LOG_ERR("Failed to acquire SAPI context.");
             return rc;
         }
+    }
 
+    if (cp_hash->size) {
         TSS2_RC rval = Tss2_Sys_Create_Prepare(sys_context, parent_obj->handle,
             in_sensitive, in_public, outside_info, creation_pcr);
         if (rval != TPM2_RC_SUCCESS) {
@@ -1328,10 +1323,8 @@ tool_rc tpm2_create(ESYS_CONTEXT *esys_context, tpm2_loaded_object *parent_obj,
             goto tpm2_create_free_name1;
         }
 
-        cp_hash->size = tpm2_alg_util_get_hash_size(
-            tpm2_session_get_authhash(parent_obj->session));
         rc = tpm2_sapi_getcphash(sys_context, name1, NULL, NULL,
-            tpm2_session_get_authhash(parent_obj->session), cp_hash);
+            parameter_hash_algorithm, cp_hash);
 
         /*
          * Exit here without making the ESYS call since we just need the cpHash
@@ -1339,6 +1332,13 @@ tool_rc tpm2_create(ESYS_CONTEXT *esys_context, tpm2_loaded_object *parent_obj,
 tpm2_create_free_name1:
         Esys_Free(name1);
         goto tpm2_create_skip_esapi_call;
+    }
+
+    ESYS_TR shandle1 = ESYS_TR_NONE;
+    rc = tpm2_auth_util_get_shandle(esys_context, parent_obj->tr_handle,
+        parent_obj->session, &shandle1);
+    if (rc != tool_rc_success) {
+        return rc;
     }
 
     TSS2_RC rval = Esys_Create(esys_context, parent_obj->tr_handle, shandle1,
@@ -1359,26 +1359,21 @@ tool_rc tpm2_create_loaded(ESYS_CONTEXT *esys_context,
         const TPM2B_SENSITIVE_CREATE *in_sensitive,
         const TPM2B_TEMPLATE *in_public, ESYS_TR *object_handle,
         TPM2B_PRIVATE **out_private, TPM2B_PUBLIC **out_public,
-        TPM2B_DIGEST *cp_hash, ESYS_TR shandle2, ESYS_TR shandle3) {
+        TPM2B_DIGEST *cp_hash, TPMI_ALG_HASH parameter_hash_algorithm,
+        ESYS_TR shandle2, ESYS_TR shandle3) {
 
-    ESYS_TR shandle1 = ESYS_TR_NONE;
-    tool_rc rc = tpm2_auth_util_get_shandle(esys_context, parent_obj->tr_handle,
-            parent_obj->session, &shandle1);
-    if (rc != tool_rc_success) {
-        return rc;
-    }
-
-    if (cp_hash) {
-        /*
-         * Need sys_context to be able to calculate CpHash
-         */
-        TSS2_SYS_CONTEXT *sys_context = NULL;
+    TSS2_SYS_CONTEXT *sys_context = NULL;
+    tool_rc rc = tool_rc_success;
+    if (cp_hash->size) {
         rc = tpm2_getsapicontext(esys_context, &sys_context);
+
         if(rc != tool_rc_success) {
             LOG_ERR("Failed to acquire SAPI context.");
             return rc;
         }
+    }
 
+    if (cp_hash->size) {
         TSS2_RC rval = Tss2_Sys_CreateLoaded_Prepare(sys_context,
             parent_obj->handle, in_sensitive, in_public);
         if (rval != TPM2_RC_SUCCESS) {
@@ -1393,10 +1388,8 @@ tool_rc tpm2_create_loaded(ESYS_CONTEXT *esys_context,
             goto tpm2_createloaded_free_name1;
         }
 
-        cp_hash->size = tpm2_alg_util_get_hash_size(
-            tpm2_session_get_authhash(parent_obj->session));
         rc = tpm2_sapi_getcphash(sys_context, name1, NULL, NULL,
-            tpm2_session_get_authhash(parent_obj->session), cp_hash);
+            parameter_hash_algorithm, cp_hash);
 
         /*
          * Exit here without making the ESYS call since we just need the cpHash
@@ -1406,6 +1399,13 @@ tpm2_createloaded_free_name1:
         goto tpm2_createloaded_skip_esapi_call;
     }
 
+    ESYS_TR shandle1 = ESYS_TR_NONE;
+    rc = tpm2_auth_util_get_shandle(esys_context, parent_obj->tr_handle,
+        parent_obj->session, &shandle1);
+    if (rc != tool_rc_success) {
+        return rc;
+    }
+
     TSS2_RC rval = Esys_CreateLoaded(esys_context, parent_obj->tr_handle,
             shandle1, shandle2, shandle3, in_sensitive, in_public,
             object_handle, out_private, out_public);
@@ -1413,6 +1413,7 @@ tpm2_createloaded_free_name1:
         LOG_PERR(Esys_CreateLoaded, rval);
         return tool_rc_from_tpm(rval);
     }
+
 tpm2_createloaded_skip_esapi_call:
     return rc;
 }

--- a/lib/tpm2.c
+++ b/lib/tpm2.c
@@ -3535,7 +3535,7 @@ tool_rc tpm2_certifycreation(ESYS_CONTEXT *esys_context,
     TPMT_TK_CREATION *creation_ticket, TPM2B_ATTEST **certify_info,
     TPMT_SIGNATURE **signature, TPM2B_DATA *policy_qualifier,
     TPM2B_DIGEST *cp_hash, TPM2B_DIGEST *rp_hash,
-    TPMI_ALG_HASH parameter_hash_algorithm) {
+    TPMI_ALG_HASH parameter_hash_algorithm, ESYS_TR shandle2, ESYS_TR shandle3) {
 
     TSS2_SYS_CONTEXT *sys_context = NULL;
     tool_rc rc = tool_rc_success;
@@ -3593,7 +3593,7 @@ tpm2_certifycreation_free_name1:
 
     TSS2_RC rval = Esys_CertifyCreation(esys_context, signingkey_obj->tr_handle,
         certifiedkey_obj->tr_handle, signingkey_obj_session_handle,
-        ESYS_TR_NONE, ESYS_TR_NONE, policy_qualifier, creation_hash, in_scheme,
+        shandle2, shandle3, policy_qualifier, creation_hash, in_scheme,
         creation_ticket, certify_info, signature);
     if (rval != TPM2_RC_SUCCESS) {
         LOG_PERR(Esys_CertifyCreation, rval);

--- a/lib/tpm2.c
+++ b/lib/tpm2.c
@@ -3751,7 +3751,8 @@ tpm2_quote_skip_esapi_call:
 
 tool_rc tpm2_changeeps(ESYS_CONTEXT *ectx,
     tpm2_session *platform_hierarchy_session, TPM2B_DIGEST *cp_hash,
-    TPM2B_DIGEST *rp_hash, TPMI_ALG_HASH parameter_hash_algorithm) {
+    TPM2B_DIGEST *rp_hash, TPMI_ALG_HASH parameter_hash_algorithm,
+    ESYS_TR shandle2, ESYS_TR shandle3) {
 
     TSS2_SYS_CONTEXT *sys_context = NULL;
     tool_rc rc = tool_rc_success;
@@ -3798,7 +3799,7 @@ tpm2_changeeps_free_name1:
     }
 
     TSS2_RC rval = Esys_ChangeEPS(ectx, ESYS_TR_RH_PLATFORM,
-        platform_hierarchy_session_handle, ESYS_TR_NONE, ESYS_TR_NONE);
+        platform_hierarchy_session_handle, shandle2, shandle3);
     if (rval != TPM2_RC_SUCCESS) {
         LOG_PERR(Esys_ChangeEPS, rval);
         return tool_rc_from_tpm(rval);

--- a/lib/tpm2.c
+++ b/lib/tpm2.c
@@ -3815,13 +3815,49 @@ tpm2_changeeps_skip_esapi_call:
 }
 
 tool_rc tpm2_changepps(ESYS_CONTEXT *ectx,
-    tpm2_session *platform_hierarchy_session) {
+    tpm2_session *platform_hierarchy_session, TPM2B_DIGEST *cp_hash) {
 
     ESYS_TR platform_hierarchy_session_handle = ESYS_TR_NONE;
     tool_rc rc = tpm2_auth_util_get_shandle(ectx, ESYS_TR_RH_PLATFORM,
         platform_hierarchy_session, &platform_hierarchy_session_handle);
     if (rc != tool_rc_success) {
         return rc;
+    }
+
+    if (cp_hash) {
+        /*
+         * Need sys_context to be able to calculate CpHash
+         */
+        TSS2_SYS_CONTEXT *sys_context = NULL;
+        rc = tpm2_getsapicontext(ectx, &sys_context);
+        if(rc != tool_rc_success) {
+            LOG_ERR("Failed to acquire SAPI context.");
+            return rc;
+        }
+
+        TSS2_RC rval = Tss2_Sys_ChangePPS_Prepare(sys_context, TPM2_RH_PLATFORM);
+        if (rval != TPM2_RC_SUCCESS) {
+            LOG_PERR(Tss2_Sys_ObjectChangeAuth_Prepare, rval);
+            return tool_rc_general_error;
+        }
+
+        TPM2B_NAME *name1 = NULL;
+        rc = tpm2_tr_get_name(ectx, ESYS_TR_RH_PLATFORM ,&name1);
+        if (rc != tool_rc_success) {
+            goto tpm2_changepps_free_name1;
+        }
+
+        cp_hash->size = tpm2_alg_util_get_hash_size(
+            tpm2_session_get_authhash(platform_hierarchy_session));
+        rc = tpm2_sapi_getcphash(sys_context, name1, NULL, NULL,
+            tpm2_session_get_authhash(platform_hierarchy_session), cp_hash);
+
+tpm2_changepps_free_name1:
+        Esys_Free(name1);
+        /*
+         * Exit here without making the ESYS call since we just need the cpHash
+         */
+        goto tpm2_changepps_skip_esapi_call;
     }
 
     TSS2_RC rval = Esys_ChangePPS(ectx, ESYS_TR_RH_PLATFORM,
@@ -3831,7 +3867,8 @@ tool_rc tpm2_changepps(ESYS_CONTEXT *ectx,
         return tool_rc_from_tpm(rval);
     }
 
-    return tool_rc_success;
+tpm2_changepps_skip_esapi_call:
+    return rc;
 }
 
 tool_rc tpm2_unseal(ESYS_CONTEXT *esys_context, tpm2_loaded_object *sealkey_obj,

--- a/lib/tpm2.h
+++ b/lib/tpm2.h
@@ -362,7 +362,7 @@ tool_rc tpm2_changeeps(ESYS_CONTEXT *ectx,
     ESYS_TR shandle2, ESYS_TR shandle3);
 
 tool_rc tpm2_changepps(ESYS_CONTEXT *ectx,
-    tpm2_session *platform_hierarchy_session);
+    tpm2_session *platform_hierarchy_session, TPM2B_DIGEST *cp_hash);
 
 tool_rc tpm2_unseal(ESYS_CONTEXT *esys_context, tpm2_loaded_object *sealkey_obj,
 TPM2B_SENSITIVE_DATA **out_data, TPM2B_DIGEST *cp_hash, ESYS_TR shandle2,

--- a/lib/tpm2.h
+++ b/lib/tpm2.h
@@ -358,7 +358,7 @@ tool_rc tpm2_quote(ESYS_CONTEXT *esys_context, tpm2_loaded_object *quote_obj,
 
 tool_rc tpm2_changeeps(ESYS_CONTEXT *ectx,
     tpm2_session *platform_hierarchy_session, TPM2B_DIGEST *cp_hash,
-    TPMI_ALG_HASH parameter_hash_algorithm);
+    TPM2B_DIGEST *rp_hash, TPMI_ALG_HASH parameter_hash_algorithm);
 
 tool_rc tpm2_changepps(ESYS_CONTEXT *ectx,
     tpm2_session *platform_hierarchy_session);

--- a/lib/tpm2.h
+++ b/lib/tpm2.h
@@ -426,7 +426,7 @@ tool_rc tpm2_certifycreation(ESYS_CONTEXT *esys_context,
     TPMT_TK_CREATION *creation_ticket, TPM2B_ATTEST **certify_info,
     TPMT_SIGNATURE **signature, TPM2B_DATA *policy_qualifier,
     TPM2B_DIGEST *cp_hash, TPM2B_DIGEST *rp_hash,
-    TPMI_ALG_HASH parameter_hash_algorithm);
+    TPMI_ALG_HASH parameter_hash_algorithm, ESYS_TR shandle2, ESYS_TR shandle3);
 
 tool_rc tpm2_nvcertify(ESYS_CONTEXT *esys_context,
     tpm2_loaded_object *signingkey_obj, tpm2_loaded_object *nvindex_authobj,

--- a/lib/tpm2.h
+++ b/lib/tpm2.h
@@ -190,16 +190,17 @@ tool_rc tpm2_create(ESYS_CONTEXT *esys_context, tpm2_loaded_object *parent_obj,
         TPM2B_PRIVATE **out_private, TPM2B_PUBLIC **out_public,
         TPM2B_CREATION_DATA **creation_data, TPM2B_DIGEST **creation_hash,
         TPMT_TK_CREATION **creation_ticket, TPM2B_DIGEST *cp_hash,
-        TPMI_ALG_HASH parameter_hash_algorithm, ESYS_TR shandle2,
-        ESYS_TR shandle3);
+        TPM2B_DIGEST *rp_hash, TPMI_ALG_HASH parameter_hash_algorithm,
+        ESYS_TR shandle2, ESYS_TR shandle3);
 
 tool_rc tpm2_create_loaded(ESYS_CONTEXT *esys_context,
         tpm2_loaded_object *parent_obj,
         const TPM2B_SENSITIVE_CREATE *in_sensitive,
         const TPM2B_TEMPLATE *in_public, ESYS_TR *object_handle,
         TPM2B_PRIVATE **out_private, TPM2B_PUBLIC **out_public,
-        TPM2B_DIGEST *cp_hash, TPMI_ALG_HASH parameter_hash_algorithm,
-        ESYS_TR shandle2, ESYS_TR shandle3);
+        TPM2B_DIGEST *cp_hash, TPM2B_DIGEST *rp_hash,
+        TPMI_ALG_HASH parameter_hash_algorithm, ESYS_TR shandle2,
+        ESYS_TR shandle3);
 
 tool_rc tpm2_object_change_auth(ESYS_CONTEXT *esys_context,
         tpm2_loaded_object *parent_object, tpm2_loaded_object *object,

--- a/lib/tpm2.h
+++ b/lib/tpm2.h
@@ -219,7 +219,7 @@ tool_rc tpm2_certify(ESYS_CONTEXT *esys_context,
     tpm2_loaded_object *certifiedkey_obj,
     tpm2_loaded_object *signingkey_obj, TPM2B_DATA *qualifying_data,
     TPMT_SIG_SCHEME *scheme, TPM2B_ATTEST **certify_info,
-    TPMT_SIGNATURE **signature, TPM2B_DIGEST *cp_hash,
+    TPMT_SIGNATURE **signature, TPM2B_DIGEST *cp_hash, TPM2B_DIGEST *rp_hash,
     TPMI_ALG_HASH parameter_hash_algorithm);
 
 tool_rc tpm2_rsa_decrypt(ESYS_CONTEXT *esys_context, tpm2_loaded_object *keyobj,

--- a/lib/tpm2.h
+++ b/lib/tpm2.h
@@ -220,7 +220,7 @@ tool_rc tpm2_certify(ESYS_CONTEXT *esys_context,
     tpm2_loaded_object *signingkey_obj, TPM2B_DATA *qualifying_data,
     TPMT_SIG_SCHEME *scheme, TPM2B_ATTEST **certify_info,
     TPMT_SIGNATURE **signature, TPM2B_DIGEST *cp_hash, TPM2B_DIGEST *rp_hash,
-    TPMI_ALG_HASH parameter_hash_algorithm);
+    TPMI_ALG_HASH parameter_hash_algorithm, ESYS_TR shandle3);
 
 tool_rc tpm2_rsa_decrypt(ESYS_CONTEXT *esys_context, tpm2_loaded_object *keyobj,
         const TPM2B_PUBLIC_KEY_RSA *cipher_text,

--- a/lib/tpm2.h
+++ b/lib/tpm2.h
@@ -358,7 +358,8 @@ tool_rc tpm2_quote(ESYS_CONTEXT *esys_context, tpm2_loaded_object *quote_obj,
 
 tool_rc tpm2_changeeps(ESYS_CONTEXT *ectx,
     tpm2_session *platform_hierarchy_session, TPM2B_DIGEST *cp_hash,
-    TPM2B_DIGEST *rp_hash, TPMI_ALG_HASH parameter_hash_algorithm);
+    TPM2B_DIGEST *rp_hash, TPMI_ALG_HASH parameter_hash_algorithm,
+    ESYS_TR shandle2, ESYS_TR shandle3);
 
 tool_rc tpm2_changepps(ESYS_CONTEXT *ectx,
     tpm2_session *platform_hierarchy_session);

--- a/lib/tpm2.h
+++ b/lib/tpm2.h
@@ -425,7 +425,7 @@ tool_rc tpm2_certifycreation(ESYS_CONTEXT *esys_context,
     TPM2B_DIGEST *creation_hash, TPMT_SIG_SCHEME *in_scheme,
     TPMT_TK_CREATION *creation_ticket, TPM2B_ATTEST **certify_info,
     TPMT_SIGNATURE **signature, TPM2B_DATA *policy_qualifier,
-    TPM2B_DIGEST *cp_hash);
+    TPM2B_DIGEST *cp_hash, TPMI_ALG_HASH parameter_hash_algorithm);
 
 tool_rc tpm2_nvcertify(ESYS_CONTEXT *esys_context,
     tpm2_loaded_object *signingkey_obj, tpm2_loaded_object *nvindex_authobj,

--- a/lib/tpm2.h
+++ b/lib/tpm2.h
@@ -363,7 +363,7 @@ tool_rc tpm2_changeeps(ESYS_CONTEXT *ectx,
 
 tool_rc tpm2_changepps(ESYS_CONTEXT *ectx,
     tpm2_session *platform_hierarchy_session, TPM2B_DIGEST *cp_hash,
-    TPMI_ALG_HASH parameter_hash_algorithm);
+    TPM2B_DIGEST *rp_hash, TPMI_ALG_HASH parameter_hash_algorithm);
 
 tool_rc tpm2_unseal(ESYS_CONTEXT *esys_context, tpm2_loaded_object *sealkey_obj,
 TPM2B_SENSITIVE_DATA **out_data, TPM2B_DIGEST *cp_hash, ESYS_TR shandle2,

--- a/lib/tpm2.h
+++ b/lib/tpm2.h
@@ -207,16 +207,19 @@ tool_rc tpm2_object_change_auth(ESYS_CONTEXT *esys_context,
     tpm2_loaded_object *parent_object, tpm2_loaded_object *object,
     const TPM2B_AUTH *new_auth, TPM2B_PRIVATE **out_private,
     TPM2B_DIGEST *cp_hash, TPM2B_DIGEST *rp_hash,
-    TPMI_ALG_HASH parameter_hash_algorithm);
+    TPMI_ALG_HASH parameter_hash_algorithm, ESYS_TR shandle2,
+    ESYS_TR shandle3);
 
 tool_rc tpm2_nv_change_auth(ESYS_CONTEXT *esys_context, tpm2_loaded_object *nv,
     const TPM2B_AUTH *new_auth, TPM2B_DIGEST *cp_hash, TPM2B_DIGEST *rp_hash,
-    TPMI_ALG_HASH parameter_hash_algorithm);
+    TPMI_ALG_HASH parameter_hash_algorithm, ESYS_TR shandle2,
+    ESYS_TR shandle3);
 
 tool_rc tpm2_hierarchy_change_auth(ESYS_CONTEXT *esys_context,
     tpm2_loaded_object *hierarchy, const TPM2B_AUTH *new_auth,
     TPM2B_DIGEST *cp_hash, TPM2B_DIGEST *rp_hash,
-    TPMI_ALG_HASH parameter_hash_algorithm);
+    TPMI_ALG_HASH parameter_hash_algorithm, ESYS_TR shandle2,
+    ESYS_TR shandle3);
 
 tool_rc tpm2_certify(ESYS_CONTEXT *esys_context,
     tpm2_loaded_object *certifiedkey_obj,

--- a/lib/tpm2.h
+++ b/lib/tpm2.h
@@ -216,10 +216,11 @@ tool_rc tpm2_hierarchy_change_auth(ESYS_CONTEXT *esys_context,
         TPM2B_DIGEST *cp_hash);
 
 tool_rc tpm2_certify(ESYS_CONTEXT *esys_context,
-        tpm2_loaded_object *certifiedkey_obj,
-        tpm2_loaded_object *signingkey_obj, TPM2B_DATA *qualifying_data,
-        TPMT_SIG_SCHEME *scheme, TPM2B_ATTEST **certify_info,
-        TPMT_SIGNATURE **signature, TPM2B_DIGEST *cp_hash);
+    tpm2_loaded_object *certifiedkey_obj,
+    tpm2_loaded_object *signingkey_obj, TPM2B_DATA *qualifying_data,
+    TPMT_SIG_SCHEME *scheme, TPM2B_ATTEST **certify_info,
+    TPMT_SIGNATURE **signature, TPM2B_DIGEST *cp_hash,
+    TPMI_ALG_HASH parameter_hash_algorithm);
 
 tool_rc tpm2_rsa_decrypt(ESYS_CONTEXT *esys_context, tpm2_loaded_object *keyobj,
         const TPM2B_PUBLIC_KEY_RSA *cipher_text,

--- a/lib/tpm2.h
+++ b/lib/tpm2.h
@@ -357,7 +357,7 @@ tool_rc tpm2_quote(ESYS_CONTEXT *esys_context, tpm2_loaded_object *quote_obj,
         TPMT_SIGNATURE **signature, TPM2B_DIGEST *cp_hash);
 
 tool_rc tpm2_changeeps(ESYS_CONTEXT *ectx,
-    tpm2_session *platform_hierarchy_session);
+    tpm2_session *platform_hierarchy_session, TPM2B_DIGEST *cp_hash);
 
 tool_rc tpm2_changepps(ESYS_CONTEXT *ectx,
     tpm2_session *platform_hierarchy_session);

--- a/lib/tpm2.h
+++ b/lib/tpm2.h
@@ -362,7 +362,8 @@ tool_rc tpm2_changeeps(ESYS_CONTEXT *ectx,
     ESYS_TR shandle2, ESYS_TR shandle3);
 
 tool_rc tpm2_changepps(ESYS_CONTEXT *ectx,
-    tpm2_session *platform_hierarchy_session, TPM2B_DIGEST *cp_hash);
+    tpm2_session *platform_hierarchy_session, TPM2B_DIGEST *cp_hash,
+    TPMI_ALG_HASH parameter_hash_algorithm);
 
 tool_rc tpm2_unseal(ESYS_CONTEXT *esys_context, tpm2_loaded_object *sealkey_obj,
 TPM2B_SENSITIVE_DATA **out_data, TPM2B_DIGEST *cp_hash, ESYS_TR shandle2,

--- a/lib/tpm2.h
+++ b/lib/tpm2.h
@@ -182,7 +182,7 @@ tool_rc tpm2_activatecredential(ESYS_CONTEXT *esys_context,
         tpm2_loaded_object *activatehandle, tpm2_loaded_object *keyhandle,
         const TPM2B_ID_OBJECT *credential_blob,
         const TPM2B_ENCRYPTED_SECRET *secret, TPM2B_DIGEST **cert_info,
-        TPM2B_DIGEST *cp_hash);
+        TPM2B_DIGEST *cp_hash, TPMI_ALG_HASH parameter_hash_algorithm);
 
 tool_rc tpm2_create(ESYS_CONTEXT *esys_context, tpm2_loaded_object *parent_obj,
         const TPM2B_SENSITIVE_CREATE *in_sensitive, const TPM2B_PUBLIC *in_public,

--- a/lib/tpm2.h
+++ b/lib/tpm2.h
@@ -425,7 +425,8 @@ tool_rc tpm2_certifycreation(ESYS_CONTEXT *esys_context,
     TPM2B_DIGEST *creation_hash, TPMT_SIG_SCHEME *in_scheme,
     TPMT_TK_CREATION *creation_ticket, TPM2B_ATTEST **certify_info,
     TPMT_SIGNATURE **signature, TPM2B_DATA *policy_qualifier,
-    TPM2B_DIGEST *cp_hash, TPMI_ALG_HASH parameter_hash_algorithm);
+    TPM2B_DIGEST *cp_hash, TPM2B_DIGEST *rp_hash,
+    TPMI_ALG_HASH parameter_hash_algorithm);
 
 tool_rc tpm2_nvcertify(ESYS_CONTEXT *esys_context,
     tpm2_loaded_object *signingkey_obj, tpm2_loaded_object *nvindex_authobj,

--- a/lib/tpm2.h
+++ b/lib/tpm2.h
@@ -204,16 +204,17 @@ tool_rc tpm2_create_loaded(ESYS_CONTEXT *esys_context,
         ESYS_TR shandle3);
 
 tool_rc tpm2_object_change_auth(ESYS_CONTEXT *esys_context,
-        tpm2_loaded_object *parent_object, tpm2_loaded_object *object,
-        const TPM2B_AUTH *new_auth, TPM2B_PRIVATE **out_private,
-        TPM2B_DIGEST *cp_hash);
+    tpm2_loaded_object *parent_object, tpm2_loaded_object *object,
+    const TPM2B_AUTH *new_auth, TPM2B_PRIVATE **out_private,
+    TPM2B_DIGEST *cp_hash, TPMI_ALG_HASH parameter_hash_algorithm);
 
 tool_rc tpm2_nv_change_auth(ESYS_CONTEXT *esys_context, tpm2_loaded_object *nv,
-        const TPM2B_AUTH *new_auth, TPM2B_DIGEST *cp_hash);
+    const TPM2B_AUTH *new_auth, TPM2B_DIGEST *cp_hash,
+    TPMI_ALG_HASH parameter_hash_algorithm);
 
 tool_rc tpm2_hierarchy_change_auth(ESYS_CONTEXT *esys_context,
-        tpm2_loaded_object *hierarchy, const TPM2B_AUTH *new_auth,
-        TPM2B_DIGEST *cp_hash);
+    tpm2_loaded_object *hierarchy, const TPM2B_AUTH *new_auth,
+    TPM2B_DIGEST *cp_hash, TPMI_ALG_HASH parameter_hash_algorithm);
 
 tool_rc tpm2_certify(ESYS_CONTEXT *esys_context,
     tpm2_loaded_object *certifiedkey_obj,

--- a/lib/tpm2.h
+++ b/lib/tpm2.h
@@ -206,15 +206,17 @@ tool_rc tpm2_create_loaded(ESYS_CONTEXT *esys_context,
 tool_rc tpm2_object_change_auth(ESYS_CONTEXT *esys_context,
     tpm2_loaded_object *parent_object, tpm2_loaded_object *object,
     const TPM2B_AUTH *new_auth, TPM2B_PRIVATE **out_private,
-    TPM2B_DIGEST *cp_hash, TPMI_ALG_HASH parameter_hash_algorithm);
+    TPM2B_DIGEST *cp_hash, TPM2B_DIGEST *rp_hash,
+    TPMI_ALG_HASH parameter_hash_algorithm);
 
 tool_rc tpm2_nv_change_auth(ESYS_CONTEXT *esys_context, tpm2_loaded_object *nv,
-    const TPM2B_AUTH *new_auth, TPM2B_DIGEST *cp_hash,
+    const TPM2B_AUTH *new_auth, TPM2B_DIGEST *cp_hash, TPM2B_DIGEST *rp_hash,
     TPMI_ALG_HASH parameter_hash_algorithm);
 
 tool_rc tpm2_hierarchy_change_auth(ESYS_CONTEXT *esys_context,
     tpm2_loaded_object *hierarchy, const TPM2B_AUTH *new_auth,
-    TPM2B_DIGEST *cp_hash, TPMI_ALG_HASH parameter_hash_algorithm);
+    TPM2B_DIGEST *cp_hash, TPM2B_DIGEST *rp_hash,
+    TPMI_ALG_HASH parameter_hash_algorithm);
 
 tool_rc tpm2_certify(ESYS_CONTEXT *esys_context,
     tpm2_loaded_object *certifiedkey_obj,

--- a/lib/tpm2.h
+++ b/lib/tpm2.h
@@ -357,7 +357,8 @@ tool_rc tpm2_quote(ESYS_CONTEXT *esys_context, tpm2_loaded_object *quote_obj,
         TPMT_SIGNATURE **signature, TPM2B_DIGEST *cp_hash);
 
 tool_rc tpm2_changeeps(ESYS_CONTEXT *ectx,
-    tpm2_session *platform_hierarchy_session, TPM2B_DIGEST *cp_hash);
+    tpm2_session *platform_hierarchy_session, TPM2B_DIGEST *cp_hash,
+    TPMI_ALG_HASH parameter_hash_algorithm);
 
 tool_rc tpm2_changepps(ESYS_CONTEXT *ectx,
     tpm2_session *platform_hierarchy_session);

--- a/lib/tpm2.h
+++ b/lib/tpm2.h
@@ -182,7 +182,8 @@ tool_rc tpm2_activatecredential(ESYS_CONTEXT *esys_context,
         tpm2_loaded_object *activatehandle, tpm2_loaded_object *keyhandle,
         const TPM2B_ID_OBJECT *credential_blob,
         const TPM2B_ENCRYPTED_SECRET *secret, TPM2B_DIGEST **cert_info,
-        TPM2B_DIGEST *cp_hash, TPMI_ALG_HASH parameter_hash_algorithm);
+        TPM2B_DIGEST *cp_hash, TPM2B_DIGEST *rp_hash,
+        TPMI_ALG_HASH parameter_hash_algorithm);
 
 tool_rc tpm2_create(ESYS_CONTEXT *esys_context, tpm2_loaded_object *parent_obj,
         const TPM2B_SENSITIVE_CREATE *in_sensitive, const TPM2B_PUBLIC *in_public,

--- a/lib/tpm2.h
+++ b/lib/tpm2.h
@@ -183,7 +183,7 @@ tool_rc tpm2_activatecredential(ESYS_CONTEXT *esys_context,
         const TPM2B_ID_OBJECT *credential_blob,
         const TPM2B_ENCRYPTED_SECRET *secret, TPM2B_DIGEST **cert_info,
         TPM2B_DIGEST *cp_hash, TPM2B_DIGEST *rp_hash,
-        TPMI_ALG_HASH parameter_hash_algorithm);
+        TPMI_ALG_HASH parameter_hash_algorithm, ESYS_TR shandle3);
 
 tool_rc tpm2_create(ESYS_CONTEXT *esys_context, tpm2_loaded_object *parent_obj,
         const TPM2B_SENSITIVE_CREATE *in_sensitive, const TPM2B_PUBLIC *in_public,

--- a/lib/tpm2.h
+++ b/lib/tpm2.h
@@ -190,14 +190,16 @@ tool_rc tpm2_create(ESYS_CONTEXT *esys_context, tpm2_loaded_object *parent_obj,
         TPM2B_PRIVATE **out_private, TPM2B_PUBLIC **out_public,
         TPM2B_CREATION_DATA **creation_data, TPM2B_DIGEST **creation_hash,
         TPMT_TK_CREATION **creation_ticket, TPM2B_DIGEST *cp_hash,
-        ESYS_TR shandle2, ESYS_TR shandle3);
+        TPMI_ALG_HASH parameter_hash_algorithm, ESYS_TR shandle2,
+        ESYS_TR shandle3);
 
 tool_rc tpm2_create_loaded(ESYS_CONTEXT *esys_context,
         tpm2_loaded_object *parent_obj,
         const TPM2B_SENSITIVE_CREATE *in_sensitive,
         const TPM2B_TEMPLATE *in_public, ESYS_TR *object_handle,
         TPM2B_PRIVATE **out_private, TPM2B_PUBLIC **out_public,
-        TPM2B_DIGEST *cp_hash, ESYS_TR shandle2, ESYS_TR shandle3);
+        TPM2B_DIGEST *cp_hash, TPMI_ALG_HASH parameter_hash_algorithm,
+        ESYS_TR shandle2, ESYS_TR shandle3);
 
 tool_rc tpm2_object_change_auth(ESYS_CONTEXT *esys_context,
         tpm2_loaded_object *parent_object, tpm2_loaded_object *object,

--- a/lib/tpm2.h
+++ b/lib/tpm2.h
@@ -363,7 +363,8 @@ tool_rc tpm2_changeeps(ESYS_CONTEXT *ectx,
 
 tool_rc tpm2_changepps(ESYS_CONTEXT *ectx,
     tpm2_session *platform_hierarchy_session, TPM2B_DIGEST *cp_hash,
-    TPM2B_DIGEST *rp_hash, TPMI_ALG_HASH parameter_hash_algorithm);
+    TPM2B_DIGEST *rp_hash, TPMI_ALG_HASH parameter_hash_algorithm,
+    ESYS_TR shandle2, ESYS_TR shandle3);
 
 tool_rc tpm2_unseal(ESYS_CONTEXT *esys_context, tpm2_loaded_object *sealkey_obj,
 TPM2B_SENSITIVE_DATA **out_data, TPM2B_DIGEST *cp_hash, ESYS_TR shandle2,

--- a/lib/tpm2_util.h
+++ b/lib/tpm2_util.h
@@ -499,15 +499,17 @@ bool tpm2_pem_encoded_key_to_fingerprint(const char* pem_encoded_key, char*
  *  An array of string data specifying the individual session file path
  * @param session_handle
  *  An array of session handles updated as a result resuming sessions
- * @param param_hash_algorithm
- *  TPM_Hash_Alg value updated from session hash alg
  * @param session
  *  An array of session structures updated as a result of resuming sessions
  * @return
  *  Success: tool_rc_success, Faiure: tool_rc_general_error
  */
 tool_rc tpm2_util_aux_sessions_setup( ESYS_CONTEXT *ectx,
-uint8_t session_cnt, const char **session_path, ESYS_TR *session_handle,
-TPMI_ALG_HASH *param_hash_algorithm, tpm2_session **session);
+    uint8_t session_cnt, const char **session_path, ESYS_TR *session_handle,
+    tpm2_session **session);
+
+TPMI_ALG_HASH tpm2_util_calculate_phash_algorithm(ESYS_CONTEXT *ectx,
+    const char **cphash_path, TPM2B_DIGEST *cp_hash, const char **rphash_path,
+    TPM2B_DIGEST *rp_hash, tpm2_session **sessions);
 
 #endif /* STRING_BYTES_H */

--- a/man/tpm2_activatecredential.1.md
+++ b/man/tpm2_activatecredential.1.md
@@ -55,6 +55,12 @@ TPM.
     File path to record the hash of the response parameters. This is commonly
     termed as rpHash.
 
+  * **-S**, **\--session**=_FILE_:
+
+    The session created using **tpm2_startauthsession**. This can be used to
+    specify an auxiliary session for auditing and or encryption/decryption of
+    the parameters.
+
 ## References
 
 [context object format](common/ctxobj.md) details the methods for specifying

--- a/man/tpm2_activatecredential.1.md
+++ b/man/tpm2_activatecredential.1.md
@@ -48,7 +48,12 @@ TPM.
 
     File path to record the hash of the command parameters. This is commonly
     termed as cpHash. NOTE: When this option is selected, The tool will not
-    actually execute the command, it simply returns a cpHash.
+    actually execute the command, it simply returns a cpHash, unless rphash is also required.
+
+  * **\--rphash**=_FILE_
+
+    File path to record the hash of the response parameters. This is commonly
+    termed as rpHash.
 
 ## References
 

--- a/man/tpm2_certify.1.md
+++ b/man/tpm2_certify.1.md
@@ -59,7 +59,13 @@ These options control the certification:
 
     File path to record the hash of the command parameters. This is commonly
     termed as cpHash. NOTE: When this option is selected, The tool will not
-    actually execute the command, it simply returns a cpHash.
+    actually execute the command, it simply returns a cpHash, unless rphash is
+    also required.
+
+  * **\--rphash**=_FILE_
+
+    File path to record the hash of the response parameters. This is commonly
+    termed as rpHash.
 
 ## References
 

--- a/man/tpm2_certify.1.md
+++ b/man/tpm2_certify.1.md
@@ -67,6 +67,12 @@ These options control the certification:
     File path to record the hash of the response parameters. This is commonly
     termed as rpHash.
 
+  * **-S**, **\--session**=_FILE_:
+
+    The session created using **tpm2_startauthsession**. This can be used to
+    specify an auxiliary session for auditing and or encryption/decryption of
+    the parameters.
+
 ## References
 
 [context object format](common/ctxobj.md) details the methods for specifying

--- a/man/tpm2_certifycreation.1.md
+++ b/man/tpm2_certifycreation.1.md
@@ -67,7 +67,12 @@ created with either **TPM2_CreatePrimary** or **TPM2_Create** commands.
 
     File path to record the hash of the command parameters. This is commonly
     termed as cpHash. NOTE: When this option is selected, The tool will not
-    actually execute the command, it simply returns a cpHash.
+    actually execute the command, it simply returns a cpHash, unless rphash is also required.
+
+  * **\--rphash**=_FILE_
+
+    File path to record the hash of the response parameters. This is commonly
+    termed as rpHash.
 
 ## References
 

--- a/man/tpm2_certifycreation.1.md
+++ b/man/tpm2_certifycreation.1.md
@@ -74,6 +74,12 @@ created with either **TPM2_CreatePrimary** or **TPM2_Create** commands.
     File path to record the hash of the response parameters. This is commonly
     termed as rpHash.
 
+  * **-S**, **\--session**=_FILE_:
+
+    The session created using **tpm2_startauthsession**. This can be used to
+    specify an auxiliary session for auditing and or encryption/decryption of
+    the parameters.
+
 ## References
 
 [context object format](common/ctxobj.md) details the methods for specifying

--- a/man/tpm2_changeauth.1.md
+++ b/man/tpm2_changeauth.1.md
@@ -52,6 +52,12 @@ see section "Authorization Formatting".
     File path to record the hash of the response parameters. This is commonly
     termed as rpHash.
 
+  * **-S**, **\--session**=_FILE_:
+
+    The session created using **tpm2_startauthsession**. This can be used to
+    specify an auxiliary session for auditing and or encryption/decryption of
+    the parameters.
+
   * **ARGUMENT** the command line argument specifies the _AUTH_ to be set for
     the object specified with **-c**.
 

--- a/man/tpm2_changeauth.1.md
+++ b/man/tpm2_changeauth.1.md
@@ -44,7 +44,13 @@ see section "Authorization Formatting".
 
     File path to record the hash of the command parameters. This is commonly
     termed as cpHash. NOTE: When this option is selected, The tool will not
-    actually execute the command, it simply returns a cpHash.
+    actually execute the command, it simply returns a cpHash, unless rphash is
+    also required.
+
+  * **\--rphash**=_FILE_
+
+    File path to record the hash of the response parameters. This is commonly
+    termed as rpHash.
 
   * **ARGUMENT** the command line argument specifies the _AUTH_ to be set for
     the object specified with **-c**.

--- a/man/tpm2_changeeps.1.md
+++ b/man/tpm2_changeeps.1.md
@@ -17,8 +17,15 @@ endorsement hierarchy are lost. This command requires platform auth.
 
 # OPTIONS
 
-  * **-p**, **\--auth** specifies the _AUTH_ for the platform.
-  hierarchy.
+  * **-p**, **\--auth**=_AUTH_
+
+    Specifies the _AUTH_ for the platform. hierarchy.
+
+  * **\--cphash**=_FILE_
+
+    File path to record the hash of the command parameters. This is commonly
+    termed as cpHash. NOTE: When this option is selected, The tool will not
+    actually execute the command, it simply returns a cpHash.
 
 ## References
 

--- a/man/tpm2_changeeps.1.md
+++ b/man/tpm2_changeeps.1.md
@@ -25,7 +25,13 @@ endorsement hierarchy are lost. This command requires platform auth.
 
     File path to record the hash of the command parameters. This is commonly
     termed as cpHash. NOTE: When this option is selected, The tool will not
-    actually execute the command, it simply returns a cpHash.
+    actually execute the command, it simply returns a cpHash, unless rphash
+    is also required.
+
+  * **\--rphash**=_FILE_
+
+    File path to record the hash of the response parameters. This is commonly
+    termed as rpHash.
 
 ## References
 

--- a/man/tpm2_changeeps.1.md
+++ b/man/tpm2_changeeps.1.md
@@ -33,6 +33,12 @@ endorsement hierarchy are lost. This command requires platform auth.
     File path to record the hash of the response parameters. This is commonly
     termed as rpHash.
 
+  * **-S**, **\--session**=_FILE_:
+
+    The session created using **tpm2_startauthsession**. This can be used to
+    specify an auxiliary session for auditing and or encryption/decryption of
+    the parameters.
+
 ## References
 
 [authorization formatting](common/authorizations.md) details the methods for

--- a/man/tpm2_changepps.1.md
+++ b/man/tpm2_changepps.1.md
@@ -20,6 +20,12 @@ platform hierarchy are lost whilst retaining the NV objects.
   * **-p**, **\--auth** specifies the _AUTH_ for the platform.
   hierarchy.
 
+  * **\--cphash**=_FILE_
+
+    File path to record the hash of the command parameters. This is commonly
+    termed as cpHash. NOTE: When this option is selected, The tool will not
+    actually execute the command, it simply returns a cpHash.
+
 ## References
 
 [authorization formatting](common/authorizations.md) details the methods for

--- a/man/tpm2_changepps.1.md
+++ b/man/tpm2_changepps.1.md
@@ -31,6 +31,12 @@ platform hierarchy are lost whilst retaining the NV objects.
     File path to record the hash of the response parameters. This is commonly
     termed as rpHash.
 
+  * **-S**, **\--session**=_FILE_:
+
+    The session created using **tpm2_startauthsession**. This can be used to
+    specify an auxiliary session for auditing and or encryption/decryption of
+    the parameters.
+
 ## References
 
 [authorization formatting](common/authorizations.md) details the methods for

--- a/man/tpm2_changepps.1.md
+++ b/man/tpm2_changepps.1.md
@@ -24,7 +24,12 @@ platform hierarchy are lost whilst retaining the NV objects.
 
     File path to record the hash of the command parameters. This is commonly
     termed as cpHash. NOTE: When this option is selected, The tool will not
-    actually execute the command, it simply returns a cpHash.
+    actually execute the command, it simply returns a cpHash, unless rphash is also required.
+
+  * **\--rphash**=_FILE_
+
+    File path to record the hash of the response parameters. This is commonly
+    termed as rpHash.
 
 ## References
 

--- a/man/tpm2_create.1.md
+++ b/man/tpm2_create.1.md
@@ -125,6 +125,11 @@ These options for creating the TPM entity:
     termed as cpHash. NOTE: When this option is selected, The tool will not
     actually execute the command, it simply returns a cpHash.
 
+* **\--rphash**=_FILE_
+
+     File path to record the hash of the response parameters. This is commonly
+     termed as rpHash.
+
   * **-S**, **\--session**=_FILE_:
 
     The session created using **tpm2_startauthsession**. Multiple of these can

--- a/test/integration/tests/abrmd_policycphash.sh
+++ b/test/integration/tests/abrmd_policycphash.sh
@@ -676,4 +676,20 @@ setup_authorized_policycphash
 tpm2 hmac -c key.ctx plain.txt -o hmac.bin -p "session:session.ctx"
 tpm2 flushcontext session.ctx
 
+# Test if specifying the <halg>: in the cphash path has effect on cphash alg
+TPM2_ALG_SHA256_SZ=34
+TPM2_ALG_SHA1_SZ=22
+
+## Default must be sha256
+expected_hash_len=$TPM2_ALG_SHA256_SZ
+tpm2 getrandom 8 --cphash cp.hash
+file_size=`ls -l cp.hash | awk {'print $5'}`
+test $file_size -eq $expected_hash_len
+
+## Check if a specific hash can be enforced with <halg>:
+expected_hash_len=$TPM2_ALG_SHA1_SZ
+tpm2 getrandom 8 --cphash sha1:cp.hash
+file_size=`ls -l cp.hash | awk {'print $5'}`
+test $file_size -eq $expected_hash_len
+
 exit 0

--- a/test/integration/tests/sessionaudit.sh
+++ b/test/integration/tests/sessionaudit.sh
@@ -167,6 +167,61 @@ diff \
 <( tail -c 32 att.data )
 
 #
+# Get audit digest: TPM command TPM2_CC_HierarchyChangeauth in an audit session
+#
+tpm2 clear -Q
+
+tpm2 createprimary -Q -C e -g sha256 -G rsa -c prim.ctx \
+-d create.dig -t create.ticket
+
+tpm2 create -Q -C prim.ctx -c signing_key.ctx -u signing_key.pub \
+-r signing_key.priv
+
+tpm2 startauthsession -S session.ctx --audit-session
+
+tpm2 changeauth -c o ownerpassword --cphash cp.hash --rphash rp.hash \
+-S session.ctx
+
+tpm2 getsessionauditdigest -c signing_key.ctx -m att.data -s att.sig \
+-S session.ctx
+
+dd if=/dev/zero bs=1 count=32 status=none of=zero.bin
+dd if=cp.hash skip=2 bs=1 count=32 status=none of=cphash.bin
+dd if=rp.hash skip=2 bs=1 count=32 status=none of=rphash.bin
+
+diff \
+<( cat zero.bin cphash.bin rphash.bin | openssl dgst -sha256 -binary ) \
+<( tail -c 32 att.data )
+
+#
+# Get audit digest: TPM command TPM2_CC_ObjectChangeauth in an audit session
+#
+tpm2 clear -Q
+
+tpm2 createprimary -Q -C e -g sha256 -G rsa -c prim.ctx \
+-d create.dig -t create.ticket
+
+tpm2 create -Q -C prim.ctx -c signing_key.ctx -u signing_key.pub \
+-r signing_key.priv
+
+tpm2 create -Q -C prim.ctx -p foo -u key.pub -r key.priv -c key.ctx
+
+tpm2 startauthsession -S session.ctx --audit-session
+
+tpm2 changeauth -C prim.ctx -p foo -c key.ctx -r new.priv bar \
+--cphash cp.hash --rphash rp.hash -S session.ctx
+
+tpm2 getsessionauditdigest -c signing_key.ctx -m att.data -s att.sig \
+-S session.ctx
+
+dd if=/dev/zero bs=1 count=32 status=none of=zero.bin
+dd if=cp.hash skip=2 bs=1 count=32 status=none of=cphash.bin
+dd if=rp.hash skip=2 bs=1 count=32 status=none of=rphash.bin
+
+diff \
+<( cat zero.bin cphash.bin rphash.bin | openssl dgst -sha256 -binary ) \
+<( tail -c 32 att.data )
+#
 # End
 #
 exit 0

--- a/test/integration/tests/sessionaudit.sh
+++ b/test/integration/tests/sessionaudit.sh
@@ -18,11 +18,10 @@ start_up
 
 cleanup "no-shutdown"
 
-tpm2 clear
-
 #
 # Get audit digest for a TPM command TPM2_GetRandom using and audit session
 #
+tpm2 clear
 
 tpm2 createprimary -Q -C e -c prim.ctx
 
@@ -32,6 +31,34 @@ tpm2 create -Q -C prim.ctx -c signing_key.ctx -u signing_key.pub \
 tpm2 startauthsession -S session.ctx --audit-session
 
 tpm2 getrandom 8 -S session.ctx --cphash cp.hash --rphash rp.hash
+
+tpm2 getsessionauditdigest -c signing_key.ctx -m att.data -s att.sig \
+-S session.ctx
+
+tpm2 flushcontext session.ctx
+
+dd if=/dev/zero bs=1 count=32 status=none of=zero.bin
+dd if=cp.hash skip=2 bs=1 count=32 status=none of=cphash.bin
+dd if=rp.hash skip=2 bs=1 count=32 status=none of=rphash.bin
+
+diff \
+<( cat zero.bin cphash.bin rphash.bin | openssl dgst -sha256 -binary ) \
+<( tail -c 32 att.data )
+
+#
+# Get audit digest for a TPM command TPM2_CC_Create in an audit session
+#
+tpm2 clear
+
+tpm2 createprimary -Q -C e -c prim.ctx
+
+tpm2 create -Q -C prim.ctx -c signing_key.ctx -u signing_key.pub \
+-r signing_key.priv
+
+tpm2 startauthsession -S session.ctx --audit-session
+
+tpm2 create -Q -C prim.ctx -u key.pub -r key.priv --cphash cp.hash \
+--rphash rp.hash -S session.ctx
 
 tpm2 getsessionauditdigest -c signing_key.ctx -m att.data -s att.sig \
 -S session.ctx

--- a/test/integration/tests/sessionaudit.sh
+++ b/test/integration/tests/sessionaudit.sh
@@ -248,6 +248,31 @@ diff \
 <( tail -c 32 att.data )
 
 #
+# Get audit digest: TPM command TPM2_CC_ChangePPS in an audit session
+#
+tpm2 clear -Q
+
+tpm2 startauthsession -S session.ctx --audit-session
+
+tpm2 changepps --cphash cp.hash --rphash rp.hash -S session.ctx
+
+tpm2 createprimary -Q -C e -g sha256 -G rsa -c prim.ctx
+
+tpm2 create -Q -C prim.ctx -c signing_key.ctx -u signing_key.pub \
+-r signing_key.priv
+
+tpm2 getsessionauditdigest -c signing_key.ctx -m att.data -s att.sig \
+-S session.ctx
+
+dd if=/dev/zero bs=1 count=32 status=none of=zero.bin
+dd if=cp.hash skip=2 bs=1 count=32 status=none of=cphash.bin
+dd if=rp.hash skip=2 bs=1 count=32 status=none of=rphash.bin
+
+diff \
+<( cat zero.bin cphash.bin rphash.bin | openssl dgst -sha256 -binary ) \
+<( tail -c 32 att.data )
+
+#
 # End
 #
 exit 0

--- a/test/integration/tests/sessionaudit.sh
+++ b/test/integration/tests/sessionaudit.sh
@@ -106,6 +106,37 @@ diff \
 <( tail -c 32 att.data )
 
 #
+# Get audit digest for a TPM command TPM2_CC_Certify in an audit session
+#
+tpm2 clear -Q
+
+tpm2 createprimary -Q -C e -g sha256 -G rsa -c primary.ctx
+
+tpm2 create -Q -C primary.ctx -c signing_key.ctx -u signing_key.pub \
+-r signing_key.priv
+
+tpm2 create -Q -g sha256 -G rsa -u certify.pub -r certify.priv -C primary.ctx
+
+tpm2 load -Q -C primary.ctx -u certify.pub -r certify.priv -n certify.name \
+-c certify.ctx
+
+tpm2 startauthsession -S session.ctx --audit-session
+
+tpm2 certify -Q -c primary.ctx -C certify.ctx -g sha256 -o attest.out -s sig.out \
+--cphash cp.hash --rphash rp.hash -S session.ctx
+
+tpm2 getsessionauditdigest -c signing_key.ctx -m att.data -s att.sig \
+-S session.ctx
+
+dd if=/dev/zero bs=1 count=32 status=none of=zero.bin
+dd if=cp.hash skip=2 bs=1 count=32 status=none of=cphash.bin
+dd if=rp.hash skip=2 bs=1 count=32 status=none of=rphash.bin
+
+diff \
+<( cat zero.bin cphash.bin rphash.bin | openssl dgst -sha256 -binary ) \
+<( tail -c 32 att.data )
+
+#
 # End
 #
 exit 0

--- a/test/integration/tests/sessionaudit.sh
+++ b/test/integration/tests/sessionaudit.sh
@@ -221,6 +221,32 @@ dd if=rp.hash skip=2 bs=1 count=32 status=none of=rphash.bin
 diff \
 <( cat zero.bin cphash.bin rphash.bin | openssl dgst -sha256 -binary ) \
 <( tail -c 32 att.data )
+
+#
+# Get audit digest: TPM command TPM2_CC_ChangeEPS in an audit session
+#
+tpm2 clear -Q
+
+tpm2 startauthsession -S session.ctx --audit-session
+
+tpm2 changeeps --cphash cp.hash --rphash rp.hash -S session.ctx
+
+tpm2 createprimary -Q -C e -g sha256 -G rsa -c prim.ctx
+
+tpm2 create -Q -C prim.ctx -c signing_key.ctx -u signing_key.pub \
+-r signing_key.priv
+
+tpm2 getsessionauditdigest -c signing_key.ctx -m att.data -s att.sig \
+-S session.ctx
+
+dd if=/dev/zero bs=1 count=32 status=none of=zero.bin
+dd if=cp.hash skip=2 bs=1 count=32 status=none of=cphash.bin
+dd if=rp.hash skip=2 bs=1 count=32 status=none of=rphash.bin
+
+diff \
+<( cat zero.bin cphash.bin rphash.bin | openssl dgst -sha256 -binary ) \
+<( tail -c 32 att.data )
+
 #
 # End
 #

--- a/tools/tpm2_certifycreation.c
+++ b/tools/tpm2_certifycreation.c
@@ -14,7 +14,9 @@
 
 typedef struct tpm_certifycreation_ctx tpm_certifycreation_ctx;
 struct tpm_certifycreation_ctx {
-    TPMT_TK_CREATION creation_ticket;
+    /*
+     * Inputs
+     */
     struct {
         const char *ctx_path;
         const char *auth_str;
@@ -27,32 +29,222 @@ struct tpm_certifycreation_ctx {
     } certified_key;
 
     char *creation_hash_path;
+    TPM2B_DIGEST creation_hash;
 
     char *creation_ticket_path;
+    TPMT_TK_CREATION creation_ticket;
+
+    TPM2B_DATA policy_qualifier;
+    const char *policy_qualifier_data;
 
     TPMI_ALG_HASH halg;
     TPMI_ALG_SIG_SCHEME sig_scheme;
     tpm2_convert_sig_fmt sig_format;
+    TPMT_SIG_SCHEME in_scheme;
+
+    /*
+     * Outputs
+     */
     char *signature_path;
+    TPMT_SIGNATURE *signature;
 
     char *certify_info_path;
+    TPM2B_ATTEST *certify_info;
 
-    const char *policy_qualifier_data;
-
+   /*
+    * Parameter hashes
+    */
     char *cp_hash_path;
+    TPM2B_DIGEST cp_hash;
+    TPM2B_DIGEST *cphash;
+    bool is_command_dispatch;
 };
 
 static tpm_certifycreation_ctx ctx = {
         .halg = TPM2_ALG_NULL,
-        .sig_scheme = TPM2_ALG_NULL
+        .sig_scheme = TPM2_ALG_NULL,
+        .policy_qualifier = TPM2B_EMPTY_INIT,
 };
 
-static bool set_digest_algorithm(char *value) {
+static tool_rc certifycreation(ESYS_CONTEXT *ectx) {
 
-    ctx.halg = tpm2_alg_util_from_optarg(value, tpm2_alg_util_flags_hash);
-    if (ctx.halg == TPM2_ALG_ERROR) {
-        LOG_ERR("Could not convert to number or lookup algorithm, got: "
-                "\"%s\"", value);
+    /*
+     * 1. TPM2_CC_<command> OR Retrieve cpHash
+     */
+    return tpm2_certifycreation(ectx, &ctx.signing_key.object,
+        &ctx.certified_key.object, &ctx.creation_hash, &ctx.in_scheme,
+        &ctx.creation_ticket, &ctx.certify_info, &ctx.signature,
+        &ctx.policy_qualifier, ctx.cphash);
+}
+
+static tool_rc process_output(void) {
+
+    /*
+     * 1. Outputs that do not require TPM2_CC_<command> dispatch
+     */
+    bool is_file_op_success = true;
+    if (ctx.cp_hash_path) {
+        is_file_op_success = files_save_digest(&ctx.cp_hash, ctx.cp_hash_path);
+
+        if (!is_file_op_success) {
+            return tool_rc_general_error;
+        }
+    }
+
+    if (!ctx.is_command_dispatch) {
+        return tool_rc_success;
+    }
+
+    /*
+     * 2. Outputs generated after TPM2_CC_<command> dispatch
+     */
+    is_file_op_success = tpm2_convert_sig_save(ctx.signature, ctx.sig_format,
+        ctx.signature_path);
+    if (!is_file_op_success) {
+        LOG_ERR("Failed saving signature data.");
+        return tool_rc_general_error;
+    }
+
+    is_file_op_success = files_save_bytes_to_file(ctx.certify_info_path,
+        ctx.certify_info->attestationData, ctx.certify_info->size);
+    if (!is_file_op_success) {
+        LOG_ERR("Failed saving attestation data.");
+    }
+
+    return is_file_op_success ? tool_rc_success : tool_rc_general_error;
+}
+
+static tool_rc process_inputs(ESYS_CONTEXT *ectx) {
+
+    /*
+     * 1. Object and auth initializations
+     */
+
+    /*
+     * 1.a Add the new-auth values to be set for the object.
+     */
+
+    /*
+     * 1.b Add object names and their auth sessions
+     */
+    tool_rc rc = tpm2_util_object_load_auth(ectx, ctx.signing_key.ctx_path,
+        ctx.signing_key.auth_str, &ctx.signing_key.object, false,
+        TPM2_HANDLES_FLAGS_TRANSIENT|TPM2_HANDLES_FLAGS_PERSISTENT);
+    if (rc != tool_rc_success) {
+        LOG_ERR("Invalid signing key/ authorization.");
+        return rc;
+    }
+
+    rc = tpm2_util_object_load(ectx, ctx.certified_key.ctx_path,
+        &ctx.certified_key.object,
+        TPM2_HANDLES_FLAGS_TRANSIENT|TPM2_HANDLES_FLAGS_PERSISTENT);
+    if (rc != tool_rc_success) {
+        LOG_ERR("Invalid key specified for certification.");
+        return rc;
+    }
+
+    /*
+     * 2. Restore auxiliary sessions
+     */
+
+    /*
+     * 3. Command specific initializations
+     */
+
+     /* Load creation hash */
+    rc = files_load_digest(ctx.creation_hash_path, &ctx.creation_hash) ?
+        tool_rc_success : tool_rc_general_error;
+    if (rc != tool_rc_success) {
+        LOG_ERR("Failed loading creation hash.");
+        return rc;
+    }
+
+    /* Set signature scheme for key type & Validate chosen scheme */
+    rc = tpm2_alg_util_get_signature_scheme(ectx,
+        ctx.signing_key.object.tr_handle, &ctx.halg, ctx.sig_scheme,
+        &ctx.in_scheme);
+    if (rc != tool_rc_success) {
+        LOG_ERR("bad signature scheme for key type!");
+        return rc;
+    }
+
+    /* Load creation ticket */
+    rc = files_load_creation_ticket(ctx.creation_ticket_path,
+        &ctx.creation_ticket) ? tool_rc_success : tool_rc_general_error;
+    if (rc != tool_rc_success) {
+        LOG_ERR("Could not load creation ticket from file");
+        return rc;
+    }
+
+    /* Qualifier data is optional. If not specified default to 0 */
+    if (ctx.policy_qualifier_data) {
+        ctx.policy_qualifier.size = sizeof(ctx.policy_qualifier.buffer);
+
+        rc = tpm2_util_bin_from_hex_or_file(ctx.policy_qualifier_data,
+            &ctx.policy_qualifier.size, ctx.policy_qualifier.buffer) ?
+            tool_rc_success : tool_rc_general_error;
+        
+        if (rc != tool_rc_success) {
+            LOG_ERR("Could not load qualifier data");
+            return rc;
+        }
+    }
+    /*
+     * 4. Configuration for calculating the pHash
+     */
+
+    /*
+     * 4.a Determine pHash length and alg
+     */
+    ctx.cphash = ctx.cp_hash_path ? &ctx.cp_hash : 0;
+
+    /*
+     * 4.b Determine if TPM2_CC_<command> is to be dispatched
+     */
+    ctx.is_command_dispatch = ctx.cp_hash_path ? false : true;
+
+    return rc;
+}
+
+static bool check_options(void) {
+
+    if (ctx.cp_hash_path && (ctx.certify_info_path || ctx.signature_path)) {
+        LOG_ERR("Cannot generate outputs when calculating cpHash.");
+        return false;
+    }
+
+    if (!ctx.signing_key.ctx_path) {
+        LOG_ERR("Must specify the signing key '-C'.");
+        return false;
+    }
+
+    if (!ctx.certified_key.ctx_path) {
+        LOG_ERR("Must specify the path of the key to certify '-c'.");
+        return false;
+    }
+
+    if (!ctx.creation_ticket_path) {
+        LOG_ERR("Must specify the creation ticket path '-t'.");
+        return false;
+    }
+
+    if (!ctx.signature_path && !ctx.cp_hash_path) {
+        LOG_ERR("Must specify the file path to save signature '-o'");
+        return false;
+    }
+
+    if (!ctx.certify_info_path && !ctx.cp_hash_path) {
+        LOG_ERR("Must specify file path to save attestation '--attestation'");
+        return false;
+    }
+
+    return true;
+}
+
+static bool set_signature_format(char *value) {
+
+    ctx.sig_format = tpm2_convert_sig_fmt_from_optarg(value);
+    if (ctx.sig_format == signature_format_err) {
         return false;
     }
     return true;
@@ -68,10 +260,12 @@ static bool set_signing_scheme(char *value) {
     return true;
 }
 
-static bool set_signature_format(char *value) {
+static bool set_digest_algorithm(char *value) {
 
-    ctx.sig_format = tpm2_convert_sig_fmt_from_optarg(value);
-    if (ctx.sig_format == signature_format_err) {
+    ctx.halg = tpm2_alg_util_from_optarg(value, tpm2_alg_util_flags_hash);
+    if (ctx.halg == TPM2_ALG_ERROR) {
+        LOG_ERR("Could not convert to number or lookup algorithm, got: "
+                "\"%s\"", value);
         return false;
     }
     return true;
@@ -148,187 +342,62 @@ static bool tpm2_tool_onstart(tpm2_options **opts) {
     return *opts != NULL;
 }
 
-static bool is_input_options_args_valid(void) {
-
-    if (ctx.cp_hash_path && (ctx.certify_info_path || ctx.signature_path)) {
-        LOG_ERR("Cannot generate outputs when calculating cpHash.");
-        return false;
-    }
-
-    if (!ctx.signing_key.ctx_path) {
-        LOG_ERR("Must specify the signing key '-C'.");
-        return false;
-    }
-
-    if (!ctx.certified_key.ctx_path) {
-        LOG_ERR("Must specify the path of the key to certify '-c'.");
-        return false;
-    }
-
-    if (!ctx.creation_ticket_path) {
-        LOG_ERR("Must specify the creation ticket path '-t'.");
-        return false;
-    }
-
-    if (!ctx.signature_path && !ctx.cp_hash_path) {
-        LOG_ERR("Must specify the file path to save signature '-o'");
-        return false;
-    }
-
-    if (!ctx.certify_info_path && !ctx.cp_hash_path) {
-        LOG_ERR("Must specify file path to save attestation '--attestation'");
-        return false;
-    }
-
-    return true;
-}
-
-static tool_rc process_certifycreation_input(ESYS_CONTEXT *ectx,
-    TPM2B_DIGEST *creation_hash, TPMT_SIG_SCHEME *in_scheme,
-    TPMT_TK_CREATION *creation_ticket, TPM2B_DATA *policy_qualifier) {
-
-    /*
-     * Load objects and auths
-     */
-    tool_rc rc = tpm2_util_object_load_auth(ectx, ctx.signing_key.ctx_path,
-            ctx.signing_key.auth_str, &ctx.signing_key.object, false,
-            TPM2_HANDLES_FLAGS_TRANSIENT|TPM2_HANDLES_FLAGS_PERSISTENT);
-    if (rc != tool_rc_success) {
-        LOG_ERR("Invalid signing key/ authorization.");
-        return rc;
-    }
-
-    rc = tpm2_util_object_load(ectx, ctx.certified_key.ctx_path,
-        &ctx.certified_key.object,
-        TPM2_HANDLES_FLAGS_TRANSIENT|TPM2_HANDLES_FLAGS_PERSISTENT);
-    if (rc != tool_rc_success) {
-        LOG_ERR("Invalid key specified for certification.");
-        return rc;
-    }
-
-    /*
-     * Load creation hash
-     */
-    bool result = files_load_digest(ctx.creation_hash_path, creation_hash);
-    if (!result) {
-        LOG_ERR("Failed loading creation hash.");
-        return tool_rc_general_error;
-    }
-
-    /*
-     * Set signature scheme for key type
-     * Validate chosen scheme is allowed for key type
-     */
-    rc = tpm2_alg_util_get_signature_scheme(ectx,
-        ctx.signing_key.object.tr_handle, &ctx.halg, ctx.sig_scheme, in_scheme);
-    if (rc != tool_rc_success) {
-        LOG_ERR("bad signature scheme for key type!");
-        return rc;
-    }
-
-    /*
-     * Load creation ticket
-     */
-    result = files_load_creation_ticket(ctx.creation_ticket_path,
-        creation_ticket);
-    if (!result) {
-        LOG_ERR("Could not load creation ticket from file");
-        return tool_rc_general_error;
-    }
-
-    /*
-     * Qualifier data is optional. If not specified default to 0
-     */
-    if (!ctx.policy_qualifier_data) {
-        return tool_rc_success;
-    }
-
-    policy_qualifier->size = sizeof(policy_qualifier->buffer);
-    result = tpm2_util_bin_from_hex_or_file(ctx.policy_qualifier_data,
-            &policy_qualifier->size, policy_qualifier->buffer);
-
-    return result ? tool_rc_success : tool_rc_general_error;;
-}
-
-static tool_rc process_certifycreation_output(TPMT_SIGNATURE *signature,
-    TPM2B_ATTEST *certify_info) {
-
-    bool result = tpm2_convert_sig_save(signature, ctx.sig_format,
-        ctx.signature_path);
-    if (!result) {
-        LOG_ERR("Failed saving signature data.");
-        return tool_rc_general_error;
-    }
-
-    result = files_save_bytes_to_file(ctx.certify_info_path,
-        certify_info->attestationData, certify_info->size);
-    if (!result) {
-        LOG_ERR("Failed saving attestation data.");
-        return tool_rc_general_error;
-    }
-
-    return tool_rc_success;
-}
-
 static tool_rc tpm2_tool_onrun(ESYS_CONTEXT *ectx, tpm2_option_flags flags) {
 
     UNUSED(flags);
 
-    bool result = is_input_options_args_valid();
+    /*
+     * 1. Process options
+     */
+    bool result = check_options();
     if (!result) {
         return tool_rc_option_error;
     }
 
-    //Input
-    TPM2B_DIGEST creation_hash;
-    TPMT_SIG_SCHEME in_scheme;
-    TPMT_TK_CREATION creation_ticket;
-    TPM2B_DATA policy_qualifier = TPM2B_EMPTY_INIT;
-    tool_rc rc = process_certifycreation_input(ectx, &creation_hash, &in_scheme,
-        &creation_ticket, &policy_qualifier);
+   /*
+     * 2. Process inputs
+     */
+    tool_rc rc = process_inputs(ectx);
     if (rc != tool_rc_success) {
         return rc;
     }
 
-    //ESAPI call
-    TPMT_SIGNATURE *signature = NULL;
-    TPM2B_ATTEST *certify_info = NULL;
-    if (ctx.cp_hash_path) {
-        TPM2B_DIGEST cp_hash = { .size = 0 };
-        rc = tpm2_certifycreation(ectx, &ctx.signing_key.object,
-        &ctx.certified_key.object, &creation_hash, &in_scheme, &creation_ticket,
-        &certify_info, &signature, &policy_qualifier, &cp_hash);
-        if (rc != tool_rc_success) {
-            return rc;
-        }
-
-        bool result = files_save_digest(&cp_hash, ctx.cp_hash_path);
-        if (!result) {
-            rc = tool_rc_general_error;
-        }
+    /*
+     * 3. TPM2_CC_<command> call
+     */
+    rc = certifycreation(ectx);
+    if (rc != tool_rc_success) {
         return rc;
     }
 
-    rc = tpm2_certifycreation(ectx, &ctx.signing_key.object,
-        &ctx.certified_key.object, &creation_hash, &in_scheme, &creation_ticket,
-        &certify_info, &signature, &policy_qualifier, NULL);
-    if (rc != tool_rc_success) {
-        goto tpm2_tool_onrun_out;
-    }
+    /*
+     * 4. Process outputs
+     */
+    rc = process_output();
 
-    //Output
-    rc = process_certifycreation_output(signature, certify_info);
-
-tpm2_tool_onrun_out:
-    Esys_Free(signature);
-    Esys_Free(certify_info);
     return rc;
 }
 
 static tool_rc tpm2_tool_onstop(ESYS_CONTEXT *ectx) {
+
     UNUSED(ectx);
+
+    /*
+     * 1. Free objects
+     */
+    Esys_Free(ctx.signature);
+    Esys_Free(ctx.certify_info);
+
+    /*
+     * 2. Close authorization sessions
+     */
     return tpm2_session_close(&ctx.signing_key.object.session);
+
+    /*
+     * 3. Close auxiliary sessions
+     */
 }
 
 // Register this tool with tpm2_tool.c
-TPM2_TOOL_REGISTER("certifycreation", tpm2_tool_onstart, tpm2_tool_onrun, tpm2_tool_onstop, NULL)
+TPM2_TOOL_REGISTER("certifycreation", tpm2_tool_onstart, tpm2_tool_onrun,
+tpm2_tool_onstop, NULL)

--- a/tools/tpm2_changeeps.c
+++ b/tools/tpm2_changeeps.c
@@ -25,6 +25,8 @@ struct changeeps_ctx {
      */
     const char *cp_hash_path;
     TPM2B_DIGEST cp_hash;
+    const char *rp_hash_path;
+    TPM2B_DIGEST rp_hash;
     bool is_command_dispatch;
     TPMI_ALG_HASH parameter_hash_algorithm;
 };
@@ -46,12 +48,21 @@ static tool_rc process_output(ESYS_CONTEXT *ectx) {
 
         if (!is_file_op_success) {
             LOG_ERR("Failed to save cpHash");
+            return tool_rc_general_error;
         }
+    }
+
+    if (!ctx.is_command_dispatch) {
+        return tool_rc_success;
     }
 
     /*
      * 2. Outputs generated after TPM2_CC_<command> dispatch
      */
+
+    if (ctx.rp_hash_path) {
+        is_file_op_success = files_save_digest(&ctx.rp_hash, ctx.rp_hash_path);
+    }
 
     return is_file_op_success ? tool_rc_success : tool_rc_general_error;
 }
@@ -97,14 +108,29 @@ static tool_rc process_inputs(ESYS_CONTEXT *ectx) {
      * 4.a Determine pHash length and alg
      */
     const char **cphash_path = ctx.cp_hash_path ? &ctx.cp_hash_path : 0;
+    const char **rphash_path = ctx.rp_hash_path ? &ctx.rp_hash_path : 0;
 
     ctx.parameter_hash_algorithm = tpm2_util_calculate_phash_algorithm(ectx,
-        cphash_path, &ctx.cp_hash, 0, 0, all_sessions);
+        cphash_path, &ctx.cp_hash, rphash_path, &ctx.rp_hash, all_sessions);
 
     /*
      * 4.b Determine if TPM2_CC_<command> is to be dispatched
+     * !rphash && !cphash [Y]
+     * !rphash && cphash  [N]
+     * rphash && !cphash  [Y]
+     * rphash && cphash   [Y]
      */
-    ctx.is_command_dispatch = ctx.cp_hash_path ? false : true;
+    ctx.is_command_dispatch = (ctx.cp_hash_path && !ctx.rp_hash_path) ?
+        false : true;
+
+    return tool_rc_success;
+}
+
+static tool_rc check_options(void) {
+
+    if (ctx.cp_hash_path && !ctx.rp_hash_path) {
+        LOG_WARN("EPS not changed. Only cpHash is calculated.");
+    }
 
     return tool_rc_success;
 }
@@ -118,6 +144,9 @@ static bool on_option(char key, char *value) {
     case 0:
         ctx.cp_hash_path = value;
         break;
+    case 1:
+        ctx.rp_hash_path = value;
+        break;
     }
 
     return true;
@@ -128,6 +157,7 @@ static bool tpm2_tool_onstart(tpm2_options **opts) {
     static struct option topts[] = {
         { "auth",   required_argument, NULL, 'p' },
         { "cphash", required_argument, NULL,  0  },
+        { "rphash", required_argument, NULL,  1  },
 
     };
 
@@ -143,11 +173,15 @@ static tool_rc tpm2_tool_onrun(ESYS_CONTEXT *ectx, tpm2_option_flags flags) {
     /*
      * 1. Process options
      */
+    tool_rc rc = check_options();
+    if (rc != tool_rc_success) {
+        return rc;
+    }
 
     /*
      * 2. Process inputs
      */
-    tool_rc rc = process_inputs(ectx);
+    rc = process_inputs(ectx);
     if (rc != tool_rc_success) {
         return rc;
     }
@@ -155,7 +189,7 @@ static tool_rc tpm2_tool_onrun(ESYS_CONTEXT *ectx, tpm2_option_flags flags) {
     /*
      * 3. TPM2_CC_<command> call
      */
-    rc = tpm2_changeeps(ectx, ctx.auth_session, &ctx.cp_hash,
+    rc = tpm2_changeeps(ectx, ctx.auth_session, &ctx.cp_hash, &ctx.rp_hash,
         ctx.parameter_hash_algorithm);
     if (rc != tool_rc_success) {
         return rc;

--- a/tools/tpm2_changeeps.c
+++ b/tools/tpm2_changeeps.c
@@ -8,6 +8,7 @@
 #include "tpm2_tool.h"
 
 typedef struct changeeps_ctx changeeps_ctx;
+#define MAX_SESSIONS 3
 struct changeeps_ctx {
     /*
      * Inputs
@@ -22,13 +23,15 @@ struct changeeps_ctx {
     /*
      * Parameter hashes
      */
-    char *cp_hash_path;
+    const char *cp_hash_path;
     TPM2B_DIGEST cp_hash;
-    TPM2B_DIGEST *cphash;
     bool is_command_dispatch;
+    TPMI_ALG_HASH parameter_hash_algorithm;
 };
 
-static changeeps_ctx ctx;
+static changeeps_ctx ctx = {
+    .parameter_hash_algorithm = TPM2_ALG_ERROR,
+};
 
 static tool_rc process_output(ESYS_CONTEXT *ectx) {
 
@@ -84,11 +87,19 @@ static tool_rc process_inputs(ESYS_CONTEXT *ectx) {
     /*
      * 4. Configuration for calculating the pHash
      */
+    tpm2_session *all_sessions[MAX_SESSIONS] = {
+        ctx.auth_session,
+        0,
+        0
+    };
 
     /*
      * 4.a Determine pHash length and alg
      */
-    ctx.cphash = ctx.cp_hash_path ? &ctx.cp_hash : 0;
+    const char **cphash_path = ctx.cp_hash_path ? &ctx.cp_hash_path : 0;
+
+    ctx.parameter_hash_algorithm = tpm2_util_calculate_phash_algorithm(ectx,
+        cphash_path, &ctx.cp_hash, 0, 0, all_sessions);
 
     /*
      * 4.b Determine if TPM2_CC_<command> is to be dispatched
@@ -144,7 +155,8 @@ static tool_rc tpm2_tool_onrun(ESYS_CONTEXT *ectx, tpm2_option_flags flags) {
     /*
      * 3. TPM2_CC_<command> call
      */
-    rc = tpm2_changeeps(ectx, ctx.auth_session, ctx.cphash);
+    rc = tpm2_changeeps(ectx, ctx.auth_session, &ctx.cp_hash,
+        ctx.parameter_hash_algorithm);
     if (rc != tool_rc_success) {
         return rc;
     }

--- a/tools/tpm2_changeeps.c
+++ b/tools/tpm2_changeeps.c
@@ -1,5 +1,6 @@
 /* SPDX-License-Identifier: BSD-3-Clause */
 
+#include "files.h"
 #include "log.h"
 #include "tpm2.h"
 #include "tpm2_auth_util.h"
@@ -8,18 +9,103 @@
 
 typedef struct changeeps_ctx changeeps_ctx;
 struct changeeps_ctx {
+    /*
+     * Inputs
+     */
     const char *auth_str;
     tpm2_session *auth_session;
+
+    /*
+     * Outputs
+     */
+
+    /*
+     * Parameter hashes
+     */
+    char *cp_hash_path;
+    TPM2B_DIGEST cp_hash;
+    TPM2B_DIGEST *cphash;
+    bool is_command_dispatch;
 };
 
 static changeeps_ctx ctx;
 
+static tool_rc process_output(ESYS_CONTEXT *ectx) {
+
+    UNUSED(ectx);
+
+    /*
+     * 1. Outputs that do not require TPM2_CC_<command> dispatch
+     */
+    bool is_file_op_success = true;
+    if (ctx.cp_hash_path) {
+        is_file_op_success = files_save_digest(&ctx.cp_hash, ctx.cp_hash_path);
+
+        if (!is_file_op_success) {
+            LOG_ERR("Failed to save cpHash");
+        }
+    }
+
+    /*
+     * 2. Outputs generated after TPM2_CC_<command> dispatch
+     */
+
+    return is_file_op_success ? tool_rc_success : tool_rc_general_error;
+}
+
+static tool_rc process_inputs(ESYS_CONTEXT *ectx) {
+
+    /*
+     * 1. Object and auth initializations
+     */
+
+    /*
+     * 1.a Add the new-auth values to be set for the object.
+     */
+
+    /*
+     * 1.b Add object names and their auth sessions
+     */
+    tool_rc rc = tpm2_auth_util_from_optarg(ectx, ctx.auth_str,
+        &ctx.auth_session, false);
+    if (rc != tool_rc_success) {
+        LOG_ERR("Failed loading platform auth.");
+        return rc;
+    }
+
+    /*
+     * 2. Restore auxiliary sessions
+     */
+
+    /*
+     * 3. Command specific initializations dependent on loaded objects
+     */
+
+    /*
+     * 4. Configuration for calculating the pHash
+     */
+
+    /*
+     * 4.a Determine pHash length and alg
+     */
+    ctx.cphash = ctx.cp_hash_path ? &ctx.cp_hash : 0;
+
+    /*
+     * 4.b Determine if TPM2_CC_<command> is to be dispatched
+     */
+    ctx.is_command_dispatch = ctx.cp_hash_path ? false : true;
+
+    return tool_rc_success;
+}
 
 static bool on_option(char key, char *value) {
 
     switch (key) {
     case 'p':
         ctx.auth_str = value;
+        break;
+    case 0:
+        ctx.cp_hash_path = value;
         break;
     }
 
@@ -29,7 +115,9 @@ static bool on_option(char key, char *value) {
 static bool tpm2_tool_onstart(tpm2_options **opts) {
 
     static struct option topts[] = {
-        { "auth", required_argument, NULL, 'p' },
+        { "auth",   required_argument, NULL, 'p' },
+        { "cphash", required_argument, NULL,  0  },
+
     };
 
     *opts = tpm2_options_new("p:", ARRAY_LEN(topts), topts, on_option, NULL, 0);
@@ -41,21 +129,48 @@ static tool_rc tpm2_tool_onrun(ESYS_CONTEXT *ectx, tpm2_option_flags flags) {
 
     UNUSED(flags);
 
-    tool_rc rc = tpm2_auth_util_from_optarg(ectx, ctx.auth_str,
-        &ctx.auth_session,
-        false);
+    /*
+     * 1. Process options
+     */
+
+    /*
+     * 2. Process inputs
+     */
+    tool_rc rc = process_inputs(ectx);
     if (rc != tool_rc_success) {
-        LOG_ERR("Failed loading platform auth.");
         return rc;
     }
 
-    return tpm2_changeeps(ectx, ctx.auth_session);
+    /*
+     * 3. TPM2_CC_<command> call
+     */
+    rc = tpm2_changeeps(ectx, ctx.auth_session, ctx.cphash);
+    if (rc != tool_rc_success) {
+        return rc;
+    }
+
+    /*
+     * 4. Process outputs
+     */
+    return process_output(ectx);
 }
 
 static tool_rc tpm2_tool_onstop(ESYS_CONTEXT *ectx) {
+
     UNUSED(ectx);
 
+    /*
+     * 1. Free objects
+     */
+
+    /*
+     * 2. Close authorization sessions
+     */
     return tpm2_session_close(&ctx.auth_session);
+
+    /*
+     * 3. Close auxiliary sessions
+     */
 }
 
 // Register this tool with tpm2_tool.c

--- a/tools/tpm2_changeeps.c
+++ b/tools/tpm2_changeeps.c
@@ -9,6 +9,7 @@
 
 typedef struct changeeps_ctx changeeps_ctx;
 #define MAX_SESSIONS 3
+#define MAX_AUX_SESSIONS 2
 struct changeeps_ctx {
     /*
      * Inputs
@@ -29,10 +30,20 @@ struct changeeps_ctx {
     TPM2B_DIGEST rp_hash;
     bool is_command_dispatch;
     TPMI_ALG_HASH parameter_hash_algorithm;
+
+    /*
+     * Aux sessions
+     */
+    uint8_t aux_session_cnt;
+    tpm2_session *aux_session[MAX_AUX_SESSIONS];
+    const char *aux_session_path[MAX_AUX_SESSIONS];
+    ESYS_TR aux_session_handle[MAX_AUX_SESSIONS];
 };
 
 static changeeps_ctx ctx = {
     .parameter_hash_algorithm = TPM2_ALG_ERROR,
+    .aux_session_handle[0] = ESYS_TR_NONE,
+    .aux_session_handle[1] = ESYS_TR_NONE,
 };
 
 static tool_rc process_output(ESYS_CONTEXT *ectx) {
@@ -90,6 +101,11 @@ static tool_rc process_inputs(ESYS_CONTEXT *ectx) {
     /*
      * 2. Restore auxiliary sessions
      */
+    rc = tpm2_util_aux_sessions_setup(ectx, ctx.aux_session_cnt,
+        ctx.aux_session_path, ctx.aux_session_handle, ctx.aux_session);
+    if (rc != tool_rc_success) {
+        return rc;
+    }
 
     /*
      * 3. Command specific initializations dependent on loaded objects
@@ -100,8 +116,8 @@ static tool_rc process_inputs(ESYS_CONTEXT *ectx) {
      */
     tpm2_session *all_sessions[MAX_SESSIONS] = {
         ctx.auth_session,
-        0,
-        0
+        ctx.aux_session[0],
+        ctx.aux_session[1]
     };
 
     /*
@@ -147,6 +163,15 @@ static bool on_option(char key, char *value) {
     case 1:
         ctx.rp_hash_path = value;
         break;
+    case 'S':
+        ctx.aux_session_path[ctx.aux_session_cnt] = value;
+        if (ctx.aux_session_cnt < MAX_AUX_SESSIONS) {
+            ctx.aux_session_cnt++;
+        } else {
+            LOG_ERR("Specify a max of 3 sessions");
+            return false;
+        }
+        break;
     }
 
     return true;
@@ -158,10 +183,10 @@ static bool tpm2_tool_onstart(tpm2_options **opts) {
         { "auth",   required_argument, NULL, 'p' },
         { "cphash", required_argument, NULL,  0  },
         { "rphash", required_argument, NULL,  1  },
-
+        { "session",required_argument, NULL, 'S' },
     };
 
-    *opts = tpm2_options_new("p:", ARRAY_LEN(topts), topts, on_option, NULL, 0);
+    *opts = tpm2_options_new("p:S:", ARRAY_LEN(topts), topts, on_option, NULL, 0);
 
     return *opts != NULL;
 }
@@ -190,7 +215,8 @@ static tool_rc tpm2_tool_onrun(ESYS_CONTEXT *ectx, tpm2_option_flags flags) {
      * 3. TPM2_CC_<command> call
      */
     rc = tpm2_changeeps(ectx, ctx.auth_session, &ctx.cp_hash, &ctx.rp_hash,
-        ctx.parameter_hash_algorithm);
+        ctx.parameter_hash_algorithm, ctx.aux_session_handle[0],
+        ctx.aux_session_handle[1]);
     if (rc != tool_rc_success) {
         return rc;
     }
@@ -212,11 +238,25 @@ static tool_rc tpm2_tool_onstop(ESYS_CONTEXT *ectx) {
     /*
      * 2. Close authorization sessions
      */
-    return tpm2_session_close(&ctx.auth_session);
-
+    tool_rc rc = tool_rc_success;
+    tool_rc tmp_rc = tpm2_session_close(&ctx.auth_session);
+    if (tmp_rc != tool_rc_success) {
+        rc = tmp_rc;
+    }
     /*
      * 3. Close auxiliary sessions
      */
+    size_t i = 0;
+    for(i = 0; i < ctx.aux_session_cnt; i++) {
+        if (ctx.aux_session_path[i]) {
+            tmp_rc = tpm2_session_close(&ctx.aux_session[i]);
+            if (tmp_rc != tool_rc_success) {
+                rc = tmp_rc;
+            }
+        }
+    }
+
+    return rc;
 }
 
 // Register this tool with tpm2_tool.c

--- a/tools/tpm2_changepps.c
+++ b/tools/tpm2_changepps.c
@@ -1,5 +1,6 @@
 /* SPDX-License-Identifier: BSD-3-Clause */
 
+#include "files.h"
 #include "log.h"
 #include "tpm2.h"
 #include "tpm2_auth_util.h"
@@ -8,18 +9,102 @@
 
 typedef struct changepps_ctx changepps_ctx;
 struct changepps_ctx {
+    /*
+     * Inputs
+     */
     const char *auth_str;
     tpm2_session *auth_session;
+
+    /*
+     * Outputs
+     */
+
+    /*
+     * Parameter hashes
+     */
+    char *cp_hash_path;
+    TPM2B_DIGEST cp_hash;
+    TPM2B_DIGEST *cphash;
+    bool is_command_dispatch;
 };
 
 static changepps_ctx ctx;
 
+static tool_rc process_output(ESYS_CONTEXT *ectx) {
+
+    UNUSED(ectx);
+
+    /*
+     * 1. Outputs that do not require TPM2_CC_<command> dispatch
+     */
+    bool is_file_op_success = true;
+    if (ctx.cp_hash_path) {
+        is_file_op_success = files_save_digest(&ctx.cp_hash, ctx.cp_hash_path);
+
+        if (!is_file_op_success) {
+            LOG_ERR("Failed to save cpHash");
+        }
+    }
+
+    /*
+     * 2. Outputs generated after TPM2_CC_<command> dispatch
+     */
+    return is_file_op_success ? tool_rc_success : tool_rc_general_error;
+}
+
+static tool_rc process_inputs(ESYS_CONTEXT *ectx) {
+
+    /*
+     * 1. Object and auth initializations
+     */
+
+    /*
+     * 1.a Add the new-auth values to be set for the object.
+     */
+
+    /*
+     * 1.b Add object names and their auth sessions
+     */
+    tool_rc rc = tpm2_auth_util_from_optarg(ectx, ctx.auth_str,
+        &ctx.auth_session, false);
+    if (rc != tool_rc_success) {
+        LOG_ERR("Failed loading platform auth.");
+        return rc;
+    }
+
+    /*
+     * 2. Restore auxiliary sessions
+     */
+
+    /*
+     * 3. Command specific initializations dependent on loaded objects
+     */
+
+    /*
+     * 4. Configuration for calculating the pHash
+     */
+
+    /*
+     * 4.a Determine pHash length and alg
+     */
+    ctx.cphash = ctx.cp_hash_path ? &ctx.cp_hash : 0;
+
+    /*
+     * 4.b Determine if TPM2_CC_<command> is to be dispatched
+     */
+    ctx.is_command_dispatch = ctx.cp_hash_path ? false : true;
+
+    return tool_rc_success;
+}
 
 static bool on_option(char key, char *value) {
 
     switch (key) {
     case 'p':
         ctx.auth_str = value;
+        break;
+    case 0:
+        ctx.cp_hash_path = value;
         break;
     }
 
@@ -29,7 +114,9 @@ static bool on_option(char key, char *value) {
 static bool tpm2_tool_onstart(tpm2_options **opts) {
 
     static struct option topts[] = {
-        { "auth", required_argument, NULL, 'p' },
+        { "auth",   required_argument, NULL, 'p' },
+        { "cphash", required_argument, NULL,  0  },
+
     };
 
     *opts = tpm2_options_new("p:", ARRAY_LEN(topts), topts, on_option, NULL, 0);
@@ -41,22 +128,50 @@ static tool_rc tpm2_tool_onrun(ESYS_CONTEXT *ectx, tpm2_option_flags flags) {
 
     UNUSED(flags);
 
-    tool_rc rc = tpm2_auth_util_from_optarg(ectx, ctx.auth_str,
-        &ctx.auth_session,
-        false);
+    /*
+     * 1. Process options
+     */
+
+    /*
+     * 2. Process inputs
+     */
+    tool_rc rc = process_inputs(ectx);
     if (rc != tool_rc_success) {
-        LOG_ERR("Failed loading platform auth.");
         return rc;
     }
 
-    return tpm2_changepps(ectx, ctx.auth_session);
+    /*
+     * 3. TPM2_CC_<command> call
+     */
+    rc = tpm2_changepps(ectx, ctx.auth_session, ctx.cphash);
+    if (rc != tool_rc_success) {
+        return rc;
+    }
+
+    /*
+     * 4. Process outputs
+     */
+    return process_output(ectx);
 }
 
 static tool_rc tpm2_tool_onstop(ESYS_CONTEXT *ectx) {
+
     UNUSED(ectx);
 
+    /*
+     * 1. Free objects
+     */
+
+    /*
+     * 2. Close authorization sessions
+     */
     return tpm2_session_close(&ctx.auth_session);
+
+    /*
+     * 3. Close auxiliary sessions
+     */
 }
 
 // Register this tool with tpm2_tool.c
-TPM2_TOOL_REGISTER("changepps", tpm2_tool_onstart, tpm2_tool_onrun, tpm2_tool_onstop, NULL)
+TPM2_TOOL_REGISTER("changepps", tpm2_tool_onstart, tpm2_tool_onrun,
+    tpm2_tool_onstop, NULL)

--- a/tools/tpm2_changepps.c
+++ b/tools/tpm2_changepps.c
@@ -9,6 +9,7 @@
 
 typedef struct changepps_ctx changepps_ctx;
 #define MAX_SESSIONS 3
+#define MAX_AUX_SESSIONS 2
 struct changepps_ctx {
     /*
      * Inputs
@@ -29,10 +30,20 @@ struct changepps_ctx {
     TPM2B_DIGEST rp_hash;
     bool is_command_dispatch;
     TPMI_ALG_HASH parameter_hash_algorithm;
+
+    /*
+     * Aux sessions
+     */
+    uint8_t aux_session_cnt;
+    tpm2_session *aux_session[MAX_AUX_SESSIONS];
+    const char *aux_session_path[MAX_AUX_SESSIONS];
+    ESYS_TR aux_session_handle[MAX_AUX_SESSIONS];
 };
 
 static changepps_ctx ctx = {
     .parameter_hash_algorithm = TPM2_ALG_ERROR,
+    .aux_session_handle[0] = ESYS_TR_NONE,
+    .aux_session_handle[1] = ESYS_TR_NONE,
 };
 
 static tool_rc process_output(ESYS_CONTEXT *ectx) {
@@ -90,6 +101,11 @@ static tool_rc process_inputs(ESYS_CONTEXT *ectx) {
     /*
      * 2. Restore auxiliary sessions
      */
+    rc = tpm2_util_aux_sessions_setup(ectx, ctx.aux_session_cnt,
+        ctx.aux_session_path, ctx.aux_session_handle, ctx.aux_session);
+    if (rc != tool_rc_success) {
+        return rc;
+    }
 
     /*
      * 3. Command specific initializations dependent on loaded objects
@@ -100,8 +116,8 @@ static tool_rc process_inputs(ESYS_CONTEXT *ectx) {
      */
     tpm2_session *all_sessions[MAX_SESSIONS] = {
         ctx.auth_session,
-        0,
-        0
+        ctx.aux_session[0],
+        ctx.aux_session[1]
     };
 
     /*
@@ -147,6 +163,15 @@ static bool on_option(char key, char *value) {
     case 1:
         ctx.rp_hash_path = value;
         break;
+    case 'S':
+        ctx.aux_session_path[ctx.aux_session_cnt] = value;
+        if (ctx.aux_session_cnt < MAX_AUX_SESSIONS) {
+            ctx.aux_session_cnt++;
+        } else {
+            LOG_ERR("Specify a max of 3 sessions");
+            return false;
+        }
+        break;
     }
 
     return true;
@@ -158,10 +183,10 @@ static bool tpm2_tool_onstart(tpm2_options **opts) {
         { "auth",   required_argument, NULL, 'p' },
         { "cphash", required_argument, NULL,  0  },
         { "rphash", required_argument, NULL,  1  },
-
+        { "session",required_argument, NULL, 'S' },
     };
 
-    *opts = tpm2_options_new("p:", ARRAY_LEN(topts), topts, on_option, NULL, 0);
+    *opts = tpm2_options_new("p:S:", ARRAY_LEN(topts), topts, on_option, NULL, 0);
 
     return *opts != NULL;
 }
@@ -190,7 +215,8 @@ static tool_rc tpm2_tool_onrun(ESYS_CONTEXT *ectx, tpm2_option_flags flags) {
      * 3. TPM2_CC_<command> call
      */
     rc = tpm2_changepps(ectx, ctx.auth_session, &ctx.cp_hash, &ctx.rp_hash,
-        ctx.parameter_hash_algorithm);
+        ctx.parameter_hash_algorithm, ctx.aux_session_handle[0],
+        ctx.aux_session_handle[1]);
     if (rc != tool_rc_success) {
         return rc;
     }
@@ -212,11 +238,25 @@ static tool_rc tpm2_tool_onstop(ESYS_CONTEXT *ectx) {
     /*
      * 2. Close authorization sessions
      */
-    return tpm2_session_close(&ctx.auth_session);
-
+    tool_rc rc = tool_rc_success;
+    tool_rc tmp_rc = tpm2_session_close(&ctx.auth_session);
+    if (tmp_rc != tool_rc_success) {
+        rc = tmp_rc;
+    }
     /*
      * 3. Close auxiliary sessions
      */
+    size_t i = 0;
+    for(i = 0; i < ctx.aux_session_cnt; i++) {
+        if (ctx.aux_session_path[i]) {
+            tmp_rc = tpm2_session_close(&ctx.aux_session[i]);
+            if (tmp_rc != tool_rc_success) {
+                rc = tmp_rc;
+            }
+        }
+    }
+
+    return rc;
 }
 
 // Register this tool with tpm2_tool.c

--- a/tools/tpm2_create.c
+++ b/tools/tpm2_create.c
@@ -125,7 +125,7 @@ static tool_rc create(ESYS_CONTEXT *ectx) {
 
         ESYS_TR aux_session_handle[MAX_AUX_SESSIONS] = {ESYS_TR_NONE, ESYS_TR_NONE};
         tmp_rc = tpm2_util_aux_sessions_setup(ectx, ctx.aux_session_cnt,
-        ctx.aux_session_path, aux_session_handle, NULL, ctx.aux_session);
+            ctx.aux_session_path, aux_session_handle, ctx.aux_session);
         if (tmp_rc != tool_rc_success) {
             return tmp_rc;
         }
@@ -167,7 +167,7 @@ static tool_rc create(ESYS_CONTEXT *ectx) {
 
         ESYS_TR aux_session_handle[MAX_AUX_SESSIONS] = {ESYS_TR_NONE, ESYS_TR_NONE};
         tmp_rc = tpm2_util_aux_sessions_setup(ectx, ctx.aux_session_cnt,
-        ctx.aux_session_path, aux_session_handle, NULL, ctx.aux_session);
+            ctx.aux_session_path, aux_session_handle, ctx.aux_session);
         if (tmp_rc != tool_rc_success) {
             return tmp_rc;
         }

--- a/tools/tpm2_getrandom.c
+++ b/tools/tpm2_getrandom.c
@@ -33,11 +33,9 @@ static tpm_random_ctx ctx;
 static tool_rc get_random_and_save(ESYS_CONTEXT *ectx) {
 
     /* Restore aux sessions */
-    TPMI_ALG_HASH param_hash_algorithm = TPM2_ALG_SHA256;
     ESYS_TR session_handle[MAX_AUX_SESSIONS] = {ESYS_TR_NONE, ESYS_TR_NONE, ESYS_TR_NONE};
     tool_rc rc = tpm2_util_aux_sessions_setup(ectx, ctx.session_cnt,
-    ctx.session_path, session_handle, &param_hash_algorithm,
-    ctx.session);
+        ctx.session_path, session_handle, ctx.session);
     if (rc != tool_rc_success) {
         return rc;
     }
@@ -47,6 +45,7 @@ static tool_rc get_random_and_save(ESYS_CONTEXT *ectx) {
     TPM2B_DIGEST *rp_hash =
         ctx.rp_hash_path ? calloc(1, sizeof(TPM2B_DIGEST)) : NULL;
 
+    TPMI_ALG_HASH param_hash_algorithm = TPM2_ALG_SHA256;
     TPM2B_DIGEST *random_bytes;
     rc = tpm2_getrandom(ectx, ctx.num_of_bytes, &random_bytes,
     cp_hash, rp_hash, session_handle[0], session_handle[1], session_handle[2],

--- a/tools/tpm2_nvdefine.c
+++ b/tools/tpm2_nvdefine.c
@@ -81,7 +81,7 @@ static tool_rc nv_space_define(ESYS_CONTEXT *ectx) {
     if (!ctx.cp_hash_path) {
         ESYS_TR aux_session_handle[MAX_AUX_SESSIONS] = {ESYS_TR_NONE, ESYS_TR_NONE};
         rc = tpm2_util_aux_sessions_setup(ectx, ctx.aux_session_cnt,
-        ctx.aux_session_path, aux_session_handle, NULL, ctx.aux_session);
+            ctx.aux_session_path, aux_session_handle, ctx.aux_session);
         if (rc != tool_rc_success) {
             return rc;
         }

--- a/tools/tpm2_nvextend.c
+++ b/tools/tpm2_nvextend.c
@@ -114,7 +114,7 @@ static tool_rc tpm2_tool_onrun(ESYS_CONTEXT *ectx, tpm2_option_flags flags) {
     if (!ctx.cp_hash_path) {
         ESYS_TR aux_session_handle[MAX_AUX_SESSIONS] = {ESYS_TR_NONE, ESYS_TR_NONE};
         tool_rc tmp_rc = tpm2_util_aux_sessions_setup(ectx, ctx.aux_session_cnt,
-        ctx.aux_session_path, aux_session_handle, NULL, ctx.aux_session);
+            ctx.aux_session_path, aux_session_handle, ctx.aux_session);
         if (tmp_rc != tool_rc_success) {
             return tmp_rc;
         }

--- a/tools/tpm2_unseal.c
+++ b/tools/tpm2_unseal.c
@@ -52,7 +52,7 @@ tool_rc unseal_and_save(ESYS_CONTEXT *ectx) {
 
     ESYS_TR aux_session_handle[MAX_AUX_SESSIONS] = {ESYS_TR_NONE, ESYS_TR_NONE};
     tool_rc rc = tpm2_util_aux_sessions_setup(ectx, ctx.aux_session_cnt,
-    ctx.aux_session_path, aux_session_handle, NULL, ctx.aux_session);
+        ctx.aux_session_path, aux_session_handle, ctx.aux_session);
     if (rc != tool_rc_success) {
         return rc;
     }


### PR DESCRIPTION
Fixes #2372
Fixes #2373
Fixes #2374
Fixes #2371
Fixes #2370
Fixes #2369
Fixes #2366
Fixes #2365
Fixes #2364 
Fixes #2358
Fixes #2357
Fixes #2356 
Fixes #2350 
Fixes #2352 
Fixes #2351 
Fixes #2349
Fixes #2347
Fixes #2348 
Fixes #2340 
Fixes #2341
Fixes #2342
Fixes #2343

It should be noted that the auths aren't checked when calculating the cpHash,
instead the sessions are consumed to determine the cpHash algorithm.

1. If cphash_path is preceded with <halg>: use that as cphash-halg return
Otherwise

 Consume session only if it is a policy-session or an hmac-session
 1. If only hmac or policy session is specified, return that session's halg
 2. If hmac-session with audit is specified, return that session's halg
 3. If policy-session, then return policy-session's halg

Otherwise
  return SHA256

Signed-off-by: Imran Desai <imran.desai@intel.com>