### PR TITLE
tpm2_eventlog: pretty print devicepath

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -25,7 +25,7 @@ AM_LDFLAGS   := $(EXTRA_LDFLAGS) $(CODE_COVERAGE_LIBS)
 
 LDADD = \
     $(LIB_COMMON) $(TSS2_ESYS_LIBS) $(TSS2_MU_LIBS) $(CRYPTO_LIBS) $(TSS2_TCTILDR_LIBS) \
-    $(TSS2_RC_LIBS) $(TSS2_SYS_LIBS) $(UUID_LIBS)
+    $(TSS2_RC_LIBS) $(TSS2_SYS_LIBS) $(UUID_LIBS) $(EFIVAR_LIBS)
 
 AM_DISTCHECK_CONFIGURE_FLAGS = --with-bashcompdir='$$(datarootdir)/bash-completion/completions'
 

--- a/configure.ac
+++ b/configure.ac
@@ -62,6 +62,10 @@ PKG_CHECK_MODULES([CRYPTO], [libcrypto >= 1.0.2g])
 PKG_CHECK_MODULES([CURL], [libcurl])
 PKG_CHECK_MODULES([UUID], [uuid])
 
+# pretty print of devicepath if efivar library is present
+PKG_CHECK_MODULES([EFIVAR], [efivar],,[true])
+AC_CHECK_HEADERS([efivar/efivar.h])
+
 # backwards compat with older pkg-config
 # - pull in AC_DEFUN from pkg.m4
 m4_ifndef([PKG_CHECK_VAR], [


### PR DESCRIPTION
Device Path field in many event types is a complicated field to parse, fortunately, `libefivar` can be used to make sense out of it. E.g.,

```
  Event:
    ImageLocationInMemory: 0xbeeed018
    ImageLengthInMemory: 205768
    ImageLinkTimeAddress: 0x0
    LengthOfDevicePath: 46
    DevicePath: "02010c00d041030a000000000101060000030408180000000000005c010000000000ff7f0400000000007fff0400"
```

can be parsed as follows:

```
  Event:
    ImageLocationInMemory: 0xbeeed018
    ImageLengthInMemory: 205768
    ImageLinkTimeAddress: 0x0
    LengthOfDevicePath: 46
    DevicePath: "PciRoot(0x0)/Pci(0x3,0x0)/Offset(0x15c00,0x47fff)"
```

This is only parsed when `eventlog-version=2`. When `libefivar` is not installed, the device path field will be printed as raw bytes. The bootlog `test/integration/fixtures/event-bootorder.bin` was used for the above example.