### PR TITLE
Add AMD EK certificate fetching support

### DIFF
--- a/man/tpm2_getekcertificate.1.md
+++ b/man/tpm2_getekcertificate.1.md
@@ -84,6 +84,12 @@ conditions dictating the certificate location lookup.
     This flags the tool to output the EK certificate as is received from the
     source: NV/ Web-Hosting.
 
+  * **-E**, **\--encoding**=_ENCODING_:
+
+    Specifies the encoding format to use explicitly. Normally, the default
+    method is the one used by Intel unless an AMD fTPM is detected, in which
+    case the AMD-specific encoding is used. Use 'a' for AMD and 'i' for Intel.
+
   * **ARGUMENT** the command line argument specifies the URL address for the EK
     certificate portal. This forces the tool to not look for the EK certificates
     on the NV indices.


### PR DESCRIPTION
Adds support for fetching AMD EK certificates via tpm2_getekcertificate. Tested on my AMD Ryzen 9 3900XT fTPM. I haven't had the opportunity to check on Intel/other platforms.