### PR TITLE
Remove support for OpenSSL < 1.1.0 and deprecated functions

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -58,7 +58,7 @@ PKG_CHECK_MODULES([TSS2_TCTILDR], [tss2-tctildr])
 PKG_CHECK_MODULES([TSS2_MU], [tss2-mu])
 PKG_CHECK_MODULES([TSS2_RC], [tss2-rc])
 PKG_CHECK_MODULES([TSS2_SYS], [tss2-sys])
-PKG_CHECK_MODULES([CRYPTO], [libcrypto >= 1.0.2g])
+PKG_CHECK_MODULES([CRYPTO], [libcrypto >= 1.1.0])
 PKG_CHECK_MODULES([CURL], [libcurl])
 
 # pretty print of devicepath if efivar library is present

--- a/doc/CHANGELOG.md
+++ b/doc/CHANGELOG.md
@@ -16,6 +16,8 @@
     converting it to a PEM or DER file format.
   * tools: Enhance error message on invalid passwords when sessions cannot
     be used.
+  * openssl:
+      - Dropped support for OpenSSL < 1.1.0
 
 ### 5.1.1 2021-06-21
 

--- a/doc/INSTALL.md
+++ b/doc/INSTALL.md
@@ -19,7 +19,7 @@ To build and install the tpm2-tools software the following software is required:
   * C compiler
   * C Library Development Libraries and Header Files (for pthreads headers)
   * ESAPI - TPM2.0 TSS ESAPI library (tss2-esys) and header files
-  * OpenSSL libcrypto library and header files
+  * OpenSSL libcrypto library and header files (version >= 1.1.0)
   * Curl library and header files
 
 #### Optional Dependencies:

--- a/doc/RELEASE.md
+++ b/doc/RELEASE.md
@@ -23,13 +23,6 @@ the next release.
 - [3.0.X](https://github.com/tpm2-software/tpm2-tools/tree/3.0.X): EOL after
 3.2.1 release.
 
-## OpenSSL
-
-tpm2-tools relies heavily on OpenSSL. OpenSSL will be EOL'ing 1.0.2 at the end
-of 2019, see: https://www.openssl.org/blog/blog/2018/05/18/new-lts/. When this
-occurs, we will remove OSSL 1.0.2 support from the tpm2-tools repository as
-supporting an EOL crypto library is not a good idea.
-
 # Release Information
 
 Releases shall be tagged following semantic version guidelines found at:

--- a/lib/tpm2_convert.c
+++ b/lib/tpm2_convert.c
@@ -277,7 +277,6 @@ static bool tpm2_convert_pubkey_bio(TPMT_PUBLIC *public,
                 "Unsupported key type for requested output format. Only RSA is supported.");
     }
 
-    ERR_free_strings();
     return result;
 }
 

