### PR TITLE
tss2_import: clarify tool description

### DIFF
--- a/man/tss2_import.1.md
+++ b/man/tss2_import.1.md
@@ -14,9 +14,8 @@
 
 # DESCRIPTION
 
-**tss2_import**(1) - This command imports a JSON encoded policy or policy
-template and stores it under the provided path or it imports a JSON encoded key
-under the provided path.
+**tss2_import**(1) - This command imports a JSON encoded key, policy or policy
+template and stores it under the provided path.
 
 # OPTIONS
 


### PR DESCRIPTION
The man page repeats JSON encoded X and stores it under a path. De deuplicate the description to make it easier to grok and get the what it imports up front in the description so the reader knows immediately that this imports keys, policies and policy templates.

Signed-off-by: William Roberts <william.c.roberts@intel.com>