### PR TITLE
Add test/ to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,4 @@ test-driver
 # dist tarball
 *.gz
 src_vars.mk
+test/


### PR DESCRIPTION
Test files are brought in when running `./bootstrap`. This prevents git from showing them as untracked.

Signed-off-by: Joe Richey <joerichey@google.com>