### PR TITLE
configure.ac: fix bashisms

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -94,9 +94,9 @@ AC_ARG_WITH([efivar],
 )
 
 # use the true program to avoid failing hard
-AS_IF([test "x$with_efivar" == "xauto"],
+AS_IF([test "x$with_efivar" = "xauto"],
   [PKG_CHECK_MODULES([EFIVAR], [efivar], [AC_CHECK_HEADERS([efivar/efivar.h], , [true])], [true])],
-  [test "x$with_efivar" == "xyes"],
+  [test "x$with_efivar" = "xyes"],
   [PKG_CHECK_MODULES([EFIVAR], [efivar], [AC_CHECK_HEADERS([efivar/efivar.h])])],
 )
 


### PR DESCRIPTION
configure scripts need to be runnable with a POSIX-compliant /bin/sh.

On many (but not all!) systems, /bin/sh is provided by Bash, so errors like this aren't spotted. Notably Debian defaults to /bin/sh provided by dash which doesn't tolerate such bashisms as '=='.

This retains compatibility with bash.

Fixes configure warnings/errors like:
```
checking for libcurl... yes
./configure: 15201: test: xauto: unexpected operator
./configure: 15286: test: xauto: unexpected operator
checking for efivar/efivar.h... yes
```

This fixes a build error later on too:
```
/usr/lib/gcc/x86_64-pc-linux-gnu/14/../../../../x86_64-pc-linux-gnu/bin/ld: lib/libcommon.a(libcommon_a-tpm2_eventlog_yaml.o): in function `yaml_devicepath':
tpm2_eventlog_yaml.c:(.text.yaml_devicepath+0x2f): undefined reference to `efidp_format_device_path'
/usr/lib/gcc/x86_64-pc-linux-gnu/14/../../../../x86_64-pc-linux-gnu/bin/ld: tpm2_eventlog_yaml.c:(.text.yaml_devicepath+0x61): undefined reference to `efidp_format_device_path'
```

Bug: https://bugs.gentoo.org/922592