### PR TITLE
tpm2_nvsetbits: Add support to calculate cpHash with --tcti=none

### DIFF
--- a/doc/CHANGELOG.md
+++ b/doc/CHANGELOG.md
@@ -14,6 +14,9 @@
         of the response parameters. This is commonly termed as rpHash.
       - Added option **-S**, **\--session** to specify to specify an auxiliary
         session for auditing and or encryption/decryption of the parameters.
+      - Added option **\-n**, **\--name** to specify the name of the nvindex in
+        hex bytes. This is used when cpHash ought to be calculated without
+        dispatching the TPM2_NV_SetBits command to the TPM.
   * tpm2_createprimary: Support outputing public key at creation time in various
     public key formats.
   * tpm2_create: Support outputing public key at creation time in various

--- a/lib/tpm2.c
+++ b/lib/tpm2.c
@@ -2990,15 +2990,24 @@ tool_rc tpm2_tr_from_tpm_public(ESYS_CONTEXT *esys_context, TPM2_HANDLE handle, 
 tool_rc tpm2_nvsetbits(ESYS_CONTEXT *esys_context,
     tpm2_loaded_object *auth_hierarchy_obj, TPM2_HANDLE nv_index,
     UINT64 bits, TPM2B_DIGEST *cp_hash, TPM2B_DIGEST *rp_hash,
-    TPMI_ALG_HASH parameter_hash_algorithm, ESYS_TR shandle2,
-    ESYS_TR shandle3) {
+    TPMI_ALG_HASH parameter_hash_algorithm, TPM2B_NAME *precalc_nvname,
+    ESYS_TR shandle2, ESYS_TR shandle3) {
 
-    ESYS_TR esys_tr_nv_handle;
-    TSS2_RC rval = Esys_TR_FromTPMPublic(esys_context, nv_index, ESYS_TR_NONE,
-        ESYS_TR_NONE, ESYS_TR_NONE, &esys_tr_nv_handle);
-    if (rval != TPM2_RC_SUCCESS) {
-        LOG_PERR(Esys_TR_FromTPMPublic, rval);
-        return tool_rc_from_tpm(rval);
+    /*
+     * If command is to be dispatched the NV index must exist.
+     * In this case get the NV index name by reading its public information.
+     * If rpHash size is non zero then command is always dispatched.
+     */
+    ESYS_TR esys_tr_nv_handle = ESYS_TR_NONE;
+    TSS2_RC rval = TSS2_RC_SUCCESS;
+    bool is_name_specified = precalc_nvname ? precalc_nvname->size : false;
+    if (!is_name_specified) {
+        rval = Esys_TR_FromTPMPublic(esys_context, nv_index, ESYS_TR_NONE,
+            ESYS_TR_NONE, ESYS_TR_NONE, &esys_tr_nv_handle);
+        if (rval != TPM2_RC_SUCCESS) {
+            LOG_PERR(Esys_TR_FromTPMPublic, rval);
+            return tool_rc_from_tpm(rval);
+        }
     }
 
     TSS2_SYS_CONTEXT *sys_context = NULL;
@@ -3020,26 +3029,47 @@ tool_rc tpm2_nvsetbits(ESYS_CONTEXT *esys_context,
             return tool_rc_general_error;
         }
 
-        TPM2B_NAME *name1 = NULL;
-        rc = tpm2_tr_get_name(esys_context, auth_hierarchy_obj->tr_handle,
-            &name1);
-        if (rc != tool_rc_success) {
-            goto tpm2_nvsetbits_free_name1;
+        /*
+         * We need this to use precalc-name for parent authorization when the
+         * NV index itself is the authorization parent AND
+         * we don't need/have the NV index defined when simply calculating cpHash.
+         */
+        bool is_auth_hierarchy_nv_index =
+            (auth_hierarchy_obj->tr_handle != ESYS_TR_RH_OWNER) &&
+            (auth_hierarchy_obj->tr_handle != ESYS_TR_RH_PLATFORM);
+
+        TPM2B_NAME *name1 = 0;
+        if (is_auth_hierarchy_nv_index && is_name_specified) {
+            name1 = precalc_nvname;
+        } else {
+            rc = tpm2_tr_get_name(esys_context, auth_hierarchy_obj->tr_handle,
+                &name1);
+            if (rc != tool_rc_success) {
+                goto tpm2_nvsetbits_free_name1;
+            }
         }
 
-        TPM2B_NAME *name2 = NULL;
-        rc = tpm2_tr_get_name(esys_context, esys_tr_nv_handle, &name2);
-        if (rc != tool_rc_success) {
-            goto tpm2_nvsetbits_free_name1_name2;
+        TPM2B_NAME *name2 = 0;
+        if (is_name_specified) {
+            name2 = precalc_nvname;
+        } else {
+            rc = tpm2_tr_get_name(esys_context, esys_tr_nv_handle, &name2);
+            if (rc != tool_rc_success) {
+                goto tpm2_nvsetbits_free_name1_name2;
+            }
         }
 
         rc = tpm2_sapi_getcphash(sys_context, name1, name2, NULL,
             parameter_hash_algorithm, cp_hash);
 
 tpm2_nvsetbits_free_name1_name2:
-        Esys_Free(name2);
+        if (!is_name_specified) {
+            Esys_Free(name2);
+        }
 tpm2_nvsetbits_free_name1:
-        Esys_Free(name1);
+        if (!is_name_specified) {
+            Esys_Free(name1);
+        }
         /*
          * Exit here without making the ESYS call since we just need the cpHash
          */

--- a/lib/tpm2.h
+++ b/lib/tpm2.h
@@ -333,8 +333,8 @@ tool_rc tpm2_tr_from_tpm_public(ESYS_CONTEXT *esys_context,
 tool_rc tpm2_nvsetbits(ESYS_CONTEXT *esys_context,
     tpm2_loaded_object *auth_hierarchy_obj, TPM2_HANDLE nv_index,
     UINT64 bits, TPM2B_DIGEST *cp_hash, TPM2B_DIGEST *rp_hash,
-    TPMI_ALG_HASH parameter_hash_algorithm, ESYS_TR shandle2,
-    ESYS_TR shandle3);
+    TPMI_ALG_HASH parameter_hash_algorithm, TPM2B_NAME *precalc_nvname,
+    ESYS_TR shandle2, ESYS_TR shandle3);
 
 tool_rc tpm2_nvundefine(ESYS_CONTEXT *esys_context,
         tpm2_loaded_object *auth_hierarchy_obj, TPM2_HANDLE nv_index,

--- a/man/tpm2_nvsetbits.1.md
+++ b/man/tpm2_nvsetbits.1.md
@@ -56,6 +56,11 @@ specified as raw handle or an offset value to the NV handle range
     specify an auxiliary session for auditing and or encryption/decryption of
     the parameters.
 
+  * **-n**, **\--name**=_FILE_:
+
+    The name of the NV index that must be provided when only calculating the
+    cpHash without actually dispatching the command to the TPM.
+
   * **ARGUMENT** the command line argument specifies the NV index or offset
     number.
 

--- a/tools/tpm2_nvsetbits.c
+++ b/tools/tpm2_nvsetbits.c
@@ -24,6 +24,7 @@ struct tpm_nvsetbits_ctx {
     const char *bit_string;
     UINT64 bits;
     TPM2_HANDLE nv_index;
+    TPM2B_NAME precalc_nvname;
 
     /*
      * Outputs
@@ -37,6 +38,7 @@ struct tpm_nvsetbits_ctx {
     const char *rp_hash_path;
     TPM2B_DIGEST rp_hash;
     bool is_command_dispatch;
+    bool is_tcti_none;
     TPMI_ALG_HASH parameter_hash_algorithm;
 
     /*
@@ -61,7 +63,8 @@ static tool_rc nvsetbits(ESYS_CONTEXT *ectx) {
      */
     return tpm2_nvsetbits(ectx, &ctx.auth_hierarchy.object, ctx.nv_index,
         ctx.bits, &ctx.cp_hash, &ctx.rp_hash, ctx.parameter_hash_algorithm,
-        ctx.aux_session_handle[0], ctx.aux_session_handle[1]);
+        &ctx.precalc_nvname, ctx.aux_session_handle[0],
+        ctx.aux_session_handle[1]);
 
 }
 
@@ -110,9 +113,17 @@ static tool_rc process_inputs(ESYS_CONTEXT *ectx) {
      */
 
     /* Object #1 */
-    tool_rc rc = tpm2_util_object_load_auth(ectx, ctx.auth_hierarchy.ctx_path,
-            ctx.auth_hierarchy.auth_str, &ctx.auth_hierarchy.object, false,
-            TPM2_HANDLE_FLAGS_NV | TPM2_HANDLE_FLAGS_O | TPM2_HANDLE_FLAGS_P);
+    tool_rc rc = (!ctx.is_tcti_none) ?
+
+            tpm2_util_object_load_auth(ectx, ctx.auth_hierarchy.ctx_path,
+                ctx.auth_hierarchy.auth_str, &ctx.auth_hierarchy.object, false,
+                TPM2_HANDLE_FLAGS_NV|TPM2_HANDLE_FLAGS_O|TPM2_HANDLE_FLAGS_P) :
+
+            tpm2_util_handle_from_optarg(ctx.auth_hierarchy.ctx_path,
+                &ctx.auth_hierarchy.object.handle,
+                TPM2_HANDLE_FLAGS_NV|TPM2_HANDLE_FLAGS_O|TPM2_HANDLE_FLAGS_P) ?
+                tool_rc_success : tool_rc_option_error;
+
     if (rc != tool_rc_success) {
         LOG_ERR("Invalid handle authorization");
         return rc;
@@ -158,18 +169,36 @@ static tool_rc process_inputs(ESYS_CONTEXT *ectx) {
 
     /*
      * 4.b Determine if TPM2_CC_<command> is to be dispatched
+     * is_tcti_none       [N]
      * !rphash && !cphash [Y]
      * !rphash && cphash  [N]
      * rphash && !cphash  [Y]
      * rphash && cphash   [Y]
      */
-    ctx.is_command_dispatch = (ctx.cp_hash_path && !ctx.rp_hash_path) ?
-        false : true;
+    ctx.is_command_dispatch = (ctx.is_tcti_none ||
+        (ctx.cp_hash_path && !ctx.rp_hash_path)) ? false : true;
 
     return rc;
 }
 
-static tool_rc check_options(void) {
+static tool_rc check_options(tpm2_option_flags flags) {
+
+    ctx.is_tcti_none = flags.tcti_none ? true : false;
+    if (ctx.is_tcti_none && !ctx.cp_hash_path) {
+        LOG_ERR("If tcti is none, then cpHash path must be specified");
+        return tool_rc_option_error;
+    }
+
+    bool is_nv_name_specified = ctx.precalc_nvname.size;
+    if (ctx.is_tcti_none && !is_nv_name_specified) {
+        LOG_ERR("Must specify the NVIndex name.");
+        return tool_rc_option_error;
+    }
+
+    if (!ctx.is_tcti_none && is_nv_name_specified) {
+        LOG_ERR("Do not specify NVIndex name, it is directly read from NV");
+        return tool_rc_option_error;
+    }
 
     if (!ctx.bit_string) {
         LOG_ERR("Expected option --bits for specifying the bits to set");
@@ -216,6 +245,15 @@ static bool on_option(char key, char *value) {
             return false;
         }
         break;
+    case 'n':
+        ctx.precalc_nvname.size = BUFFER_SIZE(TPM2B_NAME, name);
+        int q = tpm2_util_hex_to_byte_structure(value, &ctx.precalc_nvname.size,
+        ctx.precalc_nvname.name);
+        if (q) {
+            LOG_ERR("FAILED: %d", q);
+            return false;
+        }
+        break;
     }
 
     return true;
@@ -230,10 +268,11 @@ static bool tpm2_tool_onstart(tpm2_options **opts) {
         { "cphash",    required_argument, NULL,  0  },
         { "rphash",    required_argument, NULL,  1  },
         { "session",   required_argument, NULL, 'S' },
+        { "name",      required_argument, NULL, 'n' },
     };
 
-    *opts = tpm2_options_new("C:P:i:S:", ARRAY_LEN(topts), topts, on_option,
-            on_arg, 0);
+    *opts = tpm2_options_new("C:P:i:S:n:", ARRAY_LEN(topts), topts, on_option,
+            on_arg, TPM2_OPTIONS_OPTIONAL_SAPI_AND_FAKE_TCTI);
 
     return *opts != NULL;
 }
@@ -245,7 +284,7 @@ static tool_rc tpm2_tool_onrun(ESYS_CONTEXT *ectx, tpm2_option_flags flags) {
     /*
      * 1. Process options
      */
-    tool_rc rc = check_options();
+    tool_rc rc = check_options(flags);
     if (rc != tool_rc_success) {
         return rc;
     }


### PR DESCRIPTION
Signed-off-by: Imran Desai <imran.desai@intel.com>