### PR TITLE
lib/tpm2_options.c: relocate unreachable warning message

### DIFF
--- a/lib/tpm2_options.c
+++ b/lib/tpm2_options.c
@@ -443,6 +443,9 @@ tpm2_option_code tpm2_handle_options(int argc, char **argv,
             (tool_opts && tool_opts->flags & TPM2_OPTIONS_NO_SAPI);
         /* tool doesn't use sapi, skip tcti checks and continue */
         if (is_no_sapi) {
+            if (flags->tcti_none && !flags->quiet) {
+                LOG_WARN("Tool does not use SAPI. Continuing with tcti=none");
+            }
             goto out;
         }
 
@@ -471,13 +474,6 @@ tpm2_option_code tpm2_handle_options(int argc, char **argv,
         if (flags->tcti_none && is_optional_sapi) {
             if (!flags->quiet) {
                 LOG_WARN("Tool optionally uses SAPI. Continuing with tcti=none");
-            }
-            goto none;
-        }
-
-        if (flags->tcti_none && is_no_sapi) {
-            if (!flags->quiet) {
-                LOG_WARN("Tool does not use SAPI. Continuing with tcti=none");
             }
             goto none;
         }


### PR DESCRIPTION
In tpm2_handle_options there was an attempt to print a warning
message when TPM2_OPTIONS_NO_SAPI was set. However, it was done
in a location that was skipped after checking the boolean value.

Signed-off-by: Imran Desai <imran.desai@intel.com>