### PR TITLE
Save Context: Add the possibility for autoflush.

### DIFF
--- a/lib/files.c
+++ b/lib/files.c
@@ -273,11 +273,11 @@ out:
 }
 
 tool_rc files_save_tpm_context_to_file(ESYS_CONTEXT *ectx, ESYS_TR handle,
-        FILE *stream) {
+        FILE *stream, bool autoflush) {
 
     TPMS_CONTEXT *context = NULL;
 
-    tool_rc rc = tpm2_context_save(ectx, handle, &context);
+    tool_rc rc = tpm2_context_save(ectx, handle, autoflush, &context);
     if (rc != tool_rc_success) {
         return rc;
     }
@@ -288,7 +288,7 @@ tool_rc files_save_tpm_context_to_file(ESYS_CONTEXT *ectx, ESYS_TR handle,
 }
 
 tool_rc files_save_tpm_context_to_path(ESYS_CONTEXT *context, ESYS_TR handle,
-        const char *path) {
+        const char *path, bool autoflush) {
 
     FILE *f = fopen(path, "w+b");
     if (!f) {
@@ -297,7 +297,7 @@ tool_rc files_save_tpm_context_to_path(ESYS_CONTEXT *context, ESYS_TR handle,
         return tool_rc_general_error;
     }
 
-    tool_rc rc = files_save_tpm_context_to_file(context, handle, f);
+    tool_rc rc = files_save_tpm_context_to_file(context, handle, f, autoflush);
     fclose(f);
     return rc;
 }

--- a/lib/files.h
+++ b/lib/files.h
@@ -84,12 +84,14 @@ bool files_save_bytes_to_file(const char *path, UINT8 *buf, UINT16 size);
  *  The object handle for the object to save.
  * @param path
  *  The output path of the file.
+ * @param autoflush
+ *  Flush the tpm object after context save.
  *
  * @return
  *  tool_rc indicating status.
  */
 tool_rc files_save_tpm_context_to_path(ESYS_CONTEXT *context, ESYS_TR handle,
-        const char *path);
+        const char *pathm, bool autoflush);
 
 /**
  * Like files_save_tpm_context_to_path() but saves a tpm session to a FILE stream.
@@ -99,11 +101,13 @@ tool_rc files_save_tpm_context_to_path(ESYS_CONTEXT *context, ESYS_TR handle,
  *  The object handle for the object to save.
  * @param stream
  *  The FILE stream to save too.
+ * @param autoflush
+ *  Flush the tpm object after context save.
  * @return
  *  tool_rc indicating status.
  */
 tool_rc files_save_tpm_context_to_file(ESYS_CONTEXT *context, ESYS_TR handle,
-        FILE *stream);
+        FILE *stream, bool autoflush);
 
 /**
  * Loads a ESAPI TPM object context from disk or an ESAPI serialized ESYS_TR object.

--- a/lib/tpm2.h
+++ b/lib/tpm2.h
@@ -41,7 +41,7 @@ tool_rc tpm2_nv_read(ESYS_CONTEXT *esys_context,
     TPMI_ALG_HASH parameter_hash_algorithm, ESYS_TR shandle2, ESYS_TR shandle3);
 
 tool_rc tpm2_context_save(ESYS_CONTEXT *esys_context, ESYS_TR save_handle,
-        TPMS_CONTEXT **context);
+        bool autoflush, TPMS_CONTEXT **context);
 
 tool_rc tpm2_context_load(ESYS_CONTEXT *esys_context,
         const TPMS_CONTEXT *context, ESYS_TR *loaded_handle);

--- a/lib/tpm2_options.h
+++ b/lib/tpm2_options.h
@@ -8,10 +8,10 @@
 #include <stdio.h>
 
 #include <getopt.h>
-
 #include <tss2/tss2_sys.h>
 
 #define TPM2TOOLS_ENV_TCTI      "TPM2TOOLS_TCTI"
+#define TPM2TOOLS_ENV_AUTOFLUSH "TPM2TOOLS_AUTOFLUSH"
 
 #define TPM2TOOLS_ENV_ENABLE_ERRATA  "TPM2TOOLS_ENABLE_ERRATA"
 

--- a/lib/tpm2_session.c
+++ b/lib/tpm2_session.c
@@ -411,7 +411,7 @@ tool_rc tpm2_session_close(tpm2_session **s) {
     ESYS_TR handle = tpm2_session_get_handle(session);
     LOG_INFO("Saved session: ESYS_TR(0x%x)", handle);
     rc = files_save_tpm_context_to_file(session->internal.ectx, handle,
-    session_file);
+         session_file, false);
     if (rc != tool_rc_success) {
         LOG_ERR("Could not write session context");
         /* done, free session resources and use rc to indicate status */

--- a/lib/tpm2_util.c
+++ b/lib/tpm2_util.c
@@ -632,6 +632,14 @@ char *tpm2_util_getenv(const char *name) {
     return getenv(name);
 }
 
