### PR TITLE
tpm2_print: Extend printing of TPMS_ATTEST objects.

### DIFF
--- a/test/integration/tests/certify.sh
+++ b/test/integration/tests/certify.sh
@@ -41,6 +41,8 @@ tpm2 certify \
 
 verify_signature_with_ssl
 
+tpm2 print -t TPMS_ATTEST attest.out
+
 # Test with full options
 
 tpm2 certify \

--- a/test/integration/tests/certifycreation.sh
+++ b/test/integration/tests/certifycreation.sh
@@ -30,6 +30,8 @@ tpm2 certifycreation -C signing_key.ctx -c primary.ctx -d creation.digest \
 -t creation.ticket -g sha256 -o signature.bin --attestation attestation.bin \
 -f plain -s rsassa
 
+tpm2 print -t TPMS_ATTEST attestation.bin
+
 openssl dgst -verify sslpub.pem -keyform pem -sha256 -signature signature.bin \
 attestation.bin
 

--- a/test/integration/tests/commandaudit.sh
+++ b/test/integration/tests/commandaudit.sh
@@ -65,6 +65,7 @@ diff -B \
 xxd -r -p | openssl dgst -sha256 -binary ) \
 <( tail -c 32 att.data )
 
+tpm2 print -t TPMS_ATTEST att.data
 #
 # Check TPM2_CC_GetRandom is removed from the audit list
 #

--- a/test/integration/tests/gettime.sh
+++ b/test/integration/tests/gettime.sh
@@ -20,4 +20,6 @@ tpm2 load -C primary.ctx -u rsa.pub -r rsa.priv -c rsa.ctx
 
 tpm2 gettime -c rsa.ctx -o attest.sig --attestation attest.data
 
+tpm2 print -t TPMS_ATTEST attest.data
+
 exit 0

--- a/test/integration/tests/nvcertify.sh
+++ b/test/integration/tests/nvcertify.sh
@@ -43,6 +43,8 @@ dd if=/dev/urandom of=qual.dat bs=1 count=32
 tpm2 nvcertify -C signing_key.ctx -g sha256 -f plain -s rsassa \
 -o signature.bin --attestation attestation.bin --size 32 -q qual.dat 1
 
+tpm2 print -t TPMS_ATTEST attestation.bin
+
 openssl dgst -verify sslpub.pem -keyform pem -sha256 -signature signature.bin \
 attestation.bin
 

--- a/test/integration/tests/sessionaudit.sh
+++ b/test/integration/tests/sessionaudit.sh
@@ -35,6 +35,8 @@ tpm2 getrandom 8 -S session.ctx --cphash cp.hash --rphash rp.hash
 tpm2 getsessionauditdigest -c signing_key.ctx -m att.data -s att.sig \
 -S session.ctx
 
+tpm2 print -t TPMS_ATTEST att.data
+
 tpm2 flushcontext session.ctx
 
 dd if=/dev/zero bs=1 count=32 status=none of=zero.bin


### PR DESCRIPTION
Not all types of TPMU_ATTEST were supported. The printing for the missing sub types is implemented.
For every new sub type a print is added to the corresponding integration test.
Fixes: #3362