### PR TITLE
Support pcrs output file formats "values" and "serialized"

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -511,6 +511,7 @@ MARKDOWN_COMMON_DEPS = \
 	man/common/obj-attrs.md \
 	man/common/object-alg.md \
 	man/common/options.md \
+	man/common/pcrs_format.md \
 	man/common/policy-limitations.md \
 	man/common/pubkey.md \
 	man/common/returns.md \
@@ -545,6 +546,8 @@ man/man1/%.1 : man/%.1.md $(MARKDOWN_COMMON_DEPS)
 	    -e '/\[nv attributes\]/d' \
 	    -e '/\[pcr bank specifiers\]/r $(top_srcdir)/man/common/pcr.md' \
 	    -e '/\[pcr bank specifiers\]/d' \
+	    -e '/\[PCR output file format specifiers\]/r $(top_srcdir)/man/common/pcrs_format.md' \
+	    -e '/\[PCR output file format specifiers\]/d' \
 	    -e '/\[pubkey options\]/r $(top_srcdir)/man/common/pubkey.md' \
 	    -e '/\[pubkey options\]/d' \
 	    -e '/\[signature format specifiers\]/r $(top_srcdir)/man/common/signature.md' \

--- a/dist/bash-completion/tpm2-tools/tpm2_completion.bash
+++ b/dist/bash-completion/tpm2-tools/tpm2_completion.bash
@@ -3018,6 +3018,8 @@ _tpm2_pcrread()
 
         local format_methods=(tss plain)
 
+        local pcr_format_methods=(values serialized)
+
         local signing_scheme=(rsassa rsapss ecdsa ecdaa sm2 ecshnorr hmac)
 
         local key_object=(rsa ecc aes camellia hmac xor keyedhash)
@@ -3043,10 +3045,14 @@ _tpm2_pcrread()
             -o | --output)
                 _filedir
                 return;;
+            -F | --pcrs_format)
+                COMPREPLY=($(compgen -W "${pcr_format_methods[*]}" -- "$cur"))
+                return;;
         esac
 
         COMPREPLY=($(compgen -W "-h --help -v --version -V --verbose -Q --quiet \
         -Z --enable-erata -T --tcti \
+        -F --pcrs_format \
         -o --output " \
         -- "$cur"))
     } &&
@@ -4099,6 +4105,8 @@ _tpm2_quote()
 
         local format_methods=(tss plain)
 
+        local pcr_format_methods=(values serialized)
+
         local signing_scheme=(rsassa rsapss ecdsa ecdaa sm2 ecshnorr hmac)
 
         local key_object=(rsa ecc aes camellia hmac xor keyedhash)
@@ -4130,6 +4138,9 @@ _tpm2_quote()
             -l | --pcr-list)
                 _filedir
                 return;;
+            -F | --pcrs_format)
+                COMPREPLY=($(compgen -W "${pcr_format_methods[*]}" -- "$cur"))
+                return;;
             -m | --message)
                 _filedir
                 return;;
@@ -4151,7 +4162,7 @@ _tpm2_quote()
         esac
 
         COMPREPLY=($(compgen -W "-h --help -v --version -V --verbose -Q --quiet \
-        -Z --enable-erata -T --tcti \
+        -Z --enable-erata -T --tcti -F --pcrs_format \
         -c -p -l -m -s -f -o -q -g --key-context --auth --pcr-list --message --signature --format --pcr --qualification --hash-algorithm --cphash " \
         -- "$cur"))
     } &&

--- a/lib/pcr.h
+++ b/lib/pcr.h
@@ -3,6 +3,8 @@
 #ifndef SRC_PCR_H_
 #define SRC_PCR_H_
 
+#include <errno.h>
+#include <stdio.h>
 #include <stdbool.h>
 
 #include <tss2/tss2_esys.h>
