### PR TITLE
Import hmac keyedhash

### DIFF
--- a/lib/tpm2_alg_util.c
+++ b/lib/tpm2_alg_util.c
@@ -1008,6 +1008,7 @@ tool_rc tpm2_alg_util_public_init(char *alg_details, char *name_halg, char *attr
     TPM2B_PUBLIC tmp = *public;
     bool res = tpm2_alg_util_handle_ext_alg(alg_details, &tmp);
     if (!res) {
+        LOG_ERR("Could not handle algorithm: \"%s\"", alg_details);
         return tool_rc_unsupported;
     }
 

--- a/lib/tpm2_openssl.h
+++ b/lib/tpm2_openssl.h
@@ -153,21 +153,17 @@ static inline bool tpm2_openssl_did_load_public(
 }
 
 /**
- * Loads a private portion of a key, and possibly the public portion.
- * For asymmetric algorithms the public data is in  private PEM file.
- * For symmetric keys, the file type is raw. For asymmetric keys, the
- * file type is a PEM file.
- *
- * This ONLY supports AES, ECC and RSA.
- *
- * It populates the sensitive seed with a random value for symmetric keys.
+ * Loads a private portion of a key, and possibly the public portion, as for RSA the public data is in
+ * a private pem file.
  *
  * @param path
  *  The path to load from.
- * @param path
- *  The passphrase for the input file.
- * @param alg
- *  algorithm type to import.
+ * @param passin
+ *  If the path needs a password to decrypt like a password protected OpenSSL PEM file.
+ * @param object_auth
+ *  The auth value to set for the object, may be NULL.
+ * @param template
+ *  The public template to use to construct the TPM objects.
  * @param pub
  *  The public structure to populate. Note that nameAlg must be populated.
  * @param priv
@@ -177,9 +173,8 @@ static inline bool tpm2_openssl_did_load_public(
  *  A private object loading status
  */
 tpm2_openssl_load_rc tpm2_openssl_load_private(const char *path,
-        const char *pass, TPMI_ALG_PUBLIC alg, TPM2B_PUBLIC *pub,
+        const char *passin, const char *object_auth, TPM2B_PUBLIC *template, TPM2B_PUBLIC *pub,
         TPM2B_SENSITIVE *priv);
-
 
 /**
  * Load an OpenSSL private key and configure all of the flags based on
@@ -187,16 +182,13 @@ tpm2_openssl_load_rc tpm2_openssl_load_private(const char *path,
  */
 bool tpm2_openssl_import_keys(
     TPM2B_PUBLIC *parent_pub,
-    TPM2B_SENSITIVE *private,
-    TPM2B_PUBLIC *public,
     TPM2B_ENCRYPTED_SECRET *encrypted_seed,
+    const char *object_auth_value,
     const char *input_key_file,
-    TPMI_ALG_PUBLIC key_type,
-    const char *auth_key_file,
-    const char *policy_file,
-    const char *key_auth_str,
-    char *attrs_str,
-    const char *name_alg_str
+    const char *passin,
+    TPM2B_PUBLIC *template,
+    TPM2B_SENSITIVE *private,
+    TPM2B_PUBLIC *public
 );
 
 /**

--- a/lib/tpm2_util.h
+++ b/lib/tpm2_util.h
@@ -87,6 +87,11 @@ typedef struct {
     BYTE buffer[0];
 } TPM2B;
 
+#define DEFAULT_CREATE_ATTRS \
+     TPMA_OBJECT_DECRYPT|TPMA_OBJECT_SIGN_ENCRYPT|TPMA_OBJECT_FIXEDTPM \
+    |TPMA_OBJECT_FIXEDPARENT|TPMA_OBJECT_SENSITIVEDATAORIGIN \
+    |TPMA_OBJECT_USERWITHAUTH
+
 int tpm2_util_hex_to_byte_structure(const char *in_str, UINT16 *byte_length,
         BYTE *byte_buffer);
 

--- a/test/integration/tests/import.sh
+++ b/test/integration/tests/import.sh
@@ -171,7 +171,7 @@ run_aes_policy_import_test() {
 run_keyedhash_seal_import_test() {
 
     dd if=/dev/urandom of=sealdata bs=128 count=1
-    tpm2 import -C "$1" -G hmac -i sealdata -a 'userwithauth' -u seal.pub -r seal.priv
+    tpm2 import -C "$1" -G keyedhash -i sealdata -u seal.pub -r seal.priv
     tpm2 load -C "$1" -u seal.pub -r seal.priv -c seal.ctx
     tpm2 unseal -c seal.ctx -o unsealdata
     cmp sealdata unsealdata
@@ -179,7 +179,7 @@ run_keyedhash_seal_import_test() {
 
 run_keyedhash_hmac_import_test() {
 
-    dd if=/dev/urandom of=hmackey bs=73 count=1
+    dd if=/dev/urandom of=hmackey bs=64 count=1
     hexkey=$(xxd -p -c 256 < hmackey)
     tpm2 import -C "$1" -G hmac -i hmackey -u hmac.pub -r hmac.priv
     tpm2 load -C "$1" -u hmac.pub -r hmac.priv -c hmac.ctx

--- a/tools/tpm2_create.c
+++ b/tools/tpm2_create.c
@@ -12,6 +12,7 @@
 #include "tpm2_alg_util.h"
 #include "tpm2_auth_util.h"
 #include "tpm2_options.h"
+#include "tpm2_util.h"
 
 typedef struct tpm_create_ctx tpm_create_ctx;
 #define MAX_AUX_SESSIONS 2
@@ -164,11 +165,6 @@ static tool_rc create(ESYS_CONTEXT *ectx) {
 
     return tool_rc_success;
 }
-
-#define DEFAULT_ATTRS \
-     TPMA_OBJECT_DECRYPT|TPMA_OBJECT_SIGN_ENCRYPT|TPMA_OBJECT_FIXEDTPM \
-    |TPMA_OBJECT_FIXEDPARENT|TPMA_OBJECT_SENSITIVEDATAORIGIN \
-    |TPMA_OBJECT_USERWITHAUTH
 
 static void setup_attributes(TPMA_OBJECT *attrs) {
 
@@ -364,7 +360,7 @@ static tool_rc process_inputs(ESYS_CONTEXT *ectx) {
      */
 
     /* Setup attributes */
-    TPMA_OBJECT attrs = DEFAULT_ATTRS;
+    TPMA_OBJECT attrs = DEFAULT_CREATE_ATTRS;
     setup_attributes(&attrs);
 
     /* Initialize object */

--- a/tools/tpm2_import.c
+++ b/tools/tpm2_import.c
@@ -260,7 +260,7 @@ static bool tpm2_tool_onstart(tpm2_options **opts) {
       { "parent-public",      required_argument, NULL, 'U'},
       { "private",            required_argument, NULL, 'r'},
       { "public",             required_argument, NULL, 'u'},
-      { "attributes",  required_argument, NULL, 'a'},
+      { "attributes",         required_argument, NULL, 'a'},
       { "hash-algorithm",     required_argument, NULL, 'g'},
       { "seed",               required_argument, NULL, 's'},
       { "policy",             required_argument, NULL, 'L'},

--- a/tools/tpm2_import.c
+++ b/tools/tpm2_import.c
@@ -528,7 +528,7 @@ static tool_rc tpm_import(ESYS_CONTEXT *ectx) {
         assert(imported_private);
 
         result = files_save_private(imported_private, ctx.private_key_file);
-        free(imported_private);
+        Esys_Free(imported_private);
         if (!result) {
             LOG_ERR("Failed to save private key into file \"%s\"",
                     ctx.private_key_file);

--- a/tools/tpm2_import.c
+++ b/tools/tpm2_import.c
@@ -548,8 +548,8 @@ static tool_rc tpm_import(ESYS_CONTEXT *ectx) {
     if (!result) {
         rc = tool_rc_general_error;
     }
-    return rc;
 
+    return rc;
 }
 
 static tool_rc tpm2_tool_onrun(ESYS_CONTEXT *ectx, tpm2_option_flags flags) {

--- a/tools/tpm2_import.c
+++ b/tools/tpm2_import.c
@@ -425,10 +425,10 @@ static tool_rc openssl_import(ESYS_CONTEXT *ectx) {
     rc = tool_rc_success;
 
 keyout:
-    free(imported_private);
+    Esys_Free(imported_private);
 out:
     if (free_ppub) {
-        free(parent_pub);
+        Esys_Free(parent_pub);
     }
 
     return rc;

--- a/tools/tpm2_makecredential.c
+++ b/tools/tpm2_makecredential.c
@@ -325,8 +325,9 @@ static tool_rc process_input(void) {
     }
 
     if (ctx.public_key_path) {
-        bool result = tpm2_openssl_load_public(ctx.public_key_path, alg,
-            &ctx.public);
+        bool result = alg != TPM2_ALG_NULL ?
+            tpm2_openssl_load_public(ctx.public_key_path, alg,
+            &ctx.public) : files_load_public(ctx.public_key_path, &ctx.public);
         if (!result) {
             return tool_rc_general_error;
         }


### PR DESCRIPTION
This PR rectified the -G behavior between `tpm2_create` and `tpm2_createprimary` with `tpm2_import. -G keyedhash` will give you something akin to a "seal object" in `tpm2_create` and `tpm2_createprimary`, and hmac will give you an hmac object (keyedhash with an hmac hash alg). This also makes things like `-Ghmac:sha512` possible.