### PR TITLE
PCR: Allow empty PCR selection by specifying keyword none.

### DIFF
--- a/lib/pcr.c
+++ b/lib/pcr.c
@@ -54,6 +54,13 @@ static bool pcr_parse_list(const char *str, size_t len,
         pcr_select->pcrSelect[2] = 0xff;
         return true;
     }
+    
+    if (!strncmp(str, "none", 4)) {
+        pcr_select->pcrSelect[0] = 0x00;
+        pcr_select->pcrSelect[1] = 0x00;
+        pcr_select->pcrSelect[2] = 0x00;
+        return true;
+    }
 
     do {
         current_string = str;

--- a/man/tpm2_pcrallocate.1.md
+++ b/man/tpm2_pcrallocate.1.md
@@ -68,6 +68,11 @@ tpm2_pcrallocate
 tpm2_pcrallocate -P abc sha1:7,8,9,10,16,17,18,19+sha256:all
 ```
 
+## To completly switch from SHA1 bank to SHA256 with a platform authorization
+```bash
+tpm2_pcrallocate -P abc sha1:none+sha256:all
+```
+
 [returns](common/returns.md)
 
 [footer](common/footer.md)


### PR DESCRIPTION
For certain use cases (e.g. PCR allocation) an empty selection needs to be specifiable.
Since we have a keyword 'all' the opposite is 'none' is chosen for the empty selection.

Fixes: #2344

Signed-off-by: Peter Huewe <peter.huewe@infineon.com>