### PR TITLE
tpm2_eventlog: fix device path indentation issue

### DIFF
--- a/lib/tpm2_eventlog_yaml.c
+++ b/lib/tpm2_eventlog_yaml.c
@@ -226,12 +226,12 @@ static bool yaml_uefi_post_code(const TCG_EVENT2* const event) {
  * print the field in raw byte format
  */
 #ifdef HAVE_EFIVAR_EFIVAR_H
-bool yaml_devicepath(BYTE* dp, UINT64 dp_len) {
+char* yaml_devicepath(BYTE* dp, UINT64 dp_len) {
     int ret;
     ret = efidp_format_device_path(NULL, 0, (const_efidp)dp, dp_len);
     if (ret < 0) {
         LOG_ERR("failed to allocate memory: %s\n", strerror(errno));
-        return false;
+        return NULL;
     }
 
     int text_path_len;
@@ -240,7 +240,7 @@ bool yaml_devicepath(BYTE* dp, UINT64 dp_len) {
     text_path = (char*)malloc(text_path_len);
     if (!text_path) {
         LOG_ERR("failed to allocate memory: %s\n", strerror(errno));
-        return false;
+        return NULL;
     }
   
     ret = efidp_format_device_path(text_path,
@@ -248,12 +248,10 @@ bool yaml_devicepath(BYTE* dp, UINT64 dp_len) {
     if (ret < 0) {
         free(text_path);
         LOG_ERR("cannot parse device path\n");
-        return false;
+        return NULL;
     }
 
-    tpm2_tool_output("    DevicePath: \"%s\"\n", text_path);
-    free(text_path);
-    return true; 
+    return text_path; 
 }
 #endif
 /*
@@ -485,16 +483,20 @@ static bool yaml_uefi_var(UEFI_VARIABLE_DATA *data, size_t size, UINT32 type,
                 }
 
 #ifdef HAVE_EFIVAR_EFIVAR_H
-                if (!yaml_devicepath(devpath, devpath_len)) {
+                char *dp = yaml_devicepath(devpath, devpath_len);
+                if (dp) {
+                    tpm2_tool_output("      DevicePath: '%s'\n", dp);
+                    free(dp);
+                } else {
                     /* fallback to printing the raw bytes if devicepath cannot be parsed */
                     bytes_to_str(devpath, data->VariableDataLength -
                         sizeof(EFI_LOAD_OPTION) - sizeof(UINT16) * i, buf, devpath_len);
-                    tpm2_tool_output("    DevicePath: \"%s\"\n", buf);
+                    tpm2_tool_output("      DevicePath: '%s'\n", buf);
                 }
 #else
                 bytes_to_str(devpath, data->VariableDataLength -
                     sizeof(EFI_LOAD_OPTION) - sizeof(UINT16) * i, buf, devpath_len);
-                tpm2_tool_output("      DevicePath: \"%s\"\n", buf);
+                tpm2_tool_output("      DevicePath: '%s'\n", buf);
 #endif
                 free(buf);
                 return true;
@@ -568,14 +570,18 @@ bool yaml_uefi_image_load(UEFI_IMAGE_LOAD_EVENT *data, size_t size) {
                      data->ImageLinkTimeAddress, data->LengthOfDevicePath);
 
 #ifdef HAVE_EFIVAR_EFIVAR_H
-    if (!yaml_devicepath(data->DevicePath, data->LengthOfDevicePath)) {
+    char *dp = yaml_devicepath(data->DevicePath, data->LengthOfDevicePath); 
+    if (dp) {
+        tpm2_tool_output("    DevicePath: '%s'\n", dp);
+        free(dp);
+    } else {
         /* fallback to printing the raw bytes if devicepath cannot be parsed */
         bytes_to_str(data->DevicePath, size - sizeof(*data), buf, devpath_len);
-        tpm2_tool_output("    DevicePath: \"%s\"\n", buf);
+        tpm2_tool_output("    DevicePath: '%s'\n", buf);
     }
 #else
     bytes_to_str(data->DevicePath, size - sizeof(*data), buf, devpath_len);
-    tpm2_tool_output("    DevicePath: \"%s\"\n", buf);
+    tpm2_tool_output("    DevicePath: '%s'\n", buf);
 #endif
 
     free(buf);

--- a/lib/tpm2_eventlog_yaml.c
+++ b/lib/tpm2_eventlog_yaml.c
@@ -226,7 +226,7 @@ static bool yaml_uefi_post_code(const TCG_EVENT2* const event) {
  * print the field in raw byte format
  */
 #ifdef HAVE_EFIVAR_EFIVAR_H
-char* yaml_devicepath(BYTE* dp, UINT64 dp_len) {
+char *yaml_devicepath(BYTE* dp, UINT64 dp_len) {
     int ret;
     ret = efidp_format_device_path(NULL, 0, (const_efidp)dp, dp_len);
     if (ret < 0) {


### PR DESCRIPTION
DevicePath field can be included in multiple types of events, and at different indentation levels. Previous commit assumes it's always at the same indentation level, e.g.,

```
- EventNum: 15
  PCRIndex: 1
  EventType: EV_EFI_VARIABLE_BOOT
  DigestCount: 2
  Digests:
  - AlgorithmId: sha1
    Digest: "df5d6605cb8f4366d745a8464cfb26c1efdc305c"
  - AlgorithmId: sha256
    Digest: "4d387b02d63b2f4cd7f667feb0a387fe47a10a3e26bf3533ddd001c605f3dec5"
  EventSize: 136
  Event:
    VariableName: 61dfe48b-ca93-d211-aa0d-00e098032b8c
    UnicodeNameLength: 8
    VariableDataLength: 88
    UnicodeName: Boot0002
    VariableData:
      Enabled: 'Yes'
      FilePathListLength: 44
      Description: "EFI Internal Shell"
    DevicePath: "FvVol(7cb8bdc9-f8eb-4f34-aaea-3ee4af6516a1)/FvFile(7c04a583-9e3e-4f1c-ad65-e05268d0b4d1)"
```

The `DevicePath` field in the last line above should be one more level indented. This PR allows DevicePath field to be printed at the right indentation level.