### PR TITLE
tpm2_eventlog_yaml: parse EV_EFI_VARIABLE_AUTHORITY variables explicitly

### DIFF
--- a/test/integration/fixtures/event-gce-ubuntu-2104-log.bin.yaml
+++ b/test/integration/fixtures/event-gce-ubuntu-2104-log.bin.yaml
@@ -511,8 +511,8 @@ events:
     VariableDataLength: 18
     UnicodeName: SbatLevel
     VariableData:
-    - SignatureOwner: 74616273-312c-322c-3032-313033303231
-      SignatureData: 380a
+      String: |-
+        "sbat,1,2021030218"
 - EventNum: 27
   PCRIndex: 4
   EventType: EV_EFI_BOOT_SERVICES_APPLICATION

--- a/test/integration/fixtures/event-moklisttrusted.bin.yaml
+++ b/test/integration/fixtures/event-moklisttrusted.bin.yaml
@@ -445,8 +445,8 @@ events:
     VariableDataLength: 18
     UnicodeName: SbatLevel
     VariableData:
-    - SignatureOwner: 74616273-312c-322c-3032-313033303231
-      SignatureData: 380a
+      String: |-
+        "sbat,1,2021030218"
 - EventNum: 29
   PCRIndex: 7
   EventType: EV_EFI_VARIABLE_AUTHORITY


### PR DESCRIPTION
Now besides MokListTrusted only known variables are parsed any further:

- db, Shim: parsed as EFI_SIGNATURE_DATA
- SbatLevel: parsed as string
- other: variable data is printed as hex string

Fixes #3145
