### PR TITLE
tpm2_eventlog: parse BootOrder variable

### DIFF
--- a/lib/tpm2_eventlog_yaml.c
+++ b/lib/tpm2_eventlog_yaml.c
@@ -384,6 +384,24 @@ static bool yaml_uefi_var(UEFI_VARIABLE_DATA *data, size_t size, UINT32 type,
                              uuidstr, sdata);
             free(sdata);
             return true;
+        } else if (type == EV_EFI_VARIABLE_BOOT) {
+            if ((strlen(ret) == 9 && strncmp(ret, "BootOrder", 9) == 0)) {
+                free(ret);
+                tpm2_tool_output("    VariableData:\n");
+                
+                if (data->VariableDataLength % 2 != 0) {
+                    LOG_ERR("BootOrder value length %" PRIu64 " is not divisible by 2\n",
+                            data->VariableDataLength);
+                    return false;
+                }
+
+                uint8_t *variable_data = (uint8_t *)&data->UnicodeName[
+                    data->UnicodeNameLength];
+                for (uint64_t i = 0; i < data->VariableDataLength / 2; i++) {
+                    tpm2_tool_output("    - Boot%04x\n", *((uint16_t*)variable_data + i));
+                }
+                return true;
+            }
         }
         /* Other event types will be printed as a hex string */
     }


### PR DESCRIPTION
The BootOrder variable is currently shown in raw bytes, e.g.,

```
- EventNum: 12
  PCRIndex: 1
  EventType: EV_EFI_VARIABLE_BOOT
  DigestCount: 2
  Digests:
  - AlgorithmId: sha1
    Digest: "ea3f530d2b261b5a945812c15858c09de04abe9c"
  - AlgorithmId: sha256
    Digest: "263d99957c7b574c63a265b32da7fff8b8ad831828946bfbff650d7074dd9198"
  EventSize: 56
  Event:
    VariableName: 61dfe48b-ca93-d211-aa0d-00e098032b8c
    UnicodeNameLength: 9
    VariableDataLength: 6
    UnicodeName: BootOrder
    VariableData: "010000000200"
```

This PR parses it in a more human-readable format, i.e.,

```
    VariableData:
    - Boot0001
    - Boot0000
    - Boot0002
```

showing the boot ordering of all the boot devices configured in the system.

This will only parse when `--eventlog-version` is set to `2`. The file `test/integration/fixtures/event-bootorder.bin` is used for the above example.