### PR TITLE
ci: mark /workspace/tpm2-tools safe

### DIFF
--- a/.ci/docker.run
+++ b/.ci/docker.run
@@ -3,6 +3,8 @@
 
 set -e
 
+git config --global --add safe.directory "$DOCKER_BUILD_DIR"
+
 source $DOCKER_BUILD_DIR/.ci/docker-prelude.sh
 
 if [ -d build ]; then


### PR DESCRIPTION
Fixes:
fatal: unsafe repository ('/workspace/tpm2-tools' is owned by someone else)
To add an exception for this directory, call:
	git config --global --add safe.directory /workspace/tpm2-tools

Signed-off-by: William Roberts <william.c.roberts@intel.com>