### PR TITLE
tpm2_getcap: support vendor properties

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -220,6 +220,7 @@ if HAVE_FAPI
 endif
 
 if UNIT
+check_SCRIPTS =
 TESTS += $(check_PROGRAMS)
 check_PROGRAMS = \
     test/unit/test_string_bytes \
@@ -240,6 +241,11 @@ check_PROGRAMS = \
     test/unit/test_object
 
 TESTS += $(ALL_SYSTEM_TESTS)
+
+if HAVE_ESYS_4_0
+check_SCRIPTS += test/unit/vendor_tests.sh
+TESTS += test/unit/vendor_tests.sh
+endif
 
 if HAVE_FAPI
 TESTS += $(ALL_FAPI_TESTS)

--- a/configure.ac
+++ b/configure.ac
@@ -46,14 +46,29 @@ AS_IF([test "$enable_fapi" = yes -o "$enable_fapi" = check],
       ])
 AM_CONDITIONAL([HAVE_FAPI], [test "$enable_fapi" = yes])
 
-PKG_CHECK_MODULES([TSS2_ESYS_3_0], [tss2-esys >= 3.0.0],
-                  [AC_DEFINE([ESYS_3_0], [1], [Esys3.0])]
-                  [AC_SUBST([TSS2_ESYS_CFLAGS], [$TSS2_ESYS_3_0_CFLAGS])
-                   AC_SUBST([TSS2_ESYS_LIBS], [$TSS2_ESYS_3_0_LIBS])],
-                  [PKG_CHECK_MODULES([TSS2_ESYS_2_3], [tss2-esys >= 2.4.0],
-                  [AC_DEFINE([ESYS_2_3], [1], [Esys2.3])]
-                  [AC_SUBST([TSS2_ESYS_CFLAGS], [$TSS2_ESYS_2_3_CFLAGS])
-                   AC_SUBST([TSS2_ESYS_LIBS], [$TSS2_ESYS_2_3_LIBS])])])
+PKG_CHECK_MODULES(
+    [TSS2_ESYS_4_0],
+    [tss2-esys >= 4.0.0],
+    [AC_DEFINE([ESYS_4_0], [1], [Esys4.0])]
+    [AC_SUBST([TSS2_ESYS_CFLAGS], [$TSS2_ESYS_4_0_CFLAGS])
+     AC_SUBST([TSS2_ESYS_LIBS], [$TSS2_ESYS_4_0_LIBS])
+     have_esys_4_0="yes"],
+    [PKG_CHECK_MODULES(
+        [TSS2_ESYS_3_0],
+        [tss2-esys >= 3.0.0],
+        [AC_DEFINE([ESYS_3_0], [1], [Esys3.0])]
+        [AC_SUBST([TSS2_ESYS_CFLAGS], [$TSS2_ESYS_3_0_CFLAGS])
+         AC_SUBST([TSS2_ESYS_LIBS], [$TSS2_ESYS_3_0_LIBS])],
+        [PKG_CHECK_MODULES([TSS2_ESYS_2_3], [tss2-esys >= 2.4.0],
+            [AC_DEFINE([ESYS_2_3], [1], [Esys2.3])]
+            [AC_SUBST([TSS2_ESYS_CFLAGS], [$TSS2_ESYS_2_3_CFLAGS])
+            AC_SUBST([TSS2_ESYS_LIBS], [$TSS2_ESYS_2_3_LIBS])
+        ])
+    ])
+])
+
+AM_CONDITIONAL([HAVE_ESYS_4_0], [test "x${have_esys_4_0}" = "xyes"])
+
 PKG_CHECK_MODULES([TSS2_TCTILDR], [tss2-tctildr])
 PKG_CHECK_MODULES([TSS2_MU], [tss2-mu])
 PKG_CHECK_MODULES([TSS2_RC], [tss2-rc])
