### PR TITLE
tools/tpm2_nvread: use phash_alg from lib/tpm2_util to calc cphash alg

### DIFF
--- a/lib/tpm2.c
+++ b/lib/tpm2.c
@@ -128,7 +128,8 @@ tool_rc tpm2_getcap(ESYS_CONTEXT *esys_context, TPM2_CAP capability,
 
 tool_rc tpm2_nv_read(ESYS_CONTEXT *esys_context,
     tpm2_loaded_object *auth_hierarchy_obj, TPM2_HANDLE nv_index, UINT16 size,
-    UINT16 offset, TPM2B_MAX_NV_BUFFER **data, TPM2B_DIGEST *cp_hash) {
+    UINT16 offset, TPM2B_MAX_NV_BUFFER **data, TPM2B_DIGEST *cp_hash,
+    TPMI_ALG_HASH parameter_hash_algorithm) {
 
     ESYS_TR esys_tr_nv_handle;
     TSS2_RC rval = Esys_TR_FromTPMPublic(esys_context, nv_index, ESYS_TR_NONE,
@@ -138,16 +139,8 @@ tool_rc tpm2_nv_read(ESYS_CONTEXT *esys_context,
         return tool_rc_from_tpm(rval);
     }
 
-    ESYS_TR auth_hierarchy_obj_session_handle = ESYS_TR_NONE;
-    tool_rc rc = tpm2_auth_util_get_shandle(esys_context,
-            auth_hierarchy_obj->tr_handle, auth_hierarchy_obj->session,
-            &auth_hierarchy_obj_session_handle);
-    if (rc != tool_rc_success) {
-        LOG_ERR("Failed to get shandle");
-        return rc;
-    }
-
-        if (cp_hash) {
+    tool_rc rc = tool_rc_success;
+    if (cp_hash->size) {
         /*
          * Need sys_context to be able to calculate CpHash
          */
@@ -177,10 +170,8 @@ tool_rc tpm2_nv_read(ESYS_CONTEXT *esys_context,
             goto tpm2_nvread_free_name1_name2;
         }
 
-        cp_hash->size = tpm2_alg_util_get_hash_size(
-            tpm2_session_get_authhash(auth_hierarchy_obj->session));
         rc = tpm2_sapi_getcphash(sys_context, name1, name2, NULL,
-            tpm2_session_get_authhash(auth_hierarchy_obj->session), cp_hash);
+            parameter_hash_algorithm, cp_hash);
         /*
          * Exit here without making the ESYS call since we just need the cpHash
          */
@@ -189,6 +180,15 @@ tpm2_nvread_free_name1_name2:
 tpm2_nvread_free_name1:
         Esys_Free(name1);
         goto tpm2_nvread_skip_esapi_call;
+    }
+
+    ESYS_TR auth_hierarchy_obj_session_handle = ESYS_TR_NONE;
+    rc = tpm2_auth_util_get_shandle(esys_context,
+            auth_hierarchy_obj->tr_handle, auth_hierarchy_obj->session,
+            &auth_hierarchy_obj_session_handle);
+    if (rc != tool_rc_success) {
+        LOG_ERR("Failed to get shandle");
+        return rc;
     }
 
     rval = Esys_NV_Read(esys_context, auth_hierarchy_obj->tr_handle,

--- a/lib/tpm2.h
+++ b/lib/tpm2.h
@@ -33,7 +33,8 @@ tool_rc tpm2_getcap(ESYS_CONTEXT *esys_context,TPM2_CAP capability,
 
 tool_rc tpm2_nv_read(ESYS_CONTEXT *esys_context,
     tpm2_loaded_object *auth_hierarchy_obj, TPM2_HANDLE nv_index, UINT16 size,
-    UINT16 offset, TPM2B_MAX_NV_BUFFER **data, TPM2B_DIGEST *cp_hash);
+    UINT16 offset, TPM2B_MAX_NV_BUFFER **data, TPM2B_DIGEST *cp_hash,
+    TPMI_ALG_HASH parameter_hash_algorithm);
 
 tool_rc tpm2_context_save(ESYS_CONTEXT *esys_context, ESYS_TR save_handle,
         TPMS_CONTEXT **context);

--- a/lib/tpm2_nv_util.h
+++ b/lib/tpm2_nv_util.h
@@ -107,9 +107,10 @@ static inline tool_rc tpm2_util_nv_max_buffer_size(ESYS_CONTEXT *ectx,
  *  tool_rc indicating status.
  */
 static inline tool_rc tpm2_util_nv_read(ESYS_CONTEXT *ectx,
-        TPMI_RH_NV_INDEX nv_index, UINT16 size, UINT16 offset,
-        tpm2_loaded_object * auth_hierarchy_obj, UINT8 **data_buffer,
-        UINT16 *bytes_written, TPM2B_DIGEST *cp_hash) {
+    TPMI_RH_NV_INDEX nv_index, UINT16 size, UINT16 offset,
+    tpm2_loaded_object * auth_hierarchy_obj, UINT8 **data_buffer,
+    UINT16 *bytes_written, TPM2B_DIGEST *cp_hash,
+    TPMI_ALG_HASH parameter_hash_algorithm) {
 
     *data_buffer = NULL;
 
@@ -142,7 +143,7 @@ static inline tool_rc tpm2_util_nv_read(ESYS_CONTEXT *ectx,
         goto out;
     }
 
-    if (cp_hash) {
+    if (cp_hash->size) {
         goto tpm2_util_nv_read_collect_cp_hash;
     }
 
@@ -159,10 +160,10 @@ static inline tool_rc tpm2_util_nv_read(ESYS_CONTEXT *ectx,
     }
 
 tpm2_util_nv_read_collect_cp_hash:
-    if (cp_hash) {
+    if (cp_hash->size) {
         TPM2B_MAX_NV_BUFFER *nv_data;
         rc = tpm2_nv_read(ectx, auth_hierarchy_obj, nv_index, size, offset,
-            &nv_data, cp_hash);
+            &nv_data, cp_hash, parameter_hash_algorithm);
         if (rc != tool_rc_success) {
             LOG_ERR("Failed cpHash for NVRAM read at index 0x%X", nv_index);
         }
@@ -185,7 +186,7 @@ tpm2_util_nv_read_collect_cp_hash:
         TPM2B_MAX_NV_BUFFER *nv_data;
 
         rc = tpm2_nv_read(ectx, auth_hierarchy_obj, nv_index, bytes_to_read,
-            offset, &nv_data, cp_hash);
+            offset, &nv_data, cp_hash, parameter_hash_algorithm);
         if (rc != tool_rc_success) {
             LOG_ERR("Failed to read NVRAM area at index 0x%X", nv_index);
             goto out;

--- a/tools/tpm2_createek.c
+++ b/tools/tpm2_createek.c
@@ -131,8 +131,12 @@ static tool_rc set_ek_template(ESYS_CONTEXT *ectx, TPM2B_PUBLIC *input_public) {
 
     // Read EK template
     UINT16 template_size;
+    TPM2B_DIGEST cp_hash = {
+        .size = 0,
+    };
     tool_rc rc = tpm2_util_nv_read(ectx, template_nv_index, 0, 0,
-        &ctx.auth_owner_hierarchy.object, &template, &template_size, NULL);
+        &ctx.auth_owner_hierarchy.object, &template, &template_size, &cp_hash,
+        TPM2_ALG_SHA256);
     if (rc != tool_rc_success) {
         goto out;
     }
@@ -146,9 +150,10 @@ static tool_rc set_ek_template(ESYS_CONTEXT *ectx, TPM2B_PUBLIC *input_public) {
     }
 
     // Read EK nonce
-    UINT16 nonce_size;
+    UINT16 nonce_size = 0;
     rc = tpm2_util_nv_read(ectx, nonce_nv_index, 0, 0,
-        &ctx.auth_owner_hierarchy.object, &nonce, &nonce_size, NULL);
+        &ctx.auth_owner_hierarchy.object, &nonce, &nonce_size, &cp_hash,
+        TPM2_ALG_SHA256);
     if (rc != tool_rc_success) {
         goto out;
     }

--- a/tools/tpm2_getekcertificate.c
+++ b/tools/tpm2_getekcertificate.c
@@ -424,11 +424,14 @@ static tool_rc nv_read(ESYS_CONTEXT *ectx, TPMI_RH_NV_INDEX nv_index) {
         goto nv_read_out;
     }
 
+    TPM2B_DIGEST cp_hash = {
+        .size = 0,
+    };
     rc = nv_index == RSA_EK_CERT_NV_INDEX ?
          tpm2_util_nv_read(ectx, nv_index, 0, 0, &object, &ctx.rsa_cert_buffer,
-         &ctx.rsa_cert_buffer_size, 0) :
+         &ctx.rsa_cert_buffer_size, &cp_hash, TPM2_ALG_SHA256) :
          tpm2_util_nv_read(ectx, nv_index, 0, 0, &object, &ctx.ecc_cert_buffer,
-         &ctx.ecc_cert_buffer_size, 0);
+         &ctx.ecc_cert_buffer_size, &cp_hash, TPM2_ALG_SHA256);
 
 nv_read_out:
     tmp_rc = tpm2_session_close(&object.session);

--- a/tools/tpm2_nvread.c
+++ b/tools/tpm2_nvread.c
@@ -7,6 +7,7 @@
 #include "tpm2_nv_util.h"
 #include "tpm2_options.h"
 
+#define MAX_SESSIONS 3
 typedef struct tpm_nvread_ctx tpm_nvread_ctx;
 struct tpm_nvread_ctx {
     /*
@@ -32,19 +33,21 @@ struct tpm_nvread_ctx {
     /*
      * Parameter hashes
      */
-    char *cp_hash_path;
-    TPM2B_DIGEST *cphash;
+    const char *cp_hash_path;
     TPM2B_DIGEST cp_hash;
     bool is_command_dispatch;
+    TPMI_ALG_HASH parameter_hash_algorithm;
 };
 
-static tpm_nvread_ctx ctx;
+static tpm_nvread_ctx ctx = {
+    .parameter_hash_algorithm = TPM2_ALG_ERROR,
+};
 
 static tool_rc nv_read(ESYS_CONTEXT *ectx) {
 
     return tpm2_util_nv_read(ectx, ctx.nv_index, ctx.size_to_read,
         ctx.offset, &ctx.auth_hierarchy.object, &ctx.data_buffer,
-        &ctx.bytes_written, ctx.cphash);
+        &ctx.bytes_written, &ctx.cp_hash, ctx.parameter_hash_algorithm);
 }
 
 static tool_rc process_output(ESYS_CONTEXT *ectx, tpm2_option_flags flags) {
@@ -128,7 +131,16 @@ static tool_rc process_inputs(ESYS_CONTEXT *ectx) {
     /*
      * 4.a Determine pHash length and alg
      */
-    ctx.cphash = ctx.cp_hash_path ? &ctx.cp_hash : 0;
+    tpm2_session *all_sessions[MAX_SESSIONS] = {
+        ctx.auth_hierarchy.object.session,
+        0,
+        0
+    };
+
+    const char **cphash_path = ctx.cp_hash_path ? &ctx.cp_hash_path : 0;
+
+    ctx.parameter_hash_algorithm = tpm2_util_calculate_phash_algorithm(ectx,
+        cphash_path, &ctx.cp_hash, 0, 0, all_sessions);
 
     /*
      * 4.b Determine if TPM2_CC_<command> is to be dispatched


### PR DESCRIPTION
Signed-off-by: Imran Desai <imran.desai@intel.com>