### PR TITLE
test/unit: fix tpm2_header test on BE machines

### DIFF
--- a/lib/files.c
+++ b/lib/files.c
@@ -45,7 +45,7 @@ static const UINT32 MAGIC = 0xBADCC0DE;
  * @return
  *  True on success, False otherwise.
  */
-static bool writex(FILE *f, UINT8 *data, size_t size) {
+static bool writex(FILE *f, const UINT8 *data, size_t size) {
 
     size_t wrote = 0;
     size_t index = 0;
@@ -574,7 +574,7 @@ bool files_read_bytes_chunk(FILE *out, UINT8 bytes[], size_t len, size_t *read_l
     return (chunk_len == len);
 }
 
-bool files_write_bytes(FILE *out, uint8_t bytes[], size_t len) {
+bool files_write_bytes(FILE *out, const uint8_t *bytes, size_t len) {
 
     BAIL_ON_NULL("FILE", out);
     BAIL_ON_NULL("bytes", bytes);

--- a/lib/files.h
+++ b/lib/files.h
@@ -534,7 +534,7 @@ bool files_write_64(FILE *out, UINT64 data);
  * @return
  *  True on success, False otherwise.
  */
-bool files_write_bytes(FILE *out, UINT8 data[], size_t size);
+bool files_write_bytes(FILE *out, const UINT8 *data, size_t size);
 
 /**
  * Reads a 16 bit value from a file converting from big endian to host

--- a/lib/tpm2_header.h
+++ b/lib/tpm2_header.h
@@ -43,7 +43,7 @@ union tpm2_response_header {
  * @return
  *  A converted byte array.
  */
-static inline tpm2_command_header *tpm2_command_header_from_bytes(UINT8 *h) {
+static inline const tpm2_command_header *tpm2_command_header_from_bytes(const UINT8 *h) {
 
     return (tpm2_command_header *) h;
 }
@@ -55,7 +55,7 @@ static inline tpm2_command_header *tpm2_command_header_from_bytes(UINT8 *h) {
  * @return
  *  A converted byte array.
  */
-static inline tpm2_response_header *tpm2_response_header_from_bytes(UINT8 *h) {
+static inline const tpm2_response_header *tpm2_response_header_from_bytes(const UINT8 *h) {
 
     return (tpm2_response_header *) h;
 }
@@ -67,7 +67,7 @@ static inline tpm2_response_header *tpm2_response_header_from_bytes(UINT8 *h) {
  * @return
  */
 static inline TPMI_ST_COMMAND_TAG tpm2_command_header_get_tag(
-        tpm2_command_header *command) {
+        const tpm2_command_header *command) {
 
     return tpm2_util_ntoh_16(command->tag);
 }
@@ -79,7 +79,7 @@ static inline TPMI_ST_COMMAND_TAG tpm2_command_header_get_tag(
  * @param include_header
  * @return
  */
-static inline UINT32 tpm2_command_header_get_size(tpm2_command_header *command,
+static inline UINT32 tpm2_command_header_get_size(const tpm2_command_header *command,
         bool include_header) {
 
     UINT32 size = tpm2_util_ntoh_32(command->size);
@@ -92,7 +92,7 @@ static inline UINT32 tpm2_command_header_get_size(tpm2_command_header *command,
  * @param command
  * @return
  */
-static inline TPM2_CC tpm2_command_header_get_code(tpm2_command_header *command) {
+static inline TPM2_CC tpm2_command_header_get_code(const tpm2_command_header *command) {
 
     return tpm2_util_ntoh_32(command->command_code);
 }
@@ -103,7 +103,7 @@ static inline TPM2_CC tpm2_command_header_get_code(tpm2_command_header *command)
  *  The command to check for following data.
  * @return The command data or NULL if not present.
  */
-static inline UINT8 *tpm2_command_header_get_data(tpm2_command_header *command) {
+static inline const UINT8 *tpm2_command_header_get_data(const tpm2_command_header *command) {
 
     UINT32 size = tpm2_command_header_get_size(command, false);
     return size ? command->data : NULL;
@@ -117,7 +117,7 @@ static inline UINT8 *tpm2_command_header_get_data(tpm2_command_header *command) 
  * @return
  */
 static inline UINT32 tpm2_response_header_get_size(
-        tpm2_response_header *response, bool include_header) {
+        const tpm2_response_header *response, bool include_header) {
 
     UINT32 size = tpm2_util_ntoh_32(response->size);
     return include_header ? size : size - TPM2_RESPONSE_HEADER_SIZE;
@@ -130,7 +130,7 @@ static inline UINT32 tpm2_response_header_get_size(
  * @return
  */
 static inline TPM2_ST tpm2_response_header_get_tag(
-        tpm2_response_header *response) {
+        const tpm2_response_header *response) {
 
     return tpm2_util_ntoh_16(response->tag);
 }
@@ -142,7 +142,7 @@ static inline TPM2_ST tpm2_response_header_get_tag(
  * @return
  */
 static inline TSS2_RC tpm2_response_header_get_code(
-        tpm2_response_header *response) {
+        const tpm2_response_header *response) {
 
     return tpm2_util_ntoh_32(response->response_code);
 }
@@ -153,8 +153,8 @@ static inline TSS2_RC tpm2_response_header_get_code(
  *  The response_header to check for following data.
  * @return The response data or NULL if not present.
  */
-static inline UINT8 *tpm2_response_header_get_data(
-        tpm2_response_header *response) {
+static inline const UINT8 *tpm2_response_header_get_data(
+        const tpm2_response_header *response) {
 
     UINT32 size = tpm2_response_header_get_size(response, false);
     return size ? response->data : NULL;

--- a/test/unit/test_tpm2_header.c
+++ b/test/unit/test_tpm2_header.c
@@ -18,11 +18,7 @@ static void test_tpm_command_header(void **state) {
       0x00, 0x06, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x00, 0x7f
     };
 
-    tpm2_command_header *c = tpm2_command_header_from_bytes(command_bytes);
-
-    assert_true(c->tag == 0x0180);
-    assert_true(c->size == 0x16000000);
-    assert_true(c->command_code == 0x7a010000);
+    const tpm2_command_header *c = tpm2_command_header_from_bytes(command_bytes);
 
     /* everything from bytes should be the same as the byte array */
     assert_memory_equal(c->bytes, command_bytes, sizeof(command_bytes));
@@ -94,11 +90,7 @@ static void test_tpm_response_header(void **state) {
       0x00
     };
 
-    tpm2_response_header *r = tpm2_response_header_from_bytes(response_bytes);
-
-    assert_true(r->tag == 0x0180);
-    assert_true(r->size == 0x1b020000);
-    assert_true(r->response_code == 0x00);
+    const tpm2_response_header *r = tpm2_response_header_from_bytes(response_bytes);
 
     /* everything from bytes should be the same as the byte array */
     assert_memory_equal(r->bytes, response_bytes, sizeof(response_bytes));

--- a/tools/tpm2_send.c
+++ b/tools/tpm2_send.c
@@ -44,7 +44,7 @@ static int read_command_from_file(FILE *f, tpm2_command_header **c,
         return 0;
     }
 
-    tpm2_command_header *header = tpm2_command_header_from_bytes(buffer);
+    const tpm2_command_header *header = tpm2_command_header_from_bytes(buffer);
 
     UINT32 command_size = tpm2_command_header_get_size(header, true);
     UINT32 data_size = tpm2_command_header_get_size(header, false);
@@ -84,7 +84,7 @@ static int read_command_from_file(FILE *f, tpm2_command_header **c,
 
 static bool write_response_to_file(FILE *f, UINT8 *rbuf) {
 
-    tpm2_response_header *r = tpm2_response_header_from_bytes(rbuf);
+    const tpm2_response_header *r = tpm2_response_header_from_bytes(rbuf);
 
     UINT32 size = tpm2_response_header_get_size(r, true);
 


### PR DESCRIPTION
Fixes the test on BE machines by making the pointers const and thus not needing to check if underlying function is modifying things by checking the expected LE output of casting a BE scalar. Make it all const interface and let the compiler enforce that idiom.