### PR TITLE
Fix issue with reading NV indexes

### DIFF
--- a/tools/tpm2_getekcertificate.c
+++ b/tools/tpm2_getekcertificate.c
@@ -597,7 +597,7 @@ tool_rc get_tpm_properties(ESYS_CONTEXT *ectx) {
 
     free(capability_data);
     rc = tpm2_getcap(ectx, TPM2_CAP_HANDLES,
-        tpm2_util_hton_32(TPM2_HT_NV_INDEX), TPM2_PT_NV_INDEX_MAX, NULL,
+        TPM2_NV_INDEX_FIRST, TPM2_PT_NV_INDEX_MAX, NULL,
         &capability_data);
     if (rc != tool_rc_success) {
         LOG_ERR("Failed to read capability data for NV indices.");

--- a/tools/tpm2_nvdefine.c
+++ b/tools/tpm2_nvdefine.c
@@ -190,7 +190,7 @@ static tool_rc handle_no_index_specified(ESYS_CONTEXT *ectx, TPM2_NV_INDEX *chos
     capabilities = NULL;
 
     /* now find what NV indexes are in use */
-    rc = tpm2_getcap(ectx, TPM2_CAP_HANDLES, tpm2_util_hton_32(TPM2_HT_NV_INDEX),
+    rc = tpm2_getcap(ectx, TPM2_CAP_HANDLES, TPM2_NV_INDEX_FIRST,
             TPM2_PT_NV_INDEX_MAX, NULL, &capabilities);
     if (rc != tool_rc_success) {
         goto out;

--- a/tools/tpm2_nvreadpublic.c
+++ b/tools/tpm2_nvreadpublic.c
@@ -210,7 +210,7 @@ static tool_rc process_inputs(ESYS_CONTEXT *ectx) {
      */
     if (ctx.nv_index == 0 && ctx.is_command_dispatch) {
         rc = tpm2_getcap(ectx, TPM2_CAP_HANDLES,
-            TPM2_HT_NV_INDEX << 24, TPM2_PT_NV_INDEX_MAX, NULL,
+            TPM2_NV_INDEX_FIRST, TPM2_PT_NV_INDEX_MAX, NULL,
             &ctx.capability_data);
         if (rc != tool_rc_success) {
             return rc;


### PR DESCRIPTION
Wrong arguments are used in tpm2_getekcertificate and tpm2_nvdefine when accessing the list of NV indexes in use. This works fine on little-endian systems, but on big-endian systems this will not find any NV indexes, causing issues when using these functions without an argument. Also, use the same argument in tpm2_nvreadpublic.

Running on s390x system with upstream tpm2-tools:
```
[root@localhost ~]# /usr/local/bin/tpm2_nvdefine
WARNING:esys:src/tss2-esys/api/Esys_NV_DefineSpace.c:344:Esys_NV_DefineSpace_Finish() Received TPM Error
ERROR:esys:src/tss2-esys/api/Esys_NV_DefineSpace.c:122:Esys_NV_DefineSpace() Esys Finish ErrorCode (0x0000014c)
ERROR: Failed to define NV area at index 0x1000000
ERROR: Esys_NV_DefineSpace(0x14C) - tpm:error(2.0): NV Index or persistent object already defined
ERROR: Failed to create NV index 0x1000000.
ERROR: Unable to run /usr/local/bin/tpm2_nvdefine
[root@localhost ~]# /usr/local/bin/tpm2_getekcertificate > /dev/null
ERROR: Must specify the EK public key path
[root@localhost ~]#
```
Running on s390x system with fixed tpm2-tools:
```
[root@localhost ~]# /usr/local/bin/tpm2_nvdefine
nv-index: 0x1000004
[root@localhost ~]# /usr/local/bin/tpm2_getekcertificate > /dev/null
[root@localhost ~]#
```