### PR TITLE
tpm2_nvdefine: allow setting hash algorithm by command line parameter

### DIFF
--- a/dist/bash-completion/tpm2-tools/tpm2_completion.bash
+++ b/dist/bash-completion/tpm2-tools/tpm2_completion.bash
@@ -2445,11 +2445,14 @@ _tpm2_nvdefine()
             -L | --policy)
                 _filedir
                 return;;
+            -g | --hash-algorithm)
+                COMPREPLY=($(compgen -W "${hash_methods[*]}" -- "$cur"))
+                return;;
         esac
 
         COMPREPLY=($(compgen -W "-h --help -v --version -V --verbose -Q --quiet \
         -Z --enable-erata -T --tcti \
-        -C -s -a -P -p -L --hierarchy --size --attributes --hierarchy-auth --index-auth --policy --cphash " \
+        -C -s -a -P -p -L --hierarchy --size --attributes --hierarchy-auth --index-auth --policy --hash-algorithm --cphash " \
         -- "$cur"))
     } &&
     complete -F _tpm2_nvdefine tpm2_nvdefine

--- a/man/tpm2_nvdefine.1.md
+++ b/man/tpm2_nvdefine.1.md
@@ -31,6 +31,12 @@ uses the first free index. The tool outputs the nv index defined on success.
     Specifies the size of data area in bytes. Defaults to **MAX_NV_INDEX_SIZE**
     which is typically 2048.
 
+  * **-g**, **\--hash-algorithm**=_ALGORITHM_:
+
+    The hash algorithm used to compute the name of the Index and used for the
+    authorization policy. If the index is an extend index, the hash algorithm is
+    used for the extend.
+
   * **-a**, **\--attributes**=_ATTRIBUTES_
 
     Specifies the attribute values for the nv region used when creating the


### PR DESCRIPTION
This is especially useful in conjunction with endorsement authentication according to PolicyB as specified in ["TCG EK Credential Profile"](https://trustedcomputinggroup.org/wp-content/uploads/TCG_IWG_EKCredentialProfile_v2p3_r2_pub.pdf), specifically for defining Policy Index I-2 (SHA384).

Signed-off-by: Tobias Peter <tobias.peter@infineon.com>