### PR TITLE
options: fix TCTI handling

### DIFF
--- a/lib/tpm2_options.c
+++ b/lib/tpm2_options.c
@@ -434,44 +434,43 @@ tpm2_option_code tpm2_handle_options(int argc, char **argv,
          * SAPI
          */
         bool is_sapi =
-            (!tool_opts || !tool_opts->flags);
+            !tool_opts || !(tool_opts->flags & TPM2_OPTIONS_NO_SAPI);
 
-        /*
-         * NO_SAPI
-         */
-        bool is_no_sapi =
-            (tool_opts && tool_opts->flags & TPM2_OPTIONS_NO_SAPI);
-        /* tool doesn't use sapi, skip tcti checks and continue */
-        if (is_no_sapi) {
+       bool is_optional_sapi =
+           (tool_opts && (tool_opts->flags & TPM2_OPTIONS_OPTIONAL_SAPI));
+
+        /* tool doesn't REQUIRE the use sapi, skip tcti checks and continue */
+        if (!is_sapi && !is_optional_sapi) {
             if (flags->tcti_none && !flags->quiet) {
                 LOG_WARN("Tool does not use SAPI. Continuing with tcti=none");
             }
             goto out;
         }
 
-        /*
-         * OPTIONAL_SAPI
-         */
-        bool is_optional_sapi =
-            (tool_opts && tool_opts->flags & TPM2_OPTIONS_OPTIONAL_SAPI);
+        bool is_fake_tcti = (flags->tcti_none && tool_opts &&
+            (tool_opts->flags & TPM2_OPTIONS_FAKE_TCTI));
 
         /*
-         * Actions when tcti is "none"
+         * get the TCTI variable from the env if user didn't specify
+         * on command line. We cant' use flags->tcti_none until we
+         * check the env!
          */
         bool is_tcti_from_env =
-            (!is_no_sapi && tcti_conf_option == 0);
+            ((is_sapi || is_optional_sapi) && !tcti_conf_option);
         if (is_tcti_from_env) {
             tcti_conf_option = tpm2_util_getenv(TPM2TOOLS_ENV_TCTI);
+            flags->tcti_none = tcti_conf_option && !strcmp(tcti_conf_option, "none");
         }
 
-        if (flags->tcti_none && is_sapi) {
+        /* A tool the needs a SAPI (and not a fake one) should fail */
+        if (flags->tcti_none && !is_fake_tcti && !is_optional_sapi && is_sapi) {
             LOG_ERR("Requested no tcti, but tool requires TCTI.");
             rc = tpm2_option_code_err;
             goto out;
         }
 
         /* tool doesn't request a sapi, don't initialize one */
-        if (flags->tcti_none && is_optional_sapi) {
+        if (flags->tcti_none && is_optional_sapi && !is_fake_tcti) {
             if (!flags->quiet) {
                 LOG_WARN("Tool optionally uses SAPI. Continuing with tcti=none");
             }
@@ -491,9 +490,7 @@ tpm2_option_code tpm2_handle_options(int argc, char **argv,
             .finalize = tcti_fake_finalize
         };
 
-        bool is_optional_fake_tcti = (flags->tcti_none && tool_opts &&
-            tool_opts->flags & TPM2_OPTIONS_OPTIONAL_SAPI_AND_FAKE_TCTI);
-        if (is_optional_fake_tcti) {
+        if (is_fake_tcti) {
             if (!flags->quiet) {
                 LOG_WARN("Tool optionally uses SAPI. Continuing with tcti=fake");
             }

--- a/lib/tpm2_options.h
+++ b/lib/tpm2_options.h
@@ -65,9 +65,9 @@ typedef bool (*tpm2_arg_handler)(int argc, char **argv);
  * TPM2_OPTIONS_NO_SAPI:
  *  Skip SAPI initialization. Removes the "-T" common option.
  */
-#define TPM2_OPTIONS_NO_SAPI 0x1
-#define TPM2_OPTIONS_OPTIONAL_SAPI 0x2
-#define TPM2_OPTIONS_OPTIONAL_SAPI_AND_FAKE_TCTI 0x4
+#define TPM2_OPTIONS_NO_SAPI       (1 << 0)
+#define TPM2_OPTIONS_OPTIONAL_SAPI (1 << 1)
+#define TPM2_OPTIONS_FAKE_TCTI     (1 << 3)
 
 struct tpm2_options {
     struct {

--- a/tools/tpm2_nvcertify.c
+++ b/tools/tpm2_nvcertify.c
@@ -345,7 +345,7 @@ static tool_rc check_options(ESYS_CONTEXT *ectx, tpm2_option_flags flags) {
      * none we fall back to the old behavior of reading from a define NV index
      * 
      * Also, tcti is setup to a fake_tcti when tcti is specified "none" as the
-     * tool option affords TPM2_OPTIONS_OPTIONAL_SAPI_AND_FAKE_TCTI.
+     * tool option affords TPM2_OPTIONS_FAKE_TCTI.
      * 
      * If NVindex name is not specified and tcti is not none, it is expected
      * that the NV index is actually define. This behavior complies with the
@@ -535,7 +535,7 @@ static bool tpm2_tool_onstart(tpm2_options **opts) {
     };
 
     *opts = tpm2_options_new("C:P:c:p:g:s:f:o:q:S:n:", ARRAY_LEN(topts), topts,
-        on_option, on_arg, TPM2_OPTIONS_OPTIONAL_SAPI_AND_FAKE_TCTI);
+        on_option, on_arg, TPM2_OPTIONS_FAKE_TCTI);
 
     return *opts != NULL;
 }

--- a/tools/tpm2_nvdefine.c
+++ b/tools/tpm2_nvdefine.c
@@ -494,7 +494,7 @@ static bool tpm2_tool_onstart(tpm2_options **opts) {
     };
 
     *opts = tpm2_options_new("S:C:s:a:P:p:L:g:", ARRAY_LEN(topts), topts,
-        on_option, on_arg, TPM2_OPTIONS_OPTIONAL_SAPI_AND_FAKE_TCTI);
+        on_option, on_arg, TPM2_OPTIONS_FAKE_TCTI);
 
     return *opts != NULL;
 }

--- a/tools/tpm2_nvextend.c
+++ b/tools/tpm2_nvextend.c
@@ -282,7 +282,7 @@ static bool tpm2_tool_onstart(tpm2_options **opts) {
     };
 
     *opts = tpm2_options_new("S:C:P:i:n:", ARRAY_LEN(topts), topts, on_option,
-            on_arg, TPM2_OPTIONS_OPTIONAL_SAPI_AND_FAKE_TCTI);
+            on_arg, TPM2_OPTIONS_FAKE_TCTI);
 
     return *opts != NULL;
 }

--- a/tools/tpm2_nvincrement.c
+++ b/tools/tpm2_nvincrement.c
@@ -201,7 +201,7 @@ static tool_rc check_options(ESYS_CONTEXT *ectx, tpm2_option_flags flags) {
      * none we fall back to the old behavior of reading from a define NV index
      * 
      * Also, tcti is setup to a fake_tcti when tcti is specified "none" as the
-     * tool option affords TPM2_OPTIONS_OPTIONAL_SAPI_AND_FAKE_TCTI.
+     * tool option affords TPM2_OPTIONS_FAKE_TCTI.
      * 
      * If NVindex name is not specified and tcti is not none, it is expected
      * that the NV index is actually define. This behavior complies with the
@@ -292,7 +292,7 @@ static bool tpm2_tool_onstart(tpm2_options **opts) {
     };
 
     *opts = tpm2_options_new("C:P:S:n:", ARRAY_LEN(topts), topts, on_option,
-        on_arg, TPM2_OPTIONS_OPTIONAL_SAPI_AND_FAKE_TCTI);
+        on_arg, TPM2_OPTIONS_FAKE_TCTI);
 
     return *opts != NULL;
 }

--- a/tools/tpm2_nvread.c
+++ b/tools/tpm2_nvread.c
@@ -221,7 +221,7 @@ static tool_rc check_options(tpm2_option_flags flags) {
      * none we fall back to the old behavior of reading from a define NV index
      * 
      * Also, tcti is setup to a fake_tcti when tcti is specified "none" as the
-     * tool option affords TPM2_OPTIONS_OPTIONAL_SAPI_AND_FAKE_TCTI.
+     * tool option affords TPM2_OPTIONS_FAKE_TCTI.
      * 
      * If NVindex name is not specified and tcti is not none, it is expected
      * that the NV index is actually define. This behavior complies with the
@@ -361,7 +361,7 @@ static bool tpm2_tool_onstart(tpm2_options **opts) {
     };
 
     *opts = tpm2_options_new("C:s:o:P:n:S:", ARRAY_LEN(topts), topts, on_option,
-            on_arg, TPM2_OPTIONS_OPTIONAL_SAPI_AND_FAKE_TCTI);
+            on_arg, TPM2_OPTIONS_FAKE_TCTI);
 
     if (ctx.is_yaml) {
         ctx.offset = 0;

--- a/tools/tpm2_nvreadlock.c
+++ b/tools/tpm2_nvreadlock.c
@@ -186,7 +186,7 @@ static tool_rc check_options(tpm2_option_flags flags) {
      * none we fall back to the old behavior of reading from a define NV index
      * 
      * Also, tcti is setup to a fake_tcti when tcti is specified "none" as the
-     * tool option affords TPM2_OPTIONS_OPTIONAL_SAPI_AND_FAKE_TCTI.
+     * tool option affords TPM2_OPTIONS_FAKE_TCTI.
      * 
      * If NVindex name is not specified and tcti is not none, it is expected
      * that the NV index is actually define. This behavior complies with the
@@ -278,7 +278,7 @@ static bool tpm2_tool_onstart(tpm2_options **opts) {
     };
 
     *opts = tpm2_options_new("C:P:S:n:", ARRAY_LEN(topts), topts, on_option,
-        on_arg, TPM2_OPTIONS_OPTIONAL_SAPI_AND_FAKE_TCTI);
+        on_arg, TPM2_OPTIONS_FAKE_TCTI);
 
     return *opts != NULL;
 }

--- a/tools/tpm2_nvreadpublic.c
+++ b/tools/tpm2_nvreadpublic.c
@@ -291,7 +291,7 @@ static tool_rc check_options(ESYS_CONTEXT *ectx, tpm2_option_flags flags) {
      * none we fall back to the old behavior of reading from a define NV index
      * 
      * Also, tcti is setup to a fake_tcti when tcti is specified "none" as the
-     * tool option affords TPM2_OPTIONS_OPTIONAL_SAPI_AND_FAKE_TCTI.
+     * tool option affords TPM2_OPTIONS_FAKE_TCTI.
      * 
      * If NVindex name is not specified and tcti is not none, it is expected
      * that the NV index is actually define. This behavior complies with the
@@ -381,7 +381,7 @@ static bool tpm2_tool_onstart(tpm2_options **opts) {
     };
 
     *opts = tpm2_options_new("S:n:", ARRAY_LEN(topts), topts, on_option, on_arg,
-        TPM2_OPTIONS_OPTIONAL_SAPI_AND_FAKE_TCTI);
+        TPM2_OPTIONS_FAKE_TCTI);
 
     return *opts != 0;
 }

--- a/tools/tpm2_nvsetbits.c
+++ b/tools/tpm2_nvsetbits.c
@@ -283,7 +283,7 @@ static bool tpm2_tool_onstart(tpm2_options **opts) {
     };
 
     *opts = tpm2_options_new("C:P:i:S:n:", ARRAY_LEN(topts), topts, on_option,
-            on_arg, TPM2_OPTIONS_OPTIONAL_SAPI_AND_FAKE_TCTI);
+            on_arg, TPM2_OPTIONS_FAKE_TCTI);
 
     return *opts != NULL;
 }