+bool tpm2_util_env_yes(const char *name) {
+
+    char *value = getenv(name);
+    return (value && (strcasecmp(name, "yes") == 0 ||
+                      strcasecmp(name, "1") == 0 ||
+                      strcasecmp(name, "true") == 0));
+}
+
 /**
  * Parses a hierarchy value from an option argument.
  * @param value

--- a/lib/tpm2_util.h
+++ b/lib/tpm2_util.h
@@ -433,6 +433,8 @@ ESYS_TR tpm2_tpmi_hierarchy_to_esys_tr(TPMI_RH_PROVISION inh);
 
 char *tpm2_util_getenv(const char *name);
 
+bool tpm2_util_env_yes(const char *name);
+
 typedef enum tpm2_handle_flags tpm2_handle_flags;
 enum tpm2_handle_flags {
     TPM2_HANDLE_FLAGS_NONE = 0,

--- a/man/common/options.md
+++ b/man/common/options.md
@@ -27,3 +27,8 @@ information that many users may expect.
     Enable the application of errata fixups. Useful if an errata fixup needs to be
     applied to commands sent to the TPM. Defining the environment
     TPM2TOOLS\_ENABLE\_ERRATA is equivalent.
+  * **-R**, **\--autoflush**:
+    Enable autoflush for transient objects created by the command. If a parent
+    object is loaded from a context file also the transient parent object will
+    be flushed. Autoflush can also be activated if the environment variable
+    TPM2TOOLS\_AUTOFLUSH is is set to yes or true.

--- a/test/integration/tests/load.sh
+++ b/test/integration/tests/load.sh
@@ -51,13 +51,13 @@ tpm2 clear
 
 #####file test
 
-tpm2 createprimary -Q -C e -g $alg_primary_obj -G $alg_primary_key \
+tpm2 createprimary -R -Q -C e -g $alg_primary_obj -G $alg_primary_key \
 -c $file_primary_key_ctx
 
-tpm2 create -Q -g $alg_create_obj -G $alg_create_key -u $file_load_key_pub \
+tpm2 create -R -Q -g $alg_create_obj -G $alg_create_key -u $file_load_key_pub \
 -r $file_load_key_priv -C $file_primary_key_ctx
 
-tpm2 load -Q -C $file_primary_key_ctx -u $file_load_key_pub \
+tpm2 load -R -Q -C $file_primary_key_ctx -u $file_load_key_pub \
 -r $file_load_key_priv -n $file_load_key_name -c $file_load_key_ctx
 
 #####handle test

--- a/test/unit/test_tpm2_session.c
+++ b/test/unit/test_tpm2_session.c
@@ -24,10 +24,11 @@ static void test_tpm2_create_dummy_context(TPMS_CONTEXT *context) {
     memset(context->contextBlob.buffer, '\0', context->contextBlob.size);
 }
 
-tool_rc __wrap_tpm2_context_save(ESYS_CONTEXT *esysContext, ESYS_TR saveHandle,
+tool_rc __wrap_tpm2_context_save(ESYS_CONTEXT *esysContext, ESYS_TR saveHandle, bool autoflush,
         TPMS_CONTEXT **context) {
 
     UNUSED(esysContext);
+    UNUSED(autoflush);
 
     // context should be non-null or bool files_save_tpm_context_to_file()
     // segfaults

--- a/tools/fapi/tss2_gettpm2object.c
+++ b/tools/fapi/tss2_gettpm2object.c
@@ -127,7 +127,7 @@ static int tss2_tool_onrun (FAPI_CONTEXT *fctx) {
              LOG_PERR("Esys_ContextLoad", e_rc);
              goto error;
          }
-         t_rc = files_save_tpm_context_to_file(esys_ctx, esys_handle, stream);
+         t_rc = files_save_tpm_context_to_file(esys_ctx, esys_handle, stream, false);
          if (t_rc != tool_rc_success) {
              goto error;
          }

--- a/tools/tpm2_create.c
+++ b/tools/tpm2_create.c
@@ -61,7 +61,7 @@ struct tpm_create_ctx {
     } object;
 
     bool is_createloaded;
-
+    bool autoflush;
     /*
      * Parameter hashes
      */
