### PR TITLE
lib/pcr.c Fix compile error may be used uninitialized.

### DIFF
--- a/lib/pcr.c
+++ b/lib/pcr.c
@@ -65,7 +65,7 @@ static bool pcr_parse_list(const char *str, size_t len,
     do {
         char dgst_buf[sizeof(TPMU_HA) * 2 + 1];
         const char *dgst;;
-        int dgst_len;
+        int dgst_len = 0;
         UINT16 dgst_size;
         int pcr_len;
 


### PR DESCRIPTION
gcc version 10.2.1 on raspian 10.2.1 did produce the compile error "may be used uninitialized". The error was not possible. To enable compilation the affected variable is initialized.