### PR TITLE
lgtm: add uuid-dev dependency

### DIFF
--- a/.lgtm.yml
+++ b/.lgtm.yml
@@ -8,6 +8,7 @@ extraction:
       - libssl-dev
       - acl
       - git
+      - uuid-dev
     after_prepare:
     - cd "$LGTM_WORKSPACE"
     - mkdir installdir


### PR DESCRIPTION
tpm2-tss depends on uuid since commit:
1448eee7468d FAPI: Add event logging for firmware and IMA events.

Fixes:
[2022-11-16 20:57:10] [build-stderr] installed software in a non-standard prefix. [2022-11-16 20:57:10] [build-stderr] Alternatively, you may set the environment variables UUID_CFLAGS [2022-11-16 20:57:10] [build-stderr] and UUID_LIBS to avoid the need to call pkg-config. [2022-11-16 20:57:10] [build-stderr] See the pkg-config man page for more details. [2022-11-16 20:57:10] [ERROR] Spawned process exited abnormally (code 1; tried to run: [/opt/work/lgtm-workspace/lgtm/extract.sh]) A fatal error occurred: Exit status 1 from command: [/opt/work/lgtm-workspace/lgtm/extract.sh]

Signed-off-by: William Roberts <william.c.roberts@intel.com>