### PR TITLE
[RFC] session: dont start HMAC session on empty auth

### DIFF
--- a/lib/tpm2.c
+++ b/lib/tpm2.c
@@ -177,10 +177,9 @@ tool_rc tpm2_nv_read(ESYS_CONTEXT *esys_context,
             goto tpm2_nvread_free_name1_name2;
         }
 
-        cp_hash->size = tpm2_alg_util_get_hash_size(
-            tpm2_session_get_authhash(auth_hierarchy_obj->session));
+        cp_hash->size = tpm2_alg_util_get_hash_size(TPM2_ALG_SHA256);
         rc = tpm2_sapi_getcphash(sys_context, name1, name2, NULL,
-            tpm2_session_get_authhash(auth_hierarchy_obj->session), cp_hash);
+            TPM2_ALG_SHA256, cp_hash);
         /*
          * Exit here without making the ESYS call since we just need the cpHash
          */
@@ -553,10 +552,9 @@ tool_rc tpm2_policy_authorize_nv(ESYS_CONTEXT *esys_context,
             goto tpm2_policyauthorizenv_free_name1_name2_name3;
         }
 
-        cp_hash->size = tpm2_alg_util_get_hash_size(
-            tpm2_session_get_authhash(auth_hierarchy_obj->session));
+        cp_hash->size = tpm2_alg_util_get_hash_size(TPM2_ALG_SHA256);
         rc = tpm2_sapi_getcphash(sys_context, name1, name2, name3,
-            tpm2_session_get_authhash(auth_hierarchy_obj->session), cp_hash);
+            TPM2_ALG_SHA256, cp_hash);
 
         /*
          * Exit here without making the ESYS call since we just need the cpHash
@@ -642,10 +640,9 @@ tool_rc tpm2_policy_nv(ESYS_CONTEXT *esys_context,
             goto tpm2_policynv_free_name1_name2_name3;
         }
 
-        cp_hash->size = tpm2_alg_util_get_hash_size(
-            tpm2_session_get_authhash(auth_hierarchy_obj->session));
+        cp_hash->size = tpm2_alg_util_get_hash_size(TPM2_ALG_SHA256);
         rc = tpm2_sapi_getcphash(sys_context, name1, name2, name3,
-            tpm2_session_get_authhash(auth_hierarchy_obj->session), cp_hash);
+            TPM2_ALG_SHA256, cp_hash);
 
         /*
          * Exit here without making the ESYS call since we just need the cpHash
@@ -1026,10 +1023,9 @@ tool_rc tpm2_evictcontrol(ESYS_CONTEXT *esys_context,
             goto tpm2_evictcontrol_free_name1_name2;
         }
 
-        cp_hash->size = tpm2_alg_util_get_hash_size(
-            tpm2_session_get_authhash(auth_hierarchy_obj->session));
+        cp_hash->size = tpm2_alg_util_get_hash_size(TPM2_ALG_SHA256);
         rc = tpm2_sapi_getcphash(sys_context, name1, name2, NULL,
-            tpm2_session_get_authhash(auth_hierarchy_obj->session), cp_hash);
+            TPM2_ALG_SHA256, cp_hash);
 
         /*
          * Exit here without making the ESYS call since we just need the cpHash
@@ -2694,10 +2690,9 @@ tool_rc tpm2_nv_increment(ESYS_CONTEXT *esys_context,
             goto tpm2_nvincrement_free_name1_name2;
         }
 
-        cp_hash->size = tpm2_alg_util_get_hash_size(
-            tpm2_session_get_authhash(auth_hierarchy_obj->session));
+        cp_hash->size = tpm2_alg_util_get_hash_size(TPM2_ALG_SHA256);
         rc = tpm2_sapi_getcphash(sys_context, name1, name2, NULL,
-            tpm2_session_get_authhash(auth_hierarchy_obj->session), cp_hash);
+            TPM2_ALG_SHA256, cp_hash);
 
         /*
          * Exit here without making the ESYS call since we just need the cpHash
@@ -2772,10 +2767,9 @@ tool_rc tpm2_nvreadlock(ESYS_CONTEXT *esys_context,
             goto tpm2_nvreadlock_free_name1_name2;
         }
 
-        cp_hash->size = tpm2_alg_util_get_hash_size(
-            tpm2_session_get_authhash(auth_hierarchy_obj->session));
+        cp_hash->size = tpm2_alg_util_get_hash_size(TPM2_ALG_SHA256);
         rc = tpm2_sapi_getcphash(sys_context, name1, name2, NULL,
-            tpm2_session_get_authhash(auth_hierarchy_obj->session), cp_hash);
+            TPM2_ALG_SHA256, cp_hash);
 
         /*
          * Exit here without making the ESYS call since we just need the cpHash
@@ -2851,10 +2845,9 @@ tool_rc tpm2_nvwritelock(ESYS_CONTEXT *esys_context,
             goto tpm2_nvwritelock_free_name1_name2;
         }
 
-        cp_hash->size = tpm2_alg_util_get_hash_size(
-            tpm2_session_get_authhash(auth_hierarchy_obj->session));
+        cp_hash->size = tpm2_alg_util_get_hash_size(TPM2_ALG_SHA256);
         rc = tpm2_sapi_getcphash(sys_context, name1, name2, NULL,
-            tpm2_session_get_authhash(auth_hierarchy_obj->session), cp_hash);
+            TPM2_ALG_SHA256, cp_hash);
 
         /*
          * Exit here without making the ESYS call since we just need the cpHash
@@ -2916,10 +2909,9 @@ tool_rc tpm2_nvglobalwritelock(ESYS_CONTEXT *esys_context,
             goto tpm2_globalnvwritelock_free_name1;
         }
 
-        cp_hash->size = tpm2_alg_util_get_hash_size(
-            tpm2_session_get_authhash(auth_hierarchy_obj->session));
+        cp_hash->size = tpm2_alg_util_get_hash_size(TPM2_ALG_SHA256);
         rc = tpm2_sapi_getcphash(sys_context, name1, NULL, NULL,
-            tpm2_session_get_authhash(auth_hierarchy_obj->session), cp_hash);
+            TPM2_ALG_SHA256, cp_hash);
 
         /*
          * Exit here without making the ESYS call since we just need the cpHash
@@ -3004,10 +2996,9 @@ tool_rc tpm2_nvsetbits(ESYS_CONTEXT *esys_context,
             goto tpm2_nvsetbits_free_name1_name2;
         }
 
-        cp_hash->size = tpm2_alg_util_get_hash_size(
-            tpm2_session_get_authhash(auth_hierarchy_obj->session));
+        cp_hash->size = tpm2_alg_util_get_hash_size(TPM2_ALG_SHA256);
         rc = tpm2_sapi_getcphash(sys_context, name1, name2, NULL,
-            tpm2_session_get_authhash(auth_hierarchy_obj->session), cp_hash);
+            TPM2_ALG_SHA256, cp_hash);
 
         /*
          * Exit here without making the ESYS call since we just need the cpHash
@@ -3180,10 +3171,9 @@ tool_rc tpm2_nvundefine(ESYS_CONTEXT *esys_context,
             goto tpm2_nvundefine_free_name1_name2;
         }
 
-        cp_hash->size = tpm2_alg_util_get_hash_size(
-            tpm2_session_get_authhash(auth_hierarchy_obj->session));
+        cp_hash->size = tpm2_alg_util_get_hash_size(TPM2_ALG_SHA256);
         rc = tpm2_sapi_getcphash(sys_context, name1, name2, NULL,
-            tpm2_session_get_authhash(auth_hierarchy_obj->session), cp_hash);
+            TPM2_ALG_SHA256, cp_hash);
 
         /*
          * Exit here without making the ESYS call since we just need the cpHash
@@ -3264,10 +3254,9 @@ tool_rc tpm2_nvundefinespecial(ESYS_CONTEXT *esys_context,
             goto tpm2_nvundefinespecial_free_name1_name2;
         }
 
-        cp_hash->size = tpm2_alg_util_get_hash_size(
-            tpm2_session_get_authhash(auth_hierarchy_obj->session));
+        cp_hash->size = tpm2_alg_util_get_hash_size(TPM2_ALG_SHA256);
         rc = tpm2_sapi_getcphash(sys_context, name1, name2, NULL,
-            tpm2_session_get_authhash(auth_hierarchy_obj->session), cp_hash);
+            TPM2_ALG_SHA256, cp_hash);
 
         /*
          * Exit here without making the ESYS call since we just need the cpHash
@@ -3349,10 +3338,9 @@ tool_rc tpm2_nvwrite(ESYS_CONTEXT *esys_context,
             goto tpm2_nvwrite_free_name1_name2;
         }
 
-        cp_hash->size = tpm2_alg_util_get_hash_size(
-            tpm2_session_get_authhash(auth_hierarchy_obj->session));
+        cp_hash->size = tpm2_alg_util_get_hash_size(TPM2_ALG_SHA256);
         rc = tpm2_sapi_getcphash(sys_context, name1, name2, NULL,
-            tpm2_session_get_authhash(auth_hierarchy_obj->session), cp_hash);
+            TPM2_ALG_SHA256, cp_hash);
         /*
          * Exit here without making the ESYS call since we just need the cpHash
          */

