### PR TITLE
readthedocs: Add markdown to requirement file.

### DIFF
--- a/docs/requirements.in
+++ b/docs/requirements.in
@@ -1,1 +1,2 @@
+Markdown<3.2
 jinja2<3.1.0

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -6,5 +6,10 @@
 #
 jinja2==3.0.3
     # via -r requirements.in
+markdown==3.1.1
+    # via -r requirements.in
 markupsafe==2.1.2
     # via jinja2
+
+# The following packages are considered to be unsafe in a requirements file:
+# setuptools


### PR DESCRIPTION
The latest markdown version did produce the error: missing 1 required positional argument: 'md_globals' Markdown<3.2 was added to the requirement file.

Signed-off-by: Juergen Repp <juergen_repp@web.de>