### PR TITLE
doc: remove extra parentheses in link

### DIFF
--- a/doc/RELEASE.md
+++ b/doc/RELEASE.md
@@ -182,7 +182,7 @@ Below you will find information how to configure your machine locally to conduct
 Signing keys should have these four properties going forward:
   - belong to a project maintainer.
   - be discoverable using a public GPG key server.
-  - be [associated]((https://help.github.com/articles/adding-a-new-gpg-key-to-your-github-account/))
+  - be [associated](https://help.github.com/articles/adding-a-new-gpg-key-to-your-github-account/)
     with the maintainers GitHub account.
   - be discoverable via an annotated tag within the repository itself.
 


### PR DESCRIPTION
The link was not displayed in https://github.com/tpm2-software/tpm2-tools/blob/master/doc/RELEASE.md because of stray parentheses.