### PR TITLE
tpm2_encode: Fix setting emptyAuth in generated pem file.

### DIFF
--- a/tools/misc/tpm2_encodeobject.c
+++ b/tools/misc/tpm2_encodeobject.c
@@ -165,7 +165,7 @@ static int encode(ESYS_CONTEXT *ectx) {
         goto error;
     }
 
-    tpk->emptyAuth = ctx.object.needs_auth;
+    tpk->emptyAuth = !ctx.object.needs_auth;
 
     bn_parent = BN_new();
     if (!bn_parent) {


### PR DESCRIPTION
emptyAuth was set to 1 if an auth value for the input key was used  and to 0 if an auth value was used.
Fixes: #3458