### PR TITLE
policyor: test onscure -l and argument causing concatenation of policies

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -292,7 +292,9 @@ test_unit_test_tpm2_policy_LDFLAGS  = -Wl,--wrap=Esys_StartAuthSession \
                                       -Wl,--wrap=Esys_PolicyPCR \
                                       -Wl,--wrap=Esys_PCR_Read \
                                       -Wl,--wrap=Esys_PolicyGetDigest \
-                                      -Wl,--wrap=Esys_FlushContext
+                                      -Wl,--wrap=Esys_FlushContext \
+                                      -Wl,--wrap=files_get_file_size_path \
+                                      -Wl,--wrap=files_load_bytes_from_path
 
 test_unit_test_tpm2_policy_LDADD    = $(CMOCKA_LIBS) $(LDADD)
 

--- a/lib/files.c
+++ b/lib/files.c
@@ -16,6 +16,7 @@
 #include "log.h"
 #include "tpm2.h"
 #include "tpm2_tool.h"
+#include "tpm2_util.h"
 
 /**
  * This is the magic for the file header. The header is organized
@@ -163,7 +164,7 @@ bool file_read_bytes_from_file(FILE *f, UINT8 *buf, UINT16 *size,
     return true;
 }
 
-bool files_load_bytes_from_path(const char *path, UINT8 *buf, UINT16 *size) {
+TEST_WEAK bool files_load_bytes_from_path(const char *path, UINT8 *buf, UINT16 *size) {
 
     if (!buf || !size || !path) {
         return false;
@@ -494,7 +495,7 @@ bool files_does_file_exist(const char *path) {
     return false;
 }
 
-bool files_get_file_size_path(const char *path, unsigned long *file_size) {
+TEST_WEAK bool files_get_file_size_path(const char *path, unsigned long *file_size) {
 
     bool result = false;
 

--- a/lib/tpm2_util.h
+++ b/lib/tpm2_util.h
@@ -9,7 +9,14 @@
 
 #include <tss2/tss2_esys.h>
 
+#include "config.h"
 #include "tpm2_session.h"
+
+#if defined(FUZZING) || defined(UNIT_TESTING) || !defined(NDEBUG)
+#define TEST_WEAK __attribute__((weak))
+#else
+#define TEST_WEAK
+#endif
 
 #if defined (__GNUC__)
 #define COMPILER_ATTR(...) __attribute__((__VA_ARGS__))

--- a/man/tpm2_policyor.1.md
+++ b/man/tpm2_policyor.1.md
@@ -36,8 +36,11 @@ if at least one of the policy events are true.
 
   * **-l**, **\--policy-list**=_POLICY\_FILE_\_LIST:
 
-    This option is retained for backwards compatibility. Use the argument method
-    instead.
+    This option is DEPRECATED yet is retained for backwards compatibility. Use the
+    argument method instead. **NOTE**: When **-l** and an argument is specified
+    it's the same as specifying it all at once. For instance:
+    `tpm2_policyor -l sha256:file1 sha256:file2` is the same as
+    `tpm2_policyor sha256:file1,file2`.
 
 ## References
 

--- a/test/integration/tests/abrmd_policyor.sh
+++ b/test/integration/tests/abrmd_policyor.sh
@@ -42,6 +42,13 @@ tpm2 flushcontext $session_ctx
 
 diff $test_vector $o_policy_digest
 
+# test that -l option and argument are concatenated
+tpm2 startauthsession -S $session_ctx
+tpm2 policyor -L $o_policy_digest -S $session_ctx -l sha256:$policy_1 sha256:$policy_2
+tpm2 flushcontext $session_ctx
+
+diff $test_vector $o_policy_digest
+
 # Test case to compound two PCR policies
 
 tpm2 pcrreset 23


### PR DESCRIPTION
this is fun, if a user specified `-l` with an argument the result was concatenation. These two commands are the same:
```bash
tpm2 policyor -l sha256:policy1 sha256:policy2
tpm2 policyor sha256:policy1,policy2
```
So while very unlikely in use, lets not break it, its easy enough to support.