### PR TITLE
configure: check for efivar/efivar.h manually

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -92,9 +92,9 @@ AC_ARG_WITH([efivar],
 
 # use the true program to avoid failing hard
 AS_IF([test "x$with_efivar" == "xauto"],
-  [PKG_CHECK_MODULES([EFIVAR], [efivar],,[true])],
+  [PKG_CHECK_MODULES([EFIVAR], [efivar], [AC_CHECK_HEADERS([efivar/efivar.h], , [true])], [true])],
   [test "x$with_efivar" == "xyes"],
-  [PKG_CHECK_MODULES([EFIVAR], [efivar])],
+  [PKG_CHECK_MODULES([EFIVAR], [efivar], [AC_CHECK_HEADERS([efivar/efivar.h])])],
 )
 
 # backwards compat with older pkg-config

--- a/lib/tpm2_eventlog_yaml.c
+++ b/lib/tpm2_eventlog_yaml.c
@@ -277,7 +277,8 @@ char *yaml_devicepath(BYTE* dp, UINT64 dp_len) {
         return NULL;
     }
   
-    ret = efidp_format_device_path((unsigned char *)text_path,
+    /* The void* cast is a hack to support efivar versions < 38 */
+    ret = efidp_format_device_path((void *)text_path,
             text_path_len, (const_efidp)dp, dp_len);
     if (ret < 0) {
         free(text_path);


### PR DESCRIPTION
I noticed during my testing `DevicePath`s are not decoded even when compiled with `--with-efivar`.
The reason was that the code checks for `HAVE_EFIVAR_EFIVAR_H`, but only `PKG_CHECK_MODULES` is used to detect if `libefivar.so` is present, not if the header is also there. This commit adds that check.