### PR TITLE
tpm2_eventlog: add support for PCR0 replay with different StartupLocality

### DIFF
--- a/lib/efi_event.h
+++ b/lib/efi_event.h
@@ -45,6 +45,7 @@
 #define EV_EFI_HANDOFF_TABLES2           EV_EFI_EVENT_BASE + 0xb
 #define EV_EFI_VARIABLE_BOOT2            EV_EFI_EVENT_BASE + 0xc
 
+#define EV_EFI_HCRTM_EVENT               EV_EFI_EVENT_BASE + 0x10
 #define EV_EFI_VARIABLE_AUTHORITY        EV_EFI_EVENT_BASE + 0xe0
 
 #ifndef PACKED

--- a/lib/tpm2_eventlog.h
+++ b/lib/tpm2_eventlog.h
@@ -45,7 +45,7 @@ bool digest2_accumulator_callback(TCG_DIGEST2 const *digest, size_t size,
 
 bool parse_event2body(TCG_EVENT2 const *event, UINT32 type);
 bool foreach_digest2(tpm2_eventlog_context *ctx, UINT32 eventType, unsigned pcr_index,
-                     TCG_DIGEST2 const *event_hdr, size_t count, size_t size);
+                     TCG_DIGEST2 const *event_hdr, size_t count, size_t size, uint8_t locality);
 bool parse_event2(TCG_EVENT_HEADER2 const *eventhdr, size_t buf_size,
                   size_t *event_size, size_t *digests_size);
 bool foreach_event2(tpm2_eventlog_context *ctx, TCG_EVENT_HEADER2 const *eventhdr_start, size_t size);

--- a/test/unit/test_tpm2_eventlog.c
+++ b/test/unit/test_tpm2_eventlog.c
@@ -27,7 +27,7 @@ static void test_foreach_digest2_null(void **state){
     (void)state;
     tpm2_eventlog_context ctx = {0};
 
-    assert_false(foreach_digest2(&ctx, 0, 0, NULL, 0, sizeof(TCG_DIGEST2)));
+    assert_false(foreach_digest2(&ctx, 0, 0, NULL, 0, sizeof(TCG_DIGEST2), 0));
 }
 static void test_foreach_digest2_size(void **state) {
 
@@ -36,7 +36,7 @@ static void test_foreach_digest2_size(void **state) {
     TCG_DIGEST2 *digest = (TCG_DIGEST2*)buf;
     tpm2_eventlog_context ctx = { .digest2_cb = foreach_digest2_test_callback };
 
-    assert_false(foreach_digest2(&ctx, 0, 0, digest, 1, sizeof(TCG_DIGEST2) - 1));
+    assert_false(foreach_digest2(&ctx, 0, 0, digest, 1, sizeof(TCG_DIGEST2) - 1, 0));
 }
 static void test_foreach_digest2(void **state) {
 
@@ -47,7 +47,7 @@ static void test_foreach_digest2(void **state) {
     will_return(foreach_digest2_test_callback, true);
 
     tpm2_eventlog_context ctx = { .digest2_cb = foreach_digest2_test_callback };
-    assert_true(foreach_digest2(&ctx, 0, 0, digest, 1, TCG_DIGEST2_SHA1_SIZE));
+    assert_true(foreach_digest2(&ctx, 0, 0, digest, 1, TCG_DIGEST2_SHA1_SIZE, 0));
 }
 static void test_foreach_digest2_cbnull(void **state){
 
@@ -56,7 +56,7 @@ static void test_foreach_digest2_cbnull(void **state){
     TCG_DIGEST2* digest = (TCG_DIGEST2*)buf;
 
     tpm2_eventlog_context ctx = {0};
-    assert_true(foreach_digest2(&ctx, 0, 0, digest, 1, TCG_DIGEST2_SHA1_SIZE));
+    assert_true(foreach_digest2(&ctx, 0, 0, digest, 1, TCG_DIGEST2_SHA1_SIZE, 0));
 }
 static void test_sha1(void **state){
 
@@ -73,7 +73,7 @@ static void test_sha1(void **state){
     memcpy(digest->Digest, "the magic words are:", TPM2_SHA1_DIGEST_SIZE);
 
     tpm2_eventlog_context ctx = {0};
-    assert_true(foreach_digest2(&ctx, 0, pcr_index, digest, 1, TCG_DIGEST2_SHA1_SIZE));
+    assert_true(foreach_digest2(&ctx, 0, pcr_index, digest, 1, TCG_DIGEST2_SHA1_SIZE, 0));
     assert_memory_equal(ctx.sha1_pcrs[pcr_index], sha1sum, sizeof(sha1sum));
 }
 static void test_sha256(void **state){
@@ -93,7 +93,7 @@ static void test_sha256(void **state){
     memcpy(digest->Digest, "The Magic Words are Squeamish Ossifrage, for RSA-129 (from 1977)", TPM2_SHA256_DIGEST_SIZE);
 
     tpm2_eventlog_context ctx = {0};
-    assert_true(foreach_digest2(&ctx, 0, pcr_index, digest, 1, TCG_DIGEST2_SHA256_SIZE));
+    assert_true(foreach_digest2(&ctx, 0, pcr_index, digest, 1, TCG_DIGEST2_SHA256_SIZE, 0));
     assert_memory_equal(ctx.sha256_pcrs[pcr_index], sha256sum, sizeof(sha256sum));
 }
 static void test_foreach_digest2_cbfail(void **state){
@@ -105,7 +105,7 @@ static void test_foreach_digest2_cbfail(void **state){
     will_return(foreach_digest2_test_callback, false);
 
     tpm2_eventlog_context ctx = { .digest2_cb = foreach_digest2_test_callback };
-    assert_false(foreach_digest2(&ctx, 0, 0, digest, 1, TCG_DIGEST2_SHA1_SIZE));
+    assert_false(foreach_digest2(&ctx, 0, 0, digest, 1, TCG_DIGEST2_SHA1_SIZE, 0));
 }
 static void test_digest2_accumulator_callback(void **state) {
 


### PR DESCRIPTION
According to the "TCG PC Client Platform Firmware Profile Specification Level 00 Version 1.05 Revision 23" section 10.4.5.3 the startup locality is the starting value of PCR0. This can be currently either 0 or 3.

This implements support for replaying logs where locality is not 0. 

Fixes: https://github.com/tpm2-software/tpm2-tools/issues/3146
