### PR TITLE
tools/tpm2_nvincrement: mark ectx as unused for check_options()

### DIFF
--- a/tools/tpm2_nvincrement.c
+++ b/tools/tpm2_nvincrement.c
@@ -168,6 +168,8 @@ static tool_rc process_inputs(ESYS_CONTEXT *ectx) {
 
 static tool_rc check_options(ESYS_CONTEXT *ectx, tpm2_option_flags flags) {
 
+    UNUSED(ectx);
+
     ctx.is_tcti_none = flags.tcti_none ? true : false;
     if (ctx.is_tcti_none && !ctx.cp_hash_path) {
         LOG_ERR("If tcti is none, then cpHash path must be specified");


### PR DESCRIPTION
The unused parameter leads to a compiler warning/error with GCC 11.1.0:
```
tools/tpm2_nvincrement.c: In function ‘check_options’:
tools/tpm2_nvincrement.c:169:44: error: unused parameter ‘ectx’ [-Werror=unused-parameter]
  169 | static tool_rc check_options(ESYS_CONTEXT *ectx, tpm2_option_flags flags) {
      |                              ~~~~~~~~~~~~~~^~~~
```