### PR TITLE
tpm2: accept full path to tpm2 binary

### DIFF
--- a/tools/tpm2_tool.c
+++ b/tools/tpm2_tool.c
@@ -149,7 +149,8 @@ int main(int argc, char **argv) {
      */
     umask(0117);
 
-    bool is_str_tpm2 = (strcmp(argv[0], "tpm2") == 0);
+    char *argv0 = basename(argv[0]);
+    bool is_str_tpm2 = (strcmp(argv0, "tpm2") == 0);
 
     bool is_one_opt_specified = (argc == 2 && is_str_tpm2);
 


### PR DESCRIPTION
When tpm2 is placed behind a wrapper, or if not immediately in the PATH, the argv0 may be the full path to the binary.

This commit reworks the parsing of the argv0 to only read from its basename.