### PR TITLE
ci: enable -Werror for GCC builds

### DIFF
--- a/.ci/docker.run
+++ b/.ci/docker.run
@@ -41,6 +41,8 @@ if [[ "$CC" == clang* ]]; then
     unset ASAN_SYMBOLIZER_PATH
   fi
 else #GCC
+  export CFLAGS="-Wall -Wextra -Werror"
+  echo "Exported CFLAGS=$CFLAGS"
   config_flags="--disable-hardening --enable-code-coverage"
 fi
 

--- a/tools/tpm2_nvreadpublic.c
+++ b/tools/tpm2_nvreadpublic.c
@@ -269,6 +269,8 @@ static tool_rc process_inputs(ESYS_CONTEXT *ectx) {
 
 static tool_rc check_options(ESYS_CONTEXT *ectx, tpm2_option_flags flags) {
 
+    UNUSED(ectx);
+
     ctx.is_tcti_none = flags.tcti_none ? true : false;
     if (ctx.is_tcti_none && !ctx.cp_hash_path) {
         LOG_ERR("If tcti is none, then cpHash path must be specified");


### PR DESCRIPTION
Currently `-Werror` is disabled in CI as part of `--disable-hardening` because not all containers support `-Wformat-security`. This misses some compiler warnings, so enable at least `-Wall -Wextra -Werror` through custom `CFLAGS`. See the fix in the second commit as an example for the kind of warnings/errors that are otherwise missed by CI.