### PR TITLE
lib/tpm2_eventlog_yaml: use char16_t for UEFI characters

### DIFF
--- a/lib/tpm2_eventlog_yaml.c
+++ b/lib/tpm2_eventlog_yaml.c
@@ -475,7 +475,7 @@ static bool yaml_uefi_var(UEFI_VARIABLE_DATA *data, size_t size, UINT32 type,
                 tpm2_tool_output("      Description: \"");
                 int i;
                 for (i = 0; (wchar_t)loadopt->Description[i] != 0; i++) {
-                    wchar_t c = (wchar_t)loadopt->Description[i];
+                    char16_t c = (char16_t)loadopt->Description[i];
                     tpm2_tool_output("%lc", c);
                 }
                 tpm2_tool_output("\"\n");


### PR DESCRIPTION
This removes the compilation warning/error:

```
In file included from ./tools/tpm2_tool.h:11,
                 from lib/tpm2_eventlog_yaml.c:16:
lib/tpm2_eventlog_yaml.c: In function 'yaml_uefi_var':
lib/tpm2_eventlog_yaml.c:479:38: error: format '%lc' expects argument of type 'wint_t', but argument 2 has type 'wchar_t' {aka 'long int'} [-Werror=format=]
  479 |                     tpm2_tool_output("%lc", c);
      |                                      ^~~~~  ~
      |                                             |
      |                                             wchar_t {aka long int}
./lib/tpm2_tool_output.h:26:20: note: in definition of macro 'tpm2_tool_output'
   26 |             printf(fmt, ##__VA_ARGS__);         \
      |                    ^~~
lib/tpm2_eventlog_yaml.c:479:41: note: format string is defined here
  479 |                     tpm2_tool_output("%lc", c);
      |                                       ~~^
      |                                         |
      |                                         unsigned int
      |                                       %ld
``` 