@@ -56,6 +58,37 @@ bool pcr_print_pcr_struct_le(TPML_PCR_SELECTION *pcrSelect, tpm2_pcrs *pcrs);
 bool pcr_get_id(const char *arg, UINT32 *pcr_id);
 
 bool pcr_print_pcr_selections(TPML_PCR_SELECTION *pcr_selections);
+
+/**
+ * Prints the selected PCR values.
+ *
+ * @param pcr_select the selected pcrs to be printed
+ * @param pcrs the pcrs digests
+ * @return true on success; false otherwise
+ */
+bool pcr_print_values(const TPML_PCR_SELECTION *pcr_select,
+    const tpm2_pcrs *pcrs);
+
+/**
+ * Writes the selected PCR values to a file.
+ *
+ * @param pcr_select the selected pcrs to be written
+ * @param pcrs the pcrs digests
+ * @param output_file file to output the pcr values
+ * @return true on success; false otherwise
+ */
+bool pcr_fwrite_values(const TPML_PCR_SELECTION *pcr_select,
+    const tpm2_pcrs *pcrs, FILE *output_file);
+/**
+ * Writes the selected PCR values to a file in serialized format.
+ *
+ * @param pcr_select the selected pcrs to be written
+ * @param pcrs the pcrs digests
+ * @param output_file file to output the pcr values in serialized format
+ * @return true on success; false otherwise
+ */
+bool pcr_fwrite_serialized(const TPML_PCR_SELECTION *pcr_select,
+    const tpm2_pcrs *pcrs, FILE *output_file);
 
 bool pcr_parse_selections(const char *arg, TPML_PCR_SELECTION *pcr_selections);
 

--- a/lib/tpm2_convert.c
+++ b/lib/tpm2_convert.c
@@ -20,6 +20,20 @@
 static bool tpm2_convert_pubkey_ssl(TPMT_PUBLIC *public,
         tpm2_convert_pubkey_fmt format, const char *path);
 
