### PR TITLE
tools/tpm2_nvread: fix reads > TPM2_PT_NV_BUFFER_MAX with policy session

### DIFF
--- a/lib/tpm2_nv_util.h
+++ b/lib/tpm2_nv_util.h
@@ -228,7 +228,18 @@ static inline tool_rc tpm2_util_nv_read(ESYS_CONTEXT *ectx,
         "Make seperate tpm2_nvread calls with proper offsets specified to "
         "specify all NV index data to be read");
 
-        rc =-tool_rc_option_error;
+        rc = tool_rc_option_error;
+        goto out;
+    }
+
+    bool is_auth_a_policy_session = is_nvread_dispatched &&
+        tpm2_session_get_type(auth_hierarchy_obj->session) == TPM2_SE_POLICY;
+    if (is_auth_a_policy_session && is_nv_index_data_larger_than_max_read) {
+        LOG_ERR("Cannot continue as the policy auth session must be "
+                "reinstantiated for multiple iterations of NV read. "
+                "Specify a max read size of %lu or specify an offset and max "
+                "read size of %lu", max_data_size, max_data_size);
+        rc = tool_rc_option_error;
         goto out;
     }
 

--- a/tools/tpm2_nvwrite.c
+++ b/tools/tpm2_nvwrite.c
@@ -198,6 +198,16 @@ static tool_rc process_inputs(ESYS_CONTEXT *ectx) {
         return rc;
     }
 
+    bool is_auth_a_policy_session = ctx.is_command_dispatch &&
+    tpm2_session_get_type(ctx.auth_hierarchy.object.session) == TPM2_SE_POLICY;
+    if (is_auth_a_policy_session && ctx.data_size > ctx.max_data_size) {
+         LOG_ERR("Cannot continue as the policy auth session must be "
+                 "reinstantiated for multiple iterations of NV write. "
+                 "Specify a max write size of %lu or specify an offset and max "
+                 "write size of %lu", ctx.max_data_size, ctx.max_data_size);
+         return tool_rc_option_error;
+    }
+
     /*
      * 2. Restore auxiliary sessions
      */


### PR DESCRIPTION
Fixes #2875

Policy authorization session must be re-instantiated on multiple
iterations of nv read if the read size exceeds the allowed operating
size. To avoid this, only a single iteration is allowed when using
policy authorization session.

Re-instantiation is avoided because compounded policies are not
possible to be replayed to arrive at the same policy digest.

Signed-off-by: Imran Desai <imran.desai@intel.com>