### PR TITLE
tpm2_eventlog: parse BOOT#### variables

### DIFF
--- a/lib/efi_event.h
+++ b/lib/efi_event.h
@@ -175,5 +175,16 @@ typedef struct {
     BYTE SignatureData[];
 } PACKED EFI_SIGNATURE_DATA;
 
+/*
+ * EFI_LOAD_OPTION describes a load option variable. This struct is described
+ * in more details in UEFI Spec Section 3.1.3
+ */
+typedef struct {
+    UINT32 Attributes;
+    UINT16 FilePathListLength;
+    UINT16 Description[];
+    // EFI_DEVICE_PATH_PROTOCOL FilePathList[];
+    // UINT8 OptionalData[];
+} PACKED EFI_LOAD_OPTION;
 
 #endif

--- a/lib/tpm2_eventlog_yaml.c
+++ b/lib/tpm2_eventlog_yaml.c
@@ -1,10 +1,10 @@
+#include <ctype.h>
 #include <errno.h>
 #include <inttypes.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
 #include <uchar.h>
-#include <regex.h>
 
 #include <tss2/tss2_tpm2_types.h>
 
@@ -404,18 +404,11 @@ static bool yaml_uefi_var(UEFI_VARIABLE_DATA *data, size_t size, UINT32 type,
                 return true;
             }
 
-            regex_t regex;
-            int r;
+            /* Test for regex "^Boot[0-9a-fA-F]\\{4\\}$" */
+            if (strlen(ret) == 8 && strncmp(ret, "Boot", 4) == 0 &&
+                isxdigit((int)ret[4]) && isxdigit((int)ret[5]) &&
+                isxdigit((int)ret[6]) && isxdigit((int)ret[7])) {
 
-            r = regcomp(&regex, "^Boot[0-9a-fA-F]\\{4\\}$", 0);
-            if (r != 0) {
-                free(ret);
-                LOG_ERR("regcomp() returned %d\n", r);
-                return false;
-            }
-
-            r = regexec(&regex, ret, 0, NULL, 0);
-            if (r == 0) {
                 free(ret);
                 tpm2_tool_output("    VariableData:\n"
                                  "      Enabled: ");


### PR DESCRIPTION
Enabled only when `--eventlog-version=2` is set. This PR allows BOOT#### variables to be parsed, e.g.,

```
 - EventNum: 15
  PCRIndex: 1
  EventType: EV_EFI_VARIABLE_BOOT
  DigestCount: 2
  Digests:
  - AlgorithmId: sha1
    Digest: "df5d6605cb8f4366d745a8464cfb26c1efdc305c"
  - AlgorithmId: sha256
    Digest: "4d387b02d63b2f4cd7f667feb0a387fe47a10a3e26bf3533ddd001c605f3dec5"
  EventSize: 136
  Event:
    VariableName: 61dfe48b-ca93-d211-aa0d-00e098032b8c
    UnicodeNameLength: 8
    VariableDataLength: 88
    UnicodeName: Boot0002
    VariableData:
      Enabled: 'Yes'
      FilePathListLength: 44
      Description: EFI Internal Shell
      DevicePath: "04071400c9bdb87cebf8344faaea3ee4af6516a10406140083a5047c3e9e1c4fad65e05268d0b4d17fff0400"
```