### PR TITLE
fapi: add new command to enable the use of fapi objects for tpm2 tools

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -66,6 +66,7 @@ tss2_tools = \
     tools/fapi/tss2_getplatformcertificates.c \
     tools/fapi/tss2_gettpmblobs.c \
     tools/fapi/tss2_getappdata.c \
+    tools/fapi/tss2_gettpm2object.c \
     tools/fapi/tss2_setappdata.c \
     tools/fapi/tss2_setcertificate.c \
     tools/fapi/tss2_sign.c \
@@ -483,6 +484,7 @@ dist_man1_MANS += \
     man/man1/tss2_getplatformcertificates.1 \
     man/man1/tss2_gettpmblobs.1 \
     man/man1/tss2_getappdata.1 \
+    man/man1/tss2_gettpm2object.1 \
     man/man1/tss2_setappdata.1 \
     man/man1/tss2_setcertificate.1 \
     man/man1/tss2_exportkey.1 \
@@ -589,6 +591,7 @@ dist_bashcomp_DATA+= \
     dist/bash-completion/tpm2-tools/tss2_gettpmblobs \
 	dist/bash-completion/tpm2-tools/tss2_setcertificate \
     dist/bash-completion/tpm2-tools/tss2_getappdata \
+    dist/bash-completion/tpm2-tools/tss2_gettpm2object \
     dist/bash-completion/tpm2-tools/tss2_setappdata \
 	dist/bash-completion/tpm2-tools/tss2_sign \
 	dist/bash-completion/tpm2-tools/tss2_verifysignature \

--- a/dist/bash-completion/tpm2-tools/tss2_gettpm2object
+++ b/dist/bash-completion/tpm2-tools/tss2_gettpm2object
@@ -1,0 +1,26 @@
+ bash completion for tss2_gettpm2object              -*- shell-script -*-
+
+_tss2_gettpm2object()
+{
+    local cur prev words cword split
+    _init_completion -s || return
+    case $prev in
+        -!(-*)h | --help)
+            COMPREPLY=( $(compgen -W "man no-man" -- "$cur") )
+            return;;
+        -!(-*)[c] | --context)
+            _filedir
+            if [ x"$cur" = x ]; then COMPREPLY+=( '-' ); fi
+            return;;
+        -!(-*)[p] | --path)
+            return;;
+    esac
+
+    $split && return
+
+    COMPREPLY=( $(compgen -W "-h --help -v --version --force -f -p --path= --context= -c" -- "$cur") )
+    [[ $COMPREPLY == *= ]] && compopt -o nospace
+} &&
+complete -F _tss2_gettpm2object tss2_gettpm2object
+
+# ex: filetype=sh

--- a/man/tss2_gettpm2object.1.md
+++ b/man/tss2_gettpm2object.1.md
@@ -1,0 +1,63 @@
+% tss2_gettpm2object(1) tpm2-tools | General Commands Manual
+%
+% APRIL 2019
+
+# NAME
+
+**tss2_gettpm2object**(1)
+
+# SYNOPSIS
+
+**tss2_gettpm2object** [*OPTIONS*]
+
+[common fapi references](common/tss2-fapi-references.md)
+
+# DESCRIPTION
+
+**tss2_gettpm2object**(1) -  With this command for FAPI objects context
+files which can be used by tpm2 tool commands can be created.
+For persistent object only the textual representation of the handle number as
+hex number will be written and for keys a tpm2 tool context file will
+be written.
+If the default TCTI differs from the FAPI profile the default the tcti can
+be defined with the -T (--tcti) option.
+**Note** To avoid wrong nv_written state in keystore before writing data
+to the NV ram with tpm2_nvwrite, at least an empty string should be
+written with tss2_nvwrite.
+
+# OPTIONS
+
+These are the available options:
+
+  * **-f**, **\--force**:
+
+    Force overwriting the output file.
+
+  * **-p**, **\--path**=_STRING_:
+
+    Path of the object for which the application data will be loaded.
+
+  * **-c**, **\--context**=_FILENAME_ or _-_ (for stdout):
+
+     The returned key context or handle.
+
+[common tss2 options](common/tss2-options.md)
+
+# EXAMPLES
+```
+tss2_gettpm2object --path=/HS/SRK/myRSACrypt --key-context=mykey.ctx
+tss2_gettpm2object --path=/nv/Owner/mynv -c-
+```
+The command can be used in options of tpm2 commands:
+
+```
+handle=$(tss2_gettpm2object --path=/nv/Owner/mynv -c-)
+tpm2_nvread $handle
+
+```
+
+# RETURNS
+
+0 on success or 1 on failure.
+
+[footer](common/footer.md)

