### PR TITLE
testparms: fix condition for negative test

### DIFF
--- a/test/integration/tests/testparms.sh
+++ b/test/integration/tests/testparms.sh
@@ -63,7 +63,7 @@ else
 fi
 
 # Attempt to specify a suite that is not supported (error from TPM)
-if tpm2 getcap ecc-curves | grep -q TPM2_ECC_NIST_P521; then
+if ! tpm2 getcap ecc-curves | grep -q TPM2_ECC_NIST_P521; then
     if tpm2 testparms "ecc521:ecdsa:camellia" &>/dev/null; then
         echo "tpm2 testparms succeeded while it shouldn't or TPM failed"
         exit 1


### PR DESCRIPTION
Commit e858dec76686bb4c42e74e0984b433231e530f93 is supposed to ensure that the negative test is run only if `ecc521` is *not* supported, but instead it runs the negative test if `ecc521` is *available*. This worked anyway for libtpms < 0.9.0 because `camellia` was not supported, but since [libtpms 0.9.0](https://github.com/stefanberger/libtpms/releases/tag/v0.9.0) added support for this algorithm, the test suite fails now with swtpm.