### PR TITLE
openssl: Replace RSA and EC_KEY by EVP_PKEY operations

### DIFF
--- a/lib/tpm2_convert.h
+++ b/lib/tpm2_convert.h
@@ -65,6 +65,26 @@ bool tpm2_convert_pubkey_save(TPM2B_PUBLIC *public,
         tpm2_convert_pubkey_fmt format, const char *path);
 
 /**
+ * Converts the given RSA public key structure into the EVP_PKEY.
+ *
+ * @param public
+ *  TPM2 public key structure structure.
+ * @return
+ *   OpenSSL key structure, or NULL on error.
+ */
+EVP_PKEY *convert_pubkey_RSA(TPMT_PUBLIC *public);
+
+/**
+ * Converts the given ECC public key structure into the EVP_PKEY.
+ *
+ * @param public
+ *  TPM2 public key structure structure.
+ * @return
+ *   OpenSSL key structure, or NULL on error.
+ */
+EVP_PKEY *convert_pubkey_ECC(TPMT_PUBLIC *public);
+
+/**
  * Parses the given command line signature format option string and returns
  * the corresponding signature_format enum value.
  *


### PR DESCRIPTION
First, this PR implements a EVP_PKEY based key export, i.e. conversion of TPM2 public key to OpenSSL's EVP_PKEY. The functions `convert_pubkey_RSA` and `convert_pubkey_ECC` are made available in `tpm2_convert.h`.

Then, the next two commits use these conversion functions to
 * Convert deprecated `ECDH_compute_key` to `EVP_PKEY_derive`
 * Reimplement RSA OAEP encryption using EVP functions

For more details please see the individual commits.