--- a/tools/tpm2_nvundefine.c
+++ b/tools/tpm2_nvundefine.c
@@ -265,7 +265,7 @@ static tool_rc check_options(ESYS_CONTEXT *ectx, tpm2_option_flags flags) {
      * none we fall back to the old behavior of reading from a define NV index
      * 
      * Also, tcti is setup to a fake_tcti when tcti is specified "none" as the
-     * tool option affords TPM2_OPTIONS_OPTIONAL_SAPI_AND_FAKE_TCTI.
+     * tool option affords TPM2_OPTIONS_FAKE_TCTI.
      * 
      * If NVindex name is not specified and tcti is not none, it is expected
      * that the NV index is actually define. This behavior complies with the
@@ -413,7 +413,7 @@ static bool tpm2_tool_onstart(tpm2_options **opts) {
     };
 
     *opts = tpm2_options_new("C:P:S:n:", ARRAY_LEN(topts), topts, on_option,
-        on_arg, TPM2_OPTIONS_OPTIONAL_SAPI_AND_FAKE_TCTI);
+        on_arg, TPM2_OPTIONS_FAKE_TCTI);
 
     return *opts != NULL;
 }

--- a/tools/tpm2_nvwrite.c
+++ b/tools/tpm2_nvwrite.c
@@ -295,7 +295,7 @@ static tool_rc check_options(ESYS_CONTEXT *ectx, tpm2_option_flags flags) {
      * none we fall back to the old behavior of reading from a define NV index
      * 
      * Also, tcti is setup to a fake_tcti when tcti is specified "none" as the
-     * tool option affords TPM2_OPTIONS_OPTIONAL_SAPI_AND_FAKE_TCTI.
+     * tool option affords TPM2_OPTIONS_FAKE_TCTI.
      * 
      * If NVindex name is not specified and tcti is not none, it is expected
      * that the NV index is actually define. This behavior complies with the
@@ -432,7 +432,7 @@ static bool tpm2_tool_onstart(tpm2_options **opts) {
     };
 
     *opts = tpm2_options_new("C:P:i:S:n:", ARRAY_LEN(topts), topts, on_option,
-            on_arg, TPM2_OPTIONS_OPTIONAL_SAPI_AND_FAKE_TCTI);
+            on_arg, TPM2_OPTIONS_FAKE_TCTI);
 
     return *opts != NULL;
 }

