### PR TITLE
policy: support raw digest strings in -L options

### DIFF
--- a/lib/tpm2_alg_util.c
+++ b/lib/tpm2_alg_util.c
@@ -13,6 +13,7 @@
 #include "tpm2_attr_util.h"
 #include "tpm2_errata.h"
 #include "tpm2_hash.h"
+#include "tpm2_policy.h"
 
 typedef struct alg_pair alg_pair;
 struct alg_pair {
@@ -1018,13 +1019,10 @@ tool_rc tpm2_alg_util_public_init(const char *alg_details, const char *name_halg
 
     /* load a policy from a path if present */
     if (auth_policy) {
-    public->publicArea.authPolicy.size =
-                sizeof(public->publicArea.authPolicy.buffer);
-        bool res = files_load_bytes_from_path(auth_policy,
-            public->publicArea.authPolicy.buffer,
-                &public->publicArea.authPolicy.size);
-        if (!res) {
-            return tool_rc_general_error;
+        tool_rc rc = tpm2_policy_set_digest(auth_policy,
+                &public->publicArea.authPolicy);
+        if (rc != tool_rc_success) {
+            return rc;
         }
     }
 

--- a/lib/tpm2_policy.c
+++ b/lib/tpm2_policy.c
@@ -6,6 +6,7 @@
 
 #include "files.h"
 #include "log.h"
+#include "tool_rc.h"
 #include "tpm2.h"
 #include "tpm2_alg_util.h"
 #include "tpm2_openssl.h"
@@ -684,4 +685,16 @@ tool_rc tpm2_policy_tool_finish(ESYS_CONTEXT *ectx, tpm2_session *session,
 error:
     free(policy_digest);
     return rc;
+}
+
+tool_rc tpm2_policy_set_digest(const char *auth_policy, TPM2B_DIGEST *out_policy) {
+
+    if (!auth_policy) {
+        memset(out_policy, 0, sizeof(*out_policy));
+        return tool_rc_success;
+    }
+
+    out_policy->size = sizeof(out_policy->buffer);
+    bool res = tpm2_util_bin_from_hex_or_file(auth_policy, &out_policy->size, out_policy->buffer);
+    return res ? tool_rc_success : tool_rc_general_error;
 }

--- a/lib/tpm2_policy.h
+++ b/lib/tpm2_policy.h
@@ -320,4 +320,16 @@ tool_rc tpm2_policy_build_policyduplicationselect(ESYS_CONTEXT *ectx,
 tool_rc tpm2_policy_tool_finish(ESYS_CONTEXT *ectx, tpm2_session *session,
         const char *save_path);
 
+/** Sets a TPM2B_DIGEST from a file if present or a hex string.
+ *
+ * @param auth_policy
+ *  Either a file path or a hex string. A NULL pointer causes out_policy to be memset
+ *  to 0.
+ * @param out_policy
+ *  The set policy
+ * @return
+ *  tool_rc_success on success, or any tool_rc failure on failure.
+ */
+tool_rc tpm2_policy_set_digest(const char *auth_policy, TPM2B_DIGEST *out_policy);
+
 #endif /* TPM2_POLICY_H_ */

--- a/man/tpm2_create.1.md
+++ b/man/tpm2_create.1.md
@@ -68,9 +68,9 @@ These options for creating the TPM entity:
     When sealing data only the _TPM\_ALG\_KEYEDHASH_ algorithm with a NULL
     scheme is allowed. Thus, **-G** cannot be specified.
 
-  * **-L**, **\--policy**=_FILE_:
+  * **-L**, **\--policy**=_FILE_ or _HEX\_STRING_:
 
-    The input policy file, optional.
+    The input policy file or a hex string, optional.
 
   * **-u**, **\--public**=_FILE_:
 

--- a/man/tpm2_createprimary.1.md
+++ b/man/tpm2_createprimary.1.md
@@ -52,9 +52,9 @@ future interactions with the created primary.
 
     The file path to save the object context of the generated primary object.
 
-  * **-L**, **\--policy**=_FILE_:
+  * **-L**, **\--policy**=_FILE_ or _HEX\_STRING_:
 
-    An optional file input that contains the policy digest for policy based
+    An optional file input or hex string that contains the policy digest for policy based
     authorization of the object.
 
   * **-a**, **\--attributes**=_ATTRIBUTES_:

--- a/man/tpm2_import.1.md
+++ b/man/tpm2_import.1.md
@@ -86,9 +86,9 @@ These options control the key importation process:
 
     The authorization value for the imported key, optional.
 
-  * **-L**, **\--policy**=_POLICY\_FILE_:
+  * **-L**, **\--policy**=_POLICY_ or _HEX\_STRING_:
 
-    The policy file.
+    The policy file or policy hex string used for authorization to the object.
 
   * **-s**, **\--seed**=_FILE_:
 

--- a/man/tpm2_loadexternal.1.md
+++ b/man/tpm2_loadexternal.1.md
@@ -74,10 +74,11 @@ It also saves a context file for future interactions with the object.
 
     The authorization value for the key, optional.
 
-  * **-L**, **\--policy**=_POLICY\_FILE_:
+  * **-L**, **\--policy**=_FILE_ or _HEX\_STRING_:
 
-    The input policy file, optional. A file containing the hash of a policy
-    derived from `tpm2_createpolicy`.
+    The input policy file or hex string, optional. A file or hex string
+    containing the hash of a policy derived from `tpm2_createpolicy` or
+    another policy digest generating source.
 
   * **-g**, **\--hash-algorithm**=_ALGORITHM_:
 

--- a/test/integration/tests/create.sh
+++ b/test/integration/tests/create.sh
@@ -119,4 +119,14 @@ tpm2 flushcontext enc_session.ctx
 tpm2_create -C primary.ctx -u obj.pub -r obj.priv -f pem -o obj.pem
 openssl rsa -noout -text -inform PEM -in obj.pem -pubin
 
+# Test policy from hash input
+
+expected_dgst="fdb1c1e5ba81e95f2db8db6ed7627e9b01658e80df7f33220bd3638f98ad2d5f"
+tpm2 createprimary -c primary.ctx
+tpm2 create -C primary.ctx -u key.pub -r key.priv -L "$(expected_digest)"
+tpm2 load -C primary.ctx -u key.pub -r key.priv -c key.ctx
+got_digest="$(tpm2 readpublic -c key.ctx | grep "authorization policy" | cut -d ' ' -f3-)"
+test "$expected_digest" == "$got_digest"
+
+
 exit 0

--- a/test/integration/tests/createprimary.sh
+++ b/test/integration/tests/createprimary.sh
@@ -114,4 +114,11 @@ test "${BEFORE}" = "${AFTER}"
 tpm2 createprimary -f pem -o public.pem
 openssl rsa -noout -text -inform PEM -in public.pem -pubin
 
+#
+# Test policy from hash
+#
+expected_dgst="fdb1c1e5ba81e95f2db8db6ed7627e9b01658e80df7f33220bd3638f98ad2d5f"
+got_digest="$(tpm2 createprimary -L $expected_dgst -c primary.ctx | grep 'authorization policy' | cut -d ' ' -f3-)"
+test "$expected_dgst" == "$got_digest"
+
 exit 0

--- a/test/integration/tests/import.sh
+++ b/test/integration/tests/import.sh
@@ -269,4 +269,16 @@ run_rsa_import_passin_test "parent.ctx" "private.pem" "stdin" "passfile"
 
 run_aes_policy_import_test "parent.ctx"
 
+#
+# Test policy from hash
+#
+openssl genrsa -out private.pem 1024
+
+expected_dgst="fdb1c1e5ba81e95f2db8db6ed7627e9b01658e80df7f33220bd3638f98ad2d5f"
+tpm2 import -G rsa -g sha256 -i private.pem -C parent.ctx \
+    -u import_rsa_key.pub -r import_rsa_key.priv -L "$expected_digest"
+tpm2 load -C parent.ctx -u import_rsa_key.pub -r import_rsa_key.priv -c key.ctx
+got_digest="$(tpm2 readpublic -c key.ctx | grep "authorization policy" | cut -d ' ' -f3-)"
+test "$expected_digest" == "$got_digest"
+
 exit 0

--- a/tools/tpm2_import.c
+++ b/tools/tpm2_import.c
@@ -36,6 +36,7 @@
 #include "tpm2_identity_util.h"
 #include "tpm2_openssl.h"
 #include "tpm2_options.h"
+#include "tpm2_policy.h"
 #include "tpm2_tool.h"
 
 #define MAX_SESSIONS 3
@@ -439,14 +440,10 @@ static tool_rc process_input_tpm_import(void) {
     }
 
     if (ctx.policy) {
-        ctx.public.publicArea.authPolicy.size =
-            sizeof(ctx.public.publicArea.authPolicy.buffer);
-        result = files_load_bytes_from_path(ctx.policy,
-            ctx.public.publicArea.authPolicy.buffer,
-            &ctx.public.publicArea.authPolicy.size);
-        if (!result) {
-            LOG_ERR("Failed to copy over the auth policy to the public data");
-            return tool_rc_general_error;
+        tool_rc rc = tpm2_policy_set_digest(ctx.policy,
+                &ctx.public.publicArea.authPolicy);
+        if (rc != tool_rc_success) {
+            return rc;
         }
     }
 

--- a/tools/tpm2_loadexternal.c
+++ b/tools/tpm2_loadexternal.c
@@ -14,6 +14,7 @@
 #include "tpm2_auth_util.h"
 #include "tpm2_hierarchy.h"
 #include "tpm2_openssl.h"
+#include "tpm2_policy.h"
 #include "tpm2_tool.h"
 #include "object.h"
 
@@ -229,13 +230,10 @@ static tool_rc process_inputs(ESYS_CONTEXT *ectx) {
         }
 
         if (ctx.policy) {
-            ctx.pub.publicArea.authPolicy.size =
-                    sizeof(ctx.pub.publicArea.authPolicy.buffer);
-            bool res = files_load_bytes_from_path(ctx.policy,
-                ctx.pub.publicArea.authPolicy.buffer,
-                &ctx.pub.publicArea.authPolicy.size);
-            if (!res) {
-                return tool_rc_general_error;
+            rc = tpm2_policy_set_digest(ctx.policy,
+                    &ctx.pub.publicArea.authPolicy);
+            if (rc != tool_rc_success) {
+                return rc;
             }
         }
 


### PR DESCRIPTION
Support the ability to hardcode hex strings into the -L value over a
file. This allows for things like tpm2_create -L 1234...56abcd

Related-to: https://lists.01.org/hyperkitty/list/tpm2@lists.01.org/thread/AW2LZ35JSECRAW3VDE5ZF3AEP42PRCKY/

Signed-off-by: William Roberts <william.c.roberts@intel.com>
