### PR TITLE
tpm2_startauthsession: no warn: if tpmkey transient

### DIFF
--- a/tools/tpm2_startauthsession.c
+++ b/tools/tpm2_startauthsession.c
@@ -266,16 +266,6 @@ static tool_rc process_input_data(ESYS_CONTEXT *ectx) {
         if (rc != tool_rc_success) {
             return rc;
         }
-
-        /* if loaded object is non-permanant, it should ideally be persistent */
-        if (ctx.session.tpmkey.key_context_object.handle) {
-
-            bool is_transient = (ctx.session.tpmkey.key_context_object.handle
-                    >> TPM2_HR_SHIFT) == TPM2_HT_TRANSIENT;
-            if (!is_transient) {
-                LOG_WARN("check public portion of the tpmkey manually");
-            }
-        }
     }
 
     /*


### PR DESCRIPTION
Previous behavior produces misleading warning message in the following scenario:
$ tpm2_createprimary -c primary.ctx
$ tpm2_evictcontrol -C o -c primary.ctx 0x81010000 $ tpm2_flushcontext -t
$ tpm2_startauthsession --policy-session -c 0x81010000 -S mysession.ctx 
WARN: check public portion of the tpmkey manually

According to the TCG TPM 2.0 Spec only bind object checked: 11.1 TPM2_StartAuthSession:
 If bind references a transient object, then the TPM shall return
 TPM_RC_HANDLE if the sensitive portion of the object is not loaded.

User will receive TPM_RC_HANDLE error code from TPM chip immediately, no additional warning required.

Additional info:
tpmKey & bind fields checks on the TPM chip side (reference tpm_server from Ken Goldman): https://bit.ly/3fAnjRS
Only bind object checked for TPM_HT_TRANSIENT.

Signed-off-by: Abylay Ospan <aospan@amazon.com>