### PR TITLE
ci: Cirrus ci update freebsd-14-1 to freebsd-14-2

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -8,7 +8,7 @@ task:
     ibmtpm_name: ibmtpm1637
     TSS2_LOG: "all+ERROR;tcti+TRACE"
   freebsd_instance:
-    image_family: freebsd-14-1
+    image_family: freebsd-14-2
   install_script:
     - pkg update -f
     - pkg upgrade -y


### PR DESCRIPTION
The resource projects/freebsd-org-cloud-dev/global/images/family/freebsd-14-1 was not found.