### PR TITLE
Fix handling of testResult in tpm2_gettestresult

### DIFF
--- a/tools/tpm2_gettestresult.c
+++ b/tools/tpm2_gettestresult.c
@@ -35,8 +35,6 @@ static tool_rc tpm2_tool_onrun(ESYS_CONTEXT *ectx, tpm2_option_flags flags) {
     tpm2_tool_output("status: ");
     print_yaml_indent(1);
 
-    status &= TPM2_RC_TESTING;
-
     switch (status) {
     case TPM2_RC_SUCCESS:
         tpm2_tool_output("success");


### PR DESCRIPTION
The testResult returned from Esys_GetTestResult is unnecessarily masked, causing the tool to be unable to identify TPM2_RC_NEEDS_TEST.