--- a/tools/tpm2_nvwritelock.c
+++ b/tools/tpm2_nvwritelock.c
@@ -214,7 +214,7 @@ static tool_rc check_options(tpm2_option_flags flags) {
      * none we fall back to the old behavior of reading from a define NV index
      * 
      * Also, tcti is setup to a fake_tcti when tcti is specified "none" as the
-     * tool option affords TPM2_OPTIONS_OPTIONAL_SAPI_AND_FAKE_TCTI.
+     * tool option affords TPM2_OPTIONS_FAKE_TCTI.
      * 
      * If NVindex name is not specified and tcti is not none, it is expected
      * that the NV index is actually define. This behavior complies with the
@@ -313,7 +313,7 @@ static bool tpm2_tool_onstart(tpm2_options **opts) {
     };
 
     *opts = tpm2_options_new("C:P:S:n:", ARRAY_LEN(topts), topts, on_option,
-        on_arg, TPM2_OPTIONS_OPTIONAL_SAPI_AND_FAKE_TCTI);
+        on_arg, TPM2_OPTIONS_FAKE_TCTI);
 
     return *opts != NULL;
 }


### PR DESCRIPTION
A command that should work with no options would fail:

./tools/tpm2 nvdefine
ERROR:esys:src/tss2-esys/api/Esys_GetCapability.c:164:Esys_GetCapability_Async() esyscontext is NULL. ERROR:esys:src/tss2-esys/api/Esys_GetCapability.c:83:Esys_GetCapability() Error in async function ErrorCode (0x00070005) ERROR: Esys_NV_ReadPublic(0x70005) - esapi:A pointer is NULL that isn't allowed to be NULL. ERROR: Unable to run nvdefine

The handling for the optional and fake TCTI states would get conflated and not initialize an ESAPI context. Clean up the handling and make supporting a fake TCTI it's own option bit to make it less confusing to code.

After this the tool works as expected:
./tools/tpm2 nvdefine
nv-index: 0x1000000

Fixes: #3314