### PR TITLE
Remove duplicate text in tpm2_unseal.1.md

### DIFF
--- a/man/tpm2_unseal.1.md
+++ b/man/tpm2_unseal.1.md
@@ -35,8 +35,8 @@ be of the type _TPM\_ALG\_KEYEDHASH_.
 
     File path to record the hash of the command parameters. This is commonly
     termed as cpHash. NOTE: When this option is selected, The tool will not
-    actually execute the command, it simply returns a cpHash, it simply returns
-    a cpHash, unless rphash is also required.
+    actually execute the command, it simply returns a cpHash, unless rphash
+    is also required.
 
   * **\--rphash**=_FILE_
 


### PR DESCRIPTION
This fixes a small issue in the tpm2_unseal(1) markdown man page.