### PR TITLE
Adding new event types to tpm2_eventlog

### DIFF
--- a/lib/efi_event.h
+++ b/lib/efi_event.h
@@ -41,6 +41,10 @@
 #define EV_EFI_ACTION                    EV_EFI_EVENT_BASE + 0x7
 #define EV_EFI_PLATFORM_FIRMWARE_BLOB    EV_EFI_EVENT_BASE + 0x8
 #define EV_EFI_HANDOFF_TABLES            EV_EFI_EVENT_BASE + 0x9
+#define EV_EFI_PLATFORM_FIRMWARE_BLOB2   EV_EFI_EVENT_BASE + 0xa
+#define EV_EFI_HANDOFF_TABLES2           EV_EFI_EVENT_BASE + 0xb
+#define EV_EFI_VARIABLE_BOOT2            EV_EFI_EVENT_BASE + 0xc
+
 #define EV_EFI_VARIABLE_AUTHORITY        EV_EFI_EVENT_BASE + 0xe0
 
 #ifndef PACKED
@@ -95,6 +99,13 @@ typedef struct {
     UEFI_PHYSICAL_ADDRESS BlobBase;
     UINT64 BlobLength;
 } PACKED UEFI_PLATFORM_FIRMWARE_BLOB;
+
+
+typedef struct {
+  UINT8 BlobDescriptionSize;
+  BYTE  BlobDescription[];
+  /* UEFI_PLATFORM_FIRMWARE_BLOB comes next */
+} PACKED UEFI_PLATFORM_FIRMWARE_BLOB2;
 
 typedef struct {
     UINT32 pcrIndex;

--- a/lib/tpm2_eventlog_yaml.c
+++ b/lib/tpm2_eventlog_yaml.c
@@ -439,7 +439,7 @@ static bool yaml_uefi_var(UEFI_VARIABLE_DATA *data, size_t size, UINT32 type,
                              uuidstr, sdata);
             free(sdata);
             return true;
-        } else if (type == EV_EFI_VARIABLE_BOOT) {
+        } else if (type == EV_EFI_VARIABLE_BOOT || type == EV_EFI_VARIABLE_BOOT2) {
             if ((strlen(ret) == 9 && strncmp(ret, "BootOrder", 9) == 0)) {
                 free(ret);
                 tpm2_tool_output("    VariableData:\n");
@@ -750,6 +750,7 @@ bool yaml_event2data(TCG_EVENT2 const *event, UINT32 type, uint32_t eventlog_ver
     switch (type) {
     case EV_EFI_VARIABLE_DRIVER_CONFIG:
     case EV_EFI_VARIABLE_BOOT:
+    case EV_EFI_VARIABLE_BOOT2:
     case EV_EFI_VARIABLE_AUTHORITY:
         return yaml_uefi_var((UEFI_VARIABLE_DATA*)event->Event,
                                 event->EventSize, type, eventlog_version);

--- a/lib/tpm2_eventlog_yaml.c
+++ b/lib/tpm2_eventlog_yaml.c
@@ -90,6 +90,12 @@ char const *eventtype_to_string (UINT32 event_type) {
         return "EV_EFI_PLATFORM_FIRMWARE_BLOB";
     case EV_EFI_HANDOFF_TABLES:
         return "EV_EFI_HANDOFF_TABLES";
+    case EV_EFI_PLATFORM_FIRMWARE_BLOB2:
+        return "EV_EFI_PLATFORM_FIRMWARE_BLOB2";
+    case EV_EFI_HANDOFF_TABLES2:
+        return "EV_EFI_HANDOFF_TABLES2";
+    case EV_EFI_VARIABLE_BOOT2:
+        return "EV_EFI_VARIABLE_BOOT2";
     case EV_EFI_VARIABLE_AUTHORITY:
         return "EV_EFI_VARIABLE_AUTHORITY";
     default:
@@ -526,6 +532,37 @@ bool yaml_uefi_platfwblob(UEFI_PLATFORM_FIRMWARE_BLOB *data) {
                      data->BlobLength);
     return true;
 }
+
+/* TCG PC Client PFP (02 dec 2020) section 10.2.5 */
+bool yaml_uefi_platfwblob2(UEFI_PLATFORM_FIRMWARE_BLOB2 *data) {
+  UINT8 blobdescsize = data->BlobDescriptionSize;
+  UEFI_PLATFORM_FIRMWARE_BLOB * data2 = (UEFI_PLATFORM_FIRMWARE_BLOB *)((UINT8 *)data + sizeof(UINT8) + blobdescsize);
+
+  char * eventdesc = (char *)calloc (1, 2*blobdescsize+1);
+  if (!eventdesc) {
+    LOG_ERR("failed to allocate memory: %s\n", strerror(errno));
+    return false;
+  }
+
+  bytes_to_str (data->BlobDescription, blobdescsize, eventdesc, 2*blobdescsize);
+
+  tpm2_tool_output("  Event:\n"
+                   "    BlobDescriptionSize: %d\n"
+                   "    BlobDescription: \"%.*s\"\n"
+                   "    BlobBase: 0x%" PRIx64 "\n"
+                   "    BlobLength: 0x%" PRIx64 "\n",
+                   blobdescsize,
+                   2*blobdescsize,
+                   eventdesc,
+                   data2->BlobBase,
+                   data2->BlobLength);
+
+  free(eventdesc);
+  return true;
+}
+
+
+
 /* TCG PC Client PFP section 9.4.4 */
 bool yaml_uefi_action(UINT8 const *action, size_t size) {
 
@@ -721,6 +758,8 @@ bool yaml_event2data(TCG_EVENT2 const *event, UINT32 type, uint32_t eventlog_ver
     case EV_S_CRTM_CONTENTS:
     case EV_EFI_PLATFORM_FIRMWARE_BLOB:
         return yaml_uefi_platfwblob((UEFI_PLATFORM_FIRMWARE_BLOB*)event->Event);
+    case EV_EFI_PLATFORM_FIRMWARE_BLOB2:
+        return yaml_uefi_platfwblob2((UEFI_PLATFORM_FIRMWARE_BLOB2*)event->Event);
     case EV_EFI_ACTION:
         return yaml_uefi_action(event->Event, event->EventSize);
     case EV_IPL:

--- a/test/unit/test_tpm2_eventlog_yaml.c
+++ b/test/unit/test_tpm2_eventlog_yaml.c
@@ -47,6 +47,9 @@ def_eventtype_to_string(EV_EFI_GPT_EVENT)
 def_eventtype_to_string(EV_EFI_ACTION)
 def_eventtype_to_string(EV_EFI_PLATFORM_FIRMWARE_BLOB)
 def_eventtype_to_string(EV_EFI_HANDOFF_TABLES)
+def_eventtype_to_string(EV_EFI_PLATFORM_FIRMWARE_BLOB2)
+def_eventtype_to_string(EV_EFI_HANDOFF_TABLES2)
+def_eventtype_to_string(EV_EFI_VARIABLE_BOOT2)
 def_eventtype_to_string(EV_EFI_VARIABLE_AUTHORITY)
 
 static void eventtype_to_string_default(void **state) {
@@ -141,6 +144,9 @@ int main(void) {
         cmocka_unit_test(eventtype_to_string_EV_EFI_ACTION),
         cmocka_unit_test(eventtype_to_string_EV_EFI_PLATFORM_FIRMWARE_BLOB),
         cmocka_unit_test(eventtype_to_string_EV_EFI_HANDOFF_TABLES),
+        cmocka_unit_test(eventtype_to_string_EV_EFI_PLATFORM_FIRMWARE_BLOB2),
+        cmocka_unit_test(eventtype_to_string_EV_EFI_HANDOFF_TABLES2),
+        cmocka_unit_test(eventtype_to_string_EV_EFI_VARIABLE_BOOT2),
         cmocka_unit_test(eventtype_to_string_EV_EFI_VARIABLE_AUTHORITY),
         cmocka_unit_test(eventtype_to_string_default),
         cmocka_unit_test(test_yaml_event2hdr_callback),


### PR DESCRIPTION
While looking at a boot event log from a recent AMD Milan system, I discovered that tpm2_eventlog does not implement the UEFI_PLATFORM_FIRMWARE_BLOB2 structure introduced in ~ 2020 by a TCG specification update.

This patch adds 3 new definitions -- UEFI_PLATFORM_FIRMWARE_BLOB2, EV_EFI_HANDOFF_TABLES2, EV_EFI_VARIABLE_BOOT2.

Correct handling of "blob2" is included in this patch. The handling of 'boot2' is the same as the old 'boot'; added an entry in the switch statement, but have not tested.

Reference: https://trustedcomputinggroup.org/wp-content/uploads/TCG_PCClient_PFP_r1p05_v22_02dec2020.pdf