--- a/test/integration/fapi/fapi-gettpm2object.sh
+++ b/test/integration/fapi/fapi-gettpm2object.sh
@@ -1,0 +1,37 @@
+
+set -e
+source helpers.sh
+
+start_up
+
+CRYPTO_PROFILE="RSA"
+setup_fapi $CRYPTO_PROFILE
+
+function cleanup {
+    tss2 delete --path=/
+    shut_down
+}
+
+trap cleanup EXIT
+
+NV_PATH=/nv/Owner/myNV
+KEY_PATH=/HS/SRK/mykey
+KEY_CONTEXT=$TEMP_DIR/mykey.ctx
+DATA_FILE=$TEMP_DIR/data.file
+NV_BLOB_FILE=$TEMP_DIR/myNV.blob
+SIGNATURE_FILE=$TEMP_DIR/signature
+
+echo -n 0123456789 > $DATA_FILE
+
+tss2 provision
+
+tss2 createkey --path=$KEY_PATH --type="noDa, sign" --authValue=""
+tss2 gettpm2object -p $KEY_PATH --context $KEY_CONTEXT
+tpm2 sign -c $KEY_CONTEXT -g sha256 -o $SIGNATURE_FILE $DATA_FILE
+tss2 delete -p $KEY_PATH
+tss2 createnv -p $NV_PATH -s 10 --authValue=""
+echo -n ""|tss2 nvwrite -p $NV_PATH -i-
+handle=$(tss2 gettpm2object -p $NV_PATH -c-)
+tpm2 nvwrite -i $DATA_FILE $handle
+
+exit 0

