### PR TITLE
Support saving PEM/DER public keys in createprimary, create and print

### DIFF
--- a/doc/CHANGELOG.md
+++ b/doc/CHANGELOG.md
@@ -7,6 +7,8 @@
         of the response parameters. This is commonly termed as rpHash.
       - Added option **-S**, **\--session** to specify to specify an auxiliary
         session for auditing and or encryption/decryption of the parameters.
+  * tpm2_createprimary: Support outputing public key at creation time in various
+    public key formats.
 
 ### 5.1 2021-05-24
 

--- a/doc/CHANGELOG.md
+++ b/doc/CHANGELOG.md
@@ -11,6 +11,9 @@
     public key formats.
   * tpm2_create: Support outputing public key at creation time in various
     public key formats.
+  * tpm2_print: Support outputing public key in various public key formats over
+    the default YAML output. Supports taking `-u` output from `tpm2_create` and
+    converting it to a PEM or DER file format.
 
 ### 5.1 2021-05-24
 

--- a/doc/CHANGELOG.md
+++ b/doc/CHANGELOG.md
@@ -9,6 +9,8 @@
         session for auditing and or encryption/decryption of the parameters.
   * tpm2_createprimary: Support outputing public key at creation time in various
     public key formats.
+  * tpm2_create: Support outputing public key at creation time in various
+    public key formats.
 
 ### 5.1 2021-05-24
 

