### PR TITLE
Use %u instead of %lu format specifier for uint16

### DIFF
--- a/lib/tpm2_nv_util.h
+++ b/lib/tpm2_nv_util.h
@@ -237,8 +237,8 @@ static inline tool_rc tpm2_util_nv_read(ESYS_CONTEXT *ectx,
     if (is_auth_a_policy_session && is_nv_index_data_larger_than_max_read) {
         LOG_ERR("Cannot continue as the policy auth session must be "
                 "reinstantiated for multiple iterations of NV read. "
-                "Specify a max read size of %lu or specify an offset and max "
-                "read size of %lu", max_data_size, max_data_size);
+                "Specify a max read size of %u or specify an offset and max "
+                "read size of %u", max_data_size, max_data_size);
         rc = tool_rc_option_error;
         goto out;
     }

--- a/tools/tpm2_nvwrite.c
+++ b/tools/tpm2_nvwrite.c
@@ -203,8 +203,8 @@ static tool_rc process_inputs(ESYS_CONTEXT *ectx) {
     if (is_auth_a_policy_session && ctx.data_size > ctx.max_data_size) {
          LOG_ERR("Cannot continue as the policy auth session must be "
                  "reinstantiated for multiple iterations of NV write. "
-                 "Specify a max write size of %lu or specify an offset and max "
-                 "write size of %lu", ctx.max_data_size, ctx.max_data_size);
+                 "Specify a max write size of %u or specify an offset and max "
+                 "write size of %u", ctx.max_data_size, ctx.max_data_size);
          return tool_rc_option_error;
     }
 


### PR DESCRIPTION
`max_data_size` is uint16, therefore GCC 11.1.0 gives warnings/errors like
```
./lib/tpm2_nv_util.h: In function ‘tpm2_util_nv_read’:
./lib/tpm2_nv_util.h:238:17: error: format ‘%lu’ expects argument of type ‘long unsigned int’, but argument 5 has type ‘int’ [-Werror=format=]
  238 |         LOG_ERR("Cannot continue as the policy auth session must be "
      |                 ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
......
  241 |                 "read size of %lu", max_data_size, max_data_size);
      |                                     ~~~~~~~~~~~~~
      |                                     |
      |                                     int
```