### PR TITLE
fapi: fix usage of parameter pcrLog for tss2_quote.

### DIFF
--- a/tools/fapi/tss2_quote.c
+++ b/tools/fapi/tss2_quote.c
@@ -158,7 +158,7 @@ static int tss2_tool_onrun (FAPI_CONTEXT *fctx) {
     char *quoteInfo, *pcrLog = NULL, *certificate = NULL;
     r = Fapi_Quote (fctx, ctx.pcrList, ctx.pcrListSize, ctx.keyPath,
         NULL, qualifyingData, qualifyingDataSize, &quoteInfo,
-        &signature, &signatureSize, &pcrLog, &certificate);
+        &signature, &signatureSize, ctx.pcrLog ? &pcrLog : NULL, &certificate);
     if (r != TSS2_RC_SUCCESS) {
         LOG_PERR ("Fapi_Quote", r);
         free (ctx.pcrList);
@@ -175,7 +175,8 @@ static int tss2_tool_onrun (FAPI_CONTEXT *fctx) {
             strlen(quoteInfo));
         if (r) {
             Fapi_Free (quoteInfo);
-            Fapi_Free (pcrLog);
+            if (ctx.pcrLog)
+                Fapi_Free (pcrLog);
             Fapi_Free (signature);
             Fapi_Free (certificate);
             return 1;
@@ -194,7 +195,8 @@ static int tss2_tool_onrun (FAPI_CONTEXT *fctx) {
             return 1;
         }
     }
-    Fapi_Free (pcrLog);
+    if (ctx.pcrLog)
+        Fapi_Free (pcrLog);
 
     if (ctx.signature && signature) {
         r = open_write_and_close (ctx.signature, ctx.overwrite, signature,


### PR DESCRIPTION
pcrLog is an optional parameter. If pcrLog is not used as parameter currently
the pcr log is still calculated in Fapi_Quote.
To avoid this calculation a NULL pointer will be passed to Fapi_Quote if the
parameter pcrLog is not passed.
So tss2_quote can be executed for a user which has no access rights to the
files with the system measurements.

Signed-off-by: Juergen Repp <juergen.repp@sit.fraunhofer.de>