### PR TITLE
tools/tpm2_tool.c: Fix an issue where LOG_WARN is always displayed

### DIFF
--- a/lib/tpm2_options.c
+++ b/lib/tpm2_options.c
@@ -469,12 +469,16 @@ tpm2_option_code tpm2_handle_options(int argc, char **argv,
 
         /* tool doesn't request a sapi, don't initialize one */
         if (flags->tcti_none && is_optional_sapi) {
-            LOG_WARN("Tool optionally uses SAPI. Continuing with tcti=none");
+            if (!flags->quiet) {
+                LOG_WARN("Tool optionally uses SAPI. Continuing with tcti=none");
+            }
             goto none;
         }
 
         if (flags->tcti_none && is_no_sapi) {
-            LOG_WARN("Tool does not use SAPI. Continuing with tcti=none");
+            if (!flags->quiet) {
+                LOG_WARN("Tool does not use SAPI. Continuing with tcti=none");
+            }
             goto none;
         }
 
@@ -494,7 +498,9 @@ tpm2_option_code tpm2_handle_options(int argc, char **argv,
         bool is_optional_fake_tcti = (flags->tcti_none && tool_opts &&
             tool_opts->flags & TPM2_OPTIONS_OPTIONAL_SAPI_AND_FAKE_TCTI);
         if (is_optional_fake_tcti) {
-            LOG_WARN("Tool optionally uses SAPI. Continuing with tcti=fake");
+            if (!flags->quiet) {
+                LOG_WARN("Tool optionally uses SAPI. Continuing with tcti=fake");
+            }
             *tcti = (TSS2_TCTI_CONTEXT *)&fake_tcti;
             goto none;
         }

--- a/tools/tpm2_makecredential.c
+++ b/tools/tpm2_makecredential.c
@@ -310,11 +310,14 @@ static void set_default_TCG_EK_template(TPMI_ALG_PUBLIC alg) {
     ctx.public.publicArea.nameAlg = TPM2_ALG_SHA256;
 }
 
-static tool_rc process_input(void) {
+static tool_rc process_input(tpm2_option_flags flags) {
 
     TPMI_ALG_PUBLIC alg = TPM2_ALG_NULL;
     if (ctx.key_type) {
-        LOG_WARN("Because **-G** is specified, assuming input encryption public key is in PEM format.");
+        if (!flags.quiet) {
+            LOG_WARN("Because **-G** is specified, assuming input encryption "
+                     "public key is in PEM format.");
+        }
         alg = tpm2_alg_util_from_optarg(ctx.key_type,
             tpm2_alg_util_flags_asymmetric);
         if (alg == TPM2_ALG_ERROR ||
@@ -379,7 +382,7 @@ static tool_rc tpm2_tool_onrun(ESYS_CONTEXT *ectx, tpm2_option_flags flags) {
 
     UNUSED(flags);
 
-    tool_rc rc = process_input();
+    tool_rc rc = process_input(flags);
     if (rc != tool_rc_success) {
         return rc;
     }


### PR DESCRIPTION
Fixes #2961 

Despite setting the 'quiet' flag with -Q the warning messages were
always displayed.

Signed-off-by: Imran Desai <imran.desai@intel.com>