### PR TITLE
Revert "fapi: fix tests with policy and auth value."

### DIFF
--- a/test/integration/fapi/fapi-nv-write-read-policy-or.sh
+++ b/test/integration/fapi/fapi-nv-write-read-policy-or.sh
@@ -21,7 +21,7 @@ POLICY_NV_DATA=$TEMP_DIR/pol_nv_read_write.json
 POLICY_NV=/policy/nv_read_write
 LOG_FILE=$TEMP_DIR/log.file
 touch $LOG_FILE
-PW=""
+PW=abc
 
 tss2 provision
 

--- a/test/integration/fapi/fapi-nv-write-read-policy-or2.sh
+++ b/test/integration/fapi/fapi-nv-write-read-policy-or2.sh
@@ -23,14 +23,7 @@ LOG_FILE=$TEMP_DIR/log.file
 touch $LOG_FILE
 PW=abc
 
-#
-# Test will be temporally skipped because policy password does not make
-# sense because password is allways needed for paramter encryption.
-# The test has to be adapted to a better use case.
-#
 tss2 provision
-
-skip_test
 
 echo test > $DATA_WRITE_FILE
 


### PR DESCRIPTION
fapi now encrypts tpm2b parameters for objects with policy authorization in a second session. Thus the related tests which did not work because parameter encryption was done by the policy session now work again.

This reverts commit 7cb3fdf786ab6ad749174a4548f4662e56b9ae15.

Signed-off-by: Juergen Repp <juergen_repp@web.de>