### PR TITLE
tools/tpm2_unseal.c: add qualifier static to enhance privacy of unseal function

### DIFF
--- a/man/tpm2_verifysignature.1.md
+++ b/man/tpm2_verifysignature.1.md
@@ -92,7 +92,7 @@ tpm2_load -C primary.ctx -u rsa.pub -r rsa.priv -c rsa.ctx
 
 echo "my message > message.dat
 
-tpm2_sign -c rsa.ctx -g sha256 -m message.dat -s sig.rssa
+tpm2_sign -c rsa.ctx -g sha256 -s sig.rssa message.dat
 
 tpm2_verifysignature -c rsa.ctx -g sha256 -m message.dat -s sig.rssa
 ```

--- a/tools/tpm2_unseal.c
+++ b/tools/tpm2_unseal.c
@@ -51,7 +51,7 @@ static tpm_unseal_ctx ctx = {
     .parameter_hash_algorithm = TPM2_ALG_ERROR,
 };
 
-tool_rc unseal(ESYS_CONTEXT *ectx) {
+static tool_rc unseal(ESYS_CONTEXT *ectx) {
 
     /*
      * 1. TPM2_CC_<command> OR Retrieve cpHash


### PR DESCRIPTION
Other tpm2_xxx.c have qualifier "static" before their "main function",
for example: static tool_rc load(ESYS_CONTEXT *ectx) in tpm2_load.c,
only function unseal in tpm2_unseal.c lacks it, so add it before unseal
function to enhance privacy.