### PR TITLE
man/tpm2_verifysignature.1.md: correct example command tpm2_sign

### DIFF
--- a/man/tpm2_verifysignature.1.md
+++ b/man/tpm2_verifysignature.1.md
@@ -92,7 +92,7 @@ tpm2_load -C primary.ctx -u rsa.pub -r rsa.priv -c rsa.ctx
 
 echo "my message > message.dat
 
-tpm2_sign -c rsa.ctx -g sha256 -m message.dat -s sig.rssa
+tpm2_sign -c rsa.ctx -g sha256 -s sig.rssa message.dat
 
 tpm2_verifysignature -c rsa.ctx -g sha256 -m message.dat -s sig.rssa
 ```


### PR DESCRIPTION
There is actually no -m option in tpm2_sign, the example command has made a mistake, so correct it, link what's in man/tpm2_sign.1.md.