### PR TITLE
lib/tpm2_util.c fix compile error on raspian

### DIFF
--- a/lib/tpm2_util.c
+++ b/lib/tpm2_util.c
@@ -1279,7 +1279,7 @@ void tpm2_util_tpm2_nv_to_yaml(TPM2B_NV_PUBLIC *nv_public, UINT8 *data, UINT16 s
         memcpy(&v, data, sizeof(UINT64));
         v = be64toh(v);
         print_yaml_indent(indent);
-        tpm2_tool_output("counter: %lu\n", v);
+        tpm2_tool_output("counter: %" PRIu64 "\n", v);
         break;
     case TPM2_NT_BITS:
         memcpy(&v, data, sizeof(UINT64));


### PR DESCRIPTION
On raspian 11 with gcc 10.2.1 the following error occurred:

 error: format ‘%lu’ expects argument of type ‘long unsigned int’,
 but argument 2 has type ‘UINT64’

lu was replaced with PRIu64.

Signed-off-by: Juergen Repp <juergen_repp@web.de>