@@ -80,6 +95,13 @@ AS_IF([test "x$with_efivar" == "xauto"],
   [PKG_CHECK_MODULES([EFIVAR], [efivar],,[true])],
   [test "x$with_efivar" == "xyes"],
   [PKG_CHECK_MODULES([EFIVAR], [efivar])],
+)
+
+# Check if tss has the intelPtt
+AC_CHECK_MEMBER([union TPMU_CAPABILITIES.intelPttProperty],
+	[AC_DEFINE([HAVE_OLD_TPMU_CAPABILITIES], [1], [tss2 pre 4.0])],
+    [],
+    [[#include <tss2/tss2_tpm2_types.h>]]
 )
 
 # backwards compat with older pkg-config

--- a/lib/tpm2.c
+++ b/lib/tpm2.c
@@ -1737,7 +1737,7 @@ tpm2_evictcontrol_skip_esapi_call:
  */
 TSS2_RC fix_esys_hierarchy(uint32_t in, uint32_t *out)
 {
-#if defined(ESYS_3_0)
+#if !defined(ESYS_2_3)
     switch (in) {
         case ESYS_TR_RH_NULL:
             /* FALLTHRU */
@@ -1769,12 +1769,10 @@ TSS2_RC fix_esys_hierarchy(uint32_t in, uint32_t *out)
             LOG_ERR("An unknown hierarchy handle was passed: 0x%08x", in);
             return TSS2_ESYS_RC_BAD_VALUE;
     }
-#elif defined(ESYS_2_3)
-    *out = in;
-    return TSS2_RC_SUCCESS;
 #else
-#error "Need to define either ESYS_3_0 or ESYS_2_3"
+    *out = in;
 #endif
+    return TSS2_RC_SUCCESS;
 }
 
 tool_rc tpm2_hash(ESYS_CONTEXT *esys_context, ESYS_TR shandle1, ESYS_TR shandle2,

--- a/lib/tpm2_capability.h
+++ b/lib/tpm2_capability.h
@@ -2,6 +2,7 @@
 
 #ifndef LIB_TPM2_CAPABILITY_H_
 #define LIB_TPM2_CAPABILITY_H_
+#include "config.h"
 
 #include <tss2/tss2_esys.h>
 
@@ -23,6 +24,28 @@
  */
 tool_rc tpm2_capability_get(ESYS_CONTEXT *context, TPM2_CAP capability,
         UINT32 property, UINT32 count, TPMS_CAPABILITY_DATA **capability_data);
+
+/** Same as tpm2_capability_get with some extra options
+ * Invokes GetCapability to retrieve the current value of a capability from the
+ * TPM.
+ * @param context
+ *  Enhanced system api (ESAPI) context
+ * @param capability
+ *  the capability being requested from the TPM
+ * @param property
+ *  property
+ * @param count
+ *  maximum number of values to return
+ * @param ignore_more_data
+ *  Ignore the moreData value and just do one read.
+ * @param capability_data
+ *  capability data structure to populate
+ * @return
+ *  tool_rc indicating status.
+ */
+tool_rc tpm2_capability_get_ex(ESYS_CONTEXT *ectx, TPM2_CAP capability,
+        UINT32 property, UINT32 count, bool ignore_more_data,
+        TPMS_CAPABILITY_DATA **capability_data);
 
 /**
  * Attempts to find a vacant handle in the persistent handle namespace.

--- a/man/tpm2_getcap.1.md
+++ b/man/tpm2_getcap.1.md
@@ -53,6 +53,17 @@ argument to the tool. Currently supported capability groups are:
 - **handles-saved-session**:
   Display handles about saved sessions.
 
+- **vendor[:num]**:
+  Displays the vendor properties as a hex buffer output. The string "vendor"
+  can be suffixed with a colon followed by a number as understood by strtoul(3)
+  with a 0 base. That value is used as the property value within the\
+  TPM2\_GetCapability command, and defaults to 1. An example to call it with a
+  property value of 2 is:
+    tpm2\_getcap vendor:2
+
+  NOTE: if vendor requests hang, try the "-i" option to ignore the moreData field and
+  only read once.
+
 # OPTIONS
 
   * **-l**, **\--list**:
@@ -68,6 +79,10 @@ argument to the tool. Currently supported capability groups are:
       - properties-fixed
       ...
     ```
+
+  * **\--ignore-moredata**
+
+  Ignores the moreData field when dealing with buggy TPM responses.
 
 [common options](common/options.md)
 

--- a/test/integration/tests/getcap.sh
+++ b/test/integration/tests/getcap.sh
@@ -30,7 +30,7 @@ with open("$1") as f:
 pyscript
 }
 
-tpm2 getcap -l > $out
+tpm2 getcap -l | grep -v 'vendor' > $out
 
 caplist=$(yaml_to_list $out)
 

--- a/test/scripts/echo_tcti.py
+++ b/test/scripts/echo_tcti.py
@@ -1,0 +1,85 @@
+#!/usr/bin/env python
+
+#
+# This TCTI is designed to use with the subprocess TCTI and echo the contents
+# of arg1, formatted as a hex string, as a response to a single TPM command. 
+#
+# Example"
+# ./tools/tpm2 getcap --tcti='cmd:./test/scripts/echo_tcti.py 8001000000170000000001000001000000000100000003' -i vendor
+# 0000000100000003
+#
+
+import binascii
+import codecs
+import io
+import sys
+
+def from_bytes(b):
+    # python2 and 3 compat int.from_bytes(byte_order='big')
+    return int(codecs.encode(b, 'hex'), 16)
+
+class TPMCommand(object):
+    def __init__(self, data):
+        self._data = data
+
+    @property
+    def size(self, data_only=False):
+        x = from_bytes(self._data[2:6])
+        return x if data_only == False else x - 10
+
+    @property
+    def tag(self):
+        return from_bytes(self._data[0:2])
+
+    @property
+    def cc(self):
+        return from_bytes(self._data[6:10])
+
+    @property
+    def data(self):
+        return self._data[10:]
+
+    @property
+    def header(self):
+        return self._data[:10]
+
+
+def read_command(stdin):
+    # TPM Command Header
+    # TAG  UINT16 0:2
+    # SIZE UINT32 2:6
+    # CC   UINT32 6:10
+    # DATA
+    header = stdin.read(10)
+    # Check for EOF
+    if len(header) == 0:
+        return None
+    elif len(header) < 10:
+        raise RuntimeError("Length of header invalid, got: %u" % len(header))
+    size = from_bytes(header[2:6])
+    data = stdin.read(size - 10)
+    return TPMCommand(header + data)
+
+
+def write_response(data):
+    with io.open(sys.stdout.fileno(), "wb", closefd=False) as stdout:
+        bdata = binascii.unhexlify(data)
+        stdout.write(bdata)
+        stdout.flush()
+
+
+def main():
+    
+    if (len(sys.argv) < 2):
+        sys.stderr.write("Expected one argument of a hex string to use as a TPM response buffer.\n")
+        sys.exit(1)
+    
+    with io.open(sys.stdin.fileno(), "rb", closefd=False) as stdin:
+        c = read_command(stdin)
+        if c is None:
+            sys.exit
+        write_response(sys.argv[1])
+
+
+if __name__ == "__main__":
+    main()

--- a/test/unit/vendor_tests.sh
+++ b/test/unit/vendor_tests.sh
@@ -1,0 +1,7 @@
+# SPDX-License-Identifier: BSD-3-Clause
+set -e
+
+result=$(${abs_srcdir}/tools/tpm2 getcap \
+    --tcti='cmd:${abs_srcdir}/test/scripts/echo_tcti.py 8001000000170000000001000001000000000100000003' \
+    --ignore-moredata vendor)
+test ${result} == "0000000100000003"


### PR DESCRIPTION
Requires tpm2-tss 4.0

Support vendor properties as a vendor agnostic TPM2B buffer. This also introduces the -i or --ignore-more option to ignore the moreData byte returned from the TPM.

Introduce -i to ignore moreData when it's set to 1 but moreData does not follow.

Example output from my NUC:
./tools/tpm2 getcap -i --tcti=pcap:device:/dev/tpmrm0 vendor:1 0000000100000003

Signed-off-by: William Roberts <william.c.roberts@intel.com>