### PR TITLE
ci: Use the latest fedora stable release and rawhide

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -7,7 +7,7 @@ jobs:
     if: "!contains(github.ref, 'coverity_scan')"
     strategy:
       matrix:
-        docker_image: [ubuntu-18.04, ubuntu-20.04, fedora-30, opensuse-leap, fedora-32]
+        docker_image: [ubuntu-18.04, ubuntu-20.04, fedora, fedora:rawhide, opensuse-leap]
         compiler: [gcc, clang]
     steps:
       - name: Check out repository


### PR DESCRIPTION
Rather than specifying a specific release, Fedora 30 is long obsolete,
Fedora 32 is EOL on May 25th, use the latest Fedora stable release which
is the equivilent of fedora:latest, and fedora:rawhide which is the
latest development release which saves updating this all the time.

Signed-off-by: Peter Robinson <pbrobinson@gmail.com>