### PR TITLE
tpm2_ecdhzgen: Add public-key parameter.

### DIFF
--- a/man/tpm2_ecdhzgen.1.md
+++ b/man/tpm2_ecdhzgen.1.md
@@ -29,7 +29,11 @@ resultant point (Z = (xZ , yZ) ≔ [hds]QB; where h is the cofactor of the curve
 
   * **-u**, **\--public**=_FILE_:
 
-    Output ECC point Q.
+    Input ECC point Q.
+
+  * **-k**, **\--public-key**=_FILE_:
+
+    Input ECC public key with point Q.
 
   * **-o**, **\--output**=_FILE_
 

--- a/test/integration/tests/ecc.sh
+++ b/test/integration/tests/ecc.sh
@@ -136,4 +136,20 @@ openssl dgst -sha256 -binary -out test.bin
 
 cmp cp.hash test.bin 2
 
+# Test ecdhzgen with public keys instead of public points
+tpm2 createprimary -C o -c prim.ctx -Q
+
+# Create ECDH keypair A
+tpm2 create -C prim.ctx -c keyA.ctx -u ecdhA.pub -G ecc256:ecdh
+
+# Create ECDH keypair B
+tpm2 create -C prim.ctx -c keyB.ctx -u ecdhB.pub -G ecc256:ecdh
+
+# Derive ECDH secret 1 using private key A and public key B
+tpm2 ecdhzgen -c keyA.ctx -k ecdhB.pub -o secret1.dat
+
+# Derive ECDH secret 2 using private key B and public key A
+tpm2 ecdhzgen -c keyB.ctx -k ecdhA.pub -o secret2.dat
+diff secret1.dat secret2.dat
+
 exit 0


### PR DESCRIPTION
Currently the public parameter had to be an ECC point (format TPM2B_ECC_POINT). Now this point can also be used with a public key (format TPM2B_PUBLIC) by using the option (--public-key, -k).
The ecc integration tests are extended with an example were the shared secret with two ECC keys is added. 
Fixes: #3202

Signed-off-by: Juergen Repp <juergen_repp@web.de>