### PR TITLE
tpm2_duplicate: add --key-algorithm option.

### DIFF
--- a/man/tpm2_duplicate.1.md
+++ b/man/tpm2_duplicate.1.md
@@ -21,9 +21,15 @@ These options control the key importation process:
 
   * **-G**, **\--wrapper-algorithm**=_ALGORITHM_:
 
-    The symmetric algorithm to be used for the inner wrapper. Supports:
+    The symmetric algorithm to be used for the inner wrapper if -U is not used.
+    Supports:
     * aes - AES 128 in CFB mode.
     * null - none
+    The key algorithm associated with the public parent if -U is used.
+
+  * **-G**, **\--key-algorithm**=_ALGORITHM_:
+
+    The key algorithm associated with the public parent if -U is used.
 
   * **-i**, **\--encryptionkey-in**=_FILE_:
 
@@ -45,6 +51,8 @@ These options control the key importation process:
 
     Specifies the file path to the public key of the parent object on the
     destination TPM.  This should be a `TPM2B_PUBLIC` formatted file.
+    This public key is used for the wrapping of a PEM or DER key
+    which will be exported for a remote TPM.
 
   * **-k**, **\--private-key**=_FILE_:
 

--- a/tools/tpm2_duplicate.c
+++ b/tools/tpm2_duplicate.c
@@ -559,6 +559,7 @@ static bool tpm2_tool_onstart(tpm2_options **opts) {
       { "auth",              required_argument, 0, 'p'},
       { "policy",            required_argument, 0, 'L'},
       { "wrapper-algorithm", required_argument, 0, 'G'},
+      { "key-algorithm",     required_argument, 0, 'G'},
       { "private",           required_argument, 0, 'r'},
       { "public",            required_argument, 0, 'u'},
       { "private-key",       required_argument, 0, 'k'},


### PR DESCRIPTION
The -G --wrapper-algorithm option was used for the symmetric algorithm used for the inner wrapper and the algorithm of the public key used to wrap an openSSL key for the destination TPM.
To match this parameter with the options used for tpm2_create the long option --key-algorithm is now also mapped to -G. Fixes #3259