### PR TITLE
Auth input: Check for NULL termination (backport 5.6)

### DIFF
--- a/lib/tpm2_auth_util.c
+++ b/lib/tpm2_auth_util.c
@@ -81,6 +81,7 @@ static tool_rc get_auth_for_file_param(const char* password, TPM2B_AUTH *auth) {
             free(buffer);
             return tool_rc_general_error;
         }
+        buffer[fsize] = '\0';
         size = fsize;
 
     } else {


### PR DESCRIPTION
When reading auths from a file, add a check that they are NULL terminated.