### PR TITLE
build: only use -Werror for non-release builds

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -259,7 +259,7 @@ AS_IF([test x"$enable_hardening" != x"no"], [
 
   add_hardened_c_flag([-Wall])
   add_hardened_c_flag([-Wextra])
-  add_hardened_c_flag([-Werror])
+  AS_IF([test "x$ax_is_release" = "xno"], [add_hardened_c_flag([-Werror])])
 
   add_hardened_c_flag([-Wformat])
   add_hardened_c_flag([-Wformat-security])


### PR DESCRIPTION
While we want to catch any compiler warnings during development, a release build should never fail due to e.g. stricter static checks introduced by new compiler versions. Therefore make `-Werror` conditional on [`AX_IS_RELEASE`](https://github.com/tpm2-software/tpm2-tools/blob/cedf49de2e919ec32c2f104c3ea7b728b87f6714/configure.ac#L5), like e.g. [tpm2-tss does](https://github.com/tpm2-software/tpm2-tss/blob/2bae50a3551cd8b0123ef609ea973678339df5ae/configure.ac#L435-L436).

tpm2-tools has no issues with the recently released GCC 11 as far as I am aware, but it never hurts to be proactive.