### PR TITLE
tools/tpm2_loadexternal.c: fix for unchecked return value

### DIFF
--- a/tools/tpm2_loadexternal.c
+++ b/tools/tpm2_loadexternal.c
@@ -96,7 +96,10 @@ static tool_rc process_output(ESYS_CONTEXT *ectx) {
     /*
      * 2. Outputs generated after TPM2_CC_<command> dispatch
      */
-    tpm2_tr_get_name(ectx, ctx.handle, &ctx.name);
+    rc = tpm2_tr_get_name(ectx, ctx.handle, &ctx.name);
+    if (rc != tool_rc_success) {
+        return rc;
+    }
     assert(ctx.name);
 
     rc = files_save_tpm_context_to_path(ectx, ctx.handle,


### PR DESCRIPTION
In process_input the return value of the function tpm2_tr_get_name
must be tested prior to continuing.

Signed-off-by: Imran Desai <imran.desai@intel.com>