### PR TITLE
man: tpm2_readclock: dix description of TPMS_TIME_INFO structure

### DIFF
--- a/man/tpm2_readclock.1.md
+++ b/man/tpm2_readclock.1.md
@@ -16,10 +16,9 @@ restartCount. The structure is output as YAML to stdout. The YAML output is
 defined as:
 
 ```yaml
-time: 13673142     # 64 bit value of time since last _TPM_Init or TPM2_Startup
-                   # in ms.
+time: 13673142     # 64 bit value of time TPM has been powered on in ms.
 clock_info:
-  clock: 13673142  # 64 bit value of time TPM has been powered on in ms.
+  clock: 13673142  # 64 bit value of time TPM has been powered on since last TPM2_Clear in ms.
   reset_count: 0   # 32 bit value of the number of TPM Resets since the last
                    # TPM2_Clear.
   restart_count: 0 # 32 bit value of the number of times that TPM2_Shutdown or


### PR DESCRIPTION
The description of the TPMS_TIME_INFO in the tpm2_readclock is a bit misleading.
The `time` value corresponds to the power on time,
the `clock` value corresponds to the power on time since last TPM2_Clear.
See https://trustedcomputinggroup.org/wp-content/uploads/TCG_TPM2_r1p59_Part2_Structures_pub.pdf "Section 10.11.2 Clock"
Probably the short note about TPM2_Startup was mis-interpreted.
Signed-off-by: Peter Huewe <peter.huewe@infineon.com>