### PR TITLE
tpm2_getekcertificate: Provide option -u for certs in NV ram.

### DIFF
--- a/man/tpm2_getekcertificate.1.md
+++ b/man/tpm2_getekcertificate.1.md
@@ -134,6 +134,11 @@ tpm2_getekcertificate -X -x -o ECcert.bin -u ek.pub
 ```bash
 tpm2_getekcertificate -o ECcert.bin
 ```
+## Retrieve EK certificate from TPM NV indices for an EK public key, fail otherwise.
+```bash
+ tpm2_createek -G ecc384 -u ek_ecc384.pub -c ek_ecc384.ctx
+ tpm2_getekcertificate -o ek_ecc384.cert -u ek_ecc384.pub
+```
 
 ## Retrieve multiple EK certificates from TPM NV indices only, fail otherwise.
 ```bash


### PR DESCRIPTION
The option --ek-public (-u) can now used to select the certifcate in NV ram that will be written to the output file. Example:
```
tpm2_createek -G ecc384 -u ek_ecc384.pub -c ek_ecc384.ctx 
tpm2_getekcertificate -o ek_ecc384.cert -u ek_ecc384.pub
```
An integration test for ecc and rsa certificates is added.