--- a/lib/tpm2_auth_util.c
+++ b/lib/tpm2_auth_util.c
@@ -109,6 +109,10 @@ static tool_rc handle_password_session(ESYS_CONTEXT *ectx, const char *password,
         return tool_rc_general_error;
     }
 
+    if (!auth.size) {
+        return tpm2_session_open_password(session, NULL);
+    }
+
     return start_hmac_session(ectx, &auth, session);
 }
 

--- a/lib/tpm2_session.c
+++ b/lib/tpm2_session.c
@@ -197,6 +197,39 @@ tool_rc tpm2_session_open(ESYS_CONTEXT *context, tpm2_session_data *data,
     return tool_rc_success;
 }
 
+tool_rc tpm2_session_open_password(tpm2_session **session, const char *password) {
+
+    tpm2_session *s = calloc(1, sizeof(tpm2_session));
+    if (!s) {
+        LOG_ERR("oom");
+        return tool_rc_general_error;
+    }
+
+    s->input = calloc(1, sizeof(tpm2_session_data));
+    if (!s->input) {
+        free(s);
+        LOG_ERR("oom");
+        return tool_rc_general_error;
+    }
+
+    if (password) {
+        if (strlen(password) > sizeof(s->input->auth_data.buffer)) {
+            LOG_ERR("Password too big, got %zu is greater than %zu",
+                strlen(password), sizeof(s->input->auth_data.buffer));
+            free(s->input);
+            free(s);
+        }
+
+        s->input->auth_data.size = strlen(password);
+        memcpy(s->input->auth_data.buffer, password, s->input->auth_data.size);
+
+    }
+
+	s->output.session_handle = ESYS_TR_PASSWORD;
+	*session = s;
+    return tool_rc_success;
+}
+
 /* SESSION_VERSION 1 was used prior to the switch to ESAPI. As the types of
  * several of the tpm2_session_data object members have changed the version is
  * bumped.

--- a/lib/tpm2_session.h
+++ b/lib/tpm2_session.h
@@ -161,6 +161,8 @@ static inline bool tpm2_session_is_trial(tpm2_session *session) {
 tool_rc tpm2_session_open(ESYS_CONTEXT *context, tpm2_session_data *data,
         tpm2_session **session);
 
+tool_rc tpm2_session_open_password(tpm2_session **session, const char *password);
+
 /**
  * Saves session data to disk allowing tpm2_session_from_file() to
  * restore the session if applicable and frees resources.


### PR DESCRIPTION
Their are 1509 HMAC sessions started during the test code on empty
passwords. We dont need an HMAC session for an empty password.

Second thought: maybe we do? To hide that the object has an empty auth?
Granted thats security through obscurity and easily figured out.

Signed-off-by: William Roberts <william.c.roberts@intel.com>

@idesai thoughts?

This broke cphash calculations, not sure why.