### PR TITLE
policy: Support TPMLess commands

### DIFF
--- a/lib/tpm2.h
+++ b/lib/tpm2.h
@@ -117,6 +117,9 @@ tool_rc tpm2_policy_ticket(ESYS_CONTEXT *esys_context, ESYS_TR policy_session,
 tool_rc tpm2_policy_authvalue(ESYS_CONTEXT *esys_context, ESYS_TR policy_session,
         ESYS_TR shandle1, ESYS_TR shandle2, ESYS_TR shandle3);
 
+tool_rc tpm2_policy_secret_no_tpm(TPMI_ALG_HASH halg, TPM2B_DIGEST *current, TPM2B_NAME *name, TPM2B_NONCE *policy_qualifier,
+        TPMT_TK_AUTH *new);
+
 tool_rc tpm2_policy_secret(ESYS_CONTEXT *esys_context,
         tpm2_loaded_object *auth_entity_obj, ESYS_TR policy_session,
         INT32 expiration, TPMT_TK_AUTH **policy_ticket,

--- a/lib/tpm2_policy.c
+++ b/lib/tpm2_policy.c
@@ -309,6 +309,30 @@ tool_rc tpm2_policy_build_policysecret(ESYS_CONTEXT *ectx,
         }
     }
 
+    if (!ectx || true) {
+        if (is_nonce_tpm) {
+            LOG_ERR("Cannot specify is_nonce_tpm with NULL ESYS Context");
+            return tool_rc_general_error;
+        }
+        /* TODO: Get old from input file -L */
+        TPM2B_DIGEST old = { 0 };
+        old.size = 32;
+        /* TODO get name, not hardcoded! */
+        TPM2B_NAME name ={
+                .size = 4,
+                .name = { 0x40, 0x00, 0x00, 0x01 }
+        };
+        /* TODO get halg */
+        /* TODO This needs to be tied to Esys_Malloc.... but that doesn't exist */
+        TPMT_TK_AUTH *pt = calloc(sizeof(*pt), 1);
+        /* TODO error check */
+        tool_rc rc = tpm2_policy_secret_no_tpm(TPM2_ALG_SHA256, &old, &name, &policy_qualifier, pt);
+        if (rc == tool_rc_success) {
+            *policy_ticket = pt;
+        }
+        return rc;
+    }
+
     ESYS_TR policy_session_handle = tpm2_session_get_handle(policy_session);
 
     TPM2B_NONCE *nonce_tpm = NULL;


### PR DESCRIPTION
For now this works with policysecret, owner hiearchy and NULL auth.
It's hardcoded to ignore the TPM.

tpm2 policysecret -S session.ctx -c o
0d84f55daf6e43ac97966e62c9bb989d3397777d25c5f749868055d65394f952

TODO:
For each policy command:
  - Support --tcti=none
  - When --tcti is none, require:
    --name/-n
    -L/--policy for old value
    -- Require hash algorithm.
    - Don't output a TICKET, since we can't?

Todo, consider creating a session.ctx structure that can be passed
from startauthsession with --tcti=none? This was we can encapsulate
the state instead of requiring -L and hash algorithm?

Signed-off-by: William Roberts <william.c.roberts@intel.com>