### PR TITLE
CI: Remove Ubuntu 18.04 from the CI tss master test.

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -36,7 +36,7 @@ jobs:
           tpm2-software/ci/runCI@main
         with:
           PROJECT_NAME: ${{ github.event.repository.name }}
-          DOCKER_IMAGE: ubuntu-18.04
+          DOCKER_IMAGE: ubuntu-20.04
           CC: ${{ matrix.compiler }}
           TPM2_TSS_VERSION: master
           GIT_FULL_CLONE: true


### PR DESCRIPTION
Ubuntu 18.04 will not be supported for the next tss version. Thus Ubuntu 18.04 has to be removed from the tool CI for master-tss-build-test.