### PR TITLE
readthedocs: Add configuration key build to the readthedocs yaml file.

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,5 +1,8 @@
 version: 2
-
+build:
+  os: ubuntu-22.04
+  tools:
+    python: "3"
 mkdocs:
   configuration: mkdocs.yml
 python:


### PR DESCRIPTION
To fix the error "Config validation error in build.os. Value build not found".