### PR TITLE
test: Replace openssl rsautl with pkeyutl

### DIFF
--- a/test/integration/tests/duplicate.sh
+++ b/test/integration/tests/duplicate.sh
@@ -138,7 +138,7 @@ echo foo | openssl dgst \
 
 ## External RSA key, with a password authorization policy
 echo magicwords > cleartext.txt
-openssl rsautl \
+openssl pkeyutl \
 	-encrypt \
 	-pubin \
 	-inkey rsa-pub.pem \

--- a/test/integration/tests/import.sh
+++ b/test/integration/tests/import.sh
@@ -71,7 +71,7 @@ run_rsa_import_test() {
     -n import_rsa_key.name -c import_rsa_key.ctx
 
     openssl rsa -in private.pem -out public.pem -outform PEM -pubout
-    openssl rsautl -encrypt -inkey public.pem -pubin -in plain.txt \
+    openssl pkeyutl -encrypt -inkey public.pem -pubin -in plain.txt \
     -out plain.rsa.enc
 
     tpm2 rsadecrypt -c import_rsa_key.ctx -o plain.rsa.dec plain.rsa.enc

--- a/test/integration/tests/loadexternal.sh
+++ b/test/integration/tests/loadexternal.sh
@@ -84,7 +84,7 @@ run_rsa_test() {
     openssl rsa -in private.pem -out public.pem -outform PEM -pubout
 
     echo "hello world" > plain.txt
-    openssl rsautl -encrypt -inkey public.pem -pubin -in plain.txt \
+    openssl pkeyutl -encrypt -inkey public.pem -pubin -in plain.txt \
     -out plain.rsa.enc
 
     tpm2 loadexternal -G rsa -C n -p foo -r private.pem -c key.ctx
@@ -98,7 +98,7 @@ run_rsa_test() {
 
     tpm2 rsaencrypt -c key.ctx plain.txt -o plain.rsa.enc
 
-    openssl rsautl -decrypt -inkey private.pem -in plain.rsa.enc \
+    openssl pkeyutl -decrypt -inkey private.pem -in plain.rsa.enc \
     -out plain.rsa.dec
 
     diff plain.txt plain.rsa.dec


### PR DESCRIPTION
The `rsautl` is deprecated. The more generic `pkeyutl` has been there since OpenSSL 1.0.0, so it is safe to just replace it.