### PR TITLE
tpm2_getrandom: Fix --force parameter

### DIFF
--- a/tools/tpm2_getrandom.c
+++ b/tools/tpm2_getrandom.c
@@ -323,7 +323,7 @@ static bool tpm2_tool_onstart(tpm2_options **opts) {
 
     const struct option topts[] = {
         { "output",       required_argument, NULL, 'o' },
-        { "force",        required_argument, NULL, 'f' },
+        { "force",        no_argument,       NULL, 'f' },
         { "hex",          no_argument,       NULL,  0  },
         { "session",      required_argument, NULL, 'S' },
         { "cphash",       required_argument, NULL,  1  },


### PR DESCRIPTION
The --force parameter did require an argument but was always set to true if used. Now no_argument is used in the option table.