### PR TITLE
nvreadpublic: drop ntoh on attributes

### DIFF
--- a/tools/tpm2_nvreadpublic.c
+++ b/tools/tpm2_nvreadpublic.c
@@ -119,7 +119,7 @@ static tool_rc print_nv_public(ESYS_CONTEXT *context, TPMI_RH_NV_INDEX index,
     tpm2_tool_output("  attributes:\n");
     tpm2_tool_output("    friendly: %s\n", attrs);
     tpm2_tool_output("    value: 0x%X\n",
-            tpm2_util_ntoh_32(nv_public->nvPublic.attributes));
+            nv_public->nvPublic.attributes);
 
     tpm2_tool_output("  size: %d\n", nv_public->nvPublic.dataSize);
 


### PR DESCRIPTION
The attributes get marshalled to correct endianess by libmu and don't
need to be changed again.

For example:
tpm2_define
tpm2_nvreadpublic
<snip>
  attributes:
    friendly: ownerwrite|authwrite|ownerread|authread
    value: 0x6000600
</snip>
tpm2_nvdefine 0x6000600 <-- fails

Drop NTOH
tpm2_nvreadpublic
<snip>
  attributes:
    friendly: ownerwrite|authwrite|ownerread|authread
    value: 0x60006
</snip>

tpm2_nvdefine -a 0x60006 <-- works

Fixes: #3053

Signed-off-by: William Roberts <william.c.roberts@intel.com>