### PR TITLE
tpm2_startauthsession: VERIFY persistent handles

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -237,6 +237,10 @@ AS_IF([test "x$enable_unit" != xno], [
     AS_IF([test $OPENSSL = no],
           [AC_MSG_ERROR([Required executable openssl not found, some system tests will fail!])])
 
+    AC_CHECK_PROG([WC], [wc], yes, no)
+    AS_IF([test $WC = no],
+          [AC_MSG_ERROR([Required executable wc not found, some system tests will fail!])])
+
     unit_test_tool_report="- tpm2_abrmd: $tpm2_abrmd
     - TPM simulator: $TPM2_SIM
     - bash: $BASH_SHELL

--- a/lib/tpm2_util.h
+++ b/lib/tpm2_util.h
@@ -6,6 +6,7 @@
 #include <stdbool.h>
 #include <stdint.h>
 #include <stdio.h>
+#include <string.h>
 
 #include <tss2/tss2_esys.h>
 
@@ -229,6 +230,39 @@ static inline void _tpm2_util_print_tpm2b(TPM2B *buffer) {
 
     return tpm2_util_hexdump(buffer->buffer, buffer->size);
 }
+
+static inline bool _cmp_tpm2b(UINT16 size_a, const BYTE *buf_a, UINT16 size_b, const BYTE *buf_b,
+        size_t max_a, size_t max_b) {
+
+    /*
+     * overall buffers should be the same size (same object kind of check and to ensure we don't
+     * overflow a buffer
+     */
+    return max_a == max_b &&
+            /* size should be the same */
+            size_a == size_b &&
+            /* memory should be the same */
+            !memcmp(buf_a, buf_b, size_a);
+}
+
+/**
+ * Compare imple TPM2B a with b
+ *
+ * Compares simple TPM2B structures, which are structures
+ * that only have a size and buffer contents with eachother.
+ * Examples of simple TPM2B's are TPM2B_AUTH, TPM2B_DIGEST, etc.
+ *
+ * @param a
+ *  A simple TPM2B to compare
+ * @param b
+ *  A simple TPM2B to compare
+ * @returns
+ *  true if they are the same, false otherwise.
+ */
+#define cmp_tpm2b(field, a, b) \
+    _cmp_tpm2b((a)->size, (a)->field, (b)->size, (b)->field, \
+        sizeof((a)->field), \
+        sizeof((b)->field))
 
 /**
  * Prints a TPM2B as a hex dump to the FILE specified. Does NOT

--- a/man/tpm2_startauthsession.1.md
+++ b/man/tpm2_startauthsession.1.md
@@ -101,6 +101,15 @@ This will work with direct TPM access, but note that internally this calls a
     Session parameter decryption is off. Use **tpm2_sessionconfig** to turn on.
     Parameter encryption/decryption symmetric-key set to AES-CFB.
 
+  * **-n**, **\--name**=_FILE_
+
+    A name file as output from a tool like tpm2\_readpublic(1) `-n` option.
+    The name file can be used to **verify** a persistent handle input for
+    the `--tpmkey-context`, `-c`, and `--key-context` options. Verification
+    that the object referenced by a peristent handle, e.g 0x81000000, is
+    the key expected prevents attackers from performing a man-in-the-middle
+    attack on session traffic.
+
 ## References
 
 [context object format](common/ctxobj.md) details the methods for specifying


### PR DESCRIPTION
When an AuthSession is used with a tpmKey, that key MUST be verified in order to trust the connection. Think of this as analagous to known hosts with ssh. With Serialized ESYS_TR's or Context Files, the name is associated with that handle and ESAPI is instrumented to perform all the required name checks. When loaded from a persistent handle, ESAPI does not have the associated metadata and reads the name from the handle with a ReadPublic call. Becuase of this, an attacker COULD MiTM the connection with their own key. Thus, with persistent handles we must verify the name from some other source. The TPM name could be thought of as an ssh key fingerprint.

To fix this, provide a -n argument for a name file as output by readpublic or could be generated as a binary array of the objects name. When a tpmKey is provided, check the name and fail.

Fixes: #2812

Signed-off-by: William Roberts <william.c.roberts@intel.com>