### PR TITLE
readthedocs.yml add python requirements

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -2,4 +2,6 @@ version: 2
 
 mkdocs:
   configuration: mkdocs.yml
-
+python:
+   install:
+   - requirements: docs/requirements.txt


### PR DESCRIPTION
python requirements were added because of the error: module 'jinja2' has no attribute 'contextfilter'

Signed-off-by: Juergen Repp <juergen_repp@web.de>
