### PR TITLE
tools/tpm2_getekcertificate: fixed the url link to ekop.intel.com

### DIFF
--- a/test/integration/tests/getekcertificate.sh
+++ b/test/integration/tests/getekcertificate.sh
@@ -21,7 +21,7 @@ if [ -z "$(curl -V 2>/dev/null)" ]; then
     echo "curl is not not installed. Skipping connection check."
 else
     if [ "$(curl --silent --output /dev/null --write-out %{http_code} \
-    'https://ekop.intel.com/')" != '200' ]; then
+    'https://ekop.intel.com/ekcertservice/WVEG2rRwkQ7m3RpXlUphgo6Y2HLxl18h6ZZkkOAdnBE%3D')" != '200' ]; then
         echo 'No connection to https://ekop.intel.com/'
         exit 77
     fi

--- a/tools/tpm2_getekcertificate.c
+++ b/tools/tpm2_getekcertificate.c
@@ -241,7 +241,14 @@ static bool retrieve_web_endorsement_certificate(char *b64h) {
         }
     }
 
-    snprintf(weblink, len, "%s%s%s", ctx.ek_server_addr, "/", b64h);
+    bool is_slash_append_required =
+        strncmp((ctx.ek_server_addr + strlen(ctx.ek_server_addr) - 1), "/", 1);
+    if (is_slash_append_required) {
+        snprintf(weblink, len, "%s%s%s", ctx.ek_server_addr, "/", b64h);
+    } else {
+        snprintf(weblink, len, "%s%s", ctx.ek_server_addr, b64h);
+    }
+
     rc = curl_easy_setopt(curl, CURLOPT_URL, weblink);
     if (rc != CURLE_OK) {
         LOG_ERR("curl_easy_setopt for CURLOPT_URL failed: %s",


### PR DESCRIPTION
There were two places where the fix was needed
1. In the tool source code where a forward slash was always
   appended irrespective of it already being part of the link
   specified by the user.
2. In the integration test where curl tests the link to the
   ekop.intel.com backend. It now requires the full link to
   include the base64 encoded ek pub hash.

Signed-off-by: Imran Desai <imran.desai@intel.com>