### PR TITLE
tools/fapi/tpm2_gettpm2object.c: fix resource leak

### DIFF
--- a/tools/fapi/tss2_gettpm2object.c
+++ b/tools/fapi/tss2_gettpm2object.c
@@ -104,7 +104,7 @@ static int tss2_tool_onrun (FAPI_CONTEXT *fctx) {
     r = Fapi_GetTcti(fctx, &tcti);
     if (r != TSS2_RC_SUCCESS) {
         LOG_PERR ("Fapi_GetTcti", r);
-        return 1;
+        goto error;
     }
 
     e_rc = Esys_Initialize(&esys_ctx, tcti, NULL);


### PR DESCRIPTION
A potential resource leak would have occured by exiting in an error
check without freeing the file pointer in tss2_tool_onrun.

Signed-off-by: Imran Desai <imran.desai@intel.com>