--- a/lib/tpm2_convert.c
+++ b/lib/tpm2_convert.c
@@ -668,16 +668,12 @@ bool tpm2_base64_encode(BYTE *buffer, size_t buffer_length, char *base64) {
     EVP_ENCODE_CTX *ctx = EVP_ENCODE_CTX_new();
     EVP_EncodeInit(ctx);
 
-#if defined(LIB_TPM2_OPENSSL_OPENSSL_PRE11)
-    EVP_EncodeUpdate(ctx, out, &outl, buffer, buffer_length);
-#else
     int rc = EVP_EncodeUpdate(ctx, out, &outl, buffer, buffer_length);
     if(rc < 0) {
         LOG_ERR("EVP_DecodeUpdate failed with %d\n", rc);
         EVP_ENCODE_CTX_free(ctx);
         return false;
     }
-#endif
 
     EVP_EncodeFinal(ctx, out, &outl); // no return value
 

--- a/lib/tpm2_identity_util.c
+++ b/lib/tpm2_identity_util.c
@@ -289,7 +289,10 @@ static bool aes_encrypt_buffers(TPMT_SYM_DEF_OBJECT *sym,
         return false;
     }
 
-    EVP_CIPHER_CTX *ctx = tpm2_openssl_cipher_new();
+    EVP_CIPHER_CTX *ctx = EVP_CIPHER_CTX_new();
+    if (!ctx) {
+        return false;
+    }
 
     int rc = EVP_EncryptInit_ex(ctx, cipher, NULL, encryption_key, iv);
     if (!rc) {
@@ -336,7 +339,7 @@ static bool aes_encrypt_buffers(TPMT_SYM_DEF_OBJECT *sym,
     result = true;
 
 out:
-    tpm2_openssl_cipher_free(ctx);
+    EVP_CIPHER_CTX_free(ctx);
 
     return result;
 }

--- a/lib/tpm2_kdfa.c
+++ b/lib/tpm2_kdfa.c
@@ -40,7 +40,7 @@ TSS2_RC tpm2_kdfa(TPMI_ALG_HASH hash_alg, TPM2B *key, char *label,
         return TPM2_RC_HASH;
     }
 
-    HMAC_CTX *ctx = tpm2_openssl_hmac_new();
+    HMAC_CTX *ctx = HMAC_CTX_new();
     if (!ctx) {
         LOG_ERR("HMAC context allocation failed");
         return TPM2_RC_MEMORY;
@@ -100,7 +100,7 @@ TSS2_RC tpm2_kdfa(TPMI_ALG_HASH hash_alg, TPM2B *key, char *label,
     result_key->size = bytes;
 
 err:
-    tpm2_openssl_hmac_free(ctx);
+    HMAC_CTX_free(ctx);
 
     return rval;
 }

--- a/lib/tpm2_openssl.c
+++ b/lib/tpm2_openssl.c
@@ -76,70 +76,6 @@ const EVP_MD *tpm2_openssl_halg_from_tpmhalg(TPMI_ALG_HASH algorithm) {
     /* no return, not possible */
 }
 
-#if defined(LIB_TPM2_OPENSSL_OPENSSL_PRE11)
-int RSA_set0_key(RSA *r, BIGNUM *n, BIGNUM *e, BIGNUM *d) {
-
-    if ((r->n == NULL && n == NULL) || (r->e == NULL && e == NULL)) {
-        return 0;
-    }
-
-    if (n != NULL) {
-        BN_free(r->n);
-        r->n = n;
-    }
-
-    if (e != NULL) {
-        BN_free(r->e);
-        r->e = e;
-    }
-
-    if (d != NULL) {
-        BN_free(r->d);
-        r->d = d;
-    }
-
-    return 1;
-}
-
-void RSA_get0_factors(const RSA *r, const BIGNUM **p, const BIGNUM **q) {
-    if(p) {
-        *p = r->p;
-    }
-
-    if (q) {
-        *q = r->q;
-    }
-}
-
-int ECDSA_SIG_set0(ECDSA_SIG *sig, BIGNUM *r, BIGNUM *s) {
-
-    if (!r || !s) {
-        return 0;
-    }
-
-    BN_clear_free(sig->r);
-    BN_clear_free(sig->s);
-
-    sig->r = r;
-    sig->s = s;
-
-    return 1;
-}
-
-EVP_ENCODE_CTX *EVP_ENCODE_CTX_new(void) {
-	EVP_ENCODE_CTX *ctx = OPENSSL_malloc(sizeof(EVP_ENCODE_CTX));
-	if (ctx) {
-		memset(ctx, 0, sizeof(*ctx));
-	}
-	return ctx;
-}
-
-void EVP_ENCODE_CTX_free(EVP_ENCODE_CTX *ctx) {
-    OPENSSL_free(ctx);
-}
-
-#endif
-
 bool tpm2_openssl_hash_compute_data(TPMI_ALG_HASH halg, BYTE *buffer,
         UINT16 length, TPM2B_DIGEST *digest) {
 
@@ -438,54 +374,28 @@ out:
 
 HMAC_CTX *tpm2_openssl_hmac_new() {
     HMAC_CTX *ctx;
-#if defined(LIB_TPM2_OPENSSL_OPENSSL_PRE11)
-    ctx = malloc(sizeof(*ctx));
-#else
     ctx = HMAC_CTX_new();
-#endif
     if (!ctx)
         return NULL;
-
-#if defined(LIB_TPM2_OPENSSL_OPENSSL_PRE11)
-    HMAC_CTX_init(ctx);
-#endif
 
     return ctx;
 }
 
 void tpm2_openssl_hmac_free(HMAC_CTX *ctx) {
-#if defined(LIB_TPM2_OPENSSL_OPENSSL_PRE11)
-    HMAC_CTX_cleanup(ctx);
-    free(ctx);
-#else
     HMAC_CTX_free(ctx);
-#endif
 }
 
 EVP_CIPHER_CTX *tpm2_openssl_cipher_new(void) {
     EVP_CIPHER_CTX *ctx;
-#if defined(LIB_TPM2_OPENSSL_OPENSSL_PRE11)
-    ctx = malloc(sizeof(*ctx));
-#else
     ctx = EVP_CIPHER_CTX_new();
-#endif
     if (!ctx)
         return NULL;
-
-#if defined(LIB_TPM2_OPENSSL_OPENSSL_PRE11)
-    EVP_CIPHER_CTX_init(ctx);
-#endif
 
     return ctx;
 }
 
 void tpm2_openssl_cipher_free(EVP_CIPHER_CTX *ctx) {
-#if defined(LIB_TPM2_OPENSSL_OPENSSL_PRE11)
-    EVP_CIPHER_CTX_cleanup(ctx);
-    free(ctx);
-#else
     EVP_CIPHER_CTX_free(ctx);
-#endif
 }
 
 digester tpm2_openssl_halg_to_digester(TPMI_ALG_HASH halg) {
@@ -696,12 +606,7 @@ static bool load_public_RSA_from_key(RSA *k, TPM2B_PUBLIC *pub) {
     const BIGNUM *n; /* modulus */
     const BIGNUM *e; /* public key exponent */
 
-#if defined(LIB_TPM2_OPENSSL_OPENSSL_PRE11)
-    n = k->n;
-    e = k->e;
-#else
     RSA_get0_key(k, &n, &e, NULL);
-#endif
 
     /*
      * The size of the modulus is the key size in RSA, store this as the
@@ -1055,11 +960,7 @@ static bool load_private_RSA_from_key(RSA *k, TPM2B_SENSITIVE *priv) {
 
     const BIGNUM *p; /* the private key exponent */
 
-#if defined(LIB_TPM2_OPENSSL_OPENSSL_PRE11)
-    p = k->p;
-#else
     RSA_get0_factors(k, &p, NULL);
-#endif
 
     TPMT_SENSITIVE *sa = &priv->sensitiveArea;
 

--- a/lib/tpm2_openssl.c
+++ b/lib/tpm2_openssl.c
@@ -372,32 +372,6 @@ out:
     return result;
 }
 
-HMAC_CTX *tpm2_openssl_hmac_new() {
-    HMAC_CTX *ctx;
-    ctx = HMAC_CTX_new();
-    if (!ctx)
-        return NULL;
-
-    return ctx;
-}
-
-void tpm2_openssl_hmac_free(HMAC_CTX *ctx) {
-    HMAC_CTX_free(ctx);
-}
-
-EVP_CIPHER_CTX *tpm2_openssl_cipher_new(void) {
-    EVP_CIPHER_CTX *ctx;
-    ctx = EVP_CIPHER_CTX_new();
-    if (!ctx)
-        return NULL;
-
-    return ctx;
-}
-
-void tpm2_openssl_cipher_free(EVP_CIPHER_CTX *ctx) {
-    EVP_CIPHER_CTX_free(ctx);
-}
-
 digester tpm2_openssl_halg_to_digester(TPMI_ALG_HASH halg) {
 
     switch (halg) {

--- a/lib/tpm2_openssl.h
+++ b/lib/tpm2_openssl.h
@@ -68,20 +68,6 @@ int tpm2_openssl_halgid_from_tpmhalg(TPMI_ALG_HASH algorithm);
 const EVP_MD *tpm2_openssl_halg_from_tpmhalg(TPMI_ALG_HASH algorithm);
 
 /**
- * Start an openssl hmac session.
- * @return
- *  A valid session pointer or NULL on error.
- */
-HMAC_CTX *tpm2_openssl_hmac_new();
-
-/**
- * Free an hmac context created via tpm2_openssl_hmac_new().
- * @param ctx
- *  The context to release resources of.
- */
-void tpm2_openssl_hmac_free(HMAC_CTX *ctx);
-
-/**
  * Hash a byte buffer.
  * @param halg
  *  The hashing algorithm to use.
@@ -160,23 +146,6 @@ bool tpm2_openssl_hash_pcr_banks_le(TPMI_ALG_HASH hashAlg,
  */
 bool tpm2_openssl_pcr_extend(TPMI_ALG_HASH halg, BYTE *pcr,
         const BYTE *data, UINT16 length);
-
-/**
- * Obtains an OpenSSL EVP_CIPHER_CTX dealing with version
- * API changes in OSSL.
- *
- * @return
- *  An Initialized OpenSSL EVP_CIPHER_CTX.
- */
-EVP_CIPHER_CTX *tpm2_openssl_cipher_new(void);
-
-/**
- * Free's an EVP_CIPHER_CTX obtained via tpm2_openssl_cipher_new()
- * dealing with OSSL API version changes.
- * @param ctx
- *  The EVP_CIPHER_CTX to free.
- */
-void tpm2_openssl_cipher_free(EVP_CIPHER_CTX *ctx);
 
 /**
  * Returns a function pointer capable of performing the

--- a/lib/tpm2_openssl.h
+++ b/lib/tpm2_openssl.h
@@ -13,10 +13,6 @@
 
 #include "pcr.h"
 
-#if (OPENSSL_VERSION_NUMBER < 0x1010000fL && !defined(LIBRESSL_VERSION_NUMBER)) || (defined(LIBRESSL_VERSION_NUMBER) && LIBRESSL_VERSION_NUMBER < 0x20700000L) /* OpenSSL 1.1.0 */
-#define LIB_TPM2_OPENSSL_OPENSSL_PRE11
-#endif
-
 #if OPENSSL_VERSION_NUMBER >= 0x10101000L
 #define EC_POINT_set_affine_coordinates_tss(group, tpm_pub_key, bn_x, bn_y, dmy) \
         EC_POINT_set_affine_coordinates(group, tpm_pub_key, bn_x, bn_y, dmy)
@@ -31,14 +27,6 @@
 #define EC_POINT_get_affine_coordinates_tss(group, tpm_pub_key, bn_x, bn_y, dmy) \
         EC_POINT_get_affine_coordinates_GFp(group, tpm_pub_key, bn_x, bn_y, dmy)
 #endif /* OPENSSL_VERSION_NUMBER >= 0x10101000L */
-
-#if defined(LIB_TPM2_OPENSSL_OPENSSL_PRE11)
-int RSA_set0_key(RSA *r, BIGNUM *n, BIGNUM *e, BIGNUM *d);
-void RSA_get0_factors(const RSA *r, const BIGNUM **p, const BIGNUM **q);
-int ECDSA_SIG_set0(ECDSA_SIG *sig, BIGNUM *r, BIGNUM *s);
-EVP_ENCODE_CTX *EVP_ENCODE_CTX_new(void);
-void EVP_ENCODE_CTX_free(EVP_ENCODE_CTX *ctx);
-#endif
 
 /**
  * Function prototype for a hashing routine.

--- a/tools/misc/tpm2_certifyX509certutil.c
+++ b/tools/misc/tpm2_certifyX509certutil.c
@@ -260,8 +260,8 @@ static tool_rc generate_partial_X509() {
         goto out_err;
     }
 
-    X509_gmtime_adj(X509_get_notBefore(cert), 0); // add valid not before
-    X509_gmtime_adj(X509_get_notAfter(cert), valid_days * 86400); // add valid not after
+    X509_gmtime_adj(X509_getm_notBefore(cert), 0); // add valid not before
+    X509_gmtime_adj(X509_getm_notAfter(cert), valid_days * 86400); // add valid not after
 
     X509_NAME *subject = X509_get_subject_name(cert);
     if (!subject) {

--- a/tools/tpm2_getekcertificate.c
+++ b/tools/tpm2_getekcertificate.c
@@ -63,20 +63,20 @@ static unsigned char *hash_ek_public(void) {
         return NULL;
     }
 
-    SHA256_CTX sha256;
-    int is_success = SHA256_Init(&sha256);
+    EVP_MD_CTX *sha256 = EVP_MD_CTX_new();
+    int is_success = EVP_DigestInit(sha256, EVP_sha256());
     if (!is_success) {
-        LOG_ERR("SHA256_Init failed");
+        LOG_ERR("EVP_DigestInit failed");
         goto err;
     }
 
     switch (ctx.out_public->publicArea.type) {
     case TPM2_ALG_RSA:
-        is_success = SHA256_Update(&sha256,
+        is_success = EVP_DigestUpdate(sha256,
                 ctx.out_public->publicArea.unique.rsa.buffer,
                 ctx.out_public->publicArea.unique.rsa.size);
         if (!is_success) {
-            LOG_ERR("SHA256_Update failed");
+            LOG_ERR("EVP_DigestUpdate failed");
             goto err;
         }
 
@@ -85,27 +85,27 @@ static unsigned char *hash_ek_public(void) {
             goto err;
         }
         BYTE buf[3] = { 0x1, 0x00, 0x01 }; // Exponent
-        is_success = SHA256_Update(&sha256, buf, sizeof(buf));
+        is_success = EVP_DigestUpdate(sha256, buf, sizeof(buf));
         if (!is_success) {
-            LOG_ERR("SHA256_Update failed");
+            LOG_ERR("EVP_DigestUpdate failed");
             goto err;
         }
         break;
 
     case TPM2_ALG_ECC:
-        is_success = SHA256_Update(&sha256,
+        is_success = EVP_DigestUpdate(sha256,
                 ctx.out_public->publicArea.unique.ecc.x.buffer,
                 ctx.out_public->publicArea.unique.ecc.x.size);
         if (!is_success) {
-            LOG_ERR("SHA256_Update failed");
+            LOG_ERR("EVP_DigestUpdate failed");
             goto err;
         }
 
-        is_success = SHA256_Update(&sha256,
+        is_success = EVP_DigestUpdate(sha256,
                 ctx.out_public->publicArea.unique.ecc.y.buffer,
                 ctx.out_public->publicArea.unique.ecc.y.size);
         if (!is_success) {
-            LOG_ERR("SHA256_Update failed");
+            LOG_ERR("EVP_DigestUpdate failed");
             goto err;
         }
         break;
@@ -115,12 +115,13 @@ static unsigned char *hash_ek_public(void) {
         goto err;
     }
 
-    is_success = SHA256_Final(hash, &sha256);
+    is_success = EVP_DigestFinal_ex(sha256, hash, NULL);
     if (!is_success) {
-        LOG_ERR("SHA256_Final failed");
+        LOG_ERR("EVP_DigestFinal failed");
         goto err;
     }
 
+    EVP_MD_CTX_free(sha256);
     if (ctx.verbose) {
         tpm2_tool_output("public-key-hash:\n");
         tpm2_tool_output("  sha256: ");
@@ -134,6 +135,7 @@ static unsigned char *hash_ek_public(void) {
     return hash;
 err:
     free(hash);
+    EVP_MD_CTX_free(sha256);
     return NULL;
 }
 

--- a/tools/tpm2_tool.c
+++ b/tools/tpm2_tool.c
@@ -231,14 +231,6 @@ int main(int argc, char **argv) {
     }
 
     /*
-     * Load the openssl error strings and algorithms
-     * so library routines work as expected.
-     */
-    OpenSSL_add_all_algorithms();
-    OpenSSL_add_all_ciphers();
-    ERR_load_crypto_strings();
-
-    /*
      * Call the specific tool, all tools implement this function instead of
      * 'main'.
      */


### PR DESCRIPTION
This is a first step towards OpenSSL 3.0. This PR contains a set of simple 1-for-1 replacements and code removals (see individual commits), which:
 - Remove support for OpenSSL < 1.1.0, following a discussion on the mailing list and a similar step in the tpm2-tss library
 - Replace no longer necessary wrapper functions by direct calls to OpenSSL
 - Remove functions that have no effect in OpenSSL >= 1.1.0 (and will be removed in OpenSSL 3.0.0)
 - Replace deprecated SHA256_CTX by the EVP_MD_CTX, which works with OpenSSL 1.1.0 through 3.0.0
 - Replace deprecated X509_get_ with X509_getm_, which is available since OpenSSL 1.1.0

Unfortunately, all OpenSSL 3.0 related PR's must be submitted and reviewed sequentially (step-by-step). It would be very huge or cause merge conflicts otherwise.