### PR TITLE
Ensure crypto function configure-time detection uses CRYPTO_LIBS.

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -74,12 +74,15 @@ PKG_CHECK_MODULES([TSS2_MU], [tss2-mu])
 PKG_CHECK_MODULES([TSS2_RC], [tss2-rc])
 PKG_CHECK_MODULES([TSS2_SYS], [tss2-sys])
 PKG_CHECK_MODULES([CRYPTO], [libcrypto >= 1.1.0])
+LIBS_save="${LIBS}"
+LIBS="${CRYPTO_LIBS} ${LIBS}"
 AC_CHECK_LIB(crypto, [EVP_sm3], [
         AC_DEFINE([HAVE_EVP_SM3], [1], [Support EVP_sm3 in openssl])],
         [])
 AC_CHECK_LIB(crypto, [EVP_sm4_cfb128], [
         AC_DEFINE([HAVE_EVP_SM4_CFB], [1], [Support EVP_sm4_cfb in openssl])],
         [])
+LIBS="${LIBS_save}"
 PKG_CHECK_MODULES([CURL], [libcurl])
 
 # pretty print of devicepath if efivar library is present


### PR DESCRIPTION
Fixes #3286