### PR TITLE
tpm2_createek/tpm2_createak: Support alternative ECC curves

### DIFF
--- a/lib/tpm2_alg_util.c
+++ b/lib/tpm2_alg_util.c
@@ -700,6 +700,16 @@ const char *tpm2_alg_util_algtostr(TPM2_ALG_ID id, tpm2_alg_util_flags flags) {
     return userdata.name;
 }
 
+const char *tpm2_alg_util_numtoalgstr(const char *str, tpm2_alg_util_flags flags) {
+    TPM2_ALG_ID alg_id;
+
+    if (tpm2_util_string_to_uint16(str, &alg_id)) {
+        return tpm2_alg_util_algtostr(alg_id, flags);
+    } else {
+        return str;
+    }
+}
+
 tpm2_alg_util_flags tpm2_alg_util_algtoflags(TPM2_ALG_ID id) {
 
     alg_pair userdata = { .name = NULL, .id = id, .flags =

--- a/lib/tpm2_alg_util.h
+++ b/lib/tpm2_alg_util.h
@@ -46,6 +46,16 @@ TPM2_ALG_ID tpm2_alg_util_strtoalg(const char *name, tpm2_alg_util_flags flags);
 const char *tpm2_alg_util_algtostr(TPM2_ALG_ID id, tpm2_alg_util_flags flags);
 
 /**
+ * If the input is a numerical string then convert it to a nice-name.
+ * Otherwise return the unmodified nice-name.
+ * @param str
+ *  The numerical string to convert.
+ * @return
+ *  The nice-name.
+ */
+const char *tpm2_alg_util_numtoalgstr(const char* str, tpm2_alg_util_flags flags);
+
+/**
  * XXX DOC AND TESTME
  * @param id
  * @return

--- a/lib/tpm2_alg_util.h
+++ b/lib/tpm2_alg_util.h
@@ -185,8 +185,9 @@ tool_rc tpm2_alg_util_handle_rsa_ext_alg(const char *alg_spec,
  * @param public
  * @return
  */
-tool_rc tpm2_alg_util_public_init(char *alg_details, char *name_halg, char *attrs,
-        char *auth_policy,  TPMA_OBJECT def_attrs, TPM2B_PUBLIC *public);
+tool_rc tpm2_alg_util_public_init(const char *alg_details, const char *name_halg,
+        char *attrs, char *auth_policy,  TPMA_OBJECT def_attrs,
+        TPM2B_PUBLIC *public);
 
 /**
  * Returns an ECC curve as a friendly name.

--- a/man/common/alg.md
+++ b/man/common/alg.md
@@ -71,14 +71,16 @@ general format for specifying this data:
   * aes192`<mode>` - Same as aes128`<mode>`, except for a 192 bit key size.
   * aes256`<mode>` - Same as aes128`<mode>`, except for a 256 bit key size.
   * ecc - Elliptical Curve, defaults to ecc256.
-  * ecc192 - 192 bit ECC
-  * ecc224 - 224 bit ECC
-  * ecc256 - 256 bit ECC
-  * ecc384 - 384 bit ECC
-  * ecc521 - 521 bit ECC
+  * ecc192 or ecc_nist_p192 - 192 bit ECC NIST curve
+  * ecc224 or ecc_nist_p224 - 224 bit ECC NIST curve
+  * ecc256 or ecc_nist_p256 - 256 bit ECC NIST curve
+  * ecc384 or ecc_nist_p384 - 384 bit ECC NIST curve
+  * ecc521 or ecc_nist_p521 - 521 bit ECC NIST curve
+  * ecc_sm2 or ecc_sm2_p256 - 256 bit SM2 curve
   * rsa - Default RSA: rsa2048
   * rsa1024 - RSA with 1024 bit keysize.
   * rsa2048 - RSA with 2048 bit keysize.
+  * rsa3072 - RSA with 3072 bit keysize.
   * rsa4096 - RSA with 4096 bit keysize.
 
 ### Scheme Specifiers

--- a/man/tpm2_createak.1.md
+++ b/man/tpm2_createak.1.md
@@ -43,9 +43,10 @@ loaded-key:
   * **-G**, **\--key-algorithm**=_ALGORITHM_:
 
     Specifies the attestation key algorithm. Supports:
-    * ecc - An P256 key.
-    * rsa - An RSA2048 key.
-    * keyedhash - hmac key.
+    * **ecc** - A NIST_P256 key by default. Alternative curves can be selected
+      using algorithm specifiers (e.g. **ecc384** or **ecc_nist_p384**) .
+    * **rsa** - An RSA2048 key.
+    * **keyedhash** - hmac key.
 
   * **-g**, **\--hash-algorithm**=_ALGORITHM_:
 

--- a/man/tpm2_createek.1.md
+++ b/man/tpm2_createek.1.md
@@ -42,7 +42,8 @@ Refer to:
   * **-G**, **\--key-algorithm**=_ALGORITHM_:
 
     The endorsement key algorithm. Supports:
-    * **ecc** - An P256 key.
+    * **ecc** - A NIST_P256 key by default. Alternative curves can be selected
+      using algorithm specifiers (e.g. **ecc384** or **ecc_nist_p384**) .
     * **rsa** - An RSA2048 key.
     * **keyedhash** - hmac key.
 
@@ -81,9 +82,14 @@ the various known TCTI modules.
 
 # EXAMPLES
 
-### Create an Endorsement Key and make it persistent
+### Create an RSA Endorsement Key and make it persistent
 ```bash
 tpm2_createek -P abc123 -w abc123 -c 0x81010001 -G rsa -u ek.pub
+```
+
+### Create an ECC NIST_P384 Endorsement Key and make it persistent
+```bash
+tpm2_createek -G ecc384 -c 0x81010002
 ```
 
 ### Create a transient Endorsement Key, flush it, and reload it.

--- a/tools/tpm2_createak.c
+++ b/tools/tpm2_createak.c
@@ -407,46 +407,32 @@ out_session:
 
 static bool on_option(char key, char *value) {
 
-    TPM2_ALG_ID alg_id;
-
     switch (key) {
     case 'C':
         ctx.ek.ctx_arg = value;
         break;
     case 'G':
-        if (tpm2_util_string_to_uint16(value, &alg_id)) {
-            ctx.ak.in.alg.type = tpm2_alg_util_algtostr(alg_id,
-                            tpm2_alg_util_flags_base);
-            if (!ctx.ak.in.alg.type) {
-                LOG_ERR("Could not convert key algorithm, got \"%s\"", value);
-                return false;
-            }
-        } else {
-            ctx.ak.in.alg.type = value;
+        ctx.ak.in.alg.type = tpm2_alg_util_numtoalgstr(value,
+                                 tpm2_alg_util_flags_base);
+        if (!ctx.ak.in.alg.type) {
+            LOG_ERR("Could not convert key algorithm, got \"%s\"", value);
+            return false;
         }
         break;
     case 'g':
-        if (tpm2_util_string_to_uint16(value, &alg_id)) {
-            ctx.ak.in.alg.digest = tpm2_alg_util_algtostr(alg_id,
-                            tpm2_alg_util_flags_hash);
-            if (!ctx.ak.in.alg.digest) {
-                LOG_ERR("Could not convert digest algorithm, got \"%s\"", value);
-                return false;
-            }
-        } else {
-            ctx.ak.in.alg.digest = value;
+        ctx.ak.in.alg.digest = tpm2_alg_util_numtoalgstr(value,
+                                tpm2_alg_util_flags_hash);
+        if (!ctx.ak.in.alg.digest) {
+            LOG_ERR("Could not convert digest algorithm, got \"%s\"", value);
+            return false;
         }
         break;
     case 's':
-        if (tpm2_util_string_to_uint16(value, &alg_id)) {
-            ctx.ak.in.alg.sign = tpm2_alg_util_algtostr(alg_id,
-                            tpm2_alg_util_flags_sig);
-            if (!ctx.ak.in.alg.sign) {
-                LOG_ERR("Could not convert signing algorithm, got \"%s\"", value);
-                return false;
-            }
-        } else {
-            ctx.ak.in.alg.sign = value;
+         ctx.ak.in.alg.sign = tpm2_alg_util_numtoalgstr(value,
+                                tpm2_alg_util_flags_sig);
+        if (!ctx.ak.in.alg.sign) {
+            LOG_ERR("Could not convert signing algorithm, got \"%s\"", value);
+            return false;
         }
         break;
     case 'P':

--- a/tools/tpm2_createak.c
+++ b/tools/tpm2_createak.c
@@ -2,14 +2,85 @@
 
 #include <stdbool.h>
 #include <stdlib.h>
+#include <string.h>
 
 #include "files.h"
 #include "log.h"
 #include "object.h"
+#include "tpm2.h"
 #include "tpm2_alg_util.h"
 #include "tpm2_auth_util.h"
 #include "tpm2_convert.h"
 #include "tpm2_tool.h"
+
+#define ATTRS  \
+    TPMA_OBJECT_RESTRICTED|TPMA_OBJECT_USERWITHAUTH| \
+    TPMA_OBJECT_SIGN_ENCRYPT|TPMA_OBJECT_FIXEDTPM| \
+    TPMA_OBJECT_FIXEDPARENT|TPMA_OBJECT_SENSITIVEDATAORIGIN
+
+/* Templates from TCG EK Credential Profile TPM 2.0, Version 2.4 Rev. 3, 2021 */
+
+static const TPM2B_DIGEST policy_a_sha384 = {
+    .size = 48,
+    .buffer = {
+        0x8b, 0xbf, 0x22, 0x66, 0x53, 0x7c, 0x17, 0x1c, 0xb5, 0x6e,
+        0x40, 0x3c, 0x4d, 0xc1, 0xd4, 0xb6, 0x4f, 0x43, 0x26, 0x11,
+        0xdc, 0x38, 0x6e, 0x6f, 0x53, 0x20, 0x50, 0xc3, 0x27, 0x8c,
+        0x93, 0x0e, 0x14, 0x3e, 0x8b, 0xb1, 0x13, 0x38, 0x24, 0xcc,
+        0xb4, 0x31, 0x05, 0x38, 0x71, 0xc6, 0xdb, 0x53 }
+};
+
+static const TPM2B_DIGEST policy_a_sha512 = {
+    .size = 64,
+    .buffer = {
+        0x1e, 0x3b, 0x76, 0x50, 0x2c, 0x8a, 0x14, 0x25, 0xaa, 0x0b,
+        0x7b, 0x3f, 0xc6, 0x46, 0xa1, 0xb0, 0xfa, 0xe0, 0x63, 0xb0,
+        0x3b, 0x53, 0x68, 0xf9, 0xc4, 0xcd, 0xde, 0xca, 0xff, 0x08,
+        0x91, 0xdd, 0x68, 0x2b, 0xac, 0x1a, 0x85, 0xd4, 0xd8, 0x32,
+        0xb7, 0x81, 0xea, 0x45, 0x19, 0x15, 0xde, 0x5f, 0xc5, 0xbf,
+        0x0d, 0xc4, 0xa1, 0x91, 0x7c, 0xd4, 0x2f, 0xa0, 0x41, 0xe3,
+        0xf9, 0x98, 0xe0, 0xee }
+};
+
+static const TPM2B_DIGEST policy_a_sm3_256 = {
+    .size = 32,
+    .buffer = {
+        0xc6, 0x7f, 0x7d, 0x35, 0xf6, 0x6f, 0x3b, 0xec, 0x13, 0xc8,
+        0x9f, 0xe8, 0x98, 0x92, 0x1c, 0x65, 0x1b, 0x0c, 0xb5, 0xa3,
+        0x8a, 0x92, 0x69, 0x0a, 0x62, 0xa4, 0x3c, 0x00, 0x12, 0xe4,
+        0xfb, 0x8b }
+};
+
+static const TPM2B_DIGEST policy_c_sha384 = {
+    .size = 48,
+    .buffer = {
+        0xd6, 0x03, 0x2c, 0xe6, 0x1f, 0x2f, 0xb3, 0xc2, 0x40, 0xeb,
+        0x3c, 0xf6, 0xa3, 0x32, 0x37, 0xef, 0x2b, 0x6a, 0x16, 0xf4,
+        0x29, 0x3c, 0x22, 0xb4, 0x55, 0xe2, 0x61, 0xcf, 0xfd, 0x21,
+        0x7a, 0xd5, 0xb4, 0x94, 0x7c, 0x2d, 0x73, 0xe6, 0x30, 0x05,
+        0xee, 0xd2, 0xdc, 0x2b, 0x35, 0x93, 0xd1, 0x65 }
+};
+
+static const TPM2B_DIGEST policy_c_sha512 = {
+    .size = 64,
+    .buffer = {
+        0x58, 0x9e, 0xe1, 0xe1, 0x46, 0x54, 0x47, 0x16, 0xe8, 0xde,
+        0xaf, 0xe6, 0xdb, 0x24, 0x7b, 0x01, 0xb8, 0x1e, 0x9f, 0x9c,
+        0x7d, 0xd1, 0x6b, 0x81, 0x4a, 0xa1, 0x59, 0x13, 0x87, 0x49,
+        0x10, 0x5f, 0xba, 0x53, 0x88, 0xdd, 0x1d, 0xea, 0x70, 0x2f,
+        0x35, 0x24, 0x0c, 0x18, 0x49, 0x33, 0x12, 0x1e, 0x2c, 0x61,
+        0xb8, 0xf5, 0x0d, 0x3e, 0xf9, 0x13, 0x93, 0xa4, 0x9a, 0x38,
+        0xc3, 0xf7, 0x3f, 0xc8 }
+};
+
+static const TPM2B_DIGEST policy_c_sm3_256 = {
+    .size = 32,
+    .buffer = {
+        0x2d, 0x4e, 0x81, 0x57, 0x8c, 0x35, 0x31, 0xd9, 0xbd, 0x1c,
+        0xdd, 0x7d, 0x02, 0xba, 0x29, 0x8d, 0x56, 0x99, 0xa3, 0xe3,
+        0x9f, 0xc3, 0x55, 0x1b, 0xfe, 0xff, 0xcf, 0x13, 0x2b, 0x49,
+        0xe1, 0x1d }
+};
 
 typedef struct createak_context createak_context;
 struct createak_context {
@@ -23,9 +94,9 @@ struct createak_context {
         struct {
             TPM2B_SENSITIVE_CREATE in_sensitive;
             struct {
-                TPM2_ALG_ID type;
-                TPM2_ALG_ID digest;
-                TPM2_ALG_ID sign;
+                const char *type;
+                const char *digest;
+                const char *sign;
             } alg;
         } in;
         struct {
@@ -47,9 +118,9 @@ static createak_context ctx = {
     .ak = {
         .in = {
             .alg = {
-                .type = TPM2_ALG_RSA,
-                .digest = TPM2_ALG_SHA256,
-                .sign = TPM2_ALG_NULL
+                .type = "rsa2048",
+                .digest = "sha256",
+                .sign = "null"
             },
         },
         .out = {
@@ -59,131 +130,34 @@ static createak_context ctx = {
     .flags = { 0 },
 };
 
-/*
- * TODO: All these set_xxx_signing_algorithm() routines could likely somehow be refactored into one.
- */
-static bool set_rsa_signing_algorithm(UINT32 sign_alg, UINT32 digest_alg,
-        TPM2B_PUBLIC *in_public) {
+static tool_rc init_ak_public(TPMI_ALG_HASH name_alg, TPM2B_PUBLIC *public) {
 
-    if (sign_alg == TPM2_ALG_NULL) {
-        sign_alg = TPM2_ALG_RSASSA;
+    const char *name_halg;
+    char alg[256];
+
+    name_halg = tpm2_alg_util_algtostr(name_alg, tpm2_alg_util_flags_hash);
+
+    if (!strcmp(ctx.ak.in.alg.sign, "null")) {
+        if (!strncmp(ctx.ak.in.alg.type, "rsa", 3)) {
+            ctx.ak.in.alg.sign = "rsassa";
+        } else if (!strncmp(ctx.ak.in.alg.type, "ecc", 3)) {
+            ctx.ak.in.alg.sign = "ecdsa";
+        }
     }
-
-    in_public->publicArea.parameters.rsaDetail.scheme.scheme = sign_alg;
-    switch (sign_alg) {
-    case TPM2_ALG_RSASSA:
-    case TPM2_ALG_RSAPSS:
-        in_public->publicArea.parameters.rsaDetail.scheme.details.anySig.hashAlg =
-                digest_alg;
-        break;
-    default:
-        LOG_ERR("The RSA signing algorithm type input(%4.4x) is not supported!",
-                sign_alg);
-        return false;
+    if (!strcmp(ctx.ak.in.alg.type, "keyedhash"))
+    {
+        ctx.ak.in.alg.type = "hmac";
     }
+    if (!strcmp(ctx.ak.in.alg.type, "hmac"))
+    {
+        snprintf(alg, sizeof(alg), "%s:%s", ctx.ak.in.alg.type,
+            ctx.ak.in.alg.digest);
 
-    return true;
-}
-
-static bool set_ecc_signing_algorithm(UINT32 sign_alg, UINT32 digest_alg,
-        TPM2B_PUBLIC *in_public) {
-
-    if (sign_alg == TPM2_ALG_NULL) {
-        sign_alg = TPM2_ALG_ECDSA;
+    } else {
+        snprintf(alg, sizeof(alg), "%s:%s-%s:null", ctx.ak.in.alg.type,
+        ctx.ak.in.alg.sign, ctx.ak.in.alg.digest);
     }
-
-    in_public->publicArea.parameters.eccDetail.scheme.scheme = sign_alg;
-    switch (sign_alg) {
-    case TPM2_ALG_ECDSA:
-    case TPM2_ALG_SM2:
-    case TPM2_ALG_ECSCHNORR:
-    case TPM2_ALG_ECDAA:
-        in_public->publicArea.parameters.eccDetail.scheme.details.anySig.hashAlg =
-                digest_alg;
-        break;
-    default:
-        LOG_ERR("The ECC signing algorithm type input(%4.4x) is not supported!",
-                sign_alg);
-        return false;
-    }
-
-    return true;
-}
-
-static bool set_keyed_hash_signing_algorithm(UINT32 sign_alg, UINT32 digest_alg,
-        TPM2B_PUBLIC *in_public) {
-
-    if (sign_alg == TPM2_ALG_NULL) {
-        sign_alg = TPM2_ALG_HMAC;
-    }
-
-    in_public->publicArea.parameters.keyedHashDetail.scheme.scheme = sign_alg;
-    switch (sign_alg) {
-    case TPM2_ALG_HMAC:
-        in_public->publicArea.parameters.keyedHashDetail.scheme.details.hmac.hashAlg =
-                digest_alg;
-        break;
-    default:
-        LOG_ERR(
-                "The Keyedhash signing algorithm type input(%4.4x) is not supported!",
-                sign_alg);
-        return false;
-    }
-
-    return true;
-}
-
-static bool set_key_algorithm(TPM2B_PUBLIC *in_public) {
-    in_public->publicArea.nameAlg = TPM2_ALG_SHA256;
-    // First clear attributes bit field.
-    in_public->publicArea.objectAttributes = 0;
-    in_public->publicArea.objectAttributes |= TPMA_OBJECT_RESTRICTED;
-    in_public->publicArea.objectAttributes |= TPMA_OBJECT_USERWITHAUTH;
-    in_public->publicArea.objectAttributes |= TPMA_OBJECT_SIGN_ENCRYPT;
-    in_public->publicArea.objectAttributes &= ~TPMA_OBJECT_DECRYPT;
-    in_public->publicArea.objectAttributes |= TPMA_OBJECT_FIXEDTPM;
-    in_public->publicArea.objectAttributes |= TPMA_OBJECT_FIXEDPARENT;
-    in_public->publicArea.objectAttributes |= TPMA_OBJECT_SENSITIVEDATAORIGIN;
-    in_public->publicArea.authPolicy.size = 0;
-
-    in_public->publicArea.type = ctx.ak.in.alg.type;
-
-    switch (ctx.ak.in.alg.type) {
-    case TPM2_ALG_RSA:
-        in_public->publicArea.parameters.rsaDetail.symmetric.algorithm =
-                TPM2_ALG_NULL;
-        in_public->publicArea.parameters.rsaDetail.symmetric.keyBits.aes = 0;
-        in_public->publicArea.parameters.rsaDetail.symmetric.mode.aes =
-                TPM2_ALG_NULL;
-        in_public->publicArea.parameters.rsaDetail.keyBits = 2048;
-        in_public->publicArea.parameters.rsaDetail.exponent = 0;
-        in_public->publicArea.unique.rsa.size = 0;
-        return set_rsa_signing_algorithm(ctx.ak.in.alg.sign,
-                ctx.ak.in.alg.digest, in_public);
-    case TPM2_ALG_ECC:
-        in_public->publicArea.parameters.eccDetail.symmetric.algorithm =
-                TPM2_ALG_NULL;
-        in_public->publicArea.parameters.eccDetail.symmetric.mode.sym =
-                TPM2_ALG_NULL;
-        in_public->publicArea.parameters.eccDetail.symmetric.keyBits.sym = 0;
-        in_public->publicArea.parameters.eccDetail.curveID = TPM2_ECC_NIST_P256;
-        in_public->publicArea.parameters.eccDetail.kdf.scheme = TPM2_ALG_NULL;
-        in_public->publicArea.unique.ecc.x.size = 0;
-        in_public->publicArea.unique.ecc.y.size = 0;
-        return set_ecc_signing_algorithm(ctx.ak.in.alg.sign,
-                ctx.ak.in.alg.digest, in_public);
-    case TPM2_ALG_KEYEDHASH:
-        in_public->publicArea.unique.keyedHash.size = 0;
-        return set_keyed_hash_signing_algorithm(ctx.ak.in.alg.sign,
-                ctx.ak.in.alg.digest, in_public);
-    case TPM2_ALG_SYMCIPHER:
-    default:
-        LOG_ERR("The algorithm type input(%4.4x) is not supported!",
-                ctx.ak.in.alg.type);
-        return false;
-    }
-
-    return true;
+    return tpm2_alg_util_public_init(alg, name_halg, NULL, NULL, ATTRS, public);
 }
 
 static tool_rc create_ak(ESYS_CONTEXT *ectx) {
@@ -192,13 +166,44 @@ static tool_rc create_ak(ESYS_CONTEXT *ectx) {
 
     TPML_PCR_SELECTION creation_pcr = { .count = 0 };
     TPM2B_DATA outside_info = TPM2B_EMPTY_INIT;
-    TPM2B_PUBLIC *out_public;
+    TPM2B_PUBLIC *ek_public, *out_public;
     TPM2B_PRIVATE *out_private;
-    TPM2B_PUBLIC in_public = TPM2B_EMPTY_INIT;
+    TPM2B_PUBLIC in_public;
+    TPMI_ALG_HASH ek_name_alg;
+    TPML_DIGEST pHashList = { .count = 2 };
 
-    bool result = set_key_algorithm(&in_public);
-    if (!result) {
-        return tool_rc_general_error;
+    /* get the nameAlg of the EK */
+    tool_rc tmp_rc = tpm2_readpublic(ectx, ctx.ek.ek_ctx.tr_handle, &ek_public,
+            NULL, NULL);
+    if (tmp_rc != tool_rc_success) {
+        return tmp_rc;
+    }
+    ek_name_alg = ek_public->publicArea.nameAlg;
+    free(ek_public);
+
+    /* select the matching EK templates */
+    switch (ek_name_alg) {
+    case TPM2_ALG_SHA384:
+        pHashList.digests[0] = policy_a_sha384;
+        pHashList.digests[1] = policy_c_sha384;
+        break;
+    case TPM2_ALG_SHA512:
+        pHashList.digests[0] = policy_a_sha512;
+        pHashList.digests[1] = policy_c_sha512;
+        break;
+    case TPM2_ALG_SM3_256:
+        pHashList.digests[0] = policy_a_sm3_256;
+        pHashList.digests[1] = policy_c_sm3_256;
+        break;
+    case TPM2_ALG_SHA256:
+    default:
+        pHashList.count = 0;
+        break;
+    }
+
+    tmp_rc = init_ak_public(ek_name_alg, &in_public);
+    if (tmp_rc != tool_rc_success) {
+        return tmp_rc;
     }
 
     tpm2_session_data *data = tpm2_session_data_new(TPM2_SE_POLICY);
@@ -206,9 +211,10 @@ static tool_rc create_ak(ESYS_CONTEXT *ectx) {
         LOG_ERR("oom");
         return tool_rc_general_error;
     }
+    tpm2_session_set_authhash(data, ek_name_alg);
 
     tpm2_session *session = NULL;
-    tool_rc tmp_rc = tpm2_session_open(ectx, data, &session);
+    tmp_rc = tpm2_session_open(ectx, data, &session);
     if (tmp_rc != tool_rc_success) {
         LOG_ERR("Could not start tpm session");
         return tmp_rc;
@@ -236,6 +242,15 @@ static tool_rc create_ak(ESYS_CONTEXT *ectx) {
 
     LOG_INFO("Esys_PolicySecret success");
 
+    if (pHashList.count > 1) {
+        rval = Esys_PolicyOR(ectx, sess_handle, ESYS_TR_NONE, ESYS_TR_NONE,
+                ESYS_TR_NONE, &pHashList);
+        if (rval != TPM2_RC_SUCCESS) {
+            LOG_PERR(Esys_PolicyOR, rval);
+            goto out_session;
+        }
+    }
+
     TPM2B_CREATION_DATA *creation_data = NULL;
     rval = Esys_Create(ectx, ctx.ek.ek_ctx.tr_handle, sess_handle, ESYS_TR_NONE,
             ESYS_TR_NONE, &ctx.ak.in.in_sensitive, &in_public, &outside_info,
@@ -256,6 +271,7 @@ static tool_rc create_ak(ESYS_CONTEXT *ectx) {
         LOG_ERR("oom");
         goto out;
     }
+    tpm2_session_set_authhash(data, ek_name_alg);
 
     tmp_rc = tpm2_session_open(ectx, data, &session);
     if (tmp_rc != tool_rc_success) {
@@ -282,6 +298,15 @@ static tool_rc create_ak(ESYS_CONTEXT *ectx) {
         goto out;
     }
     LOG_INFO("Esys_PolicySecret success");
+
+    if (pHashList.count > 1) {
+        rval = Esys_PolicyOR(ectx, sess_handle, ESYS_TR_NONE, ESYS_TR_NONE,
+                ESYS_TR_NONE, &pHashList);
+        if (rval != TPM2_RC_SUCCESS) {
+            LOG_PERR(Esys_PolicyOR, rval);
+            goto out;
+        }
+    }
 
     ESYS_TR loaded_sha1_key_handle;
     rval = Esys_Load(ectx, ctx.ek.ek_ctx.tr_handle, sess_handle, ESYS_TR_NONE,
@@ -326,19 +351,17 @@ static tool_rc create_ak(ESYS_CONTEXT *ectx) {
 
     // write name to ak.name file
     if (ctx.ak.out.name_file) {
-        result = files_save_bytes_to_file(ctx.ak.out.name_file, key_name->name,
-                key_name->size);
-        if (!result) {
-            LOG_ERR("Failed to save AK name into file \"%s\"",
+        if (!files_save_bytes_to_file(ctx.ak.out.name_file, key_name->name,
+                key_name->size)) {
+             LOG_ERR("Failed to save AK name into file \"%s\"",
                     ctx.ak.out.name_file);
             goto nameout;
         }
     }
 
     if (ctx.ak.out.qname_file) {
-        result = files_save_bytes_to_file(ctx.ak.out.qname_file, qname.name,
-                qname.size);
-        if (!result) {
+        if (!files_save_bytes_to_file(ctx.ak.out.qname_file, qname.name,
+                qname.size)) {
             LOG_ERR("Failed to save AK qualified name into file \"%s\"",
                     ctx.ak.out.name_file);
             goto nameout;
@@ -356,16 +379,14 @@ static tool_rc create_ak(ESYS_CONTEXT *ectx) {
     }
 
     if (ctx.ak.out.pub_file) {
-        result = tpm2_convert_pubkey_save(out_public, ctx.ak.out.pub_fmt,
-                ctx.ak.out.pub_file);
-        if (!result) {
+        if (!tpm2_convert_pubkey_save(out_public, ctx.ak.out.pub_fmt,
+                ctx.ak.out.pub_file)) {
             goto nameout;
         }
     }
 
     if (ctx.ak.out.priv_file) {
-        result = files_save_private(out_private, ctx.ak.out.priv_file);
-        if (!result) {
+        if (!files_save_private(out_private, ctx.ak.out.priv_file)) {
             goto nameout;
         }
     }
@@ -386,32 +407,46 @@ out_session:
 
 static bool on_option(char key, char *value) {
 
+    TPM2_ALG_ID alg_id;
+
     switch (key) {
     case 'C':
         ctx.ek.ctx_arg = value;
         break;
     case 'G':
-        ctx.ak.in.alg.type = tpm2_alg_util_from_optarg(value,
-                tpm2_alg_util_flags_base);
-        if (ctx.ak.in.alg.type == TPM2_ALG_ERROR) {
-            LOG_ERR("Could not convert algorithm. got: \"%s\".", value);
-            return false;
+        if (tpm2_util_string_to_uint16(value, &alg_id)) {
+            ctx.ak.in.alg.type = tpm2_alg_util_algtostr(alg_id,
+                            tpm2_alg_util_flags_base);
+            if (!ctx.ak.in.alg.type) {
+                LOG_ERR("Could not convert key algorithm, got \"%s\"", value);
+                return false;
+            }
+        } else {
+            ctx.ak.in.alg.type = value;
         }
         break;
     case 'g':
-        ctx.ak.in.alg.digest = tpm2_alg_util_from_optarg(value,
-                tpm2_alg_util_flags_hash);
-        if (ctx.ak.in.alg.digest == TPM2_ALG_ERROR) {
-            LOG_ERR("Could not convert digest algorithm.");
-            return false;
+        if (tpm2_util_string_to_uint16(value, &alg_id)) {
+            ctx.ak.in.alg.digest = tpm2_alg_util_algtostr(alg_id,
+                            tpm2_alg_util_flags_hash);
+            if (!ctx.ak.in.alg.digest) {
+                LOG_ERR("Could not convert digest algorithm, got \"%s\"", value);
+                return false;
+            }
+        } else {
+            ctx.ak.in.alg.digest = value;
         }
         break;
     case 's':
-        ctx.ak.in.alg.sign = tpm2_alg_util_from_optarg(value,
-                tpm2_alg_util_flags_sig);
-        if (ctx.ak.in.alg.sign == TPM2_ALG_ERROR) {
-            LOG_ERR("Could not convert signing algorithm.");
-            return false;
+        if (tpm2_util_string_to_uint16(value, &alg_id)) {
+            ctx.ak.in.alg.sign = tpm2_alg_util_algtostr(alg_id,
+                            tpm2_alg_util_flags_sig);
+            if (!ctx.ak.in.alg.sign) {
+                LOG_ERR("Could not convert signing algorithm, got \"%s\"", value);
+                return false;
+            }
+        } else {
+            ctx.ak.in.alg.sign = value;
         }
         break;
     case 'P':

--- a/tools/tpm2_createek.c
+++ b/tools/tpm2_createek.c
@@ -322,17 +322,10 @@ static bool on_option(char key, char *value) {
         ctx.auth_ek.auth_str = value;
         break;
     case 'G': {
-        /* first check for numeric key_alg ID */
-        TPM2_ALG_ID algID;
-        if (tpm2_util_string_to_uint16(value, &algID)) {
-            ctx.key_alg = tpm2_alg_util_algtostr(algID,
-                            tpm2_alg_util_flags_base);
-            if (!ctx.key_alg) {
-                LOG_ERR("Invalid key algorithm, got \"%s\"", value);
-                return false;
-            }
-        } else {
-            ctx.key_alg = value;
+        ctx.key_alg = tpm2_alg_util_numtoalgstr(value, tpm2_alg_util_flags_base);
+        if (!ctx.key_alg) {
+            LOG_ERR("Invalid key algorithm, got \"%s\"", value);
+            return false;
         }
         break;
     }

--- a/tools/tpm2_createek.c
+++ b/tools/tpm2_createek.c
@@ -158,7 +158,6 @@ static const alg_map *lookup_alg_map(const char *alg) {
 }
 
 static tool_rc init_ek_public(const char *key_alg, TPM2B_PUBLIC *public) {
-
     const alg_map *m = lookup_alg_map(key_alg);
 
     if (!m) {


### PR DESCRIPTION
Newer TPM devices like the ST33HTPHAHD4 model from STMicroelectronics support **ECC NIST_P384** besides the default **ECC NIST_P256** curve.

This patch allows to create Endorsement Keys for all ECC curves for which default EK templates are defined by the **TCG EK Credential Profile Specification Version 2.1 Rev. 13** (NIST_P256, NIST_P384, NIST_P521, and SM2_P256). 

The attached file shows that the derived **ECC NIST_P384** EK key corresponds to the public key contained in the STMicroelectronics EK certificate:
[ECC_NIST_P384_EK.txt](https://github.com/tpm2-software/tpm2-tools/files/7712062/ECC_NIST_P384_EK.txt)

