### PR TITLE
Options: Add option to allow usage of password session.

### DIFF
--- a/lib/tpm2_auth_util.c
+++ b/lib/tpm2_auth_util.c
@@ -467,7 +467,13 @@ tool_rc tpm2_auth_util_from_optarg(ESYS_CONTEXT *ectx, const char *password,
     }
 
     /* must be a password */
-    return handle_password_session(ectx, password, session);
+    if (is_restricted) {
+        /* ESYS_TR_PASSWORD will be used as handle. */
+        return handle_password_session(NULL, password, session);
+    } else {
+        /* A hmac session will be created. */
+        return handle_password_session(ectx, password, session);
+    }
 }
 
 tool_rc tpm2_auth_util_get_shandle(ESYS_CONTEXT *ectx, ESYS_TR object,

--- a/lib/tpm2_options.c
+++ b/lib/tpm2_options.c
@@ -288,11 +288,12 @@ tpm2_option_code tpm2_handle_options(int argc, char **argv,
         { "quiet",         no_argument,       NULL, 'Q' },
         { "version",       no_argument,       NULL, 'v' },
         { "enable-errata", no_argument,       NULL, 'Z' },
+        { "pwd-session",   no_argument,       NULL, 'z' },
     };
 
 
     /* handle any options */
-    const char* common_short_opts = "T:h::vVQZ";
+    const char* common_short_opts = "T:h::vVQZz";
     tpm2_options *opts = tpm2_options_new(common_short_opts,
             ARRAY_LEN(long_options), long_options, NULL, NULL, 0);
     if (!opts) {
@@ -372,6 +373,9 @@ tpm2_option_code tpm2_handle_options(int argc, char **argv,
             goto out;
         case 'V':
             flags->verbose = 1;
+            break;
+        case 'z':
+            flags->restricted_pwd_session = 1;
             break;
         case 'Q':
             flags->quiet = 1;

--- a/lib/tpm2_options.h
+++ b/lib/tpm2_options.h
@@ -22,6 +22,8 @@ union tpm2_option_flags {
         uint8_t quiet :1;
         uint8_t enable_errata :1;
         uint8_t tcti_none :1;
+        uint8_t restricted_pwd_session :1;
+        
     };
     uint8_t all;
 };

--- a/man/common/options.md
+++ b/man/common/options.md
@@ -22,11 +22,16 @@ information that many users may expect.
 
   * **-Q**, **\--quiet**:
     Silence normal tool output to stdout.
-
+x
   * **-Z**, **\--enable-errata**:
     Enable the application of errata fixups. Useful if an errata fixup needs to be
     applied to commands sent to the TPM. Defining the environment
     TPM2TOOLS\_ENABLE\_ERRATA is equivalent.
+  * **-z**, **\--pwd-session**:
+    Use password session instead of a HMAC session for authentication. A clear text password
+    is passed to the TPM to authorize the action. This option can be used to avoid problems
+    when unsalted sessions are used in OpenSSL FIPS mode. If auth values are used
+    a salted session should be used for authentication.
   * **-R**, **\--autoflush**:
     Enable autoflush for transient objects created by the command. If a parent
     object is loaded from a context file also the transient parent object will

--- a/tools/misc/tpm2_encodeobject.c
+++ b/tools/misc/tpm2_encodeobject.c
@@ -113,7 +113,7 @@ static tool_rc check_opts(void) {
     return rc;
 }
 
-static tool_rc init(ESYS_CONTEXT *ectx) {
+static tool_rc init(ESYS_CONTEXT *ectx, tpm2_option_flags flags) {
     bool res = files_load_public(ctx.object.pubpath, &ctx.object.public);
     if (!res) {
         return tool_rc_general_error;
@@ -125,7 +125,7 @@ static tool_rc init(ESYS_CONTEXT *ectx) {
     }
 
     return tpm2_util_object_load_auth(ectx, ctx.parent.ctx_path,
-            ctx.parent.auth_str, &ctx.parent.object, false,
+            ctx.parent.auth_str, &ctx.parent.object, flags.restricted_pwd_session,
             TPM2_HANDLE_ALL_W_NV);
 }
 
@@ -212,14 +212,13 @@ static int encode(ESYS_CONTEXT *ectx) {
 }
 
 static tool_rc tpm2_tool_onrun(ESYS_CONTEXT *ectx, tpm2_option_flags flags) {
-    UNUSED(flags);
 
     tool_rc rc = check_opts();
     if (rc != tool_rc_success) {
         return rc;
     }
 
-    rc = init(ectx);
+    rc = init(ectx, flags);
     if (rc != tool_rc_success) {
         return rc;
     }

--- a/tools/tpm2_activatecredential.c
+++ b/tools/tpm2_activatecredential.c
@@ -173,7 +173,7 @@ out:
     return result;
 }
 
-static tool_rc process_inputs(ESYS_CONTEXT *ectx) {
+static tool_rc process_inputs(ESYS_CONTEXT *ectx, tpm2_option_flags flags) {
 
     /*
      * 1. Object and auth initializations
@@ -189,14 +189,14 @@ static tool_rc process_inputs(ESYS_CONTEXT *ectx) {
 
     /* Object #1 */
     tool_rc rc = tpm2_util_object_load_auth(ectx, ctx.credential_key.ctx_path,
-        ctx.credential_key.auth_str, &ctx.credential_key.object, false,
+        ctx.credential_key.auth_str, &ctx.credential_key.object, flags.restricted_pwd_session,
         TPM2_HANDLE_ALL_W_NV);
     if (rc != tool_rc_success) {
         return rc;
     }
     /* Object #2 */
     rc = tpm2_util_object_load_auth(ectx, ctx.credentialed_key.ctx_path,
-        ctx.credentialed_key.auth_str, &ctx.credentialed_key.object, false,
+        ctx.credentialed_key.auth_str, &ctx.credentialed_key.object, flags.restricted_pwd_session,
         TPM2_HANDLE_ALL_W_NV);
     if (rc != tool_rc_success) {
         return rc;
@@ -341,7 +341,7 @@ static tool_rc tpm2_tool_onrun(ESYS_CONTEXT *ectx, tpm2_option_flags flags) {
     /*
      * 2. Process inputs
      */
-    rc = process_inputs(ectx);
+    rc = process_inputs(ectx, flags);
     if (rc != tool_rc_success) {
         return rc;
     }

--- a/tools/tpm2_certify.c
+++ b/tools/tpm2_certify.c
@@ -137,7 +137,7 @@ out:
     return is_file_op_success ? tool_rc_success : tool_rc_general_error;
 }
 
-static tool_rc process_inputs(ESYS_CONTEXT *ectx) {
+static tool_rc process_inputs(ESYS_CONTEXT *ectx, tpm2_option_flags flags) {
 
     /*
      * 1. Object and auth initializations
@@ -152,7 +152,7 @@ static tool_rc process_inputs(ESYS_CONTEXT *ectx) {
      */
     /* Object #1 */
     tool_rc rc = tpm2_util_object_load_auth(ectx, ctx.certified_key.ctx_path,
-        ctx.certified_key.auth_str, &ctx.certified_key.object, false,
+        ctx.certified_key.auth_str, &ctx.certified_key.object, flags.restricted_pwd_session,
         TPM2_HANDLE_ALL_W_NV);
     if (rc != tool_rc_success) {
         return rc;
@@ -160,7 +160,7 @@ static tool_rc process_inputs(ESYS_CONTEXT *ectx) {
 
     /* Object #2 */
     rc = tpm2_util_object_load_auth(ectx, ctx.signing_key.ctx_path,
-        ctx.signing_key.auth_str, &ctx.signing_key.object, false,
+        ctx.signing_key.auth_str, &ctx.signing_key.object, flags.restricted_pwd_session,
         TPM2_HANDLE_ALL_W_NV);
     if (rc != tool_rc_success) {
         return rc;
@@ -333,7 +333,7 @@ static tool_rc tpm2_tool_onrun(ESYS_CONTEXT *ectx, tpm2_option_flags flags) {
     /*
      * 2. Process inputs
      */
-    rc = process_inputs(ectx);
+    rc = process_inputs(ectx, flags);
     if (rc != tool_rc_success) {
         return rc;
     }

--- a/tools/tpm2_certifycreation.c
+++ b/tools/tpm2_certifycreation.c
@@ -135,7 +135,7 @@ static tool_rc process_output(void) {
     return is_file_op_success ? tool_rc_success : tool_rc_general_error;
 }
 
-static tool_rc process_inputs(ESYS_CONTEXT *ectx) {
+static tool_rc process_inputs(ESYS_CONTEXT *ectx, tpm2_option_flags flags) {
 
     /*
      * 1. Object and auth initializations
@@ -149,7 +149,7 @@ static tool_rc process_inputs(ESYS_CONTEXT *ectx) {
      * 1.b Add object names and their auth sessions
      */
     tool_rc rc = tpm2_util_object_load_auth(ectx, ctx.signing_key.ctx_path,
-        ctx.signing_key.auth_str, &ctx.signing_key.object, false,
+        ctx.signing_key.auth_str, &ctx.signing_key.object, flags.restricted_pwd_session,
         TPM2_HANDLES_FLAGS_TRANSIENT|TPM2_HANDLES_FLAGS_PERSISTENT);
     if (rc != tool_rc_success) {
         LOG_ERR("Invalid signing key/ authorization.");
@@ -413,7 +413,7 @@ static tool_rc tpm2_tool_onrun(ESYS_CONTEXT *ectx, tpm2_option_flags flags) {
    /*
      * 2. Process inputs
      */
-    tool_rc rc = process_inputs(ectx);
+    tool_rc rc = process_inputs(ectx, flags);
     if (rc != tool_rc_success) {
         return rc;
     }

--- a/tools/tpm2_changeauth.c
+++ b/tools/tpm2_changeauth.c
@@ -181,7 +181,7 @@ static inline bool object_needs_parent(tpm2_loaded_object *obj) {
     return (h == TPM2_HR_TRANSIENT) || (h == TPM2_HR_PERSISTENT);
 }
 
-static tool_rc process_inputs(ESYS_CONTEXT *ectx) {
+static tool_rc process_inputs(ESYS_CONTEXT *ectx, tpm2_option_flags flags) {
 
     /*
      * 1. Object and auth initializations
@@ -206,7 +206,7 @@ static tool_rc process_inputs(ESYS_CONTEXT *ectx) {
 
     /* Object #1 */
     rc = tpm2_util_object_load_auth(ectx, ctx.object.ctx,
-        ctx.object.auth_current, &ctx.object.obj, false, TPM2_HANDLE_ALL_W_NV);
+        ctx.object.auth_current, &ctx.object.obj, flags.restricted_pwd_session, TPM2_HANDLE_ALL_W_NV);
     if (rc != tool_rc_success) {
         return rc;
     }
@@ -377,7 +377,7 @@ static tool_rc tpm2_tool_onrun(ESYS_CONTEXT *ectx, tpm2_option_flags flags) {
     /*
      * 2. Process inputs
      */
-    rc = process_inputs(ectx);
+    rc = process_inputs(ectx, flags);
     if (rc != tool_rc_success) {
         return rc;
     }

--- a/tools/tpm2_clear.c
+++ b/tools/tpm2_clear.c
@@ -70,7 +70,7 @@ static tool_rc process_output(ESYS_CONTEXT *ectx) {
 }
 
 
-static tool_rc process_inputs(ESYS_CONTEXT *ectx) {
+static tool_rc process_inputs(ESYS_CONTEXT *ectx, tpm2_option_flags flags) {
 
     /*
      * 1. Object and auth initializations
@@ -86,7 +86,7 @@ static tool_rc process_inputs(ESYS_CONTEXT *ectx) {
 
     /* Object #1 */
     tool_rc rc = tpm2_util_object_load_auth(ectx, ctx.auth_hierarchy.ctx_path,
-            ctx.auth_hierarchy.auth_str, &ctx.auth_hierarchy.object, false,
+            ctx.auth_hierarchy.auth_str, &ctx.auth_hierarchy.object, flags.restricted_pwd_session,
             TPM2_HANDLE_FLAGS_L | TPM2_HANDLE_FLAGS_P);
     if (rc != tool_rc_success) {
         LOG_ERR("Invalid lockout authorization");
@@ -199,7 +199,7 @@ static tool_rc tpm2_tool_onrun(ESYS_CONTEXT *ectx, tpm2_option_flags flags) {
     /*
      * 2. Process inputs
      */
-    rc = process_inputs(ectx);
+    rc = process_inputs(ectx, flags);
     if (rc != tool_rc_success) {
         return rc;
     }

--- a/tools/tpm2_clearcontrol.c
+++ b/tools/tpm2_clearcontrol.c
@@ -78,7 +78,7 @@ static tool_rc process_output(ESYS_CONTEXT *ectx) {
     return rc;
 }
 
-static tool_rc process_inputs(ESYS_CONTEXT *ectx) {
+static tool_rc process_inputs(ESYS_CONTEXT *ectx, tpm2_option_flags flags) {
 
     /*
      * 1. Object and auth initializations
@@ -94,7 +94,7 @@ static tool_rc process_inputs(ESYS_CONTEXT *ectx) {
 
     /* Object #1 */
     tool_rc rc = tpm2_util_object_load_auth(ectx, ctx.auth_hierarchy.ctx_path,
-            ctx.auth_hierarchy.auth_str, &ctx.auth_hierarchy.object, false,
+            ctx.auth_hierarchy.auth_str, &ctx.auth_hierarchy.object, flags.restricted_pwd_session,
             TPM2_HANDLE_FLAGS_L | TPM2_HANDLE_FLAGS_P);
     if (rc != tool_rc_success) {
         LOG_ERR("Invalid lockout authorization");
@@ -233,7 +233,7 @@ static tool_rc tpm2_tool_onrun(ESYS_CONTEXT *ectx, tpm2_option_flags flags) {
     /*
      * 2. Process inputs
      */
-    rc = process_inputs(ectx);
+    rc = process_inputs(ectx, flags);
     if (rc != tool_rc_success) {
         return rc;
     }

--- a/tools/tpm2_clockrateadjust.c
+++ b/tools/tpm2_clockrateadjust.c
@@ -77,7 +77,7 @@ static tool_rc process_output(ESYS_CONTEXT *ectx) {
 }
 
 
-static tool_rc process_inputs(ESYS_CONTEXT *ectx) {
+static tool_rc process_inputs(ESYS_CONTEXT *ectx, tpm2_option_flags flags) {
 
     /*
      * 1. Object and auth initializations
@@ -93,7 +93,7 @@ static tool_rc process_inputs(ESYS_CONTEXT *ectx) {
 
     /* Object #1 */
     tool_rc rc = tpm2_util_object_load_auth(ectx, ctx.auth_hierarchy.ctx_path,
-            ctx.auth_hierarchy.auth_str, &ctx.auth_hierarchy.object, false,
+            ctx.auth_hierarchy.auth_str, &ctx.auth_hierarchy.object, flags.restricted_pwd_session,
             TPM2_HANDLE_FLAGS_O | TPM2_HANDLE_FLAGS_P);
     if (rc != tool_rc_success) {
         LOG_ERR("Invalid lockout authorization");
@@ -225,7 +225,7 @@ static tool_rc tpm2_tool_onrun(ESYS_CONTEXT *ectx, tpm2_option_flags flags) {
     /*
      * 2. Process inputs
      */
-    rc = process_inputs(ectx);
+    rc = process_inputs(ectx, flags);
     if (rc != tool_rc_success) {
         return rc;
     }

--- a/tools/tpm2_commit.c
+++ b/tools/tpm2_commit.c
@@ -110,7 +110,7 @@ static tool_rc process_outputs(ESYS_CONTEXT *ectx) {
     return tool_rc_success;
 }
 
-static tool_rc process_inputs(ESYS_CONTEXT *ectx) {
+static tool_rc process_inputs(ESYS_CONTEXT *ectx, tpm2_option_flags flags) {
 
     UNUSED(ectx);
     /*
@@ -125,7 +125,7 @@ static tool_rc process_inputs(ESYS_CONTEXT *ectx) {
      * 1.b Add object names and their auth sessions
      */
     tool_rc rc = tpm2_util_object_load_auth(ectx, ctx.signing_key.ctx_path,
-            ctx.signing_key.auth_str, &ctx.signing_key.object, false,
+            ctx.signing_key.auth_str, &ctx.signing_key.object, flags.restricted_pwd_session,
             TPM2_HANDLES_FLAGS_TRANSIENT|TPM2_HANDLES_FLAGS_PERSISTENT);
     if (rc != tool_rc_success) {
         return rc;
@@ -272,7 +272,7 @@ static tool_rc tpm2_tool_onrun(ESYS_CONTEXT *ectx, tpm2_option_flags flags) {
     /*
      * 2. Process inputs
      */
-    rc = process_inputs(ectx);
+    rc = process_inputs(ectx, flags);
     if (rc != tool_rc_success) {
         return rc;
     }

--- a/tools/tpm2_create.c
+++ b/tools/tpm2_create.c
@@ -344,7 +344,7 @@ out:
     return rc;
 }
 
-static tool_rc process_inputs(ESYS_CONTEXT *ectx) {
+static tool_rc process_inputs(ESYS_CONTEXT *ectx, tpm2_option_flags flags) {
 
     /*
      * 1. Object and auth initializations
@@ -368,7 +368,7 @@ static tool_rc process_inputs(ESYS_CONTEXT *ectx) {
      * 1.b Add object names and their auth sessions
      */
     rc = tpm2_util_object_load_auth(ectx, ctx.parent.ctx_path,
-        ctx.parent.auth_str, &ctx.parent.object, false, TPM2_HANDLE_ALL_W_NV);
+        ctx.parent.auth_str, &ctx.parent.object, flags.restricted_pwd_session, TPM2_HANDLE_ALL_W_NV);
     if (rc != tool_rc_success) {
         return rc;
     }
@@ -626,7 +626,7 @@ static tool_rc tpm2_tool_onrun(ESYS_CONTEXT *ectx, tpm2_option_flags flags) {
     /*
      * 2. Process inputs
      */
-    rc = process_inputs(ectx);
+    rc = process_inputs(ectx, flags);
     if (rc != tool_rc_success) {
         return rc;
     }

--- a/tools/tpm2_createprimary.c
+++ b/tools/tpm2_createprimary.c
@@ -169,7 +169,7 @@ static tool_rc process_output(ESYS_CONTEXT *ectx) {
     |TPMA_OBJECT_FIXEDTPM|TPMA_OBJECT_FIXEDPARENT \
     |TPMA_OBJECT_SENSITIVEDATAORIGIN|TPMA_OBJECT_USERWITHAUTH
 
-static tool_rc process_inputs(ESYS_CONTEXT *ectx) {
+static tool_rc process_inputs(ESYS_CONTEXT *ectx, tpm2_option_flags flags) {
 
     /*
      * 1. Object and auth initializations
@@ -197,7 +197,7 @@ static tool_rc process_inputs(ESYS_CONTEXT *ectx) {
 
     /* Object #1 */
     rc = tpm2_util_object_load_auth(ectx, ctx.auth_hierarchy.ctx_path,
-        ctx.auth_hierarchy.auth_str, &ctx.auth_hierarchy.object, false,
+        ctx.auth_hierarchy.auth_str, &ctx.auth_hierarchy.object, flags.restricted_pwd_session,
         TPM2_HANDLE_FLAGS_ALL_HIERACHIES);
     if (rc != tool_rc_success) {
         LOG_ERR("Invalid hierarchy authorization");
@@ -407,7 +407,7 @@ static tool_rc tpm2_tool_onrun(ESYS_CONTEXT *ectx, tpm2_option_flags flags) {
     /*
      * 2. Process inputs
      */
-    rc = process_inputs(ectx);
+    rc = process_inputs(ectx, flags);
     if (rc != tool_rc_success) {
         return rc;
     }

--- a/tools/tpm2_dictionarylockout.c
+++ b/tools/tpm2_dictionarylockout.c
@@ -108,7 +108,7 @@ static tool_rc process_output(ESYS_CONTEXT *ectx) {
 }
 
 
-static tool_rc process_inputs(ESYS_CONTEXT *ectx) {
+static tool_rc process_inputs(ESYS_CONTEXT *ectx, tpm2_option_flags flags) {
 
     /*
      * 1. Object and auth initializations
@@ -124,7 +124,7 @@ static tool_rc process_inputs(ESYS_CONTEXT *ectx) {
 
     /* Object #1 */
     tool_rc rc = tpm2_util_object_load_auth(ectx, ctx.auth_hierarchy.ctx_path,
-            ctx.auth_hierarchy.auth_str, &ctx.auth_hierarchy.object, false,
+            ctx.auth_hierarchy.auth_str, &ctx.auth_hierarchy.object, flags.restricted_pwd_session,
             TPM2_HANDLE_FLAGS_L);
     if (rc != tool_rc_success) {
         LOG_ERR("Invalid lockout authorization");
@@ -310,7 +310,7 @@ static tool_rc tpm2_tool_onrun(ESYS_CONTEXT *ectx, tpm2_option_flags flags) {
     /*
      * 2. Process inputs
      */
-    rc = process_inputs(ectx);
+    rc = process_inputs(ectx, flags);
     if (rc != tool_rc_success) {
         return rc;
     }

--- a/tools/tpm2_duplicate.c
+++ b/tools/tpm2_duplicate.c
@@ -328,7 +328,7 @@ out:
     return rc;
 }
 
-static tool_rc process_inputs(ESYS_CONTEXT *ectx) {
+static tool_rc process_inputs(ESYS_CONTEXT *ectx, tpm2_option_flags flags) {
 
     /*
      * 3.a Command specific initializations
@@ -354,7 +354,7 @@ static tool_rc process_inputs(ESYS_CONTEXT *ectx) {
 
     /* Object #1 */
     tool_rc rc = tpm2_util_object_load_auth(ectx, ctx.duplicable_key.ctx_path,
-            ctx.duplicable_key.auth_str, &ctx.duplicable_key.object, false,
+            ctx.duplicable_key.auth_str, &ctx.duplicable_key.object, flags.restricted_pwd_session,
             TPM2_HANDLE_ALL_W_NV);
     if (rc != tool_rc_success) {
         LOG_ERR("Invalid authorization");
@@ -594,7 +594,7 @@ static tool_rc tpm2_tool_onrun(ESYS_CONTEXT *ectx, tpm2_option_flags flags) {
     /*
      * 2. Process inputs
      */
-    rc = process_inputs(ectx);
+    rc = process_inputs(ectx, flags);
     if (rc != tool_rc_success) {
         return rc;
     }

--- a/tools/tpm2_ecdhzgen.c
+++ b/tools/tpm2_ecdhzgen.c
@@ -87,7 +87,7 @@ static tool_rc process_outputs(ESYS_CONTEXT *ectx) {
     return tool_rc_success;
 }
 
-static tool_rc process_inputs(ESYS_CONTEXT *ectx) {
+static tool_rc process_inputs(ESYS_CONTEXT *ectx, tpm2_option_flags flags) {
 
     UNUSED(ectx);
     /*
@@ -102,7 +102,7 @@ static tool_rc process_inputs(ESYS_CONTEXT *ectx) {
      * 1.b Add object names and their auth sessions
      */
     tool_rc  rc = tpm2_util_object_load_auth(ectx, ctx.ecc_key.ctx_path,
-        ctx.ecc_key.auth_str, &ctx.ecc_key.object, false,
+        ctx.ecc_key.auth_str, &ctx.ecc_key.object, flags.restricted_pwd_session,
         TPM2_HANDLES_FLAGS_TRANSIENT|TPM2_HANDLES_FLAGS_PERSISTENT);
     if (rc != tool_rc_success) {
         LOG_ERR("Failed to load object/ auth");
@@ -241,7 +241,7 @@ static tool_rc tpm2_tool_onrun(ESYS_CONTEXT *ectx, tpm2_option_flags flags) {
     /*
      * 2. Process inputs
      */
-    rc = process_inputs(ectx);
+    rc = process_inputs(ectx, flags);
     if (rc != tool_rc_success) {
         return rc;
     }

--- a/tools/tpm2_encryptdecrypt.c
+++ b/tools/tpm2_encryptdecrypt.c
@@ -303,7 +303,7 @@ static bool setup_alg_mode(ESYS_CONTEXT *ectx) {
     return true;
 }
 
-static tool_rc process_inputs(ESYS_CONTEXT *ectx) {
+static tool_rc process_inputs(ESYS_CONTEXT *ectx, tpm2_option_flags flags) {
 
     /*
      * 1. Object and auth initializations
@@ -319,7 +319,7 @@ static tool_rc process_inputs(ESYS_CONTEXT *ectx) {
 
     /* Object #1 */
     tool_rc rc = tpm2_util_object_load_auth(ectx, ctx.encryption_key.ctx_path,
-            ctx.encryption_key.auth_str, &ctx.encryption_key.object, false,
+            ctx.encryption_key.auth_str, &ctx.encryption_key.object, flags.restricted_pwd_session,
             TPM2_HANDLE_ALL_W_NV);
     if (rc != tool_rc_success) {
         LOG_ERR("Invalid object key authorization");
@@ -530,7 +530,7 @@ static tool_rc tpm2_tool_onrun(ESYS_CONTEXT *ectx, tpm2_option_flags flags) {
     /*
      * 2. Process inputs
      */
-    rc = process_inputs(ectx);
+    rc = process_inputs(ectx, flags);
     if (rc != tool_rc_success) {
         return rc;
     }

--- a/tools/tpm2_evictcontrol.c
+++ b/tools/tpm2_evictcontrol.c
@@ -117,7 +117,7 @@ static tool_rc process_output(ESYS_CONTEXT *ectx) {
 }
 
 
-static tool_rc process_inputs(ESYS_CONTEXT *ectx) {
+static tool_rc process_inputs(ESYS_CONTEXT *ectx, tpm2_option_flags flags) {
 
     /*
      * 1. Object and auth initializations
@@ -133,7 +133,7 @@ static tool_rc process_inputs(ESYS_CONTEXT *ectx) {
 
     /* Object #1 */
     tool_rc rc = tpm2_util_object_load_auth(ectx, ctx.auth_hierarchy.ctx_path,
-            ctx.auth_hierarchy.auth_str, &ctx.auth_hierarchy.object, false,
+            ctx.auth_hierarchy.auth_str, &ctx.auth_hierarchy.object, flags.restricted_pwd_session,
             TPM2_HANDLE_FLAGS_O | TPM2_HANDLE_FLAGS_P);
     if (rc != tool_rc_success) {
         return rc;
@@ -298,7 +298,7 @@ static tool_rc tpm2_tool_onrun(ESYS_CONTEXT *ectx, tpm2_option_flags flags) {
     /*
      * 2. Process inputs
      */
-    rc = process_inputs(ectx);
+    rc = process_inputs(ectx, flags);
     if (rc != tool_rc_success) {
         return rc;
     }

--- a/tools/tpm2_getcommandauditdigest.c
+++ b/tools/tpm2_getcommandauditdigest.c
@@ -143,21 +143,21 @@ static bool check_input_options_and_args(void) {
     return true;
 }
 
-static tool_rc process_inputs(ESYS_CONTEXT *ectx) {
+static tool_rc process_inputs(ESYS_CONTEXT *ectx, tpm2_option_flags flags) {
 
     /*
      * Load auths
      */
     tool_rc rc = tpm2_util_object_load_auth(ectx,
         ctx.endorsement_hierarchy.ctx_path, ctx.endorsement_hierarchy.auth_str,
-        &ctx.endorsement_hierarchy.object, false, TPM2_HANDLE_FLAGS_E);
+        &ctx.endorsement_hierarchy.object, flags.restricted_pwd_session, TPM2_HANDLE_FLAGS_E);
     if (rc != tool_rc_success) {
         LOG_ERR("Invalid endorsement hierarchy authorization");
         return rc;
     }
 
     rc = tpm2_util_object_load_auth(ectx, ctx.key.ctx_path,
-            ctx.key.auth_str, &ctx.key.object, false,
+            ctx.key.auth_str, &ctx.key.object, flags.restricted_pwd_session,
             TPM2_HANDLES_FLAGS_TRANSIENT|TPM2_HANDLES_FLAGS_PERSISTENT);
     if (rc != tool_rc_success) {
         LOG_ERR("Invalid key authorization");
@@ -214,7 +214,7 @@ static tool_rc tpm2_tool_onrun(ESYS_CONTEXT *ectx, tpm2_option_flags flags) {
     }
 
     //Process inputs
-    tool_rc rc = process_inputs(ectx);
+    tool_rc rc = process_inputs(ectx, flags);
     if (rc != tool_rc_success) {
         return rc;
     }

--- a/tools/tpm2_getsessionauditdigest.c
+++ b/tools/tpm2_getsessionauditdigest.c
@@ -157,7 +157,7 @@ static bool check_input_options_and_args(void) {
     return true;
 }
 
-static tool_rc process_inputs(ESYS_CONTEXT *ectx) {
+static tool_rc process_inputs(ESYS_CONTEXT *ectx, tpm2_option_flags flags) {
 
     tool_rc rc = tpm2_session_restore(ectx, ctx.audit_session_path,
         false, &ctx.audit_session);
@@ -172,14 +172,14 @@ static tool_rc process_inputs(ESYS_CONTEXT *ectx) {
      */
     rc = tpm2_util_object_load_auth(ectx,
         ctx.endorsement_hierarchy.ctx_path, ctx.endorsement_hierarchy.auth_str,
-        &ctx.endorsement_hierarchy.object, false, TPM2_HANDLE_FLAGS_E);
+        &ctx.endorsement_hierarchy.object, flags.restricted_pwd_session, TPM2_HANDLE_FLAGS_E);
     if (rc != tool_rc_success) {
         LOG_ERR("Invalid endorsement hierarchy authorization");
         return rc;
     }
 
     rc = tpm2_util_object_load_auth(ectx, ctx.key.ctx_path,
-            ctx.key.auth_str, &ctx.key.object, false,
+            ctx.key.auth_str, &ctx.key.object, flags.restricted_pwd_session,
             TPM2_HANDLES_FLAGS_TRANSIENT|TPM2_HANDLES_FLAGS_PERSISTENT);
     if (rc != tool_rc_success) {
         LOG_ERR("Invalid key authorization");
@@ -236,7 +236,7 @@ static tool_rc tpm2_tool_onrun(ESYS_CONTEXT *ectx, tpm2_option_flags flags) {
     }
 
     //Process inputs
-    tool_rc rc = process_inputs(ectx);
+    tool_rc rc = process_inputs(ectx, flags);
     if (rc != tool_rc_success) {
         return rc;
     }

--- a/tools/tpm2_gettime.c
+++ b/tools/tpm2_gettime.c
@@ -124,7 +124,7 @@ static tool_rc process_output(ESYS_CONTEXT *ectx) {
 }
 
 
-static tool_rc process_inputs(ESYS_CONTEXT *ectx) {
+static tool_rc process_inputs(ESYS_CONTEXT *ectx, tpm2_option_flags flags) {
 
     /*
      * 1. Object and auth initializations
@@ -141,7 +141,7 @@ static tool_rc process_inputs(ESYS_CONTEXT *ectx) {
     /* Object #1 */
     /* set up the privacy admin (always endorsement) hard coded in ctx init */
     tool_rc rc = tpm2_util_object_load_auth(ectx, ctx.privacy_admin.ctx_path,
-        ctx.privacy_admin.auth_str, &ctx.privacy_admin.object, false,
+        ctx.privacy_admin.auth_str, &ctx.privacy_admin.object, flags.restricted_pwd_session,
         TPM2_HANDLE_FLAGS_E);
     if (rc != tool_rc_success) {
         return rc;
@@ -150,7 +150,7 @@ static tool_rc process_inputs(ESYS_CONTEXT *ectx) {
     /* Object #2 */
     /* load the signing key */
     rc = tpm2_util_object_load_auth(ectx, ctx.signing_key.ctx_path,
-        ctx.signing_key.auth_str, &ctx.signing_key.object, false,
+        ctx.signing_key.auth_str, &ctx.signing_key.object, flags.restricted_pwd_session,
         TPM2_HANDLES_FLAGS_TRANSIENT|TPM2_HANDLES_FLAGS_PERSISTENT);
     if (rc != tool_rc_success) {
         LOG_ERR("Invalid key authorization");
@@ -309,7 +309,7 @@ static tool_rc tpm2_tool_onrun(ESYS_CONTEXT *ectx, tpm2_option_flags flags) {
     /*
      * 2. Process inputs
      */
-    rc = process_inputs(ectx);
+    rc = process_inputs(ectx, flags);
     if (rc != tool_rc_success) {
         return rc;
     }

--- a/tools/tpm2_hierarchycontrol.c
+++ b/tools/tpm2_hierarchycontrol.c
@@ -144,10 +144,10 @@ static tool_rc process_inputs(ESYS_CONTEXT *ectx) {
     return tool_rc_success;
 }
 
-static tool_rc check_options(ESYS_CONTEXT *ectx) {
+static tool_rc check_options(ESYS_CONTEXT *ectx, tpm2_option_flags flags) {
 
     tool_rc rc = tpm2_util_object_load_auth(ectx, ctx.auth_hierarchy.ctx_path,
-            ctx.auth_hierarchy.auth_str, &ctx.auth_hierarchy.object, false,
+            ctx.auth_hierarchy.auth_str, &ctx.auth_hierarchy.object, flags.restricted_pwd_session,
             TPM2_HANDLE_FLAGS_P | TPM2_HANDLE_FLAGS_O | TPM2_HANDLE_FLAGS_E);
     if (rc != tool_rc_success) {
         LOG_ERR("Invalid authorization");
@@ -300,12 +300,10 @@ static bool tpm2_tool_onstart(tpm2_options **opts) {
 
 static tool_rc tpm2_tool_onrun(ESYS_CONTEXT *ectx, tpm2_option_flags flags) {
 
-    UNUSED(flags);
-
     /*
      * 1. Process options
      */
-    tool_rc rc = check_options(ectx);
+    tool_rc rc = check_options(ectx, flags);
     if (rc != tool_rc_success) {
         return rc;
     }

--- a/tools/tpm2_hmac.c
+++ b/tools/tpm2_hmac.c
@@ -220,7 +220,7 @@ out:
     return rc;
 }
 
-static tool_rc process_inputs(ESYS_CONTEXT *ectx) {
+static tool_rc process_inputs(ESYS_CONTEXT *ectx, tpm2_option_flags flags) {
 
     /*
      * 1. Object and auth initializations
@@ -236,7 +236,7 @@ static tool_rc process_inputs(ESYS_CONTEXT *ectx) {
 
     /* Object #1 */
     tool_rc rc = tpm2_util_object_load_auth(ectx, ctx.hmac_key.ctx_path,
-        ctx.hmac_key.auth_str, &ctx.hmac_key.object, false,
+        ctx.hmac_key.auth_str, &ctx.hmac_key.object, flags.restricted_pwd_session,
         TPM2_HANDLE_ALL_W_NV);
     if (rc != tool_rc_success) {
         LOG_ERR("Invalid key handle authorization");
@@ -398,7 +398,7 @@ static tool_rc tpm2_tool_onrun(ESYS_CONTEXT *ectx, tpm2_option_flags flags) {
     /*
      * 2. Process inputs
      */
-    rc = process_inputs(ectx);
+    rc = process_inputs(ectx, flags);
     if (rc != tool_rc_success) {
         return rc;
     }

--- a/tools/tpm2_import.c
+++ b/tools/tpm2_import.c
@@ -466,7 +466,7 @@ static tool_rc process_input_tpm_import(void) {
     return tool_rc_success;
 }
 
-static tool_rc process_inputs(ESYS_CONTEXT *ectx) {
+static tool_rc process_inputs(ESYS_CONTEXT *ectx, tpm2_option_flags flags) {
 
     /*
      * 1. Object and auth initializations
@@ -478,7 +478,7 @@ static tool_rc process_inputs(ESYS_CONTEXT *ectx) {
      * 1.b Add object names and their auth sessions
      */
     tool_rc rc = tpm2_util_object_load_auth(ectx, ctx.parent.ctx_path,
-        ctx.parent.auth_str, &ctx.parent.object, false, TPM2_HANDLE_ALL_W_NV);
+        ctx.parent.auth_str, &ctx.parent.object, flags.restricted_pwd_session, TPM2_HANDLE_ALL_W_NV);
     if (rc != tool_rc_success) {
         LOG_ERR("Invalid parent key authorization");
         return rc;
@@ -695,7 +695,7 @@ static tool_rc tpm2_tool_onrun(ESYS_CONTEXT *ectx, tpm2_option_flags flags) {
     /*
      * 2. Process inputs
      */
-    rc = process_inputs(ectx);
+    rc = process_inputs(ectx, flags);
     if (rc != tool_rc_success) {
         return rc;
     }

--- a/tools/tpm2_load.c
+++ b/tools/tpm2_load.c
@@ -129,7 +129,7 @@ static tool_rc process_output(ESYS_CONTEXT *ectx) {
            ctx.contextpath, ctx.autoflush);
 }
 
-static tool_rc process_inputs(ESYS_CONTEXT *ectx) {
+static tool_rc process_inputs(ESYS_CONTEXT *ectx, tpm2_option_flags flags) {
 
     UNUSED(ectx);
     /*
@@ -162,7 +162,7 @@ static tool_rc process_inputs(ESYS_CONTEXT *ectx) {
      * tssprivkey, the parent object is always loaded.
      */
     tool_rc rc = tpm2_util_object_load_auth(ectx, objectstr, auth,
-        &ctx.parent.object, false, TPM2_HANDLE_ALL_W_NV);
+        &ctx.parent.object, flags.restricted_pwd_session, TPM2_HANDLE_ALL_W_NV);
     if (rc != tool_rc_success) {
         return rc;
     }
@@ -340,7 +340,7 @@ static tool_rc tpm2_tool_onrun(ESYS_CONTEXT *ectx, tpm2_option_flags flags) {
     /*
      * 2. Process inputs
      */
-    rc = process_inputs(ectx);
+    rc = process_inputs(ectx, flags);
     if (rc != tool_rc_success) {
         return rc;
     }

--- a/tools/tpm2_nvcertify.c
+++ b/tools/tpm2_nvcertify.c
@@ -162,7 +162,7 @@ static bool set_signature_format(char *value) {
     return true;
 }
 
-static tool_rc process_inputs(ESYS_CONTEXT *ectx) {
+static tool_rc process_inputs(ESYS_CONTEXT *ectx, tpm2_option_flags flags) {
 
     /*
      * 1. Object and auth initializations
@@ -185,7 +185,7 @@ static tool_rc process_inputs(ESYS_CONTEXT *ectx) {
      */
     if (!ctx.is_tcti_none) {
         rc = tpm2_util_object_load_auth(ectx, ctx.signing_key.ctx_path,
-                ctx.signing_key.auth_str, &ctx.signing_key.object, false,
+                ctx.signing_key.auth_str, &ctx.signing_key.object, flags.restricted_pwd_session,
                 TPM2_HANDLES_FLAGS_TRANSIENT|TPM2_HANDLES_FLAGS_PERSISTENT);
         if (rc != tool_rc_success) {
             LOG_ERR("Invalid signing key/ authorization.");
@@ -213,7 +213,7 @@ static tool_rc process_inputs(ESYS_CONTEXT *ectx) {
           tpm2_tpmi_hierarchy_to_esys_tr(ctx.nvindex_authobj.object.handle) : 0;
     } else {
         rc = tpm2_util_object_load_auth(ectx, ctx.nvindex_authobj.ctx_path,
-            ctx.nvindex_authobj.auth_str, &ctx.nvindex_authobj.object, false,
+            ctx.nvindex_authobj.auth_str, &ctx.nvindex_authobj.object, flags.restricted_pwd_session,
             TPM2_HANDLE_FLAGS_NV | TPM2_HANDLE_FLAGS_O | TPM2_HANDLE_FLAGS_P);
     }
 
@@ -556,7 +556,7 @@ static tool_rc tpm2_tool_onrun(ESYS_CONTEXT *ectx, tpm2_option_flags flags) {
     /*
      * 2. Process inputs
      */
-    rc = process_inputs(ectx);
+    rc = process_inputs(ectx, flags);
     if (rc != tool_rc_success) {
         return rc;
     }

--- a/tools/tpm2_nvdefine.c
+++ b/tools/tpm2_nvdefine.c
@@ -278,7 +278,7 @@ static tool_rc validate_size(ESYS_CONTEXT *ectx) {
     return tool_rc_success;
 }
 
-static tool_rc process_inputs(ESYS_CONTEXT *ectx) {
+static tool_rc process_inputs(ESYS_CONTEXT *ectx, tpm2_option_flags flags) {
 
     /*
      * 1. Object and auth initializations
@@ -304,7 +304,7 @@ static tool_rc process_inputs(ESYS_CONTEXT *ectx) {
      */
     rc = (!ctx.is_tcti_none) ?
         tpm2_util_object_load_auth(ectx, ctx.auth_hierarchy.ctx_path,
-            ctx.auth_hierarchy.auth_str, &ctx.auth_hierarchy.object, false,
+            ctx.auth_hierarchy.auth_str, &ctx.auth_hierarchy.object, flags.restricted_pwd_session,
             TPM2_HANDLE_FLAGS_O | TPM2_HANDLE_FLAGS_P) :
 
         tpm2_util_object_load(ectx, ctx.auth_hierarchy.ctx_path,
@@ -514,7 +514,7 @@ static tool_rc tpm2_tool_onrun(ESYS_CONTEXT *ectx, tpm2_option_flags flags) {
     /*
      * 2. Process inputs
      */
-    rc = process_inputs(ectx);
+    rc = process_inputs(ectx, flags);
     if (rc != tool_rc_success) {
         return rc;
     }

--- a/tools/tpm2_nvextend.c
+++ b/tools/tpm2_nvextend.c
@@ -100,7 +100,7 @@ static tool_rc process_output(ESYS_CONTEXT *ectx) {
 }
 
 
-static tool_rc process_inputs(ESYS_CONTEXT *ectx) {
+static tool_rc process_inputs(ESYS_CONTEXT *ectx, tpm2_option_flags flags) {
 
     /*
      * 1. Object and auth initializations
@@ -131,7 +131,7 @@ static tool_rc process_inputs(ESYS_CONTEXT *ectx) {
             tpm2_tpmi_hierarchy_to_esys_tr(ctx.auth_hierarchy.object.handle) : 0;
     } else {
         rc = tpm2_util_object_load_auth(ectx, ctx.auth_hierarchy.ctx_path,
-            ctx.auth_hierarchy.auth_str, &ctx.auth_hierarchy.object, false,
+            ctx.auth_hierarchy.auth_str, &ctx.auth_hierarchy.object, flags.restricted_pwd_session,
             TPM2_HANDLE_FLAGS_NV | TPM2_HANDLE_FLAGS_O | TPM2_HANDLE_FLAGS_P);
     }
 
@@ -302,7 +302,7 @@ static tool_rc tpm2_tool_onrun(ESYS_CONTEXT *ectx, tpm2_option_flags flags) {
     /*
      * 2. Process inputs
      */
-    rc = process_inputs(ectx);
+    rc = process_inputs(ectx, flags);
     if (rc != tool_rc_success) {
         return rc;
     }

--- a/tools/tpm2_nvincrement.c
+++ b/tools/tpm2_nvincrement.c
@@ -96,7 +96,7 @@ static tool_rc process_output(ESYS_CONTEXT *ectx) {
     return rc;
 }
 
-static tool_rc process_inputs(ESYS_CONTEXT *ectx) {
+static tool_rc process_inputs(ESYS_CONTEXT *ectx, tpm2_option_flags flags) {
 
     /*
      * 1. Object and auth initializations
@@ -133,7 +133,7 @@ static tool_rc process_inputs(ESYS_CONTEXT *ectx) {
            tpm2_tpmi_hierarchy_to_esys_tr(ctx.auth_hierarchy.object.handle) : 0;
     } else {
         rc = tpm2_util_object_load_auth(ectx, ctx.auth_hierarchy.ctx_path,
-            ctx.auth_hierarchy.auth_str, &ctx.auth_hierarchy.object, false,
+            ctx.auth_hierarchy.auth_str, &ctx.auth_hierarchy.object, flags.restricted_pwd_session,
             TPM2_HANDLE_FLAGS_NV | TPM2_HANDLE_FLAGS_O | TPM2_HANDLE_FLAGS_P);
     }
 
@@ -310,7 +310,7 @@ static tool_rc tpm2_tool_onrun(ESYS_CONTEXT *ectx, tpm2_option_flags flags) {
     /*
      * 2. Process inputs
      */
-    rc = process_inputs(ectx);
+    rc = process_inputs(ectx, flags);
     if (rc != tool_rc_success) {
         return rc;
     }

--- a/tools/tpm2_nvread.c
+++ b/tools/tpm2_nvread.c
@@ -119,7 +119,7 @@ out:
     return rc;
 }
 
-static tool_rc process_inputs(ESYS_CONTEXT *ectx) {
+static tool_rc process_inputs(ESYS_CONTEXT *ectx, tpm2_option_flags flags) {
 
     /*
      * 1. Object and auth initializations
@@ -156,7 +156,7 @@ static tool_rc process_inputs(ESYS_CONTEXT *ectx) {
            tpm2_tpmi_hierarchy_to_esys_tr(ctx.auth_hierarchy.object.handle) : 0;
     } else {
         rc = tpm2_util_object_load_auth(ectx, ctx.auth_hierarchy.ctx_path,
-            ctx.auth_hierarchy.auth_str, &ctx.auth_hierarchy.object, false,
+            ctx.auth_hierarchy.auth_str, &ctx.auth_hierarchy.object, flags.restricted_pwd_session,
             TPM2_HANDLE_FLAGS_NV | TPM2_HANDLE_FLAGS_O | TPM2_HANDLE_FLAGS_P);
     }
 
@@ -391,7 +391,7 @@ static tool_rc tpm2_tool_onrun(ESYS_CONTEXT *ectx, tpm2_option_flags flags) {
     /*
      * 2. Process inputs
      */
-    rc = process_inputs(ectx);
+    rc = process_inputs(ectx, flags);
     if (rc != tool_rc_success) {
         return rc;
     }

--- a/tools/tpm2_nvreadlock.c
+++ b/tools/tpm2_nvreadlock.c
@@ -93,7 +93,7 @@ static tool_rc process_output(ESYS_CONTEXT *ectx) {
     return rc;
 }
 
-static tool_rc process_inputs(ESYS_CONTEXT *ectx) {
+static tool_rc process_inputs(ESYS_CONTEXT *ectx, tpm2_option_flags flags) {
 
     /*
      * 1. Object and auth initializations
@@ -120,7 +120,7 @@ static tool_rc process_inputs(ESYS_CONTEXT *ectx) {
             tpm2_tpmi_hierarchy_to_esys_tr(ctx.auth_hierarchy.object.handle) : 0;
      } else {
          rc = tpm2_util_object_load_auth(ectx, ctx.auth_hierarchy.ctx_path,
-             ctx.auth_hierarchy.auth_str, &ctx.auth_hierarchy.object, false,
+             ctx.auth_hierarchy.auth_str, &ctx.auth_hierarchy.object, flags.restricted_pwd_session,
              valid_handles);
      }
 
@@ -298,7 +298,7 @@ static tool_rc tpm2_tool_onrun(ESYS_CONTEXT *ectx, tpm2_option_flags flags) {
     /*
      * 2. Process inputs
      */
-    rc = process_inputs(ectx);
+    rc = process_inputs(ectx, flags);
     if (rc != tool_rc_success) {
         return rc;
     }

--- a/tools/tpm2_nvsetbits.c
+++ b/tools/tpm2_nvsetbits.c
@@ -98,7 +98,7 @@ static tool_rc process_output(ESYS_CONTEXT *ectx) {
     return is_file_op_success ? tool_rc_success : tool_rc_general_error;
 }
 
-static tool_rc process_inputs(ESYS_CONTEXT *ectx) {
+static tool_rc process_inputs(ESYS_CONTEXT *ectx, tpm2_option_flags flags) {
 
     /*
      * 1. Object and auth initializations
@@ -131,7 +131,7 @@ static tool_rc process_inputs(ESYS_CONTEXT *ectx) {
            tpm2_tpmi_hierarchy_to_esys_tr(ctx.auth_hierarchy.object.handle) : 0;
     } else {
         rc = tpm2_util_object_load_auth(ectx, ctx.auth_hierarchy.ctx_path,
-            ctx.auth_hierarchy.auth_str, &ctx.auth_hierarchy.object, false,
+            ctx.auth_hierarchy.auth_str, &ctx.auth_hierarchy.object, flags.restricted_pwd_session,
             TPM2_HANDLE_FLAGS_NV | TPM2_HANDLE_FLAGS_O | TPM2_HANDLE_FLAGS_P);
     }
 
@@ -303,7 +303,7 @@ static tool_rc tpm2_tool_onrun(ESYS_CONTEXT *ectx, tpm2_option_flags flags) {
     /*
      * 2. Process inputs
      */
-    rc = process_inputs(ectx);
+    rc = process_inputs(ectx, flags);
     if (rc != tool_rc_success) {
         return rc;
     }

--- a/tools/tpm2_nvundefine.c
+++ b/tools/tpm2_nvundefine.c
@@ -112,7 +112,7 @@ static tool_rc process_output(ESYS_CONTEXT *ectx) {
 }
 
 
-static tool_rc process_inputs(ESYS_CONTEXT *ectx) {
+static tool_rc process_inputs(ESYS_CONTEXT *ectx, tpm2_option_flags flags) {
 
     /*
      * 1. Object and auth initializations
@@ -139,7 +139,7 @@ static tool_rc process_inputs(ESYS_CONTEXT *ectx) {
             tpm2_tpmi_hierarchy_to_esys_tr(ctx.auth_hierarchy.object.handle) : 0;
      } else {
          rc = tpm2_util_object_load_auth(ectx, ctx.auth_hierarchy.ctx_path,
-             ctx.auth_hierarchy.auth_str, &ctx.auth_hierarchy.object, false,
+             ctx.auth_hierarchy.auth_str, &ctx.auth_hierarchy.object, flags.restricted_pwd_session,
              valid_handles);
      }
 
@@ -433,7 +433,7 @@ static tool_rc tpm2_tool_onrun(ESYS_CONTEXT *ectx, tpm2_option_flags flags) {
     /*
      * 2. Process inputs
      */
-    rc = process_inputs(ectx);
+    rc = process_inputs(ectx, flags);
     if (rc != tool_rc_success) {
         return rc;
     }

--- a/tools/tpm2_nvwrite.c
+++ b/tools/tpm2_nvwrite.c
@@ -63,7 +63,7 @@ static tpm_nvwrite_ctx ctx = {
     .aux_session_handle[1] = ESYS_TR_NONE,
 };
 
-static tool_rc nv_write(ESYS_CONTEXT *ectx) {
+static tool_rc nv_write(ESYS_CONTEXT *ectx, tpm2_option_flags flags) {
 
     TPM2B_MAX_NV_BUFFER nv_write_data;
     UINT16 data_offset = 0;
@@ -93,7 +93,7 @@ static tool_rc nv_write(ESYS_CONTEXT *ectx) {
             }
 
             rc = tpm2_util_object_load_auth(ectx, ctx.auth_hierarchy.ctx_path,
-            ctx.auth_hierarchy.auth_str, &ctx.auth_hierarchy.object, false,
+            ctx.auth_hierarchy.auth_str, &ctx.auth_hierarchy.object, flags.restricted_pwd_session,
             TPM2_HANDLE_FLAGS_NV | TPM2_HANDLE_FLAGS_O | TPM2_HANDLE_FLAGS_P);
             if (rc != tool_rc_success) {
                 LOG_ERR("Failed updating the auth");
@@ -152,7 +152,7 @@ static tool_rc process_output(ESYS_CONTEXT *ectx) {
 }
 
 
-static tool_rc process_inputs(ESYS_CONTEXT *ectx) {
+static tool_rc process_inputs(ESYS_CONTEXT *ectx, tpm2_option_flags flags) {
 
     /*
      * 1. Object and auth initializations
@@ -189,7 +189,7 @@ static tool_rc process_inputs(ESYS_CONTEXT *ectx) {
            tpm2_tpmi_hierarchy_to_esys_tr(ctx.auth_hierarchy.object.handle) : 0;
     } else {
         rc = tpm2_util_object_load_auth(ectx, ctx.auth_hierarchy.ctx_path,
-            ctx.auth_hierarchy.auth_str, &ctx.auth_hierarchy.object, false,
+            ctx.auth_hierarchy.auth_str, &ctx.auth_hierarchy.object, flags.restricted_pwd_session,
             TPM2_HANDLE_FLAGS_NV | TPM2_HANDLE_FLAGS_O | TPM2_HANDLE_FLAGS_P);
     }
 
@@ -450,7 +450,7 @@ static tool_rc tpm2_tool_onrun(ESYS_CONTEXT *ectx, tpm2_option_flags flags) {
     /*
      * 2. Process inputs
      */
-    rc = process_inputs(ectx);
+    rc = process_inputs(ectx, flags);
     if (rc != tool_rc_success) {
         return rc;
     }
@@ -458,7 +458,7 @@ static tool_rc tpm2_tool_onrun(ESYS_CONTEXT *ectx, tpm2_option_flags flags) {
     /*
      * 3. TPM2_CC_<command> call
      */
-    rc = nv_write(ectx);
+    rc = nv_write(ectx, flags);
     if (rc != tool_rc_success) {
         return rc;
     }

--- a/tools/tpm2_nvwritelock.c
+++ b/tools/tpm2_nvwritelock.c
@@ -101,7 +101,7 @@ static tool_rc process_output(ESYS_CONTEXT *ectx) {
     return rc;
 }
 
-static tool_rc process_inputs(ESYS_CONTEXT *ectx) {
+static tool_rc process_inputs(ESYS_CONTEXT *ectx, tpm2_option_flags flags) {
 
     /*
      * 1. Object and auth initializations
@@ -138,7 +138,7 @@ static tool_rc process_inputs(ESYS_CONTEXT *ectx) {
            tpm2_tpmi_hierarchy_to_esys_tr(ctx.auth_hierarchy.object.handle) : 0;
      } else {
          rc = tpm2_util_object_load_auth(ectx, ctx.auth_hierarchy.ctx_path,
-             ctx.auth_hierarchy.auth_str, &ctx.auth_hierarchy.object, false,
+             ctx.auth_hierarchy.auth_str, &ctx.auth_hierarchy.object, flags.restricted_pwd_session,
              valid_handles);
      }
 
@@ -334,7 +334,7 @@ static tool_rc tpm2_tool_onrun(ESYS_CONTEXT *ectx, tpm2_option_flags flags) {
     /*
      * 2. Process inputs
      */
-    rc = process_inputs(ectx);
+    rc = process_inputs(ectx, flags);
     if (rc != tool_rc_success) {
         return rc;
     }

--- a/tools/tpm2_pcrallocate.c
+++ b/tools/tpm2_pcrallocate.c
@@ -92,7 +92,7 @@ static tool_rc process_outputs(ESYS_CONTEXT *ectx) {
     return tool_rc_success;
 }
 
-static tool_rc process_inputs(ESYS_CONTEXT *ectx) {
+static tool_rc process_inputs(ESYS_CONTEXT *ectx, tpm2_option_flags flags) {
 
     UNUSED(ectx);
     /*
@@ -107,7 +107,7 @@ static tool_rc process_inputs(ESYS_CONTEXT *ectx) {
      * 1.b Add object names and their auth sessions
      */
     tool_rc rc = tpm2_util_object_load_auth(ectx, ctx.auth_hierarchy.ctx_path,
-            ctx.auth_hierarchy.auth_str, &ctx.auth_hierarchy.object, false,
+            ctx.auth_hierarchy.auth_str, &ctx.auth_hierarchy.object, flags.restricted_pwd_session,
             TPM2_HANDLE_FLAGS_P);
     if (rc != tool_rc_success) {
         LOG_ERR("Invalid platform authorization format.");
@@ -222,7 +222,7 @@ static tool_rc tpm2_tool_onrun(ESYS_CONTEXT *ectx, tpm2_option_flags flags) {
     /*
      * 2. Process inputs
      */
-    rc = process_inputs(ectx);
+    rc = process_inputs(ectx, flags);
     if (rc != tool_rc_success) {
         return rc;
     }

--- a/tools/tpm2_policyauthorizenv.c
+++ b/tools/tpm2_policyauthorizenv.c
@@ -77,7 +77,7 @@ static tool_rc process_output(ESYS_CONTEXT *ectx) {
     return tpm2_policy_tool_finish(ectx, ctx.session, ctx.out_policy_dgst_path);
 }
 
-static tool_rc process_inputs(ESYS_CONTEXT *ectx) {
+static tool_rc process_inputs(ESYS_CONTEXT *ectx, tpm2_option_flags flags) {
 
     UNUSED(ectx);
     /*
@@ -92,7 +92,7 @@ static tool_rc process_inputs(ESYS_CONTEXT *ectx) {
      * 1.b Add object names and their auth sessions
      */
     tool_rc rc = tpm2_util_object_load_auth(ectx, ctx.auth_hierarchy.ctx_path,
-            ctx.auth_hierarchy.auth_str, &ctx.auth_hierarchy.object, false,
+            ctx.auth_hierarchy.auth_str, &ctx.auth_hierarchy.object, flags.restricted_pwd_session,
             TPM2_HANDLE_FLAGS_NV | TPM2_HANDLE_FLAGS_O | TPM2_HANDLE_FLAGS_P);
     if (rc != tool_rc_success) {
         LOG_ERR("Invalid handle authorization");
@@ -220,7 +220,7 @@ static tool_rc tpm2_tool_onrun(ESYS_CONTEXT *ectx, tpm2_option_flags flags) {
     /*
      * 2. Process inputs
      */
-    rc = process_inputs(ectx);
+    rc = process_inputs(ectx, flags);
     if (rc != tool_rc_success) {
         return rc;
     }

--- a/tools/tpm2_policynv.c
+++ b/tools/tpm2_policynv.c
@@ -83,7 +83,7 @@ static tool_rc process_output(ESYS_CONTEXT *ectx) {
     return tpm2_policy_tool_finish(ectx, ctx.session, ctx.policy_digest_path);
 }
 
-static tool_rc process_inputs(ESYS_CONTEXT *ectx) {
+static tool_rc process_inputs(ESYS_CONTEXT *ectx, tpm2_option_flags flags) {
 
     UNUSED(ectx);
     /*
@@ -98,7 +98,7 @@ static tool_rc process_inputs(ESYS_CONTEXT *ectx) {
      * 1.b Add object names and their auth sessions
      */
     tool_rc rc = tpm2_util_object_load_auth(ectx, ctx.auth_hierarchy.ctx_path,
-        ctx.auth_hierarchy.auth_str, &ctx.auth_hierarchy.object, false,
+        ctx.auth_hierarchy.auth_str, &ctx.auth_hierarchy.object, flags.restricted_pwd_session,
         TPM2_HANDLE_FLAGS_NV | TPM2_HANDLE_FLAGS_O | TPM2_HANDLE_FLAGS_P);
     if (rc != tool_rc_success) {
         LOG_ERR("Invalid handle authorization");
@@ -323,7 +323,7 @@ static tool_rc tpm2_tool_onrun(ESYS_CONTEXT *ectx, tpm2_option_flags flags) {
     /*
      * 2. Process inputs
      */
-    rc = process_inputs(ectx);
+    rc = process_inputs(ectx, flags);
     if (rc != tool_rc_success) {
         return rc;
     }

--- a/tools/tpm2_policysecret.c
+++ b/tools/tpm2_policysecret.c
@@ -119,7 +119,7 @@ static tool_rc process_output(ESYS_CONTEXT *ectx) {
     return rc;
 }
 
-static tool_rc process_inputs(ESYS_CONTEXT *ectx) {
+static tool_rc process_inputs(ESYS_CONTEXT *ectx, tpm2_option_flags flags) {
 
     UNUSED(ectx);
     /*
@@ -139,7 +139,7 @@ static tool_rc process_inputs(ESYS_CONTEXT *ectx) {
      * a password session
      */
     tool_rc rc = tpm2_util_object_load_auth(ectx, ctx.auth_entity.ctx_path,
-            ctx.auth_entity.auth_str, &ctx.auth_entity.object, false,
+            ctx.auth_entity.auth_str, &ctx.auth_entity.object, flags.restricted_pwd_session,
             TPM2_HANDLE_ALL_W_NV);
     if (rc != tool_rc_success) {
         return rc;
@@ -301,7 +301,7 @@ static tool_rc tpm2_tool_onrun(ESYS_CONTEXT *ectx, tpm2_option_flags flags) {
     /*
      * 2. Process inputs
      */
-    rc = process_inputs(ectx);
+    rc = process_inputs(ectx, flags);
     if (rc != tool_rc_success) {
         return rc;
     }

--- a/tools/tpm2_quote.c
+++ b/tools/tpm2_quote.c
@@ -205,7 +205,7 @@ static tool_rc process_output(ESYS_CONTEXT *ectx) {
     return write_output_files();
 }
 
-static tool_rc process_inputs(ESYS_CONTEXT *ectx) {
+static tool_rc process_inputs(ESYS_CONTEXT *ectx, tpm2_option_flags flags) {
 
     UNUSED(ectx);
     /*
@@ -220,7 +220,7 @@ static tool_rc process_inputs(ESYS_CONTEXT *ectx) {
      * 1.b Add object names and their auth sessions
      */
     tool_rc rc = tpm2_util_object_load_auth(ectx, ctx.key.ctx_path,
-            ctx.key.auth_str, &ctx.key.object, false, TPM2_HANDLE_ALL_W_NV);
+            ctx.key.auth_str, &ctx.key.object, flags.restricted_pwd_session, TPM2_HANDLE_ALL_W_NV);
     if (rc != tool_rc_success) {
         LOG_ERR("Invalid key authorization");
         return rc;
@@ -405,7 +405,7 @@ static tool_rc tpm2_tool_onrun(ESYS_CONTEXT *ectx, tpm2_option_flags flags) {
     /*
      * 2. Process inputs
      */
-    rc = process_inputs(ectx);
+    rc = process_inputs(ectx, flags);
     if (rc != tool_rc_success) {
         return rc;
     }

--- a/tools/tpm2_rsadecrypt.c
+++ b/tools/tpm2_rsadecrypt.c
@@ -88,7 +88,7 @@ static tool_rc process_output(ESYS_CONTEXT *ectx) {
     return is_file_op_success ? tool_rc_success : tool_rc_general_error;
 }
 
-static tool_rc process_inputs(ESYS_CONTEXT *ectx) {
+static tool_rc process_inputs(ESYS_CONTEXT *ectx, tpm2_option_flags flags) {
 
     UNUSED(ectx);
     /*
@@ -103,7 +103,7 @@ static tool_rc process_inputs(ESYS_CONTEXT *ectx) {
      * 1.b Add object names and their auth sessions
      */
     tool_rc rc = tpm2_util_object_load_auth(ectx, ctx.key.ctx_path,
-        ctx.key.auth_str, &ctx.key.object, false,
+        ctx.key.auth_str, &ctx.key.object, flags.restricted_pwd_session,
         TPM2_HANDLES_FLAGS_TRANSIENT|TPM2_HANDLES_FLAGS_PERSISTENT);
     if (rc != tool_rc_success) {
         return rc;
@@ -275,7 +275,7 @@ static tool_rc tpm2_tool_onrun(ESYS_CONTEXT *ectx, tpm2_option_flags flags) {
     /*
      * 2. Process inputs
      */
-    rc = process_inputs(ectx);
+    rc = process_inputs(ectx, flags);
     if (rc != tool_rc_success) {
         return rc;
     }

--- a/tools/tpm2_setclock.c
+++ b/tools/tpm2_setclock.c
@@ -72,7 +72,7 @@ static tool_rc process_output(ESYS_CONTEXT *ectx) {
     return rc;
 }
 
-static tool_rc process_inputs(ESYS_CONTEXT *ectx) {
+static tool_rc process_inputs(ESYS_CONTEXT *ectx, tpm2_option_flags flags) {
 
     UNUSED(ectx);
     /*
@@ -87,7 +87,7 @@ static tool_rc process_inputs(ESYS_CONTEXT *ectx) {
      * 1.b Add object names and their auth sessions
      */
     tool_rc rc = tpm2_util_object_load_auth(ectx, ctx.auth_hierarchy.ctx_path,
-            ctx.auth_hierarchy.auth_str, &ctx.auth_hierarchy.object, false,
+            ctx.auth_hierarchy.auth_str, &ctx.auth_hierarchy.object, flags.restricted_pwd_session,
             TPM2_HANDLE_FLAGS_P|TPM2_HANDLE_FLAGS_O);
     if (rc != tool_rc_success) {
         return rc;
@@ -204,7 +204,7 @@ static tool_rc tpm2_tool_onrun(ESYS_CONTEXT *ectx, tpm2_option_flags flags) {
     /*
      * 2. Process inputs
      */
-    rc = process_inputs(ectx);
+    rc = process_inputs(ectx, flags);
     if (rc != tool_rc_success) {
         return rc;
     }

--- a/tools/tpm2_setcommandauditstatus.c
+++ b/tools/tpm2_setcommandauditstatus.c
@@ -98,7 +98,7 @@ static tool_rc tpm2_tool_onrun(ESYS_CONTEXT *ectx, tpm2_option_flags flags) {
     UNUSED(flags);
 
     tool_rc rc = tpm2_util_object_load_auth(ectx, ctx.hierarchy.ctx_path,
-    ctx.hierarchy.auth_str , &ctx.hierarchy.object, false,
+    ctx.hierarchy.auth_str , &ctx.hierarchy.object, flags.restricted_pwd_session,
     TPM2_HANDLE_FLAGS_O|TPM2_HANDLE_FLAGS_P);
     if (rc != tool_rc_success) {
         return rc;

--- a/tools/tpm2_setprimarypolicy.c
+++ b/tools/tpm2_setprimarypolicy.c
@@ -75,7 +75,7 @@ static tool_rc process_output(ESYS_CONTEXT *ectx) {
     return rc;
 }
 
-static tool_rc process_inputs(ESYS_CONTEXT *ectx) {
+static tool_rc process_inputs(ESYS_CONTEXT *ectx, tpm2_option_flags flags) {
 
     UNUSED(ectx);
     /*
@@ -90,7 +90,7 @@ static tool_rc process_inputs(ESYS_CONTEXT *ectx) {
      * 1.b Add object names and their auth sessions
      */
     tool_rc rc = tpm2_util_object_load_auth(ectx, ctx.hierarchy.ctx_path,
-            ctx.hierarchy.auth_str, &ctx.hierarchy.object, false,
+            ctx.hierarchy.auth_str, &ctx.hierarchy.object, flags.restricted_pwd_session,
             TPM2_HANDLE_FLAGS_O|TPM2_HANDLE_FLAGS_P|TPM2_HANDLE_FLAGS_E|
             TPM2_HANDLE_FLAGS_L);
     if (rc != tool_rc_success) {
@@ -232,7 +232,7 @@ static tool_rc tpm2_tool_onrun(ESYS_CONTEXT *ectx, tpm2_option_flags flags) {
     /*
      * 2. Process inputs
      */
-    rc = process_inputs(ectx);
+    rc = process_inputs(ectx, flags);
     if (rc != tool_rc_success) {
         return rc;
     }

--- a/tools/tpm2_sign.c
+++ b/tools/tpm2_sign.c
@@ -210,10 +210,10 @@ static tool_rc process_inputs(ESYS_CONTEXT *ectx) {
     return rc;
 }
 
-static tool_rc check_options(ESYS_CONTEXT *ectx) {
+static tool_rc check_options(ESYS_CONTEXT *ectx, tpm2_option_flags flags) {
 
     tool_rc rc = tpm2_util_object_load_auth(ectx, ctx.signing_key.ctx_path,
-            ctx.signing_key.auth_str, &ctx.signing_key.object, false,
+            ctx.signing_key.auth_str, &ctx.signing_key.object, flags.restricted_pwd_session,
             TPM2_HANDLE_ALL_W_NV);
     if (rc != tool_rc_success) {
         LOG_ERR("Invalid key authorization");
@@ -367,12 +367,10 @@ static bool tpm2_tool_onstart(tpm2_options **opts) {
 
 static tool_rc tpm2_tool_onrun(ESYS_CONTEXT *ectx, tpm2_option_flags flags) {
 
-    UNUSED(flags);
-
     /*
      * 1. Process options
      */
-    tool_rc rc = check_options(ectx);
+    tool_rc rc = check_options(ectx, flags);
     if (rc != tool_rc_success) {
         return rc;
     }

--- a/tools/tpm2_unseal.c
+++ b/tools/tpm2_unseal.c
@@ -107,7 +107,7 @@ static tool_rc process_output(ESYS_CONTEXT *ectx) {
     return is_file_op_success ? tool_rc_success : tool_rc_general_error;
 }
 
-static tool_rc process_inputs(ESYS_CONTEXT *ectx) {
+static tool_rc process_inputs(ESYS_CONTEXT *ectx, tpm2_option_flags flags) {
 
     /*
      * 1. Object and auth initializations
@@ -121,7 +121,7 @@ static tool_rc process_inputs(ESYS_CONTEXT *ectx) {
      * 1.b Add object names and their auth sessions
      */
     tool_rc rc = tpm2_util_object_load_auth(ectx, ctx.sealkey.ctx_path,
-            ctx.sealkey.auth_str, &ctx.sealkey.object, false,
+            ctx.sealkey.auth_str, &ctx.sealkey.object, flags.restricted_pwd_session,
             TPM2_HANDLES_FLAGS_TRANSIENT | TPM2_HANDLES_FLAGS_PERSISTENT);
     if (rc != tool_rc_success) {
         LOG_ERR("Invalid item handle authorization");
@@ -245,7 +245,7 @@ static tool_rc tpm2_tool_onrun(ESYS_CONTEXT *ectx, tpm2_option_flags flags) {
     /*
      * 2. Process inputs
      */
-    rc = process_inputs(ectx);
+    rc = process_inputs(ectx, flags);
     if (rc != tool_rc_success) {
         return rc;
     }

--- a/tools/tpm2_zgen2phase.c
+++ b/tools/tpm2_zgen2phase.c
@@ -130,10 +130,10 @@ static tool_rc check_options(void) {
     return tool_rc_success;
 }
 
-static tool_rc process_inputs(ESYS_CONTEXT *ectx) {
+static tool_rc process_inputs(ESYS_CONTEXT *ectx, tpm2_option_flags flags) {
 
     tool_rc rc = tpm2_util_object_load_auth(ectx, ctx.ecc_key.ctx_path,
-        ctx.ecc_key.auth_str, &ctx.ecc_key.object, false,
+        ctx.ecc_key.auth_str, &ctx.ecc_key.object, flags.restricted_pwd_session,
         TPM2_HANDLES_FLAGS_TRANSIENT|TPM2_HANDLES_FLAGS_PERSISTENT);
     if (rc != tool_rc_success) {
         return rc;
@@ -183,7 +183,7 @@ static tool_rc tpm2_tool_onrun(ESYS_CONTEXT *ectx, tpm2_option_flags flags) {
     }
 
     // Process inputs
-    rc = process_inputs(ectx);
+    rc = process_inputs(ectx, flags);
     if (rc != tool_rc_success) {
         return rc;
     }


### PR DESCRIPTION
For authentication of an object always an HMAC session was used. For an unsalted session an openssl HMAC key with the size of the auth value was created. This caused problems with the OpenSSL FIPS mode if the key length is less than 112 bits. To avoid this the option --pwd-session (-z) is added. Here the session handle ESYS_TR_PASSWORD will be used. For example, now the EK can be used to create a salted session:
```
tpm2_createek --pwd-session -Q --key-algorithm rsa --ek-context ek.ctx
tpm2_startauthsession -Q  --session salted_session.ctx --hmac-session --tpmkey-context ek.ctx
tpm2_sessionconfig -Q  salted_session.ctx --enable-decrypt 
tpm2_createprimary -c prim.ctx -P session:salted_session.ctx
```
Adresses: #3420