### PR TITLE
tpm errata: switch to twos-complement.

### DIFF
--- a/test/integration/tests/abrmd_policynv.sh
+++ b/test/integration/tests/abrmd_policynv.sh
@@ -36,17 +36,34 @@ evaluate_failing_test_case() {
 }
 
 evaluate_passing_test_case() {
-
-    # the tests wich use sign comparison operators will be skipped. After a CI
-    # update these tests did produce strange error(0x126) which did not occur outside the
-    # new docker images. Downgrade to the version of swtpm where this error did not occur
-    # did not change the behaviour.
-  if [[ ${1:0:1} != "s" ]]; then
-     tpm2 startauthsession -S session.ctx --policy-session
-     echo $operandB | xxd -r -p | \
-     tpm2 policynv -S session.ctx -i- -P nvpass $nv_test_index $1
-     tpm2 flushcontext session.ctx
-  fi
+    tpm2 startauthsession -S session.ctx --policy-session
+    if [[ ${1:0:1} == "s" ]]; then
+        echo "Test sign: $1 $operandA $operandB"
+        # check whether sign compare fails with 0x126
+        trap - ERR
+        output=$(echo $operandB | xxd -r -p | \
+                     tpm2 policynv -S session.ctx -i- -P nvpass $nv_test_index $1 2>&1)
+        result=$?
+        if [ $result != 0 ] && echo $output | grep "ErrorCode.*0126" > /dev/null
+        then
+            echo "This test failed due to a TPM bug regarding signed comparison as described"
+            echo "in TCG's Errata for TCG Trusted Platform Module Library Revision 1.59 Version 1.4,"
+            echo "Section 2.5 TPM_EO – two’s complement"
+            tpm2 flushcontext session.ctx
+            skip_test
+        else
+            if [ $result != 0 ]; then
+                tpm2 flushcontext session.ctx
+                exit 1
+            fi
+        fi
+        tpm2 flushcontext session.ctx
+        trap onerror ERR
+    else
+        echo $operandB | xxd -r -p | \
+            tpm2 policynv -S session.ctx -i- -P nvpass $nv_test_index $1
+        tpm2 flushcontext session.ctx
+    fi
 }
 
 trap cleanup EXIT
@@ -77,39 +94,19 @@ evaluate_passing_test_case eq
 operandB=0x80
 evaluate_passing_test_case neq
 
-# Perform comparison operation "sgt"
-operandB=0x82
-evaluate_passing_test_case sgt
-
 # Perform comparison operation "ugt"
 operandB=0x80
 evaluate_passing_test_case ugt
 
-# Perform comparison operation "slt"
-operandB=0x80
-evaluate_passing_test_case slt
-
 # Perform comparison operation "ult"
 operandB=0x82
 evaluate_passing_test_case ult
-
-# Perform comparison operation "sge"
-operandB=0x82
-evaluate_passing_test_case sge
-operandB=0x81
-evaluate_passing_test_case sge
 
 # Perform comparison operation "uge"
 operandB=0x80
 evaluate_passing_test_case uge
 operandB=0x81
 evaluate_passing_test_case uge
-
-# Perform comparison operation "sle"
-operandB=0x80
-evaluate_passing_test_case sle
-operandB=0x81
-evaluate_passing_test_case sle
 
 # Perform comparison operation "ule"
 operandB=0x82
@@ -124,5 +121,28 @@ evaluate_passing_test_case bs
 # Perform comparison operation "bc"
 operandB=0x7E
 evaluate_passing_test_case bc
+
+operandA=0xfe # -1
+echo $operandA | xxd -r -p | tpm2 nvwrite -P nvpass -i- $nv_test_index
+
+# Perform comparison operation "sgt"
+operandB=0xfd # -2
+evaluate_passing_test_case sgt
+
+# Perform comparison operation "slt"
+operandB=0xff # 0
+evaluate_passing_test_case slt
+
+# Perform comparison operation "sle"
+operandB=0xff #0
+evaluate_passing_test_case sle
+operandB=0xfe # -1
+evaluate_passing_test_case sle
+
+# Perform comparison operation "sge"
+operandB=0xfd # -2
+evaluate_passing_test_case sge
+operandB=0xfe # -1
+evaluate_passing_test_case sge
 
 exit 0


### PR DESCRIPTION
Errata TCG Trusted Platform Module Library Revision 1.59 Version 1.4, Section 2.5 TPM_EO – two’s complement states:
"The signed arithmetic operations are performed using twos-complement." The tests policynv and policycountertimer were adapted to work with the complement representation of signed numbers. If the tests return the error 0x126 the test will be skipped.
Fixes:  #3233

Signed-off-by: Juergen Repp <juergen_repp@web.de>