### PR TITLE
tpm2_eventlog_yaml: Supress -Wpointer-sign warning

### DIFF
--- a/lib/tpm2_eventlog_yaml.c
+++ b/lib/tpm2_eventlog_yaml.c
@@ -251,7 +251,7 @@ char *yaml_devicepath(BYTE* dp, UINT64 dp_len) {
         return NULL;
     }
   
-    ret = efidp_format_device_path(text_path,
+    ret = efidp_format_device_path((unsigned char *)text_path,
             text_path_len, (const_efidp)dp, dp_len);
     if (ret < 0) {
         free(text_path);


### PR DESCRIPTION
When compiled with efivar-37, the following warning is printed:
```console
  lib/tpm2_eventlog_yaml.c: In function ‘yaml_devicepath’:
  lib/tpm2_eventlog_yaml.c:254:36: error: pointer targets in passing argument 1 of ‘efidp_format_device_path’ differ in signedness [-Werror=pointer-sign]
    254 |     ret = efidp_format_device_path(text_path,
        |                                    ^~~~~~~~~
        |                                    |
        |                                    char *
```

Signed-off-by: Daiki Ueno <ueno@gnu.org>