### PR TITLE
session: do not delete on flush

### DIFF
--- a/lib/tpm2_session.c
+++ b/lib/tpm2_session.c
@@ -361,14 +361,8 @@ tool_rc tpm2_session_close(tpm2_session **s) {
     }
 
     if ((*s)->internal.delete && path) {
-        if (remove(path)) {
-            LOG_ERR("File \"%s\" can't be deleted.", path);
-            rc = tool_rc_general_error;
-            goto out2;
-        } else {
-            rc = tool_rc_success;
-            goto out2;
-        }
+        rc = tool_rc_success;
+        goto out2;
     }
 
     FILE *session_file = path ? fopen(path, "w+b") : NULL;

--- a/test/integration/tests/unseal.sh
+++ b/test/integration/tests/unseal.sh
@@ -156,9 +156,4 @@ tpm2 sessionconfig enc_session.ctx --enable-encrypt --disable-continuesession
 unsealed=`tpm2 unseal -c seal_key.ctx -p sealkeypass -S enc_session.ctx`
 test "$unsealed" == "$secret"
 
-if [ -e enc_session.ctx ]; then
-    echo "enc_session.ctx was not deleted.";
-    exit 1
-fi
-
 exit 0


### PR DESCRIPTION
This behavior would not be backwards compat, but this patch does the bare minimum so we can just revert it on the next major release.