### PR TITLE
cirrus-ci update image-family to freebsd-14-1

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -8,11 +8,12 @@ task:
     ibmtpm_name: ibmtpm1637
     TSS2_LOG: "all+ERROR;tcti+TRACE"
   freebsd_instance:
-    image_family: freebsd-14-0
+    image_family: freebsd-14-1
   install_script:
     - pkg update -f
     - pkg upgrade -y
-    - pkg install -y bash gmake coreutils libtool pkgconf autoconf autoconf-archive e2fsprogs-libuuid py311-yaml expect
+    - pkg install -y bash gmake coreutils libtool pkgconf autoconf autoconf-archive e2fsprogs-libuuid py311-pip expect
+    - python3 -m pip install pyyaml
     - pkg install -y automake glib dbus dbus-glib cmocka wget git openssl json-c vim hs-pandoc
     - pkg install -y swtpm
     - mkdir tss


### PR DESCRIPTION
* 14.0 did produce the error:
 FreeBSD contains packages for wrong OS version: FreeBSD:14:amd64
* pyyaml is now installed via pip.