### PR TITLE
tools/tpm2_createek: initialize size to 0

### DIFF
--- a/tools/tpm2_createek.c
+++ b/tools/tpm2_createek.c
@@ -130,7 +130,7 @@ static tool_rc set_ek_template(ESYS_CONTEXT *ectx, TPM2B_PUBLIC *input_public) {
     UINT8* nonce = NULL;
 
     // Read EK template
-    UINT16 template_size;
+    UINT16 template_size = 0;
     TPM2B_DIGEST cp_hash = {
         .size = 0,
     };


### PR DESCRIPTION
Even though the below error seems like a flase positive, lets just avoid
any other issues and ensure that if the function call doesn't initialize
size to 0, that the unmarshal won't go super crazy.

tools/tpm2_createek.c: In function ‘tpm2_tool_onrun’:
tools/tpm2_createek.c:144:19: error: ‘template_size’ may be used uninitialized in this function [-Werror=maybe-uninitialized]
     TSS2_RC ret = Tss2_MU_TPMT_PUBLIC_Unmarshal(template, template_size,
                   ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     NULL, &input_public->publicArea);
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
tools/tpm2_createek.c:133:12: note: ‘template_size’ was declared here
     UINT16 template_size;
            ^~~~~~~~~~~~~
cc1: all warnings being treated as errors
Makefile:3797: recipe for target 'tools/tools_tpm2-tpm2_createek.o' failed
make: *** [tools/tools_tpm2-tpm2_createek.o] Error 1

Fixes: #2766

Signed-off-by: William Roberts <william.c.roberts@intel.com>