### PR TITLE
tpm2_nvread: fix input handling no nv index

### DIFF
--- a/tools/tpm2_nvread.c
+++ b/tools/tpm2_nvread.c
@@ -25,6 +25,7 @@ struct tpm_nvread_ctx {
     UINT32 size_to_read;
     UINT32 offset;
     bool is_yaml;
+    bool nv_specified;
 
     /*
      * Outputs
@@ -207,6 +208,11 @@ static tool_rc check_options(tpm2_option_flags flags) {
         return tool_rc_option_error;
     }
 
+    if(!ctx.nv_specified) {
+        LOG_ERR("Must specify NV index argument");
+        return tool_rc_option_error;
+    }
+
     /*
      * Peculiar to this and some other tools, the object (nvindex) name must
      * be specified when only calculating the cpHash.
@@ -281,7 +287,8 @@ static bool on_arg(int argc, char **argv) {
     if (!ctx.auth_hierarchy.ctx_path) {
         ctx.auth_hierarchy.ctx_path = argv[0];
     }
-    return on_arg_nv_index(argc, argv, &ctx.nv_index);
+
+    return ctx.nv_specified = on_arg_nv_index(argc, argv, &ctx.nv_index);
 }
 
 static bool on_option(char key, char *value) {


### PR DESCRIPTION
Fixes:
./tools/tpm2 nvread
WARN: Reading full size of the NV index
ERROR: object string is empty
ERROR: Invalid handle authorization.
ERROR: Unable to run nvread

with:
./tools/tpm2 nvread
ERROR: Must specify NV index argument
Usage: nvread [<options>] <arguments>
Where <options> are:
    [ -C | --hierarchy=<value>] [ -o | --output=<value>] [ -s | --size=<value>] [ --offset=<value>]
    [ --cphash=<value>] [ --rphash=<value>] [ -n | --name=<value>] [ -P | --auth=<value>]
    [ -S | --session=<value>] [ --print-yaml]