### PR TITLE
tpm2_util.c: fix check of environment  variable.

### DIFF
--- a/lib/tpm2_util.c
+++ b/lib/tpm2_util.c
@@ -635,9 +635,9 @@ char *tpm2_util_getenv(const char *name) {
 bool tpm2_util_env_yes(const char *name) {
 
     char *value = getenv(name);
-    return (value && (strcasecmp(name, "yes") == 0 ||
-                      strcasecmp(name, "1") == 0 ||
-                      strcasecmp(name, "true") == 0));
+    return (value && (strcasecmp(value, "yes") == 0 ||
+                      strcasecmp(value, "1") == 0 ||
+                      strcasecmp(value, "true") == 0));
 }
 
 /**


### PR DESCRIPTION
The function tpm2_util_env_yes did check the name of the variable instead of the value. Fixes: #3353