### PR TITLE
tpm2_duplicate: support duplicating external non-TPM keys

### DIFF
--- a/lib/tpm2_identity_util.c
+++ b/lib/tpm2_identity_util.c
@@ -99,7 +99,7 @@ static TPM2_KEY_BITS get_pub_asym_key_bits(TPM2B_PUBLIC *public) {
 }
 
 static bool share_secret_with_tpm2_rsa_public_key(TPM2B_DIGEST *protection_seed,
-        TPM2B_PUBLIC *parent_pub, unsigned char *label, int label_len,
+        TPM2B_PUBLIC *parent_pub, const unsigned char *label, int label_len,
         TPM2B_ENCRYPTED_SECRET *encrypted_protection_seed) {
     bool rval = false;
     RSA *rsa = NULL;
@@ -218,7 +218,7 @@ bool tpm2_identity_util_calc_outer_integrity_hmac_key_and_dupsensitive_enc_key(
 
 bool tpm2_identity_util_share_secret_with_public_key(
         TPM2B_DIGEST *protection_seed, TPM2B_PUBLIC *parent_pub,
-        unsigned char *label, int label_len,
+        const unsigned char *label, int label_len,
         TPM2B_ENCRYPTED_SECRET *encrypted_protection_seed) {
     bool result = false;
     TPMI_ALG_PUBLIC alg = parent_pub->publicArea.type;

--- a/lib/tpm2_identity_util.h
+++ b/lib/tpm2_identity_util.h
@@ -102,4 +102,14 @@ void tpm2_identity_util_calculate_outer_integrity(TPMI_ALG_HASH parent_name_alg,
         TPM2B_MAX_BUFFER *encrypted_duplicate_sensitive,
         TPM2B_DIGEST *outer_hmac);
 
+/**
+ * Computes the name of a TPM key.
+ *
+ * @param public
+ *  Public key structure
+ * @param pubname
+ *  The name structure to populate.
+ */
+bool tpm2_identity_create_name(TPM2B_PUBLIC *public, TPM2B_NAME *pubname);
+
 #endif /* LIB_TPM2_IDENTITY_UTIL_H_ */

--- a/lib/tpm2_identity_util.h
+++ b/lib/tpm2_identity_util.h
@@ -49,7 +49,7 @@ bool tpm2_identity_util_calc_outer_integrity_hmac_key_and_dupsensitive_enc_key(
  */
 bool tpm2_identity_util_share_secret_with_public_key(
         TPM2B_DIGEST *protection_seed, TPM2B_PUBLIC *parent_pub,
-        unsigned char *label, int label_len,
+        const unsigned char *label, int label_len,
         TPM2B_ENCRYPTED_SECRET *encrypted_protection_seed);
 
 /**

--- a/lib/tpm2_kdfe.c
+++ b/lib/tpm2_kdfe.c
@@ -17,7 +17,7 @@
 
 TSS2_RC tpm2_kdfe(
         TPMI_ALG_HASH hash_alg, TPM2B_ECC_PARAMETER *Z,
-        unsigned char *label, int label_length,
+        const unsigned char *label, int label_length,
         TPM2B_ECC_PARAMETER *party_u, TPM2B_ECC_PARAMETER *party_v,
         UINT16 size_in_bits, TPM2B_MAX_BUFFER  *result_key ) {
 
@@ -173,7 +173,7 @@ static int get_ECDH_shared_secret(EC_KEY *key,
 
 bool ecdh_derive_seed_and_encrypted_seed(
         TPM2B_PUBLIC *parent_pub,
-        unsigned char *label, int label_len,
+        const unsigned char *label, int label_len,
         TPM2B_DIGEST *seed,
         TPM2B_ENCRYPTED_SECRET *out_sym_seed) {
 

--- a/lib/tpm2_kdfe.h
+++ b/lib/tpm2_kdfe.h
@@ -32,7 +32,7 @@
  */
 TSS2_RC tpm2_kdfe(
         TPMI_ALG_HASH hash_alg, TPM2B_ECC_PARAMETER *Z,
-        unsigned char *label, int label_length,
+        const unsigned char *label, int label_length,
         TPM2B_ECC_PARAMETER *party_u_info, TPM2B_ECC_PARAMETER *party_v_info,
         UINT16 size_in_bits, TPM2B_MAX_BUFFER  *result_key );
 
@@ -55,7 +55,7 @@ TSS2_RC tpm2_kdfe(
  *  True on success, false otherwise.
  */
 bool ecdh_derive_seed_and_encrypted_seed(
-        TPM2B_PUBLIC *parent_pub, unsigned char *label, int label_len,
+        TPM2B_PUBLIC *parent_pub, const unsigned char *label, int label_len,
         TPM2B_DIGEST *seed, TPM2B_ENCRYPTED_SECRET *out_sym_seed);
 
 

--- a/lib/tpm2_openssl.h
+++ b/lib/tpm2_openssl.h
@@ -251,6 +251,25 @@ tpm2_openssl_load_rc tpm2_openssl_load_private(const char *path,
         const char *pass, TPMI_ALG_PUBLIC alg, TPM2B_PUBLIC *pub,
         TPM2B_SENSITIVE *priv);
 
+
+/**
+ * Load an OpenSSL private key and configure all of the flags based on
+ * a parent key, policy, attributes, and authorization.
+ */
+bool tpm2_openssl_import_keys(
+    TPM2B_PUBLIC *parent_pub,
+    TPM2B_SENSITIVE *private,
+    TPM2B_PUBLIC *public,
+    TPM2B_ENCRYPTED_SECRET *encrypted_seed,
+    const char *input_key_file,
+    TPMI_ALG_PUBLIC key_type,
+    const char *auth_key_file,
+    const char *policy_file,
+    const char *key_auth_str,
+    char *attrs_str,
+    const char *name_alg_str
+);
+
 /**
  * Loads a public portion of a key from a file. Files can be the raw key, in the case
  * of symmetric ciphers, or a PEM file.

--- a/tools/tpm2_import.c
+++ b/tools/tpm2_import.c
@@ -74,7 +74,7 @@ static tool_rc readpublic(ESYS_CONTEXT *ectx, ESYS_TR handle,
     return tpm2_readpublic(ectx, handle, public, NULL, NULL);
 }
 
-static void create_import_key_private_data(TPM2B_PRIVATE *private,
+static bool create_import_key_private_data(TPM2B_PRIVATE *private,
         TPMI_ALG_HASH parent_name_alg,
         TPM2B_MAX_BUFFER *encrypted_duplicate_sensitive,
         TPM2B_DIGEST *outer_hmac) {
@@ -82,16 +82,25 @@ static void create_import_key_private_data(TPM2B_PRIVATE *private,
     //UINT16 hash_size = tpm2_alg_util_get_hash_size(ctx.name_alg);
     UINT16 parent_hash_size = tpm2_alg_util_get_hash_size(parent_name_alg);
 
-private->size = sizeof(uint16_t) + parent_hash_size
+    private->size = sizeof(parent_hash_size) + parent_hash_size
             + encrypted_duplicate_sensitive->size;
+
     size_t hmac_size_offset = 0;
-    Tss2_MU_UINT16_Marshal(parent_hash_size, private->buffer, sizeof(uint16_t),
-            &hmac_size_offset);
+    TSS2_RC rval = Tss2_MU_UINT16_Marshal(parent_hash_size, private->buffer,
+            sizeof(parent_hash_size), &hmac_size_offset);
+    if (rval != TPM2_RC_SUCCESS)
+    {
+        LOG_ERR("Error serializing parent hash size");
+        return false;
+    }
+
     memcpy(private->buffer + hmac_size_offset, outer_hmac->buffer,
             parent_hash_size);
     memcpy(private->buffer + hmac_size_offset + parent_hash_size,
             encrypted_duplicate_sensitive->buffer,
             encrypted_duplicate_sensitive->size);
+
+    return true;
 }
 
 static tool_rc key_import(ESYS_CONTEXT *ectx, TPM2B_PUBLIC *parent_pub,
@@ -139,8 +148,11 @@ static tool_rc key_import(ESYS_CONTEXT *ectx, TPM2B_PUBLIC *parent_pub,
             &encrypted_duplicate_sensitive, &outer_hmac);
 
     TPM2B_PRIVATE private = TPM2B_EMPTY_INIT;
-    create_import_key_private_data(&private, parent_pub->publicArea.nameAlg,
+    res = create_import_key_private_data(&private, parent_pub->publicArea.nameAlg,
             &encrypted_duplicate_sensitive, &outer_hmac);
+    if (!res) {
+        return false;
+    }
 
     TPMT_SYM_DEF_OBJECT *sym_alg =
             &parent_pub->publicArea.parameters.rsaDetail.symmetric;


### PR DESCRIPTION
Wrapping a key for a remote TPM2 right now requires loading the key into the local TPM. For some use cases it is not necessary to involve the local TPM, such as sending an openssl generated key to a remote machine.

`tpm2_duplicate` seems like the right place to put this functionality, although it shares a large amount of code with `tpm2_import`, and some with `tpm2_makecredential`.  If there is a better place to locate the code, please let me know.

Some todo's before it is ready for merging:

* [x] need to add documentation
* [x] write test cases
* [x] add output option for public section
* [x] move `DUPLICATE\0` seed generation into shared routine