### PR TITLE
tpm2_create: Fix context save error.

### DIFF
--- a/tools/tpm2_create.c
+++ b/tools/tpm2_create.c
@@ -405,9 +405,7 @@ static tool_rc process_inputs(ESYS_CONTEXT *ectx) {
     }
 
     /* Check command type */
-    if ((ctx.object.ctx_path || ctx.object.template_data_path) &&
-        (!ctx.object.creation_data_file && !ctx.object.creation_ticket_file &&
-        !ctx.object.creation_hash_file)) {
+    if ((ctx.object.ctx_path || ctx.object.template_data_path)) {
         ctx.is_createloaded = true;
     }
 


### PR DESCRIPTION
If the options --creation-hash,  --creation-ticket, or --creation-data were used together with --key-context context save for the handle ESYS_TR_NONE was called and did produce an error.
Now the object is loaded and context save is calles with the correct handle. Fixes: #3379