### PR TITLE
ci: update codecoverage action.

### DIFF
--- a/.ci/docker.run
+++ b/.ci/docker.run
@@ -152,7 +152,7 @@ check_branch="origin/${TRAVIS_BRANCH:-master}"
 [ -z "$TRAVIS_TAG" ] && git fetch "$check_branch" && git diff --check "$check_branch"
 
 if [ "$ENABLE_COVERAGE" == "true" ]; then
-    bash <(curl -s https://codecov.io/bash)
+    lcov --capture --directory . --output-file ./coverage.info
 else
     echo "ENABLE_COVERAGE not true, got \"$ENABLE_COVERAGE\""
 fi

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -63,6 +63,13 @@ jobs:
           ENABLE_COVERAGE: true
           DOCKER_IMAGE: ubuntu-20.04
           CC: gcc
+      - name: Upload Coverage to Codecov
+        uses: codecov/codecov-action@v5
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          files: ./coverage.info
+          fail_ci_if_error: true
+          verbose: true
       - name: failure cat build logs
         if: ${{ failure() }}
         run: cat build/test-suite.log || true


### PR DESCRIPTION
The usage of https://codecov.io/bash is deprecated and replaced with a github action using codecov/codecov-action@v5.