### PR TITLE
tools/tpm2_certify: fix man page for short options and add tests

### DIFF
--- a/man/tpm2_certify.1.md
+++ b/man/tpm2_certify.1.md
@@ -31,7 +31,7 @@ These options control the certification:
 
     The key used to sign the attestation structure.
 
-  * **-p**, **\--certifiedkey-auth**=_AUTH_:
+  * **-P**, **\--certifiedkey-auth**=_AUTH_:
 
     The authorization value provided for the object specified with -c.
 
@@ -50,7 +50,7 @@ These options control the certification:
     If left unspecified, a default signature scheme for the key type will
      be used.
 
-  * **-P**, **\--signingkey-auth**=_AUTH_:
+  * **-p**, **\--signingkey-auth**=_AUTH_:
 
     The authorization value for the signing key specified with -C.
 

--- a/test/integration/tests/certify.sh
+++ b/test/integration/tests/certify.sh
@@ -10,6 +10,14 @@ cleanup() {
         shut_down
     fi
 }
+
+verify_signature_with_ssl() {
+# Verify the signatures with openssl
+tpm2 readpublic -Q -c certify.ctx -f pem -o certify.pem
+openssl dgst -verify certify.pem -keyform pem -sha256 \
+    -signature sig.out attest.out
+}
+
 trap cleanup EXIT
 
 start_up
@@ -18,20 +26,29 @@ cleanup "no-shut-down"
 
 tpm2 clear -Q
 
-tpm2 createprimary -Q -C e -g sha256 -G rsa -c primary.ctx
+tpm2 createprimary -Q -C e -g sha256 -G rsa -c primary.ctx -p signedpass
 
 tpm2 create -Q -g sha256 -G rsa:rsassa -u certify.pub -r certify.priv \
-    -C primary.ctx
+    -C primary.ctx -P signedpass -p certifypass
 
-tpm2 load -Q -C primary.ctx -u certify.pub -r certify.priv -n certify.name \
--c certify.ctx
+tpm2 load -Q -C primary.ctx -P signedpass -u certify.pub -r certify.priv \
+    -n certify.name -c certify.ctx
 
-tpm2 certify -Q -c primary.ctx -C certify.ctx -g sha256 -o attest.out \
-    -f plain -s sig.out
+tpm2 certify \
+    -c primary.ctx -P signedpass \
+    -C certify.ctx -p certifypass \
+    -g sha256 -o attest.out -f plain -s sig.out  
 
-# Verify the signatures with openssl
-tpm2 readpublic -Q -c certify.ctx -f pem -o certify.pem
-openssl dgst -verify certify.pem -keyform pem -sha256 \
-    -signature sig.out attest.out
+verify_signature_with_ssl
+
+# Test with full options
+
+tpm2 certify \
+    --certifiedkey-context primary.ctx --certifiedkey-auth signedpass \
+    --signingkey-context certify.ctx --signingkey-auth certifypass \
+    --hash-algorithm sha256 --attestation attest.out \
+    --format plain --signature sig.out
+
+verify_signature_with_ssl
 
 exit 0

--- a/tools/tpm2_certify.c
+++ b/tools/tpm2_certify.c
@@ -300,8 +300,8 @@ static bool tpm2_tool_onstart(tpm2_options **opts) {
     const struct option topts[] = {
       { "certifiedkey-context", required_argument, NULL, 'c' },
       { "signingkey-context",   required_argument, NULL, 'C' },
-      { "certifiedkey-auth",    required_argument, NULL, 'p' },
-      { "signingkey-auth",      required_argument, NULL, 'P' },
+      { "certifiedkey-auth",    required_argument, NULL, 'P' },
+      { "signingkey-auth",      required_argument, NULL, 'p' },
       { "hash-algorithm",       required_argument, NULL, 'g' },
       { "attestation",          required_argument, NULL, 'o' },
       { "signature",            required_argument, NULL, 's' },


### PR DESCRIPTION
Fixes #3082

The short options for the signing-key-auth and certified-key-auth
were swapped. The case fix in the man page makes it less intuitive
but have to go through with the change so we don't break any
existing scripts.

This change does not affect the long options. Tests have been
added to ensure the functionality.

Signed-off-by: Imran Desai <imran.desai@intel.com>