### PR TITLE
tpm2_import: add support for importing HMAC keys and sealed data blobs

### DIFF
--- a/man/tpm2_import.1.md
+++ b/man/tpm2_import.1.md
@@ -25,6 +25,7 @@ These options control the key importation process:
     * **aes** - AES 128, 192 or 256 key.
     * **rsa** - RSA 1024 or 2048 key.
     * **ecc** - ECC NIST P192, P224, P256, P384 or P521 public and private key.
+	* **hmac** - HMAC key.
 
   * **-g**, **\--hash-algorithm**=_ALGORITHM_:
 

--- a/tools/tpm2_import.c
+++ b/tools/tpm2_import.c
@@ -197,7 +197,7 @@ static bool on_option(char key, char *value) {
         break;
     case 'G':
         ctx.key_type = tpm2_alg_util_from_optarg(value,
-                tpm2_alg_util_flags_asymmetric | tpm2_alg_util_flags_symmetric);
+                tpm2_alg_util_flags_asymmetric | tpm2_alg_util_flags_symmetric | tpm2_alg_util_flags_keyedhash );
         if (ctx.key_type == TPM2_ALG_ERROR) {
             LOG_ERR("Unsupported key type");
             return false;


### PR DESCRIPTION
This enables wrapping an external HMAC key or a data blob under a key hierarchy.

Fixes https://github.com/tpm2-software/tpm2-tools/issues/1597