### PR TITLE
tools/tpm2_nvread: add human readable output for NV content

### DIFF
--- a/lib/tpm2_nv_util.h
+++ b/lib/tpm2_nv_util.h
@@ -147,7 +147,7 @@ static inline tool_rc tpm2_util_nv_read(ESYS_CONTEXT *ectx,
     tpm2_loaded_object * auth_hierarchy_obj, UINT8 **data_buffer,
     UINT16 *bytes_read, TPM2B_DIGEST *cp_hash, TPM2B_DIGEST *rp_hash,
     TPMI_ALG_HASH parameter_hash_algorithm, TPM2B_NAME *precalc_nvname,
-    ESYS_TR shandle2, ESYS_TR shandle3) {
+    ESYS_TR shandle2, ESYS_TR shandle3, TPM2B_NV_PUBLIC **nv_pub_out) {
 
     /*
      * NVRead is not dispatched when:
@@ -177,8 +177,11 @@ static inline tool_rc tpm2_util_nv_read(ESYS_CONTEXT *ectx,
         }
 
         UINT16 data_size = nv_public->nvPublic.dataSize;
-        free(nv_public);
-
+        if (nv_pub_out) {
+            *nv_pub_out = nv_public;
+        } else {
+            free(nv_public);
+        }
         /* if size is 0, assume the whole object */
         if (size == 0) {
             size = data_size;

--- a/lib/tpm2_util.h
+++ b/lib/tpm2_util.h
@@ -517,4 +517,5 @@ TPMI_ALG_HASH tpm2_util_calculate_phash_algorithm(ESYS_CONTEXT *ectx,
     const char **cphash_path, TPM2B_DIGEST *cp_hash, const char **rphash_path,
     TPM2B_DIGEST *rp_hash, tpm2_session **sessions);
 
+void tpm2_util_tpm2_nv_to_yaml(TPM2B_NV_PUBLIC *, UINT8 *, UINT16, int);
 #endif /* STRING_BYTES_H */

--- a/man/tpm2_nvread.1.md
+++ b/man/tpm2_nvread.1.md
@@ -69,6 +69,12 @@ index can be specified as raw handle or an offset value to the nv handle range
     specify an auxiliary session for auditing and or encryption/decryption of
     the parameters.
 
+  * **\--print-yaml**:
+
+	Output the content of the NV index in a human readable format, useful
+	for displaying the content of counter, bits and extend and pin indices.
+	When this argument is provided size and offset is ignored.
+
   * **ARGUMENT** the command line argument specifies the NV index or offset
     number.
 

--- a/tools/tpm2_createek.c
+++ b/tools/tpm2_createek.c
@@ -213,7 +213,7 @@ static tool_rc set_ek_template(ESYS_CONTEXT *ectx, TPM2B_PUBLIC *input_public) {
     TPM2B_DIGEST rp_hash = { 0 };
     tool_rc rc = tpm2_util_nv_read(ectx, template_nv_index, 0, 0,
         &ctx.auth_owner_hierarchy.object, &template, &template_size, &cp_hash,
-        &rp_hash, TPM2_ALG_SHA256, 0, ESYS_TR_NONE, ESYS_TR_NONE);
+        &rp_hash, TPM2_ALG_SHA256, 0, ESYS_TR_NONE, ESYS_TR_NONE, NULL);
     if (rc != tool_rc_success) {
         goto out;
     }
@@ -230,7 +230,7 @@ static tool_rc set_ek_template(ESYS_CONTEXT *ectx, TPM2B_PUBLIC *input_public) {
     UINT16 nonce_size = 0;
     rc = tpm2_util_nv_read(ectx, nonce_nv_index, 0, 0,
         &ctx.auth_owner_hierarchy.object, &nonce, &nonce_size, &cp_hash,
-        &rp_hash, TPM2_ALG_SHA256, 0, ESYS_TR_NONE, ESYS_TR_NONE);
+        &rp_hash, TPM2_ALG_SHA256, 0, ESYS_TR_NONE, ESYS_TR_NONE, NULL);
     if (rc != tool_rc_success) {
         goto out;
     }

--- a/tools/tpm2_getekcertificate.c
+++ b/tools/tpm2_getekcertificate.c
@@ -439,11 +439,11 @@ static tool_rc nv_read(ESYS_CONTEXT *ectx, TPMI_RH_NV_INDEX nv_index) {
 
          tpm2_util_nv_read(ectx, nv_index, 0, 0, &object, &ctx.rsa_cert_buffer,
             &ctx.rsa_cert_buffer_size, &cp_hash, &rp_hash, TPM2_ALG_SHA256, 0,
-            ESYS_TR_NONE, ESYS_TR_NONE) :
+            ESYS_TR_NONE, ESYS_TR_NONE, NULL) :
 
          tpm2_util_nv_read(ectx, nv_index, 0, 0, &object, &ctx.ecc_cert_buffer,
             &ctx.ecc_cert_buffer_size, &cp_hash, &rp_hash, TPM2_ALG_SHA256, 0,
-            ESYS_TR_NONE, ESYS_TR_NONE);
+            ESYS_TR_NONE, ESYS_TR_NONE, NULL);
 
 nv_read_out:
     tmp_rc = tpm2_session_close(&object.session);


### PR DESCRIPTION
Enable parsing and YAML-style output for the different NV index types.

Fixes #2253

