### PR TITLE
tpm2_sessionconfig fix usage of --disable-continuesession (5.6.X)

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -36,7 +36,7 @@ jobs:
           tpm2-software/ci/runCI@main
         with:
           PROJECT_NAME: ${{ github.event.repository.name }}
-          DOCKER_IMAGE: ubuntu-18.04
+          DOCKER_IMAGE: ubuntu-20.04
           CC: ${{ matrix.compiler }}
           TPM2_TSS_VERSION: master
           GIT_FULL_CLONE: true

--- a/lib/pcr.c
+++ b/lib/pcr.c
@@ -65,7 +65,7 @@ static bool pcr_parse_list(const char *str, size_t len,
     do {
         char dgst_buf[sizeof(TPMU_HA) * 2 + 1];
         const char *dgst;;
-        int dgst_len;
+        int dgst_len = 0;
         UINT16 dgst_size;
         int pcr_len;
 

--- a/test/integration/tests/unseal.sh
+++ b/test/integration/tests/unseal.sh
@@ -152,10 +152,13 @@ tpm2 sessionconfig enc_session.ctx --disable-encrypt
 tpm2 create -Q -C prim.ctx -u seal_key.pub -r seal_key.priv -c seal_key.ctx \
 -p sealkeypass -i- <<< $secret -S enc_session.ctx
 
-tpm2 sessionconfig enc_session.ctx --enable-encrypt
+tpm2 sessionconfig enc_session.ctx --enable-encrypt --disable-continuesession
 unsealed=`tpm2 unseal -c seal_key.ctx -p sealkeypass -S enc_session.ctx`
 test "$unsealed" == "$secret"
 
-tpm2 flushcontext enc_session.ctx
+if [ -e enc_session.ctx ]; then
+    echo "enc_session.ctx was not deleted.";
+    exit 1
+fi
 
 exit 0


### PR DESCRIPTION
* The test with the tss master is now running on ubuntu 20.04 instead of 18.04
* If continue session was disabled a error did occur in the function for restoring the session context.
Now after usage of an session with continue session disabled the context will not be saved and the session context file will be deleted.
In one integration test continue session is now disabled and the flush for this session is removed.