### PR TITLE
tss2_provision: fix usage of -L parameter.

### DIFF
--- a/tools/fapi/tss2_provision.c
+++ b/tools/fapi/tss2_provision.c
@@ -33,7 +33,7 @@ static bool tss2_tool_onstart(tpm2_options **opts) {
         {"authValueSh",         required_argument, NULL, 'S'},
         {"authValueLockout",    required_argument, NULL, 'L'},
     };
-    return (*opts = tpm2_options_new ("E:S:L",
+    return (*opts = tpm2_options_new ("E:S:L:",
         ARRAY_LEN(topts), topts, on_option, NULL, 0)) != NULL;
 }
 


### PR DESCRIPTION
The -L short parameter was not marked as parameter with required arg in the short opt list.
Fixes #3147.

Signed-off-by: Juergen Repp <juergen_repp@web.de>