### PR TITLE
tpm2_sessionconfig fix usage of --disable-continuesession

### DIFF
--- a/test/integration/tests/unseal.sh
+++ b/test/integration/tests/unseal.sh
@@ -152,10 +152,13 @@ tpm2 sessionconfig enc_session.ctx --disable-encrypt
 tpm2 create -Q -C prim.ctx -u seal_key.pub -r seal_key.priv -c seal_key.ctx \
 -p sealkeypass -i- <<< $secret -S enc_session.ctx
 
-tpm2 sessionconfig enc_session.ctx --enable-encrypt
+tpm2 sessionconfig enc_session.ctx --enable-encrypt --disable-continuesession
 unsealed=`tpm2 unseal -c seal_key.ctx -p sealkeypass -S enc_session.ctx`
 test "$unsealed" == "$secret"
 
-tpm2 flushcontext enc_session.ctx
+if [ -e enc_session.ctx ]; then
+    echo "enc_session.ctx was not deleted.";
+    exit 1
+fi
 
 exit 0


### PR DESCRIPTION
If continue session was disabled a error did occur in the function for restoring the session context.
Now after usage of an session with continue session disabled the context will not be saved and the session context file will be deleted.
In one integration test continue session is now disabled and the flush for this session is removed.

Fixes: #3295

Signed-off-by: Juergen Repp <juergen_repp@web.de>