### PR TITLE
[RFC] support keyedhash and hmac seperatley

### DIFF
--- a/lib/tpm2_alg_util.c
+++ b/lib/tpm2_alg_util.c
@@ -100,7 +100,7 @@ static void tpm2_alg_util_for_each_alg(alg_iter iterator, void *userdata) {
         { .name = "ecb", .id = TPM2_ALG_ECB, .flags = tpm2_alg_util_flags_mode },
 
         { .name = "symcipher", .id = TPM2_ALG_SYMCIPHER, .flags = tpm2_alg_util_flags_base },
-        { .name = "keyedhash", .id = TPM2_ALG_KEYEDHASH, .flags = tpm2_alg_util_flags_base },
+        { .name = "keyedhash", .id = TPM2_ALG_KEYEDHASH, .flags = tpm2_alg_util_flags_base | tpm2_alg_util_flags_keyedhash_base },
 
         // Misc
         { .name = "null", .id = TPM2_ALG_NULL, .flags = tpm2_alg_util_flags_misc | tpm2_alg_util_flags_rsa_scheme },

--- a/lib/tpm2_alg_util.h
+++ b/lib/tpm2_alg_util.h
@@ -24,6 +24,7 @@ enum tpm2_alg_util_flags {
     tpm2_alg_util_flags_misc       = 1 << 9,
     tpm2_alg_util_flags_enc_scheme = 1 << 10,
     tpm2_alg_util_flags_rsa_scheme = 1 << 11,
+    tpm2_alg_util_flags_keyedhash_base = 1 << 12,
     tpm2_alg_util_flags_any        = ~0
 };
 

--- a/tools/tpm2_import.c
+++ b/tools/tpm2_import.c
@@ -197,7 +197,7 @@ static bool on_option(char key, char *value) {
         break;
     case 'G':
         ctx.key_type = tpm2_alg_util_from_optarg(value,
-                tpm2_alg_util_flags_asymmetric | tpm2_alg_util_flags_symmetric | tpm2_alg_util_flags_keyedhash );
+                tpm2_alg_util_flags_asymmetric | tpm2_alg_util_flags_symmetric | tpm2_alg_util_flags_keyedhash | tpm2_alg_util_flags_keyedhash_base);
         if (ctx.key_type == TPM2_ALG_ERROR) {
             LOG_ERR("Unsupported key type");
             return false;


### PR DESCRIPTION
Currently -Ghmac in tpm2_create will produce a keyedhash object with a
scheme of hmac-sha256. However, import -G hmac will produce a keyedhash
with a scheme of null. Have import use hmac to create a fully specified
keyedhash object like create, and have keyedhash perform a null alg.

For HMAC the hashing algorithm will be the same as the key size, so only
hmac keys of a certain size will be accepted. This might not be
desirable. We might want to extend the parsing routines to handle
hmac:sha256, etc, and then default to the normal sha256 if left off.

Signed-off-by: William Roberts <william.c.roberts@intel.com>