### PR TITLE
tpm2_createak: use Esys_TR_GetName over ReadPublic

### DIFF
--- a/lib/tpm2_alg_util.c
+++ b/lib/tpm2_alg_util.c
@@ -1108,3 +1108,23 @@ bool tpm2_alg_util_is_aes_size_valid(UINT16 size_in_bytes) {
         return false;
     }
 }
+
+TPM2_ALG_ID tpm2_alg_util_get_name_alg(ESYS_CONTEXT *ectx, ESYS_TR handle) {
+
+    TPM2B_NAME *name = NULL;
+    TSS2_RC rc = Esys_TR_GetName(ectx, handle, &name);
+    if (rc != TSS2_RC_SUCCESS) {
+        return TPM2_ALG_ERROR;
+    }
+
+    if (name->size < 2) {
+        Esys_Free(name);
+        return TPM2_ALG_ERROR;
+    }
+
+    UINT16 *big_endian_alg = (UINT16 *)name->name;
+
+    TPM2_ALG_ID name_alg = tpm2_util_ntoh_16(*big_endian_alg);
+    Esys_Free(name);
+    return name_alg;
+}

--- a/lib/tpm2_alg_util.h
+++ b/lib/tpm2_alg_util.h
@@ -217,4 +217,17 @@ const char *tpm2_alg_util_ecc_to_str(TPM2_ECC_CURVE curve_id);
  */
 bool tpm2_alg_util_is_aes_size_valid(UINT16 size_in_bytes);
 
+/**
+ * Given an ESYS_TR handle to an object, retrieves the name algorithm
+ * without making a readpublic call.
+ *
+ * @param ectx
+ *  The ESAPI context.
+ * @param handle
+ *  The handle of the object to query.
+ * @return
+ *  The TPM2_ALG_ID name algorithm identifier or TPM2_ALG_ERROR for an error.
+ */
+TPM2_ALG_ID tpm2_alg_util_get_name_alg(ESYS_CONTEXT *ectx, ESYS_TR handle);
+
 #endif /* LIB_TPM2_ALG_UTIL_H_ */

--- a/lib/tpm2_util.h
+++ b/lib/tpm2_util.h
@@ -303,7 +303,7 @@ UINT64 tpm2_util_hton_64(UINT64 data);
 UINT16 tpm2_util_ntoh_16(UINT16 data);
 
 /**
- * Just like string_bytes_endian_ntoh_16 but for 32 bit values.
+ * Just like tpm2_util_ntoh_16 but for 32 bit values.
  */
 UINT32 tpm2_util_ntoh_32(UINT32 data);
 

--- a/tools/tpm2_createak.c
+++ b/tools/tpm2_createak.c
@@ -166,20 +166,16 @@ static tool_rc create_ak(ESYS_CONTEXT *ectx) {
 
     TPML_PCR_SELECTION creation_pcr = { .count = 0 };
     TPM2B_DATA outside_info = TPM2B_EMPTY_INIT;
-    TPM2B_PUBLIC *ek_public, *out_public;
+    TPM2B_PUBLIC *out_public;
     TPM2B_PRIVATE *out_private;
     TPM2B_PUBLIC in_public;
-    TPMI_ALG_HASH ek_name_alg;
     TPML_DIGEST pHashList = { .count = 2 };
 
     /* get the nameAlg of the EK */
-    tool_rc tmp_rc = tpm2_readpublic(ectx, ctx.ek.ek_ctx.tr_handle, &ek_public,
-            NULL, NULL);
-    if (tmp_rc != tool_rc_success) {
-        return tmp_rc;
+    TPM2_ALG_ID ek_name_alg = tpm2_alg_util_get_name_alg(ectx, ctx.ek.ek_ctx.tr_handle);
+    if (ek_name_alg == TPM2_ALG_ERROR) {
+        return tool_rc_general_error;
     }
-    ek_name_alg = ek_public->publicArea.nameAlg;
-    free(ek_public);
 
     /* select the matching EK templates */
     switch (ek_name_alg) {
@@ -201,7 +197,7 @@ static tool_rc create_ak(ESYS_CONTEXT *ectx) {
         break;
     }
 
-    tmp_rc = init_ak_public(ek_name_alg, &in_public);
+    tool_rc tmp_rc = init_ak_public(ek_name_alg, &in_public);
     if (tmp_rc != tool_rc_success) {
         return tmp_rc;
     }


### PR DESCRIPTION
Rather than going to the TPM to get the name alg for the EK via a
TPM2_ReadPublic call, just use the name as cached by ESYS. The name of
an object is the name algorithm followed by the hash itself.

Not only is this faster, but prevents a MITM from lying to use about the
EK properties as the TPM2_Readpublic was not protected with a session.

Signed-off-by: William Roberts <william.c.roberts@intel.com>