### PR TITLE
tpm2_getekcertificate: sanitize the url path when concatenating

### DIFF
--- a/tools/tpm2_getekcertificate.c
+++ b/tools/tpm2_getekcertificate.c
@@ -198,9 +198,13 @@ static size_t writecallback(char *contents, size_t size, size_t nitems,
 
     return ctx.rsa_cert_buffer_size;
 }
+
 static bool retrieve_web_endorsement_certificate(char *b64h) {
 
-    size_t len = 1 + strlen(b64h) + strlen(ctx.ek_server_addr);
+    #define NULL_TERM_LEN 1                 // '\0'
+    #define PATH_JOIN_CHAR_LEN 1            // '/'
+    size_t len = strlen(ctx.ek_server_addr) + strlen(b64h) + NULL_TERM_LEN +
+        PATH_JOIN_CHAR_LEN;
     char *weblink = (char *) malloc(len);
     if (!weblink) {
         LOG_ERR("oom");
@@ -235,7 +239,7 @@ static bool retrieve_web_endorsement_certificate(char *b64h) {
         }
     }
 
-    snprintf(weblink, len, "%s%s", ctx.ek_server_addr, b64h);
+    snprintf(weblink, len, "%s%s%s", ctx.ek_server_addr, "/", b64h);
     rc = curl_easy_setopt(curl, CURLOPT_URL, weblink);
     if (rc != CURLE_OK) {
         LOG_ERR("curl_easy_setopt for CURLOPT_URL failed: %s",


### PR DESCRIPTION
Fixes #2338

Signed-off-by: Imran Desai <imran.desai@intel.com>