### PR TITLE
Convert deprecated digesters to EVP_Digest

### DIFF
--- a/lib/tpm2_identity_util.c
+++ b/lib/tpm2_identity_util.c
@@ -134,7 +134,7 @@ static bool share_secret_with_tpm2_rsa_public_key(TPM2B_DIGEST *protection_seed,
     unsigned char encoded[TPM2_MAX_DIGEST_BUFFER];
     return_code = RSA_padding_add_PKCS1_OAEP_mgf1(encoded, mod_size,
             protection_seed->buffer, protection_seed->size, label, label_len,
-            tpm2_openssl_halg_from_tpmhalg(parent_name_alg), NULL);
+            tpm2_openssl_md_from_tpmhalg(parent_name_alg), NULL);
     if (return_code != 1) {
         LOG_ERR("Failed RSA_padding_add_PKCS1_OAEP_mgf1\n");
         goto error;
@@ -356,7 +356,7 @@ static void hmac_outer_integrity(TPMI_ALG_HASH parent_name_alg,
 
     UINT16 hash_size = tpm2_alg_util_get_hash_size(parent_name_alg);
 
-    HMAC(tpm2_openssl_halg_from_tpmhalg(parent_name_alg), hmac_key, hash_size,
+    HMAC(tpm2_openssl_md_from_tpmhalg(parent_name_alg), hmac_key, hash_size,
             to_hmac_buffer, buffer1_size + buffer2_size,
             outer_integrity_hmac->buffer, &size);
     outer_integrity_hmac->size = size;
@@ -409,7 +409,7 @@ bool tpm2_identity_util_calculate_inner_integrity(TPMI_ALG_HASH name_alg,
         return false;
     }
 
-    const EVP_MD *md = tpm2_openssl_halg_from_tpmhalg(name_alg);
+    const EVP_MD *md = tpm2_openssl_md_from_tpmhalg(name_alg);
     if (!md) {
         LOG_ERR("Algorithm not supported: %x", name_alg);
         return false;
@@ -490,7 +490,7 @@ bool tpm2_identity_create_name(TPM2B_PUBLIC *public, TPM2B_NAME *pubname) {
     }
 
     // Step 3 - Hash the data into name just past the alg type.
-    const EVP_MD *md = tpm2_openssl_halg_from_tpmhalg(name_alg);
+    const EVP_MD *md = tpm2_openssl_md_from_tpmhalg(name_alg);
     if (!md) {
         LOG_ERR("Algorithm not supported: %x", name_alg);
         return false;

--- a/lib/tpm2_kdfa.c
+++ b/lib/tpm2_kdfa.c
@@ -34,7 +34,7 @@ TSS2_RC tpm2_kdfa(TPMI_ALG_HASH hash_alg, TPM2B *key, char *label,
 
     i = 1;
 
-    const EVP_MD *md = tpm2_openssl_halg_from_tpmhalg(hash_alg);
+    const EVP_MD *md = tpm2_openssl_md_from_tpmhalg(hash_alg);
     if (!md) {
         LOG_ERR("Algorithm not supported for hmac: %x", hash_alg);
         return TPM2_RC_HASH;

--- a/lib/tpm2_kdfe.c
+++ b/lib/tpm2_kdfe.c
@@ -42,7 +42,7 @@ TSS2_RC tpm2_kdfe(
     tpm2_util_concat_buffer(&hash_input, (TPM2B *) party_u);
     tpm2_util_concat_buffer(&hash_input, (TPM2B *) party_v);
 
-    const EVP_MD *md = tpm2_openssl_halg_from_tpmhalg(hash_alg);
+    const EVP_MD *md = tpm2_openssl_md_from_tpmhalg(hash_alg);
     if (!md) {
         LOG_ERR("Algorithm not supported: %x", hash_alg);
         return TPM2_RC_HASH;

--- a/lib/tpm2_openssl.c
+++ b/lib/tpm2_openssl.c
@@ -59,7 +59,7 @@ int tpm2_openssl_halgid_from_tpmhalg(TPMI_ALG_HASH algorithm) {
     /* no return, not possible */
 }
 
-const EVP_MD *tpm2_openssl_halg_from_tpmhalg(TPMI_ALG_HASH algorithm) {
+const EVP_MD *tpm2_openssl_md_from_tpmhalg(TPMI_ALG_HASH algorithm) {
 
     switch (algorithm) {
     case TPM2_ALG_SHA1:
@@ -81,7 +81,7 @@ bool tpm2_openssl_hash_compute_data(TPMI_ALG_HASH halg, BYTE *buffer,
 
     bool result = false;
 
-    const EVP_MD *md = tpm2_openssl_halg_from_tpmhalg(halg);
+    const EVP_MD *md = tpm2_openssl_md_from_tpmhalg(halg);
     if (!md) {
         return false;
     }
@@ -125,7 +125,7 @@ bool tpm2_openssl_pcr_extend(TPMI_ALG_HASH halg, BYTE *pcr,
 
     bool result = false;
 
-    const EVP_MD *md = tpm2_openssl_halg_from_tpmhalg(halg);
+    const EVP_MD *md = tpm2_openssl_md_from_tpmhalg(halg);
     if (!md) {
         return false;
     }
@@ -174,7 +174,7 @@ bool tpm2_openssl_hash_pcr_values(TPMI_ALG_HASH halg, TPML_DIGEST *digests,
 
     bool result = false;
 
-    const EVP_MD *md = tpm2_openssl_halg_from_tpmhalg(halg);
+    const EVP_MD *md = tpm2_openssl_md_from_tpmhalg(halg);
     if (!md) {
         return false;
     }
@@ -226,7 +226,7 @@ bool tpm2_openssl_hash_pcr_banks(TPMI_ALG_HASH hash_alg,
     UINT32 vi = 0, di = 0, i;
     bool result = false;
 
-    const EVP_MD *md = tpm2_openssl_halg_from_tpmhalg(hash_alg);
+    const EVP_MD *md = tpm2_openssl_md_from_tpmhalg(hash_alg);
     if (!md) {
         return false;
     }
@@ -303,7 +303,7 @@ bool tpm2_openssl_hash_pcr_banks_le(TPMI_ALG_HASH hash_alg,
     UINT32 vi = 0, di = 0, i;
     bool result = false;
 
-    const EVP_MD *md = tpm2_openssl_halg_from_tpmhalg(hash_alg);
+    const EVP_MD *md = tpm2_openssl_md_from_tpmhalg(hash_alg);
     if (!md) {
         return false;
     }

--- a/lib/tpm2_openssl.c
+++ b/lib/tpm2_openssl.c
@@ -372,23 +372,6 @@ out:
     return result;
 }
 
-digester tpm2_openssl_halg_to_digester(TPMI_ALG_HASH halg) {
-
-    switch (halg) {
-    case TPM2_ALG_SHA1:
-        return SHA1;
-    case TPM2_ALG_SHA256:
-        return SHA256;
-    case TPM2_ALG_SHA384:
-        return SHA384;
-    case TPM2_ALG_SHA512:
-        return SHA512;
-        /* no default */
-    }
-
-    return NULL;
-}
-
 /*
  * Per man openssl(1), handle the following --passin formats:
  *     pass:password

--- a/lib/tpm2_openssl.h
+++ b/lib/tpm2_openssl.h
@@ -48,7 +48,7 @@ int tpm2_openssl_halgid_from_tpmhalg(TPMI_ALG_HASH algorithm);
  * @return
  *  A pointer to a message digester or NULL on failure.
  */
-const EVP_MD *tpm2_openssl_halg_from_tpmhalg(TPMI_ALG_HASH algorithm);
+const EVP_MD *tpm2_openssl_md_from_tpmhalg(TPMI_ALG_HASH algorithm);
 
 /**
  * Hash a byte buffer.

--- a/lib/tpm2_openssl.h
+++ b/lib/tpm2_openssl.h
@@ -28,23 +28,6 @@
         EC_POINT_get_affine_coordinates_GFp(group, tpm_pub_key, bn_x, bn_y, dmy)
 #endif /* OPENSSL_VERSION_NUMBER >= 0x10101000L */
 
-/**
- * Function prototype for a hashing routine.
- *
- * This is a wrapper around OSSL SHA256|384 and etc digesters.
- *
- * @param d
- *  The data to digest.
- * @param n
- *  The length of the data to digest.
- * @param md
- *  The output message digest.
- * @return
- * A pointer to the digest or NULL on error.
- */
-typedef unsigned char *(*digester)(const unsigned char *d, size_t n,
-        unsigned char *md);
-
 static inline const char *tpm2_openssl_get_err(void) {
     return ERR_error_string(ERR_get_error(), NULL);
 }
@@ -146,17 +129,6 @@ bool tpm2_openssl_hash_pcr_banks_le(TPMI_ALG_HASH hashAlg,
  */
 bool tpm2_openssl_pcr_extend(TPMI_ALG_HASH halg, BYTE *pcr,
         const BYTE *data, UINT16 length);
-
-/**
- * Returns a function pointer capable of performing the
- * given digest from a TPMI_HASH_ALG.
- *
- * @param halg
- *  The hashing algorithm to use.
- * @return
- *  NULL on failure or a valid digester on success.
- */
-digester tpm2_openssl_halg_to_digester(TPMI_ALG_HASH halg);
 
 typedef enum tpm2_openssl_load_rc tpm2_openssl_load_rc;
 enum tpm2_openssl_load_rc {

--- a/lib/tpm2_util.c
+++ b/lib/tpm2_util.c
@@ -577,7 +577,7 @@ bool tpm2_util_calc_unique(TPMI_ALG_HASH name_alg,
     memcpy(buf.buffer, seed->buffer, seed->size);
     memcpy(&buf.buffer[seed->size], key->buffer, key->size);
 
-    const EVP_MD *md = tpm2_openssl_halg_from_tpmhalg(name_alg);
+    const EVP_MD *md = tpm2_openssl_md_from_tpmhalg(name_alg);
     if (!md) {
         LOG_ERR("Algorithm not supported: %x", name_alg);
         return false;
@@ -949,7 +949,7 @@ bool tpm2_calq_qname(TPM2B_NAME *pqname,
     // QNB ≔ HB (QNA || NAMEB)
     bool result = false;
 
-    const EVP_MD *md = tpm2_openssl_halg_from_tpmhalg(halg);
+    const EVP_MD *md = tpm2_openssl_md_from_tpmhalg(halg);
 
     EVP_MD_CTX *mdctx = EVP_MD_CTX_create();
     if (!mdctx) {

--- a/tools/misc/tpm2_checkquote.c
+++ b/tools/misc/tpm2_checkquote.c
@@ -74,7 +74,7 @@ static bool verify(void) {
     /* get the digest alg */
     /* TODO SPlit loading on plain vs tss format to detect the hash alg */
     /* If its a plain sig we need -g */
-    const EVP_MD *md = tpm2_openssl_halg_from_tpmhalg(ctx.halg);
+    const EVP_MD *md = tpm2_openssl_md_from_tpmhalg(ctx.halg);
     // TODO error handling
 
     int rc = EVP_PKEY_verify_init(pkey_ctx);


### PR DESCRIPTION
Before, two approaches were used for digest calculation:
1) `tpm2_openssl_halg_from_tpmhalg` and the EVP_Digest
2) `tpm2_openssl_halg_to_digester` and (deprecated) digesters such as SHA256 or SHA384 

After this PR, only a single approach is used: `tpm2_openssl_md_from_tpmhalg` and the EVP_Digest. The function name was changed to highlight it returns `EVP_MD *` (the term "halg" is not much used in openssl).
