### PR TITLE
tpm2_eventlog: Flush the eventlog stream data pointed by the fileptr.

### DIFF
--- a/tools/misc/tpm2_eventlog.c
+++ b/tools/misc/tpm2_eventlog.c
@@ -95,6 +95,7 @@ static tool_rc tpm2_tool_onrun(ESYS_CONTEXT *ectx, tpm2_option_flags flags) {
     }
 
     ret = files_read_bytes(fileptr, eventlog, size);
+    fclose(fileptr);
     if (!ret) {
         rc = tool_rc_general_error;
         goto out;


### PR DESCRIPTION
Signed-off-by: Imran Desai <imran.desai@intel.com>