### PR TITLE
openssl: Implement EVP_PKEY based key import

### DIFF
--- a/lib/tpm2_openssl.c
+++ b/lib/tpm2_openssl.c
@@ -18,30 +18,6 @@
 #include "tpm2_errata.h"
 #include "tpm2_systemdeps.h"
 
-/* compatibility function for OpenSSL versions < 1.1.0 */
-#if OPENSSL_VERSION_NUMBER < 0x10100000L
-static int BN_bn2binpad(const BIGNUM *a, unsigned char *to, int tolen) {
-    int r;
-    int topad;
-    int islen;
-
-    islen = BN_num_bytes(a);
-
-    if (tolen < islen)
-        return -1;
-
-    topad = tolen - islen;
-
-    memset(to, 0x00, topad);
-    r = BN_bn2bin(a, to + topad);
-    if (r == 0) {
-        return -1;
-    }
-
-    return tolen;
-}
-#endif
-
 int tpm2_openssl_halgid_from_tpmhalg(TPMI_ALG_HASH algorithm) {
 
     switch (algorithm) {

--- a/lib/tpm2_openssl.h
+++ b/lib/tpm2_openssl.h
@@ -216,18 +216,6 @@ bool tpm2_openssl_load_public(const char *path, TPMI_ALG_PUBLIC alg,
         TPM2B_PUBLIC *pub);
 
 /**
- * Retrieves a public portion of an ECC key from a PEM file.
- *
- * @param f
- *  The FILE object that is open for reading the path.
- * @param path
- *  The path to load from.
- * @return
- *  The public structure.
- */
-EC_KEY* tpm2_openssl_get_public_ECC_from_pem(FILE *f, const char *path);
-
-/**
  * Maps an ECC curve to an openssl nid value.
  * @param curve
  *  The curve to map.


### PR DESCRIPTION
The `RSA_KEY` and `EC_KEY` are not publicly available in OpenSSL 3.0 and the generic `EVP_PKEY` must be used instead.
Since import of raw keys still requires access to the internal structures the OpenSSL 3.0 introduced a completely new approach to access key internals.

This PR mainly:
* removes the unnecessary BN_bn2binpad compatibility function
* changes `PEM_read_RSA_PUBKEY`/`PEM_read_RSAPublicKey` and `PEM_read_EC_PUBKEY` to a generic `PEM_read_PUBKEY`
* changes `PEM_read_RSAPrivateKey` and `PEM_read_ECPrivateKey` to `PEM_read_PrivateKey`
* adds functions for key import from OpenSSL 3.0 key internals via the `EVP_PKEY_get_xxx_param` functions
* removes NULL checks before OpenSSL `xxx_free` functions as these checks are done internally; the OpenSSL itself heavily relies on that