### PR TITLE
Fix build failure due to `-Werror=calloc-transposed-args`

### DIFF
--- a/lib/tpm2_openssl.c
+++ b/lib/tpm2_openssl.c
@@ -430,7 +430,7 @@ static bool do_open_file(FILE *f, const char *path, char **pass) {
         goto out;
     }
 
-    char *tmp = calloc(sizeof(char), file_size + 1);
+    char *tmp = calloc(file_size + 1, sizeof(char));
     if (!tmp) {
         LOG_ERR("oom");
         goto out;
@@ -485,7 +485,7 @@ static bool do_stdin(const char *passin, char **pass) {
 
     UNUSED(passin);
 
-    void *buf = calloc(sizeof(BYTE), UINT16_MAX + 1);
+    void *buf = calloc(UINT16_MAX + 1, sizeof(BYTE));
     if (!buf) {
         LOG_ERR("oom");
         return false;


### PR DESCRIPTION
```
lib/tpm2_openssl.c: In function ‘do_open_file’:
lib/tpm2_openssl.c:433:31: error: ‘calloc’ sizes specified with ‘sizeof’ in the earlier argument and not in the later argument [-Werror=calloc-transposed-args]
  433 |     char *tmp = calloc(sizeof(char), file_size + 1);
      |                               ^~~~
lib/tpm2_openssl.c:433:31: note: earlier argument should specify number of elements, later size of each element
lib/tpm2_openssl.c: In function ‘do_stdin’:
lib/tpm2_openssl.c:488:31: error: ‘calloc’ sizes specified with ‘sizeof’ in the earlier argument and not in the later argument [-Werror=calloc-transposed-args]
  488 |     void *buf = calloc(sizeof(BYTE), UINT16_MAX + 1);
      |                               ^~~~
lib/tpm2_openssl.c:488:31: note: earlier argument should specify number of elements, later size of each element
```