### PR TITLE
tpm2_create: add NOTE for CreateLoaded ENOTSUPP

### DIFF
--- a/lib/tool_rc.c
+++ b/lib/tool_rc.c
@@ -7,9 +7,14 @@
 #include "tool_rc.h"
 
 #define UNFMT1(x) (x - TPM2_RC_FMT1)
+#define UNVER1(x) (x - TPM2_RC_VER1)
 
 static inline UINT16 tpm2_rc_fmt1_error_get(TPM2_RC rc) {
     return (rc & 0x3F);
+}
+
+static inline UINT16 tpm2_rc_fmt0_error_get(TPM2_RC rc) {
+    return (rc & 0x7F);
 }
 
 static inline UINT8 tss2_rc_layer_format_get(TSS2_RC rc) {
@@ -27,6 +32,17 @@ static tool_rc flatten_fmt1(TSS2_RC rc) {
     }
 }
 
+static tool_rc flatten_fmt0(TSS2_RC rc) {
+
+    UINT8 errnum = tpm2_rc_fmt0_error_get(rc);
+    switch (errnum) {
+    case UNVER1(TPM2_RC_COMMAND_CODE):
+        return tool_rc_unsupported;
+    default:
+        return tool_rc_general_error;
+    }
+}
+
 tool_rc tool_rc_from_tpm(TSS2_RC rc) {
 
     bool is_fmt_1 = tss2_rc_layer_format_get(rc);
@@ -34,5 +50,5 @@ tool_rc tool_rc_from_tpm(TSS2_RC rc) {
         return flatten_fmt1(rc);
     }
 
-    return tool_rc_general_error;
+    return flatten_fmt0(rc);
 }

--- a/tools/tpm2_create.c
+++ b/tools/tpm2_create.c
@@ -112,6 +112,17 @@ static bool load_outside_info(TPM2B_DATA *outside_info) {
         &outside_info->size, outside_info->buffer);
 }
 
+static void print_help_message() {
+
+    static const char *msg =
+        "NOTE: The TPM does not support CreateLoaded command!\n"
+        "Use tpm2_create with the -u and -r options and then\n"
+        "call tpm2_load with -c and use the -u and -r outputs\n"
+        "of tpm2_create in tpm2_load.";
+
+    tpm2_tool_output("%s\n", msg);
+}
+
 static tool_rc create(ESYS_CONTEXT *ectx) {
 
     /*
@@ -137,6 +148,9 @@ static tool_rc create(ESYS_CONTEXT *ectx) {
             &ctx.rp_hash, ctx.parameter_hash_algorithm,
             ctx.aux_session_handle[0], ctx.aux_session_handle[1]);
         if (tmp_rc != tool_rc_success) {
+            if (tmp_rc == tool_rc_unsupported) {
+                print_help_message();
+            }
             return tmp_rc;
         }
     }


### PR DESCRIPTION
tpm2_create option -c uses TPM2_CreateLoaded under the hood which is not always supported, thus add a note bolstering what users should do, which is to use tpm2_create -u -r with tpm2_load -u -r -c to get the desired result. This is already documented in the man page, but add a note.

$ ./tools/tpm2 create -C primary.ctx -c key.ctx
ERROR: Esys_CreateLoaded(0x143) - tpm:error(2.0): command code not supported NOTE: The TPM does not support CreateLoaded command!! Use tpm2_create with the -u and -r options and then call tpm2_load with -c and use the -u and -r outputs of tpm2_create in tpm2_load.
ERROR: Unable to run create

$ echo $?
5

Fixes: #3171

Signed-off-by: William Roberts <william.c.roberts@intel.com>