### PR TITLE
nvtools: fixes for Esys_TR names when calc cphash with tcti=none

### DIFF
--- a/tools/tpm2_nvincrement.c
+++ b/tools/tpm2_nvincrement.c
@@ -115,16 +115,27 @@ static tool_rc process_inputs(ESYS_CONTEXT *ectx) {
      * When tcti is none AND only calculating cpHash only load the object
      * strings to calculate the names.
      */
-    tool_rc rc = (!ctx.is_tcti_none) ?
-
-        tpm2_util_object_load_auth(ectx, ctx.auth_hierarchy.ctx_path,
-            ctx.auth_hierarchy.auth_str, &ctx.auth_hierarchy.object, false,
-            TPM2_HANDLE_FLAGS_NV | TPM2_HANDLE_FLAGS_O | TPM2_HANDLE_FLAGS_P) :
-
-        tpm2_util_handle_from_optarg(ctx.auth_hierarchy.ctx_path,
+    tool_rc rc = tool_rc_success;
+    if (ctx.is_tcti_none) {
+        /*
+         * Cannot use tpm2_util_object_load like in nvdefine as it makes a call
+         * to tpm2_util_sys_handle_to_esys_handle which then tries to read the
+         * ESYS_TR object off of the TPM expecting it to be there.
+         * Note: this if it is a permanent handle ESYS_TR is fixed and so the
+         * TPM is not probed even with tpm2_util_sys_handle_to_esys_handle.
+         */
+        rc = tpm2_util_handle_from_optarg(ctx.auth_hierarchy.ctx_path,
             &ctx.auth_hierarchy.object.handle,
             TPM2_HANDLE_FLAGS_NV | TPM2_HANDLE_FLAGS_O | TPM2_HANDLE_FLAGS_P) ?
-        tool_rc_success : tool_rc_option_error;
+            tool_rc_success : tool_rc_option_error;
+
+        ctx.auth_hierarchy.object.tr_handle = (rc == tool_rc_success) ?
+           tpm2_tpmi_hierarchy_to_esys_tr(ctx.auth_hierarchy.object.handle) : 0;
+    } else {
+        rc = tpm2_util_object_load_auth(ectx, ctx.auth_hierarchy.ctx_path,
+            ctx.auth_hierarchy.auth_str, &ctx.auth_hierarchy.object, false,
+            TPM2_HANDLE_FLAGS_NV | TPM2_HANDLE_FLAGS_O | TPM2_HANDLE_FLAGS_P);
+    }
 
     if (rc != tool_rc_success) {
         LOG_ERR("Invalid handle or authorization.");

--- a/tools/tpm2_nvread.c
+++ b/tools/tpm2_nvread.c
@@ -135,6 +135,13 @@ static tool_rc process_inputs(ESYS_CONTEXT *ectx) {
      */
     tool_rc rc = tool_rc_success;
     if (ctx.is_tcti_none) {
+        /*
+         * Cannot use tpm2_util_object_load like in nvdefine as it makes a call
+         * to tpm2_util_sys_handle_to_esys_handle which then tries to read the
+         * ESYS_TR object off of the TPM expecting it to be there.
+         * Note: this if it is a permanent handle ESYS_TR is fixed and so the
+         * TPM is not probed even with tpm2_util_sys_handle_to_esys_handle.
+         */
         rc = tpm2_util_handle_from_optarg(ctx.auth_hierarchy.ctx_path,
             &ctx.auth_hierarchy.object.handle,
             TPM2_HANDLE_FLAGS_NV | TPM2_HANDLE_FLAGS_O | TPM2_HANDLE_FLAGS_P) ?

--- a/tools/tpm2_nvsetbits.c
+++ b/tools/tpm2_nvsetbits.c
@@ -115,6 +115,13 @@ static tool_rc process_inputs(ESYS_CONTEXT *ectx) {
     /* Object #1 */
     tool_rc rc = tool_rc_success;
     if (ctx.is_tcti_none) {
+        /*
+         * Cannot use tpm2_util_object_load like in nvdefine as it makes a call
+         * to tpm2_util_sys_handle_to_esys_handle which then tries to read the
+         * ESYS_TR object off of the TPM expecting it to be there.
+         * Note: this if it is a permanent handle ESYS_TR is fixed and so the
+         * TPM is not probed even with tpm2_util_sys_handle_to_esys_handle.
+         */
         rc = tpm2_util_handle_from_optarg(ctx.auth_hierarchy.ctx_path,
             &ctx.auth_hierarchy.object.handle,
             TPM2_HANDLE_FLAGS_NV | TPM2_HANDLE_FLAGS_O | TPM2_HANDLE_FLAGS_P) ?

--- a/tools/tpm2_nvwrite.c
+++ b/tools/tpm2_nvwrite.c
@@ -173,6 +173,13 @@ static tool_rc process_inputs(ESYS_CONTEXT *ectx) {
      */
     tool_rc rc = tool_rc_success;
     if (ctx.is_tcti_none) {
+        /*
+         * Cannot use tpm2_util_object_load like in nvdefine as it makes a call
+         * to tpm2_util_sys_handle_to_esys_handle which then tries to read the
+         * ESYS_TR object off of the TPM expecting it to be there.
+         * Note: this if it is a permanent handle ESYS_TR is fixed and so the
+         * TPM is not probed even with tpm2_util_sys_handle_to_esys_handle.
+         */
         rc = tpm2_util_handle_from_optarg(ctx.auth_hierarchy.ctx_path,
             &ctx.auth_hierarchy.object.handle,
             TPM2_HANDLE_FLAGS_NV | TPM2_HANDLE_FLAGS_O | TPM2_HANDLE_FLAGS_P) ?

--- a/tools/tpm2_nvwritelock.c
+++ b/tools/tpm2_nvwritelock.c
@@ -123,12 +123,19 @@ static tool_rc process_inputs(ESYS_CONTEXT *ectx) {
 
     tool_rc rc = tool_rc_success;
     if (ctx.is_tcti_none) {
+        /*
+         * Cannot use tpm2_util_object_load like in nvdefine as it makes a call
+         * to tpm2_util_sys_handle_to_esys_handle which then tries to read the
+         * ESYS_TR object off of the TPM expecting it to be there.
+         * Note: this if it is a permanent handle ESYS_TR is fixed and so the
+         * TPM is not probed even with tpm2_util_sys_handle_to_esys_handle.
+         */
          rc = tpm2_util_handle_from_optarg(ctx.auth_hierarchy.ctx_path,
              &ctx.auth_hierarchy.object.handle, valid_handles) ?
              tool_rc_success : tool_rc_option_error;
 
          ctx.auth_hierarchy.object.tr_handle = (rc == tool_rc_success) ?
-            tpm2_tpmi_hierarchy_to_esys_tr(ctx.auth_hierarchy.object.handle) : 0;
+           tpm2_tpmi_hierarchy_to_esys_tr(ctx.auth_hierarchy.object.handle) : 0;
      } else {
          rc = tpm2_util_object_load_auth(ectx, ctx.auth_hierarchy.ctx_path,
              ctx.auth_hierarchy.auth_str, &ctx.auth_hierarchy.object, false,


### PR DESCRIPTION
Signed-off-by: Imran Desai <imran.desai@intel.com>