### PR TITLE
echo_tcti: call python3 binary

### DIFF
--- a/test/scripts/echo_tcti.py
+++ b/test/scripts/echo_tcti.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 #
 # This TCTI is designed to use with the subprocess TCTI and echo the contents


### PR DESCRIPTION
Most distributions are now in Python3.  The binary for Python3 is still called `python3`.

Signed-off-by: Alberto Planas <aplanas@suse.com>