### PR TITLE
tpm2_policyor: fix unallocated policy list

### DIFF
--- a/tools/tpm2_policyor.c
+++ b/tools/tpm2_policyor.c
@@ -14,7 +14,7 @@ struct tpm2_policyor_ctx {
     //File path for the session context data
     const char *session_path;
     //List of policy digests that will be compounded
-    TPML_DIGEST *policy_list;
+    TPML_DIGEST policy_list;
     //File path for storing the policy digest output
     const char *out_policy_dgst_path;
 
@@ -36,8 +36,7 @@ static bool on_option(char key, char *value) {
         ctx.session_path = value;
         break;
     case 'l':
-        ctx.policy_list = calloc(1, sizeof(TPML_DIGEST));
-        result = tpm2_policy_parse_policy_list(value, ctx.policy_list);
+        result = tpm2_policy_parse_policy_list(value, &ctx.policy_list);
         if (!result) {
             return false;
         }
@@ -54,8 +53,7 @@ static bool on_arg(int argc, char **argv) {
         return false;
     }
 
-    ctx.policy_list = calloc(1, sizeof(TPML_DIGEST));
-    bool result = tpm2_policy_parse_policy_list(argv[0], ctx.policy_list);
+    bool result = tpm2_policy_parse_policy_list(argv[0], &ctx.policy_list);
     if (!result) {
         return false;
     }
@@ -85,7 +83,7 @@ static bool is_input_option_args_valid(void) {
     }
 
     //Minimum two policies needed to be specified for compounding
-    if (ctx.policy_list->count < 1) {
+    if (ctx.policy_list.count < 1) {
         LOG_ERR("Must specify at least 2 policy digests for compounding.");
         return false;
     }
@@ -109,14 +107,14 @@ static tool_rc tpm2_tool_onrun(ESYS_CONTEXT *ectx, tpm2_option_flags flags) {
     }
 
     /* Policy digest hash alg should match that of the session */
-    if (ctx.policy_list->digests[0].size
+    if (ctx.policy_list.digests[0].size
             != tpm2_alg_util_get_hash_size(
                     tpm2_session_get_authhash(ctx.session))) {
         LOG_ERR("Policy digest hash alg should match that of the session.");
         return tool_rc_general_error;
     }
 
-    rc = tpm2_policy_build_policyor(ectx, ctx.session, ctx.policy_list);
+    rc = tpm2_policy_build_policyor(ectx, ctx.session, &ctx.policy_list);
     if (rc != tool_rc_success) {
         LOG_ERR("Could not build policyor TPM");
         return rc;
@@ -127,7 +125,6 @@ static tool_rc tpm2_tool_onrun(ESYS_CONTEXT *ectx, tpm2_option_flags flags) {
 
 static tool_rc tpm2_tool_onstop(ESYS_CONTEXT *ectx) {
     UNUSED(ectx);
-    free(ctx.policy_list);
     free(ctx.policy_digest);
     return tpm2_session_close(&ctx.session);
 }


### PR DESCRIPTION
The TPML_DIGEST policy list was calloc'd for some reason, however it
could just be statically allocated in the context. The side effect is
that when no options or arguments were given a NPD occured when checking
the count of the policy list. TO fix this, just statically allocate it.

Signed-off-by: William Roberts <william.c.roberts@intel.com>