### PR TITLE
man/tpm2_encodeobject: Correct example usage

### DIFF
--- a/man/tpm2_encodeobject.1.md
+++ b/man/tpm2_encodeobject.1.md
@@ -86,7 +86,7 @@ The final step, is encoding the public and private portions of the object into a
 PEM format.
 
 ```bash
-tpm2_encodeobject -C primary.ctx -u key.pub -r key.priv -c priv.pem
+tpm2_encodeobject -C primary.ctx -u key.pub -r key.priv -o priv.pem
 ```
 
 The generated `priv.pem` can be used together with `pub.pem` created in the


### PR DESCRIPTION
There is no -c option in encodeobject, use the correct -o option for output instead.