### PR TITLE
.cirrus.yml: update freebsd version

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -8,7 +8,7 @@ task:
     ibmtpm_name: ibmtpm1637
     TSS2_LOG: "all+ERROR;tcti+TRACE"
   freebsd_instance:
-    image_family: freebsd-12-2
+    image_family: freebsd-13-0
   install_script:
     - pkg update -f
     - pkg upgrade -y


### PR DESCRIPTION
Fixes CI Error:
pkg update -f
Updating FreeBSD repository catalogue...
Fetching meta.conf: . done
Fetching packagesite.pkg: .......... done
Processing entries:
Newer FreeBSD version for package php74-pear-channel-pirum:
To ignore this error set IGNORE_OSVERSION=yes

package: 1203000
running kernel: 1202000
Ignore the mismatch and continue? [y/N]: pkg: repository FreeBSD contains packages for wrong OS version: FreeBSD:12:amd64
Processing entries... done
Unable to update repository FreeBSD
Error updating repositories!
Seems as though 12-2 is EOL so update to something newer.

Related to:

https://forums.freebsd.org/threads/pkg-repository-freebsd-contains-packages-for-wrong-os-version-freebsd-12-amd64.78856/
http://soulrace.top:3000/mirror_group/curl/commit/7db6bc5ecaef321f32639149ba3737b1c8393b9c?lang=zh-HK

Signed-off-by: Imran Desai <imran.desai@intel.com>