### PR TITLE
ci: update default in download deps to tss 3.2.2

### DIFF
--- a/.ci/download-deps.sh
+++ b/.ci/download-deps.sh
@@ -3,7 +3,7 @@
 
 function get_deps() {
 
-	export TSS_VERSION=${TPM2_TSS_VERSION:-3.2.0}
+	export TSS_VERSION=${TPM2_TSS_VERSION:-3.2.2}
 	ABRMD_VERSION=2.4.1
 	EXTRA_CONFIG_FLAGS=''
 


### PR DESCRIPTION
The error undefined reference to curl_url_strerror when using curl less than 7.80.0 should be fixed.

Signed-off-by: Juergen Repp <juergen_repp@web.de>