@@ -103,6 +103,7 @@ static tpm_create_ctx ctx = {
         .is_command_dispatch = true,
         .parameter_hash_algorithm = TPM2_ALG_ERROR,
         .format = pubkey_format_tss,
+        .autoflush = false,
 };
 
 static bool load_outside_info(TPM2B_DATA *outside_info) {
@@ -124,6 +125,8 @@ static void print_help_message() {
 }
 
 static tool_rc create(ESYS_CONTEXT *ectx) {
+
+    TSS2_RC rval;
 
     /*
      * 1. TPM2_CC_<command> OR Retrieve cpHash
@@ -179,6 +182,14 @@ static tool_rc create(ESYS_CONTEXT *ectx) {
         }
     }
 
+    if ((ctx.autoflush || tpm2_util_env_yes(TPM2TOOLS_ENV_AUTOFLUSH)) &&
+        ctx.parent.object.path &&
+        (ctx.parent.object.handle & TPM2_HR_RANGE_MASK) == TPM2_HR_TRANSIENT) {
+        rval = Esys_FlushContext(ectx, ctx.parent.object.tr_handle);
+        if (rval != TPM2_RC_SUCCESS) {
+            return tool_rc_general_error;
+        }
+    }
     return tool_rc_success;
 }
 
@@ -311,8 +322,8 @@ create_out:
 
     if (ctx.object.ctx_path) {
         rc = files_save_tpm_context_to_path(ectx, ctx.object.object_handle,
-            ctx.object.ctx_path);
-
+             ctx.object.ctx_path, ctx.autoflush);
+        
         if (rc != tool_rc_success) {
             goto out;
         }
@@ -559,6 +570,9 @@ static bool on_option(char key, char *value) {
     case 'o':
         ctx.output_path = value;
         break;
+    case 'R':
+        ctx.autoflush = true;
+        break;
         /* no default */
     };
 
@@ -590,9 +604,10 @@ static bool tpm2_tool_onstart(tpm2_options **opts) {
       { "session",        required_argument, NULL, 'S' },
       { "format",         required_argument, NULL, 'f' },
       { "output",         required_argument, NULL, 'o' },
+      { "autoflush",      no_argument,       NULL, 'R' },
     };
 
-    *opts = tpm2_options_new("P:p:g:G:a:i:L:u:r:C:c:t:d:q:l:S:o:f:",
+    *opts = tpm2_options_new("P:p:g:G:a:i:L:u:r:C:c:t:d:q:l:S:o:f:R",
     ARRAY_LEN(topts), topts, on_option, NULL, 0);
 
     return *opts != NULL;

--- a/tools/tpm2_load.c
+++ b/tools/tpm2_load.c
@@ -44,13 +44,17 @@ struct tpm_tool_ctx {
     TPM2B_DIGEST cp_hash;
     bool is_command_dispatch;
     TPMI_ALG_HASH parameter_hash_algorithm;
+    bool autoflush;
 };
 
 static tpm_load_ctx ctx = {
     .parameter_hash_algorithm = TPM2_ALG_ERROR,
+    .autoflush = false,
 };
 
 static tool_rc load(ESYS_CONTEXT *ectx) {
+
+    TSS2_RC rval;
 
     /*
      * If a tssprivkey was specified, load the private and public from the
@@ -62,8 +66,20 @@ static tool_rc load(ESYS_CONTEXT *ectx) {
     TPM2B_PUBLIC *to_load_pub =
         ctx.is_tss_pem ? &tpm2_util_object_tsspem_pub : &ctx.object.public;
 
-    return tpm2_load(ectx, &ctx.parent.object, to_load_priv, to_load_pub,
+    tool_rc tmp_rc = tpm2_load(ectx, &ctx.parent.object, to_load_priv, to_load_pub,
         &ctx.object.handle, &ctx.cp_hash, ctx.parameter_hash_algorithm);
+    if (tmp_rc != tool_rc_success) {
+        return tmp_rc;
+    }
+    if ((ctx.autoflush || tpm2_util_env_yes(TPM2TOOLS_ENV_AUTOFLUSH)) &&
+        ctx.parent.object.path &&
+        (ctx.parent.object.handle & TPM2_HR_RANGE_MASK) == TPM2_HR_TRANSIENT) {
+        rval = Esys_FlushContext(ectx, ctx.parent.object.tr_handle);
+        if (rval != TPM2_RC_SUCCESS) {
+            return tool_rc_general_error;
+        }
+    }
+    return tool_rc_success;
 }
 
 static tool_rc process_output(ESYS_CONTEXT *ectx) {
@@ -110,7 +126,7 @@ static tool_rc process_output(ESYS_CONTEXT *ectx) {
     }
 
     return files_save_tpm_context_to_path(ectx, ctx.object.handle,
-            ctx.contextpath);
+           ctx.contextpath, ctx.autoflush);
 }
 
 static tool_rc process_inputs(ESYS_CONTEXT *ectx) {
@@ -281,6 +297,10 @@ static bool on_option(char key, char *value) {
     case 0:
         ctx.cp_hash_path = value;
         break;
+    case 'R':
+        ctx.autoflush = true;
+        break;
+
     }
 
     return true;
@@ -296,9 +316,10 @@ static bool tpm2_tool_onstart(tpm2_options **opts) {
       { "key-context",    required_argument, 0, 'c' },
       { "parent-context", required_argument, 0, 'C' },
       { "cphash",         required_argument, 0,  0  },
+      { "autoflush",      no_argument,       0, 'R' },
     };
 
-    *opts = tpm2_options_new("P:u:r:n:C:c:", ARRAY_LEN(topts), topts, on_option,
+    *opts = tpm2_options_new("P:u:r:n:C:c:R", ARRAY_LEN(topts), topts, on_option,
         0, 0);
 
     return *opts != 0;


### PR DESCRIPTION
If the environment variable TPM2TOOLS_AUTOFLUSH exists transient objects will be removed after they were saved and stored to disk. Also a transient parent will be removed if a context file for this parent was used by this command.
For the commands which will check the autoflush also an option -R is added to enable the autoflush independent from the environment variable.
Addresses: #1511

Signed-off-by: Juergen Repp <juergen_repp@web.de>