--- a/lib/files.c
+++ b/lib/files.c
@@ -199,7 +199,7 @@ bool files_save_bytes_to_file(const char *path, UINT8 *buf, UINT16 size) {
 
     bool result = files_write_bytes(fp, buf, size);
     if (!result) {
-        LOG_ERR("Could not write data to file \"%s\"", path);
+        LOG_ERR("Could not write data to file \"%s\"", path ? path : "<stdout>");
     }
 
     if (fp != stdout) {

--- a/lib/tpm2_convert.c
+++ b/lib/tpm2_convert.c
@@ -270,9 +270,9 @@ static bool tpm2_convert_pubkey_bio(TPMT_PUBLIC *public,
 static bool tpm2_convert_pubkey_ssl(TPMT_PUBLIC *public,
         tpm2_convert_pubkey_fmt format, const char *path) {
 
-    BIO *bio = BIO_new_file(path, "wb");
+    BIO *bio = path ? BIO_new_file(path, "wb") : BIO_new_fp(stdout, BIO_NOCLOSE);
     if (!bio) {
-        LOG_ERR("Failed to open public key output file '%s': %s", path,
+        LOG_ERR("Failed to open public key output file '%s': %s", path ? path : "<stdin>",
                 ERR_error_string(ERR_get_error(), NULL));
         return false;
     }

--- a/man/tpm2_create.1.md
+++ b/man/tpm2_create.1.md
@@ -136,6 +136,14 @@ These options for creating the TPM entity:
     be specified. For example, you can have one session for auditing and another
     for encryption/decryption of the parameters.
 
+[pubkey options](common/pubkey.md)
+
+    Public key format.
+
+  * **-o**, **\--output**=_FILE_:
+
+    The output file path, recording the public portion of the object.
+
 ## References
 
 [context object format](common/ctxobj.md) details the methods for specifying
@@ -199,6 +207,16 @@ that manpage for details on its usage.
 
 ```bash
 tpm2_create -C primary.ctx -G ecc -u obj.pub -r obj.priv -c ecc.ctx
+```
+
+## Create an Object and get the public key as a PEM file
+
+This will create an object using all the default values but also output the
+public key as a PEM file compatible with tools like OpenSSL and whatever supports
+PEM files.
+
+```bash
+tpm2_create -C primary.ctx -u obj.pub -r obj.priv -f pem -o obj.pem
 ```
 
 [returns](common/returns.md)

--- a/man/tpm2_createprimary.1.md
+++ b/man/tpm2_createprimary.1.md
@@ -122,6 +122,15 @@ future interactions with the created primary.
     termed as cpHash. NOTE: When this option is selected, The tool will not
     actually execute the command, it simply returns a cpHash.
 
+[pubkey options](common/pubkey.md)
+
+    Public key format.
+
+  * **-o**, **\--output**=_FILE_:
+
+    The output file path, recording the public portion of the object.
+
+
 ## References
 
 [context object format](common/ctxobj.md) details the methods for specifying
@@ -160,6 +169,10 @@ Where unique.dat contains the binary-formatted data: 0x00 0x01 (0x00 * 256)
 tpm2_createprimary -C o -G rsa2048:aes128cfb -g sha256 -c prim.ctx \
 -a 'restricted|decrypt|fixedtpm|fixedparent|sensitivedataorigin|userwithauth|\
 noda' -u unique.dat
+
+## Create a primary object and output the public key in pem format
+```bash
+tpm2_createprimary -c primary.ctx --format=pem --output=public.pem
 ```
 
 [returns](common/returns.md)

--- a/man/tpm2_print.1.md
+++ b/man/tpm2_print.1.md
@@ -25,6 +25,11 @@ path argument. Reads from stdin if unspecified.
       * **TPMT_PUBLIC**
   * **ARGUMENT** the command line argument specifies the path of the TPM data.
 
+[pubkey options](common/pubkey.md)
+
+    Public key format. This only works if option `--type/-t` is set to
+    TPM2B_PUBLIC or TPMT_PUBLIC.
+
 ## References
 
 [context object format](common/ctxobj.md) details the methods for specifying
@@ -76,6 +81,13 @@ tpm2_print -t TPM2B_PUBLIC key.pub
 tpm2_readpublic -c key.ctx -f tpmt -o key.tpmt
 tpm2_print -t TPMT_PUBLIC key.tpmt
 ```
+
+### Print a TPM2B_PUBLIC file and convert to PEM format
+
+```bash
+tpm2 print -t TPM2B_PUBLIC -f pem key.pub
+```
+
 
 [returns](common/returns.md)
 

--- a/test/integration/tests/create.sh
+++ b/test/integration/tests/create.sh
@@ -115,4 +115,8 @@ tpm2 create -C prim.ctx -u key.pub -r key.priv -p apple \
 tpm2 flushcontext audit_session.ctx
 tpm2 flushcontext enc_session.ctx
 
+# Test public key output
+tpm2_create -C primary.ctx -u obj.pub -r obj.priv -f pem -o obj.pem
+openssl rsa -noout -text -inform PEM -in obj.pem -pubin
+
 exit 0

--- a/test/integration/tests/createprimary.sh
+++ b/test/integration/tests/createprimary.sh
@@ -110,4 +110,8 @@ tpm2 createprimary -Q
 AFTER=$(tpm2 getcap handles-loaded-session; tpm2 getcap handles-saved-session)
 test "${BEFORE}" = "${AFTER}"
 
+# Test pem key
+tpm2 createprimary -f pem -o public.pem
+openssl rsa -noout -text -inform PEM -in public.pem -pubin
+
 exit 0

--- a/test/integration/tests/print.sh
+++ b/test/integration/tests/print.sh
@@ -41,6 +41,9 @@ yaml_verify $print_file
 tpm2 print -t TPMT_PUBLIC tpmt_public.ak > $print_file
 yaml_verify $print_file
 
+tpm2 print -t TPMT_PUBLIC -f pem tpmt_public.ak > $print_file
+openssl rsa -noout -text -inform PEM -in $print_file -pubin
+
 # Take PCR quote
 tpm2 quote -Q -c $ak_ctx -l "sha256:0,2,4,9,10,11,12,17" -q "0f8beb45ac" \
 -m $quote_file


### PR DESCRIPTION
Support `-o` and `-f` options, like in tpm2_readpublic, in tpm2_createprimary, tpm2_create and tpm2_print. This way public PEM files can be generated along with the object. Also, document the netcat listener approach for working with non session-gapping RM's, like the in-kernel RM, in tpm2_startauthsession.