### PR TITLE
Fix issue where oaep hash algorithm was hardcoded

### DIFF
--- a/lib/tpm2_alg_util.c
+++ b/lib/tpm2_alg_util.c
@@ -194,9 +194,7 @@ static alg_parser_rc handle_scheme_sign(const char *scheme,
     bool do_scheme_hash_alg = false;
 
     if (public->publicArea.type == TPM2_ALG_ECC) {
-        if (!strncmp(scheme, "oaep", 4)) {
-            do_scheme_halg(scheme, 4, TPM2_ALG_OAEP);
-        } else if (!strncmp(scheme, "ecdsa", 5)) {
+        if (!strncmp(scheme, "ecdsa", 5)) {
             do_scheme_halg(scheme, 5, TPM2_ALG_ECDSA);
         } else if (!strncmp(scheme, "ecdh", 4)) {
             do_scheme_halg(scheme, 4, TPM2_ALG_ECDH);
@@ -237,6 +235,8 @@ static alg_parser_rc handle_scheme_sign(const char *scheme,
             do_scheme_halg(scheme, 6, TPM2_ALG_RSAPSS);
         } else if (!strncmp("rsassa", scheme, 6)) {
             do_scheme_halg(scheme, 6, TPM2_ALG_RSASSA);
+        } else if (!strncmp(scheme, "oaep", 4)) {
+            do_scheme_halg(scheme, 4, TPM2_ALG_OAEP);
         }
     }
 

--- a/lib/tpm2_alg_util.c
+++ b/lib/tpm2_alg_util.c
@@ -595,6 +595,32 @@ bool tpm2_alg_util_handle_ext_alg(const char *alg_spec, TPM2B_PUBLIC *public) {
     return false;
 }
 
+tool_rc tpm2_alg_util_handle_rsa_ext_alg(const char *alg_spec,
+    TPM2B_PUBLIC *public) {
+
+    #define RSA_KEYBITS_STRLEN 6
+    char *ext_alg_str = calloc(1, strlen(alg_spec) + strlen("rsa") +
+        RSA_KEYBITS_STRLEN);
+
+    strcat(ext_alg_str, "rsa");
+    switch(public->publicArea.parameters.rsaDetail.keyBits) {
+        case 1024: strcat(ext_alg_str, "1024:");
+                   break;
+        case 2048: strcat(ext_alg_str, "2048:");
+                   break;
+        case 3072: strcat(ext_alg_str, "3072:");
+                   break;
+        case 4096: strcat(ext_alg_str, "4096:");
+                   break;
+    };
+    strcat(ext_alg_str, alg_spec);
+
+    bool result = tpm2_alg_util_handle_ext_alg(ext_alg_str, public);
+    free(ext_alg_str);
+
+    return result ? tool_rc_success : tool_rc_general_error;
+}
+
 static alg_iter_res find_match(TPM2_ALG_ID id, const char *name,
         tpm2_alg_util_flags flags, void *userdata) {
 

--- a/lib/tpm2_alg_util.h
+++ b/lib/tpm2_alg_util.h
@@ -163,6 +163,18 @@ tool_rc tpm2_alg_util_get_signature_scheme(ESYS_CONTEXT *context,
 bool tpm2_alg_util_handle_ext_alg(const char *alg_spec, TPM2B_PUBLIC *public);
 
 /**
+ * Retrieves the scheme information for an RSA key to be used in
+ * TPM2_CC_RSA_Encrypt or TPM2_CC_RSA_Decrypt
+ * @param alg_spec
+ *  Friendly specification of the RSA scheme (oaep-sha1)
+ * @param public
+ *  Public structure which will contain relevant information about
+ *  specified algorithm
+ */
+tool_rc tpm2_alg_util_handle_rsa_ext_alg(const char *alg_spec,
+    TPM2B_PUBLIC *public);
+
+/**
  *
  * @param alg_details
  * @param name_halg

--- a/test/integration/tests/rsadecrypt.sh
+++ b/test/integration/tests/rsadecrypt.sh
@@ -89,4 +89,12 @@ tpm2 rsaencrypt -Q -c $file_rsaencrypt_key_ctx -o $file_rsa_en_output_data \
 tpm2 rsadecrypt -Q -c $file_rsadecrypt_key_ctx -p foo -o \
 $file_rsa_de_output_data -s oaep $file_rsa_en_output_data
 
+# Test RSA enc/ dec with OAEP-SHA1 mode
+tpm2 rsaencrypt -Q -c $file_rsaencrypt_key_ctx -o $file_rsa_en_output_data \
+-s oaep-sha1 < $file_input_data
+
+tpm2 rsadecrypt -Q -c $file_rsadecrypt_key_ctx -p foo -o \
+$file_rsa_de_output_data -s oaep-sha1 $file_rsa_en_output_data
+
+
 exit 0

--- a/tools/tpm2_rsadecrypt.c
+++ b/tools/tpm2_rsadecrypt.c
@@ -21,7 +21,9 @@ struct tpm_rsadecrypt_ctx {
     TPM2B_PUBLIC_KEY_RSA cipher_text;
     char *input_path;
     char *output_file_path;
+
     TPMT_RSA_DECRYPT scheme;
+    const char *scheme_str;
 
     char *cp_hash_path;
 };
@@ -88,14 +90,7 @@ static bool on_option(char key, char *value) {
         break;
     }
     case 's':
-        ctx.scheme.scheme = tpm2_alg_util_from_optarg(value,
-                tpm2_alg_util_flags_rsa_scheme);
-        if (ctx.scheme.scheme == TPM2_ALG_ERROR) {
-            LOG_ERR("Invalid scheme.");
-            return false;
-        }
-        ctx.scheme.details.oaep.hashAlg = ctx.scheme.scheme == TPM2_ALG_OAEP ?
-            TPM2_ALG_SHA256 : 0;
+        ctx.scheme_str = value;
         break;
     case 0:
         ctx.cp_hash_path = value;
@@ -147,15 +142,58 @@ static tool_rc init(ESYS_CONTEXT *ectx) {
         return tool_rc_option_error;
     }
 
+    /*
+     * Load the decryption key
+     */
+    tool_rc rc = tpm2_util_object_load_auth(ectx, ctx.key.ctx_path,
+        ctx.key.auth_str, &ctx.key.object, false,
+        TPM2_HANDLES_FLAGS_TRANSIENT|TPM2_HANDLES_FLAGS_PERSISTENT);
+    if (rc != tool_rc_success) {
+        return rc;
+    }
+
+    TPM2B_PUBLIC *key_public_info = 0;
+    rc = tpm2_readpublic(ectx, ctx.key.object.tr_handle, &key_public_info,
+        NULL, NULL);
+    if (rc != tool_rc_success) {
+        goto out;
+    }
+
+    if (key_public_info->publicArea.type != TPM2_ALG_RSA) {
+            LOG_ERR("Unsupported key type for RSA decryption.");
+            rc = tool_rc_general_error;
+            goto out;
+    }
+
+    /*
+     * Get scheme information
+     */
+    if (ctx.scheme_str) {
+        rc = tpm2_alg_util_handle_rsa_ext_alg(ctx.scheme_str, key_public_info);
+        ctx.scheme.scheme =
+            key_public_info->publicArea.parameters.rsaDetail.scheme.scheme;
+        ctx.scheme.details.anySig.hashAlg =
+            key_public_info->publicArea.parameters.rsaDetail.scheme.details.anySig.hashAlg;
+
+        if (rc != tool_rc_success) {
+            goto out;
+        }
+    }
+
+    /*
+     * Get enc data blob
+     */
     ctx.cipher_text.size = BUFFER_SIZE(TPM2B_PUBLIC_KEY_RSA, buffer);
     bool result = files_load_bytes_from_buffer_or_file_or_stdin(NULL,
             ctx.input_path, &ctx.cipher_text.size, ctx.cipher_text.buffer);
     if (!result) {
-        return tool_rc_general_error;
+        rc = tool_rc_general_error;
     }
 
-    return tpm2_util_object_load_auth(ectx, ctx.key.ctx_path, ctx.key.auth_str,
-            &ctx.key.object, false, TPM2_HANDLE_ALL_W_NV);
+out:
+    Esys_Free(key_public_info);
+
+    return rc;
 }
 
 static tool_rc tpm2_tool_onrun(ESYS_CONTEXT *ectx, tpm2_option_flags flags) {


### PR DESCRIPTION
Fixes #2691 

With this one the scheme halg can be specified in an already known nice name format.
Eg. oaep-sha1