### PR TITLE
tpm2_createek: Correct man page example

### DIFF
--- a/man/tpm2_createek.1.md
+++ b/man/tpm2_createek.1.md
@@ -94,7 +94,7 @@ tpm2_createek -G ecc384 -c 0x81010002
 
 ### Create a transient Endorsement Key, flush it, and reload it.
 ```bash
-tpm2_createek -G rsa -u ek.pub
+tpm2_createek -c ek.ctx -G rsa -u ek.pub
 
 # Check that it is loaded in transient memory
 tpm2_getcap handles-transient


### PR DESCRIPTION
The example
```
tpm2_createek -G rsa -u ek.pub
```
from `man tpm2_createek` misses to provide `-c`.

It thus fails with
```
ERROR: Expected option -c
```

According to [tools/tpm2_createek.c:441](https://github.com/tpm2-software/tpm2-tools/blob/master/tools/tpm2_createek.c#L441), the option must be present in any case. Adjust the man page example accordingly.