### PR TITLE
tpm2_createek: Fix integrating nonce

### DIFF
--- a/tools/tpm2_createek.c
+++ b/tools/tpm2_createek.c
@@ -270,13 +270,13 @@ static tool_rc set_ek_template(ESYS_CONTEXT *ectx, TPM2B_PUBLIC *input_public) {
 
     if (input_public->publicArea.type == TPM2_ALG_RSA) {
         if (nonce_size) {
-            memcpy(&input_public->publicArea.unique.rsa.buffer, &nonce, nonce_size);
+            memcpy(&input_public->publicArea.unique.rsa.buffer, nonce, nonce_size);
             input_public->publicArea.unique.rsa.size = 256;
         }
     } else {
         // ECC is only other supported algorithm
         if (nonce_size) {
-            memcpy(&input_public->publicArea.unique.ecc.x.buffer, &nonce, nonce_size);
+            memcpy(&input_public->publicArea.unique.ecc.x.buffer, nonce, nonce_size);
             input_public->publicArea.unique.ecc.x.size = 32;
             input_public->publicArea.unique.ecc.y.size = 32;
         }


### PR DESCRIPTION
I externally create the EK with a given template and nonce. And I wondered why `tpm2_createek` yields a different EK than what I retrieve. I eventually figured out that the `tpm2_createek` code falsely copies the pointer into the final template, instead of the actual nonce.

By fixing this with these changes, the EK from `tpm2_createek` and my code is consistent.