### PR TITLE
fapi: fix tests with policy and auth value.

### DIFF
--- a/test/integration/fapi/fapi-nv-write-read-policy-or.sh
+++ b/test/integration/fapi/fapi-nv-write-read-policy-or.sh
@@ -21,7 +21,7 @@ POLICY_NV_DATA=$TEMP_DIR/pol_nv_read_write.json
 POLICY_NV=/policy/nv_read_write
 LOG_FILE=$TEMP_DIR/log.file
 touch $LOG_FILE
-PW=abc
+PW=""
 
 tss2 provision
 

--- a/test/integration/fapi/fapi-nv-write-read-policy-or2.sh
+++ b/test/integration/fapi/fapi-nv-write-read-policy-or2.sh
@@ -23,7 +23,14 @@ LOG_FILE=$TEMP_DIR/log.file
 touch $LOG_FILE
 PW=abc
 
+#
+# Test will be temporally skipped because policy password does not make
+# sense because password is allways needed for paramter encryption.
+# The test has to be adapted to a better use case.
+#
 tss2 provision
+
+skip_test
 
 echo test > $DATA_WRITE_FILE
 


### PR DESCRIPTION
fapi did not encrypt tpm2b parameters for objects with policy authorization. After this error is fixed the auth value is required to compute the key for parameter encryption. The affected tests were skipped or adapted.

Signed-off-by: Juergen Repp <juergen_repp@web.de>