### PR TITLE
tpm2_tool.c Fix missing include for basename.

### DIFF
--- a/tools/tpm2_tool.c
+++ b/tools/tpm2_tool.c
@@ -3,6 +3,7 @@
 #include <stdbool.h>
 #include <stdlib.h>
 #include <string.h>
+#include <libgen.h>
 
 #include <openssl/err.h>
 #include <openssl/evp.h>


### PR DESCRIPTION
tpm2_tool.c did not compile without the include libgen.h on netbsd. Fixes: #3321