### PR TITLE
VERSION: add version file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,4 @@ test-driver
 # dist tarball
 *.gz
 src_vars.mk
+VERSION

--- a/Makefile.am
+++ b/Makefile.am
@@ -354,7 +354,8 @@ EXTRA_DIST = \
     doc/RELEASE.md \
     man \
     scripts \
-    test
+    test \
+    VERSION
 
 if HAVE_MAN_PAGES
     dist_man1_MANS := \

--- a/bootstrap
+++ b/bootstrap
@@ -3,6 +3,10 @@
 
 set -e
 
+# Generate a VERSION file that is included in the dist tarball to avoid needed git
+# when calling autoreconf in a release tarball.
+git describe --tags --always --dirty > VERSION
+
 # generate list of source files for use in Makefile.am
 # if you add new source files, you must run ./bootstrap again
 src_listvar () {

--- a/configure.ac
+++ b/configure.ac
@@ -1,5 +1,5 @@
 AC_INIT([tpm2-tools],
-    [m4_esyscmd_s([git describe --tags --always --dirty])])
+    [m4_esyscmd_s([cat ./VERSION])])
 AC_CONFIG_MACRO_DIR([m4])
 
 AX_IS_RELEASE([dash-version])


### PR DESCRIPTION
Generate the version file with bootstrap and include in the DIST tarball
so endusers can call autoreconf on a dist tarball which doesn't have
git. This alleviates git describe errors on release tarballs in the
autoreconf case.

Signed-off-by: William Roberts <william.c.roberts@intel.com>