--- a/tools/fapi/tss2_gettpm2object.c
+++ b/tools/fapi/tss2_gettpm2object.c
@@ -1,0 +1,184 @@
+/* SPDX-License-Identifier: BSD-3-Clause */
+
+#include <errno.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+#include <tss2/tss2_tctildr.h>
+#include <tss2/tss2_esys.h>
+#include <tss2/tss2_mu.h>
+
+#include "tools/fapi/tss2_template.h"
+#include "lib/tpm2.h"
+#include "lib/files.h"
+
+/* Context struct used to store passed commandline parameters */
+static struct cxt {
+    char const *data;
+    char const *path;
+    char const *tcti;
+    bool        overwrite;
+} ctx;
+
+/* Parse commandline parameters */
+static bool on_option(char key, char *value) {
+    switch (key) {
+    case 'c':
+        ctx.data = value;
+        break;
+    case 'f':
+        ctx.overwrite = true;
+        break;
+    case 'p':
+        ctx.path = value;
+        break;
+    }
+    return true;
+}
+
+/* Define possible commandline parameters */
+static bool tss2_tool_onstart(tpm2_options **opts) {
+    struct option topts[] = {
+        {"path", required_argument, NULL, 'p'},
+        {"context",required_argument, NULL, 'c'},
+        {"force" , no_argument, NULL, 'f'},
+        {"tcti", required_argument, NULL, 'T'},
+
+    };
+    return (*opts = tpm2_options_new ("c:fp:", ARRAY_LEN(topts), topts,
+                                      on_option, NULL, 0)) != NULL;
+}
+
+/* Execute specific tool */
+static int tss2_tool_onrun (FAPI_CONTEXT *fctx) {
+    uint8_t blob_type;
+    uint8_t *esys_blob = NULL;
+    size_t esys_blob_size;
+    ESYS_CONTEXT *esys_ctx = NULL;
+    ESYS_TR esys_handle = ESYS_TR_NONE;
+    ESYS_TR esys_handle_deser = ESYS_TR_NONE;
+    FILE *stream = NULL;
+    TPM2_HANDLE tpm_handle;
+    TSS2_RC e_rc;
+    TSS2_TCTI_CONTEXT *tcti = NULL;
+    tool_rc t_rc;
+
+    /* Check availability of required parameters */
+    if (!ctx.path) {
+        fprintf (stderr, "path is missing, use --path\n");
+        return -1;
+    }
+
+    if (!ctx.data) {
+        ctx.data = "-";
+    }
+
+    /* Execute FAPI command with passed arguments */
+    TSS2_RC r = Fapi_GetEsysBlob (fctx, ctx.path, &blob_type, &esys_blob, &esys_blob_size);
+    if (r != TSS2_RC_SUCCESS) {
+        LOG_PERR ("Fapi_GetAppData", r);
+        return 1;
+    }
+
+    if (strcmp(ctx.data, "-")) {
+        if (!ctx.overwrite) {
+            FILE *fp = fopen(ctx.data, "rb");
+            if (fp) {
+                fclose(fp);
+                LOG_ERR("Path: %s already exists. Please rename or delete the file!\n",
+                ctx.data);
+                goto error;
+            }
+        }
+        stream = fopen(ctx.data, "w+b");
+        if (!stream) {
+            LOG_ERR("Could not open path \"%s\", due to error: \"%s\"", ctx.data,
+                    strerror(errno));
+            goto error;
+        }
+    } else {
+        stream = stdout;
+    }
+
+    r = Fapi_GetTcti(fctx, &tcti);
+    if (r != TSS2_RC_SUCCESS) {
+        LOG_PERR ("Fapi_GetTcti", r);
+        return 1;
+    }
+
+    e_rc = Esys_Initialize(&esys_ctx, tcti, NULL);
+  
+    if (blob_type == FAPI_ESYSBLOB_CONTEXTLOAD) {
+        size_t offset = 0;
+        TPMS_CONTEXT context;
+      
+        if (e_rc != TPM2_RC_SUCCESS) {
+            LOG_PERR("Esys_Initialize", e_rc);
+            goto error;
+        }
+         e_rc = Tss2_MU_TPMS_CONTEXT_Unmarshal(esys_blob, esys_blob_size, &offset, &context);
+         if (e_rc != TPM2_RC_SUCCESS) {
+             LOG_PERR("Tss2_MU_TPMS_CONTEXT_Unmarshal", e_rc);
+             goto error;
+         }
+         e_rc = Esys_ContextLoad(esys_ctx, &context, &esys_handle);
+         if (e_rc != TPM2_RC_SUCCESS) {
+             LOG_PERR("Esys_ContextLoad", e_rc);
+             goto error;
+         }
+         t_rc = files_save_tpm_context_to_file(esys_ctx, esys_handle, stream);
+         if (t_rc != tool_rc_success) {
+             goto error;
+         }
+         Esys_FlushContext(esys_ctx, esys_handle);
+         Esys_Finalize(&esys_ctx);
+    } else {
+        t_rc = tpm2_tr_deserialize(esys_ctx, esys_blob, esys_blob_size, &esys_handle_deser);
+        if (t_rc != tool_rc_success) {
+             goto error;
+        }
+        e_rc = Esys_TR_GetTpmHandle(esys_ctx, esys_handle_deser, &tpm_handle);
+        if (e_rc != TSS2_RC_SUCCESS) {
+            LOG_PERR("Esys_TR_GetTpmHandle", e_rc);
+            goto error;
+        }
+        int bytes_written = fprintf(stream,"0x%08x", tpm_handle);
+        if (bytes_written != 10) {
+            LOG_ERR("IO error for path \"%s\"", ctx.data);
+            goto error;
+        }
+                
+        Esys_TR_Close(esys_ctx, &esys_handle_deser);
+        Esys_Finalize(&esys_ctx);
+    }
+
+    /* Free allocated variables */
+    Fapi_Free (esys_blob);
+    if (stream && stream != stdout) {
+        fclose(stream);
+    }
+
+    return 0;
+
+ error:
+    if (stream && stream != stdout) {
+        fclose(stream);
+    }
+    Fapi_Free (esys_blob);
+    if (esys_handle != ESYS_TR_NONE) {
+        Esys_FlushContext(esys_ctx, esys_handle);
+    }
+    if (esys_handle_deser != ESYS_TR_NONE) {
+        Esys_TR_Close(esys_ctx, &esys_handle_deser);
+    }
+    if (esys_ctx) {
+        Esys_Finalize(&esys_ctx);
+    }
+    if (tcti) {
+        Tss2_TctiLdr_Finalize(&tcti);
+    }
+    return 1;
+}
+
+TSS2_TOOL_REGISTER("gettpm2object", tss2_tool_onstart, tss2_tool_onrun, NULL)


### PR DESCRIPTION
* The new command tss2_gettpm2object was added. With this command context
  files which can be used for tpm2 tool commands can be created.
* For persistent objects only the textual representation of the handle as
  hex number will be written and for keys a tpm2 tool context file will
  be written.
* Creation of a context file: tss2_gettpm2object -p /HS/SRK/mykey -c mykey.ctx
* Output of an NV index: tss2_gettpm2object -p /nv/Owner/mynv -c-
* An Integration test and a man page with examples is also added.

Signed-off-by: Juergen Repp <juergen.repp@sit.fraunhofer.de>