### PR TITLE
tpm2_import: do not allow -p with TPM objects

### DIFF
--- a/tools/tpm2_import.c
+++ b/tools/tpm2_import.c
@@ -290,6 +290,12 @@ static tool_rc check_options(void) {
             ctx.key_type = TPM2_ALG_AES;
         }
 
+        if (ctx.key_auth_str) {
+            LOG_ERR("Cannot specify key password when importing a TPM key.\n"
+                "use tpm2_changeauth after import");
+            rc = tool_rc_option_error;
+        }
+
     } else { /* Openssl specific option(s) */
 
         if (!ctx.key_type) {


### PR DESCRIPTION
When you import from a TPM object, you're importing from a TPM2B_PRIVATE,
which is opaque to us. Thus we cannot modify it to change it. You can only
change the TPM object at creation time, when you have the clear text
TPM2B_SENSITIVE or through certain APIs like tpm2_changeauth.

However, when importing from an openssl key, we create the object from a
TPM2B_SENSITIVE and perform the parent key wrapping work of the TPM and
thus generate the TPM2B_PRIVATE. Thus we can modify it.

Thus complain when -p is set but the user is importing TPM objects.

Fixes: #2708

Signed-off-by: William Roberts <william.c.roberts@intel.com>