### PR TITLE
tpm2_flushcontext: fix overflow in option handler

### DIFF
--- a/test/integration/tests/flushcontext.sh
+++ b/test/integration/tests/flushcontext.sh
@@ -26,7 +26,9 @@ fi
 
 # Test for flushing a transient object
 tpm2 createprimary -Q -C o -g sha256 -G rsa
-tpm2 flushcontext -Q -t
+# make sure multiple options don't overflow
+# bug: https://github.com/tpm2-software/tpm2-tools/issues/3035
+tpm2 flushcontext -Q -ttttttttttt
 
 # Test for flushing a loaded session
 tpm2 createpolicy -Q --policy-session --policy-pcr -l sha256:0


### PR DESCRIPTION
tpm2_flushcontext will sigfault when the options -[t|s|l] are
specified in a combination larger than 3 times because the counter
always increments and is used in a fixed size array. Fix this by
just using a bitmask of encountered options and then setting the
array manually

The fix in #3015 doesn't actually fix the issue becuase the option
handler is accessing the array out of bounds before the bounds check
that was added there. It just takes more work to get it to trigger since
their is a large block of allocated memory after the array for ESYS_TR
handles.

Fixes: #3035

Signed-off-by: William Roberts <william.c.roberts@intel.com>