### PR TITLE
Fix import CVE-2021-3565

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -174,7 +174,7 @@ AS_IF([test "x$enable_unit" != xno], [
     AS_IF([test $BASH_SHELL = no],
           [AC_MSG_ERROR([Required executable bash not found, system tests require a bash shell!])])
 
-    AM_PATH_PYTHON([2.7],
+    AM_PATH_PYTHON([],
         [],
         [AC_MSG_ERROR([Required executable python not found, some system tests will fail!])]
     )

--- a/tools/tpm2_import.c
+++ b/tools/tpm2_import.c
@@ -118,7 +118,17 @@ static tool_rc key_import(ESYS_CONTEXT *ectx, TPM2B_PUBLIC *parent_pub,
     TPM2B_DATA enc_sensitive_key = {
         .size = parent_pub->publicArea.parameters.rsaDetail.symmetric.keyBits.sym / 8
     };
-    memset(enc_sensitive_key.buffer, 0xFF, enc_sensitive_key.size);
+
+    if(enc_sensitive_key.size < 16) {
+        LOG_ERR("Calculated wrapping keysize is less than 16 bytes, got: %u", enc_sensitive_key.size);
+        return tool_rc_general_error;
+    }
+
+    int ossl_rc = RAND_bytes(enc_sensitive_key.buffer, enc_sensitive_key.size);
+    if (ossl_rc != 1) {
+        LOG_ERR("RAND_bytes failed: %s", ERR_error_string(ERR_get_error(), NULL));
+        return tool_rc_general_error;
+    }
 
     /*
      * Calculate the object name.


### PR DESCRIPTION
tpm2_import: fix fixed AES key CVE-2021-3565
    
tpm2_import used a fixed AES key for the inner wrapper, which means that
a MITM attack would be able to unwrap the imported key. Even the
use of an encrypted session will not prevent this. The TPM only
encrypts the first parameter which is the fixed symmetric key.
    
To fix this, ensure the key size is 16 bytes or bigger and use
OpenSSL to generate a secure random AES key.
    
Fixes: #2738