### PR TITLE
tpm2_eventlog: read eventlog file in chunks

### DIFF
--- a/lib/files.c
+++ b/lib/files.c
@@ -564,6 +564,15 @@ bool files_read_bytes(FILE *out, UINT8 bytes[], size_t len) {
     return (readx(out, bytes, len) == len);
 }
 
+bool files_read_bytes_chunk(FILE *out, UINT8 bytes[], size_t len, size_t *read_len) {
+
+    BAIL_ON_NULL("FILE", out);
+    BAIL_ON_NULL("bytes", bytes);
+    size_t chunk_len = readx(out, bytes, len);
+    *read_len += chunk_len;
+    return (chunk_len == len);
+}
+
 bool files_write_bytes(FILE *out, uint8_t bytes[], size_t len) {
 
     BAIL_ON_NULL("FILE", out);

--- a/lib/files.h
+++ b/lib/files.h
@@ -572,6 +572,21 @@ bool files_read_64(FILE *out, UINT64 *data);
 bool files_read_bytes(FILE *out, UINT8 data[], size_t size);
 
 /**
+ * Reads len bytes from a file and set the read length.
+ * @param out
+ *  The file to read from.
+ * @param data
+ *  The buffer to read into, only valid on a True return.
+ * @param size
+ *  The number of bytes to read.
+ * @param read_size
+ *  Total number of bytes read.
+ * @return
+ *  True on success, False otherwise.
+ */
+bool files_read_bytes_chunk(FILE *out, UINT8 data[], size_t size, size_t *read_size);
+
+/**
  * Converts a TPM2B_ATTEST to a TPMS_ATTEST using libmu.
  * @param quoted
  *  The attestation quote structure.


### PR DESCRIPTION
The eventlog file lives is securityfs, that do not return the file size.
The current implementation first try to do a "fseek(fp, 0, SEEK_END)"
for this file, and this will always return 0.

This generate an error, and tpm2_eventlog exit with:

ERROR: Unable to run tpm2_eventlog

This patch replace the reading logic, now reading in chunks of 16KB and
reallocating the buffer if needed. Also introduces a new function in
files.c ("files_read_bytes_chunk") that helps counting the total read
size, that now is different from the ammount of allocated memory.

Fixes #2775

Signed-off-by: Alberto Planas <aplanas@suse.com>