### PR TITLE
tools/tpm2_nvextend: Fix where ESYS_TR handle is not used in name

### DIFF
--- a/tools/tpm2_nvextend.c
+++ b/tools/tpm2_nvextend.c
@@ -113,14 +113,23 @@ static tool_rc process_inputs(ESYS_CONTEXT *ectx) {
     /*
      * 1.b Add object names and their auth sessions
      */
-    tool_rc rc = (!ctx.is_tcti_none) ?
-            tpm2_util_object_load_auth(ectx, ctx.auth_hierarchy.ctx_path,
-                ctx.auth_hierarchy.auth_str, &ctx.auth_hierarchy.object, false,
-                TPM2_HANDLE_FLAGS_NV|TPM2_HANDLE_FLAGS_O|TPM2_HANDLE_FLAGS_P) :
-            tpm2_util_handle_from_optarg(ctx.auth_hierarchy.ctx_path,
-                &ctx.auth_hierarchy.object.handle,
-                TPM2_HANDLE_FLAGS_NV|TPM2_HANDLE_FLAGS_O|TPM2_HANDLE_FLAGS_P) ?
-                tool_rc_success : tool_rc_option_error;
+    tool_rc rc = tool_rc_success;
+    if (ctx.is_tcti_none) {
+        rc = tpm2_util_handle_from_optarg(ctx.auth_hierarchy.ctx_path,
+            &ctx.auth_hierarchy.object.handle,
+            TPM2_HANDLE_FLAGS_NV | TPM2_HANDLE_FLAGS_O | TPM2_HANDLE_FLAGS_P) ?
+        tool_rc_success : tool_rc_option_error;
+        if (rc != tool_rc_success) {
+             return rc;
+         }
+
+         ctx.auth_hierarchy.object.tr_handle =
+              tpm2_tpmi_hierarchy_to_esys_tr(ctx.auth_hierarchy.object.handle);
+    } else {
+        rc = tpm2_util_object_load_auth(ectx, ctx.auth_hierarchy.ctx_path,
+            ctx.auth_hierarchy.auth_str, &ctx.auth_hierarchy.object, false,
+            TPM2_HANDLE_FLAGS_NV | TPM2_HANDLE_FLAGS_O | TPM2_HANDLE_FLAGS_P);
+    }
 
     if (rc != tool_rc_success) {
         LOG_ERR("Invalid handle authorization");


### PR DESCRIPTION
Fixes #2866

When calculating cpHash with tcti=none, the ESYS_TR handle was
not used when calculating the name.

Signed-off-by: Imran Desai <imran.desai@intel.com>