### PR TITLE
tpm2_print: support printing serialized ESYS_TR's

### DIFF
--- a/man/tpm2_print.1.md
+++ b/man/tpm2_print.1.md
@@ -25,6 +25,7 @@ unspecified.
       * **TPM2B_PUBLIC**
       * **TPMT_PUBLIC**
       * **TSSPRIVKEY_OBJ**
+      * **ESYS_TR**
   * **ARGUMENT** the command line argument specifies the path of the TPM data.
 
 [pubkey options](common/pubkey.md)
@@ -95,6 +96,17 @@ tpm2 print -t TPM2B_PUBLIC -f pem key.pub
 ```bash
 tpm2 print -t TSSPRIVKEY_OBJ tssprivkey.pem
 tpm2 print -t TSSPRIVKEY_OBJ tssprivkey.pem -f pem > publickey.pem
+```
+
+### Print the name of a serialized ESYS\_TR handle.
+
+Serialized ESYS\_TR handles are returned from tools like `tpm2_evictcontrol`'s
+`-o` and `tpm2_readpublic`'s `-t` options.
+
+```bash
+tpm2_createprimary -c primary.ctx
+tpm2_evictcontrol -c primary.ctx -o primary.tr
+tpm2 print -t ESYS_TR primary.tr
 ```
 
 [returns](common/returns.md)

--- a/test/integration/tests/print.sh
+++ b/test/integration/tests/print.sh
@@ -18,7 +18,7 @@ tss_prim=prim
 cleanup() {
     rm -f $ak_name_file $ak_pubkey_file \
           $quote_file $print_file $ak_ctx \
-          tpmt_public.ak
+          tpmt_public.ak ${tss_prim}\.*
 
     if [ "$1" != "no-shut-down" ]; then
        shut_down
@@ -112,5 +112,11 @@ tpm2 print -t TSSPRIVKEY_OBJ $pem_file.pem
 tpm2 print -t TSSPRIVKEY_OBJ -f pem $pem_file.pem > $pem_pub.pem
 
 openssl rsa -pubin -in $pem_pub.pem -text
+
+tpm2 evictcontrol -c ${tss_prim}.ctx -o ${tss2_prim}.tr
+tpm2 readpublic -n ${tss_prim}.name
+name="$(tpm2 print -t ESYS_TR ${tss2_prim}.tr | grep 'name:' | cut -d' ' -f2-)"
+expected_name="$(xxd -c256 -p ${tss_prim}.name)"
+test "${name}" == "${expected_name}"
 
 exit 0


### PR DESCRIPTION
Support printing the handle and name from a serialized ESYS_TR. This could be useful for verifying an object is what's expected before using it to start an auth session for instance.

Signed-off-by: William Roberts <william.c.roberts@intel.com>