### PR TITLE
tpm2_getekcertificate: add support to high range NV indexes 

### DIFF
--- a/test/integration/tests/getekcertificate.sh
+++ b/test/integration/tests/getekcertificate.sh
@@ -71,6 +71,7 @@ tpm2 loadexternal -C e  -u test_rsa_ek.pub -c rsa_key.ctx
 tpm2 readpublic -c rsa_key.ctx -f pem -o test_rsa_ek.pem
 openssl x509 -pubkey -in rsa_ek_cert.bin -noout -out test_ek.pem
 diff test_rsa_ek.pem test_ek.pem
+tpm2 flushcontext -t
 
 # Sample ECC ek public from a real platform
 echo "007a0023000b000300b20020837197674484b3f81a90cc8d46a5d724fd52
@@ -90,6 +91,7 @@ tpm2 loadexternal -C e  -u test_ecc_ek.pub -c ecc_key.ctx
 tpm2 readpublic -c ecc_key.ctx -f pem -o test_ecc_ek.pem
 openssl x509 -pubkey -in ecc_ek_cert.bin -noout -out test_ek.pem
 diff test_ecc_ek.pem test_ek.pem
+tpm2 flushcontext -t
 
 # Retrieve EK certificates from NV indices
 RSA_EK_CERT_NV_INDEX=0x01C00002
@@ -170,14 +172,15 @@ tpm2 getekcertificate -o nv_rsa_ek_cert.der -o nv_ecc_ek_cert.der
 diff nv_rsa_ek_cert.der rsa_ek_cert.der
 diff nv_ecc_ek_cert.der ecc_ek_cert.der
 
-rm nv_rsa_ek_cert.der rsa_ek_cert.der nv_ecc_ek_cert.der ecc_ek_cert.der priv_key.pem -f
+rm nv_rsa_ek_cert.der nv_ecc_ek_cert.der -f
 
 ## Make sure that if there are several certificates of the same type, then the one belonging to low range has priority
 openssl x509 -in ecc_ek_cert.bin -out ecc_low_range_ek_cert.der -outform DER
 define_ek_cert_nv_index ecc_low_range_ek_cert.der $ECC_EK_CERT_NV_INDEX
 
-tpm2 getekcertificate -o nv_ecc_ek_cert.der
+tpm2 getekcertificate -o nv_rsa_ek_cert.der -o nv_ecc_ek_cert.der
 
 diff nv_ecc_ek_cert.der ecc_low_range_ek_cert.der
+diff nv_rsa_ek_cert.der rsa_ek_cert.der
 
 exit 0

--- a/test/integration/tests/getekcertificate.sh
+++ b/test/integration/tests/getekcertificate.sh
@@ -172,4 +172,12 @@ diff nv_ecc_ek_cert.der ecc_ek_cert.der
 
 rm nv_rsa_ek_cert.der rsa_ek_cert.der nv_ecc_ek_cert.der ecc_ek_cert.der priv_key.pem -f
 
+## Make sure that if there are several certificates of the same type, then the one belonging to low range has priority
+openssl x509 -in ecc_ek_cert.bin -out ecc_low_range_ek_cert.der -outform DER
+define_ek_cert_nv_index ecc_low_range_ek_cert.der $ECC_EK_CERT_NV_INDEX
+
+tpm2 getekcertificate -o nv_ecc_ek_cert.der
+
+diff nv_ecc_ek_cert.der ecc_low_range_ek_cert.der
+
 exit 0

--- a/tools/tpm2_getekcertificate.c
+++ b/tools/tpm2_getekcertificate.c
@@ -665,6 +665,9 @@ tool_rc get_tpm_properties(ESYS_CONTEXT *ectx) {
         goto get_tpm_properties_out;
     }
 
+    ctx.rsa_ek_cert_nv_location = 0xffffffff;
+    ctx.ecc_ek_cert_nv_location = 0xffffffff;
+    
     UINT32 i;
     for (i = 0; i < capability_data->data.handles.count; i++) {
         TPMI_RH_NV_INDEX index = capability_data->data.handles.handle[i];
@@ -673,12 +676,12 @@ tool_rc get_tpm_properties(ESYS_CONTEXT *ectx) {
             continue;
         }
 
-        if (m->key_type == KTYPE_RSA) {
+        if (m->key_type == KTYPE_RSA && index < ctx.rsa_ek_cert_nv_location) {
             LOG_INFO("Found pre-provisioned RSA EK certificate at %u [type=%s]", index, m->name);
             ctx.is_rsa_ek_cert_nv_location_defined = true;
             ctx.rsa_ek_cert_nv_location = m->index;
         }
-        if (m->key_type == KTYPE_ECC) {
+        if (m->key_type == KTYPE_ECC && index < ctx.ecc_ek_cert_nv_location) {
             LOG_INFO("Found pre-provisioned ECC EK certificate at %u [type=%s]", index, m->name);
             ctx.is_ecc_ek_cert_nv_location_defined = true;
             ctx.ecc_ek_cert_nv_location = m->index;


### PR DESCRIPTION
Fixes #3435.

_Note_:

* The test case uses self-signed certificates because I didn't found a valid one in `https://ekop.intel.com` (e.g. RSA 3072 or ECC P384)