### PR TITLE
tpm2_eventlog: fix buffer offset when reading the event log

### DIFF
--- a/tools/misc/tpm2_eventlog.c
+++ b/tools/misc/tpm2_eventlog.c
@@ -92,7 +92,7 @@ static tool_rc tpm2_tool_onrun(ESYS_CONTEXT *ectx, tpm2_option_flags flags) {
     unsigned long size = 0;
     bool is_file_read = false;
     do {
-        is_file_read = files_read_bytes_chunk(fileptr, eventlog, CHUNK_SIZE, &size);
+        is_file_read = files_read_bytes_chunk(fileptr, eventlog + size, CHUNK_SIZE, &size);
         UINT8 *eventlog_tmp = realloc(eventlog, size + CHUNK_SIZE);
         if (!eventlog_tmp){
             LOG_ERR("failed to allocate %lu bytes: %s", size + CHUNK_SIZE, strerror(errno));


### PR DESCRIPTION
The event log is read in chunks of CHUNK_SIZE blocks (16KB), always
checking when the EOF is reached, so is compatible with virtual files
that lives in securefs and we do not know the full size.  The current
code is not taking care of adjusting the offset when the next chunk is
read.

This patch add "size" to the base buffer where the event log is stored
in memory.

Fix #2778

Signed-off-by: Alberto Planas <aplanas@suse.com>