### PR TITLE
readthedocs: update markdown

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -6,7 +6,7 @@
 #
 jinja2==3.1.4
     # via -r requirements.in
-markdown==3.1.1
+markdown==3.3.6
     # via -r requirements.in
 markupsafe==2.1.2
     # via jinja2


### PR DESCRIPTION
markdown 3.1.1 is incompatible to mkdocs 1.6.1 therefore markdown 3.3.6 is now used.