### PR TITLE
Adds support for tpm2_contextload command

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -369,6 +369,7 @@ if HAVE_MAN_PAGES
     man/man1/tpm2_clear.1 \
     man/man1/tpm2_clearcontrol.1 \
 	man/man1/tpm2_clockrateadjust.1 \
+    man/man1/tpm2_contextload.1 \
     man/man1/tpm2_create.1 \
     man/man1/tpm2_createak.1 \
     man/man1/tpm2_createek.1 \

--- a/Makefile.am
+++ b/Makefile.am
@@ -200,6 +200,7 @@ tpm2_tools = \
     tools/tpm2_ecdhzgen.c \
     tools/tpm2_zgen2phase.c \
     tools/tpm2_sessionconfig.c \
+    tools/tpm2_contextload.c \
     tools/tpm2_getpolicydigest.c
 
 # Create the symlinks for each tool to the tpm2 and optional tss2 bundled executables

--- a/man/tpm2.1.md
+++ b/man/tpm2.1.md
@@ -57,6 +57,8 @@ List of possible tool names. NOTE: Specify only one of these. Look at examples.
 
 **clockrateadjust**
 
+**contextload**
+
 **create**
 
 **createak**

--- a/man/tpm2_contextload.1.md
+++ b/man/tpm2_contextload.1.md
@@ -1,0 +1,53 @@
+% tpm2_contextload(1) tpm2-tools | General Commands Manual
+
+# NAME
+
+**tpm2_contextload**(1) - Loads the session into the TPM, so that it can be
+referenced using the TPM session handle.
+
+# SYNOPSIS
+
+**tpm2_contextload** [*OPTIONS*] [*ARGUMENT*]
+
+# DESCRIPTION
+
+**tpm2_contextload**(1) - Loads the session into the TPM, so that it can be
+referenced using the TPM session handle.
+
+The tool returns the TPM handle the session is currently loaded on, and that
+handle value can be used directly when communicating directly with the TPM.
+
+**NOTE**: The session context file will not be usable on subsequent calls. As
+all tools invoke contextload/contextsave before/after using the session, the
+contextload call for subsequent commands will fail as the session is loaded
+already.
+
+**NOTE 2**: When working with the in-kernel resource manager, the contextload
+command should be executed directly against the TPM (using the --tcti option)
+, as the in-kernel RM flushes the objects upon exiting.
+
+* **ARGUMENT** the session context file.
+
+## References
+
+[common options](common/options.md) collection of common options that provide
+information many users may expect.
+
+[common tcti options](common/tcti.md) collection of options used to configure
+the various known TCTI modules.
+
+# EXAMPLES
+
+## Create a policy session, contextload it into the TPM
+
+```bash
+
+tpm2 startauthsession -S session.ctx --policy-session
+
+tpm2 contextload -T "device:/dev/tpm0" session.ctx
+
+```
+
+[returns](common/returns.md)
+
+[footer](common/footer.md)

--- a/man/tpm2_contextload.1.md
+++ b/man/tpm2_contextload.1.md
@@ -42,9 +42,9 @@ the various known TCTI modules.
 
 ```bash
 
-tpm2 startauthsession -S session.ctx --policy-session
+tpm2_startauthsession -S session.ctx --policy-session
 
-tpm2 contextload -T "device:/dev/tpm0" session.ctx
+tpm2_contextload -T "device:/dev/tpm0" session.ctx
 
 ```
 

--- a/tools/tpm2_contextload.c
+++ b/tools/tpm2_contextload.c
@@ -53,7 +53,7 @@ static tool_rc tpm2_tool_onrun(ESYS_CONTEXT *ectx, tpm2_option_flags flags) {
 
     UNUSED(flags);
 
-   bool retval = is_input_option_args_valid();
+    bool retval = is_input_option_args_valid();
     if (!retval) {
         return tool_rc_option_error;
     }

--- a/tools/tpm2_contextload.c
+++ b/tools/tpm2_contextload.c
@@ -1,0 +1,83 @@
+/* SPDX-License-Identifier: BSD-3-Clause */
+
+#include <inttypes.h>
+#include <stdbool.h>
+#include <stdlib.h>
+
+#include "files.h"
+#include "log.h"
+#include "pcr.h"
+#include "tpm2_policy.h"
+#include "tpm2_tool.h"
+#include "tpm2_session.h"
+#include "tpm2.h"
+
+typedef struct tpm2_contextload_ctx tpm2_contextload_ctx;
+struct tpm2_contextload_ctx {
+    const char *session_path;
+    tpm2_session *session;
+};
+
+static tpm2_contextload_ctx ctx;
+
+static bool on_option(char key, char *value) {
+
+    switch (key) {
+    case 'S':
+        ctx.session_path = value;
+        break;
+    }
+    return true;
+}
+
+static bool tpm2_tool_onstart(tpm2_options **opts) {
+
+    static struct option topts[] = {
+        { "session",  required_argument,  NULL, 'S' },
+    };
+
+    *opts = tpm2_options_new("S:", ARRAY_LEN(topts), topts, on_option,
+    NULL, 0);
+
+    return *opts != NULL;
+}
+
+static tool_rc tpm2_tool_onrun(ESYS_CONTEXT *ectx, tpm2_option_flags flags) {
+
+    UNUSED(flags);
+
+    bool option_fail = false;
+    if (!ctx.session_path) {
+        LOG_ERR("Must specify -S session file.");
+        option_fail = true;
+    }
+
+    if (option_fail) {
+        return tool_rc_general_error;
+    }
+
+    tool_rc rc = tpm2_session_restore(ectx, ctx.session_path, false,
+            &ctx.session);
+    if (rc != tool_rc_success) {
+        return rc;
+    }
+
+    ESYS_TR sessionhandle = tpm2_session_get_handle(ctx.session);
+    if (!sessionhandle) {
+        LOG_ERR("Session handle cannot be null");
+        return tool_rc_general_error;
+    }
+
+    TPM2_HANDLE tpm_handle;
+    TSS2_RC rv = Esys_TR_GetTpmHandle(ectx, sessionhandle, &tpm_handle);
+    if (rv != TSS2_RC_SUCCESS) {
+        return tool_rc_general_error;
+    }
+
+    tpm2_tool_output("Session-Handle: 0x%.8"PRIx32"\n", tpm_handle);
+
+    return rc;
+}
+
+// Register this tool with tpm2_tool.c
+TPM2_TOOL_REGISTER("contextload", tpm2_tool_onstart, tpm2_tool_onrun, NULL, NULL)


### PR DESCRIPTION
Add standalone support to the standard contexload command, so that one can convert a session stored in a context file into the correspondent session handle, and having the session resident in the TPM memory.

After context loading a session using this command, the session context file cannot be used anymore for further commands, as there is no guarantee the data stored in it is accurate anymore. Executing any tpm2_tools command using the session context file will also fail, since the tools will attempt to context load the session before executing, but it will be already loaded at that point. The only alternative to have the same session being used again would be to have a corresponding tpm2_contextsave command, which is not included in this PR.

I also noticed that, when using the in-kernel RM (haven't tested on abrmd, but assuming previous @williamcroberts feedback it shouldn't happen there) executing the contextload command results in the session being lost, as the RM flushes it out when the command finishes executing. That is explicitly called out on the tool man page, so that users can now they have to execute the tpm2_contextload command directly against the TPM using the TCTI option specifier.