+tpm2_convert_pcrs_output_fmt tpm2_convert_pcrs_output_fmt_from_optarg(
+    const char *label) {
+
+    if (strcasecmp(label, "values") == 0) {
+        return pcrs_output_format_values;
+    } else if (strcasecmp(label, "serialized") == 0) {
+        return pcrs_output_format_serialized;
+    }
+
+    LOG_ERR("Invalid pcrs output format '%s' specified", label);
+
+    return pcrs_output_format_err;
+}
+
 tpm2_convert_pubkey_fmt tpm2_convert_pubkey_fmt_from_optarg(const char *label) {
     if (strcasecmp(label, "der") == 0) {
         return pubkey_format_der;

--- a/lib/tpm2_convert.h
+++ b/lib/tpm2_convert.h
@@ -25,6 +25,25 @@ enum tpm2_convert_sig_fmt {
     signature_format_err
 };
 
+typedef enum tpm2_convert_pcrs_output_fmt tpm2_convert_pcrs_output_fmt;
+enum tpm2_convert_pcrs_output_fmt {
+    pcrs_output_format_values,
+    pcrs_output_format_serialized,
+    pcrs_output_format_err
+};
+
+/**
+ * Parses the given command line PCRS file output format option string and
+ * returns the corresponding pcrs_output_fmt enum value.
+ *
+ * LOG_ERR is used to communicate errors.
+ *
+ * @return
+ *   On error pcrs_output_format_err is returned.
+ */
+tpm2_convert_pcrs_output_fmt tpm2_convert_pcrs_output_fmt_from_optarg(
+    const char *label);
+
 /**
  * Parses the given command line public key format option string and returns
  * the corresponding pubkey_format enum value.

--- a/man/common/pcrs_format.md
+++ b/man/common/pcrs_format.md
@@ -1,0 +1,3 @@
+  * **-F**, **\--pcrs_format**=_FORMAT_:
+
+    Format selection for the binary blob in the PCR output file. 'values' will output a binary blob of the PCR values. 'serialized' will output a binary blob of the PCR values in the form of serialized data structure in little endian format. Optional.

--- a/man/tpm2_pcrread.1.md
+++ b/man/tpm2_pcrread.1.md
@@ -42,6 +42,8 @@ sha256 :
 
     The output file to write the PCR values in binary format, optional.
 
+[PCR output file format specifiers](common/pcrs_format.md)
+    Default is 'values'.
 
 [common options](common/options.md)
 

--- a/man/tpm2_quote.1.md
+++ b/man/tpm2_quote.1.md
@@ -47,6 +47,9 @@ algorithm/banks.
     PCR output file, optional, records the list of PCR values as defined
     by **-l**.
 
+[PCR output file format specifiers](common/pcrs_format.md)
+    Default is 'serialized'.
+
   * **-q**, **\--qualification**=_HEX\_STRING\_OR\_PATH_:
 
     Data given as a Hex string or binary file to qualify the quote, optional.

--- a/test/integration/tests/pcrs_format.sh
+++ b/test/integration/tests/pcrs_format.sh
@@ -1,0 +1,61 @@
+# SPDX-License-Identifier: BSD-3-Clause
+
+# shellcheck disable=SC1091
+source helpers.sh
+
+cleanup() {
+    rm -f ek.ctx ak.ctx nonce.bin \
+      quote.pcr quote.pcr.serialized quote.pcr.values \
+      pcr.read, pcr.read.serialized, pcr.read.values
+    [[ "$1" = "no-shut-down" ]] || shut_down
+}
+
+fail() {
+  echo "$*" > /dev/stderr
+  exit 1
+}
+
+trap cleanup EXIT
+
+start_up
+
+cleanup "no-shut-down"
+
+# Generate artifacts necessary to make a quote
+tpm2 createek -G ecc -c ek.ctx
+tpm2 createak -C ek.ctx -c ak.ctx -G ecc -g sha256 -s ecdsa
+tpm2 getrandom -o nonce.bin 20
+
+readonly pcrs_selection="sha1:15,16,22+sha256:15,16,22"
+tpm2 quote -c ak.ctx -l $pcrs_selection -q nonce.bin -m /dev/null -s /dev/null \
+  -g sha256 -o quote.pcr
+
+tpm2 quote -c ak.ctx -l $pcrs_selection -q nonce.bin -m /dev/null -s /dev/null \
+  -g sha256 -o quote.pcr.serialized -F serialized
+
+tpm2 quote -c ak.ctx -l $pcrs_selection -q nonce.bin -m /dev/null -s /dev/null \
+  -g sha256 -o quote.pcr.values -F values
+
+tpm2 pcrread $pcrs_selection -o pcr.read
+tpm2 pcrread $pcrs_selection -o pcr.read.serialized -F serialized
+tpm2 pcrread $pcrs_selection -o pcr.read.values -F values
+
+diff quote.pcr quote.pcr.serialized >& /dev/null ||
+  fail "default pcrs output format of tpm2 quote is expected to be 'serialized'"
+
+diff quote.pcr.serialized quote.pcr.values >& /dev/null &&
+  fail "pcrs output in 'serialized' format must be different from that" \
+    "in 'values' format for tpm2 quote"
+
+diff quote.pcr.serialized pcr.read.serialized >& /dev/null ||
+  fail "pcrs output in 'serialized' format of tpm2 quote and tpm2 pcrread" \
+    "must be identical"
+
+diff quote.pcr.values pcr.read.values >& /dev/null ||
+  fail "pcrs output in 'values' format of tpm2 quote and tpm2 pcrread" \
+    "must be identical"
+
+diff pcr.read pcr.read.values >& /dev/null ||
+  fail "default pcrs output format of tpm2 pcrread is expected to be 'values'"
+
+exit 0


### PR DESCRIPTION
for tpm2_pcrread and tpm2_quote, with backward compatible defaults.

Signed-off-by: Hanson Char <hchar@amazon.com>