### PR TITLE
build: Remove deprecrated ACLOCAL_AMFLAGS

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -11,8 +11,6 @@ endif
 
 include src_vars.mk
 
-ACLOCAL_AMFLAGS = -I m4 --install
-
 INCLUDE_DIRS = -I$(top_srcdir)/tools -I$(top_srcdir)/lib
 LIB_COMMON := lib/libcommon.a
 


### PR DESCRIPTION
In parallel with https://github.com/tpm2-software/tpm2-tss/pull/2952