### PR TITLE
update rsa2048 and ecc_nist_p256 to policy_b

### DIFF
--- a/tools/tpm2_createek.c
+++ b/tools/tpm2_createek.c
@@ -136,14 +136,14 @@ struct alg_map {
 
 static const alg_map alg_maps[] = {
     { "rsa",           "rsa2048:aes128cfb", "sha256", &policy_a_sha256, ATTRS_A },
-    { "rsa2048",       "rsa2048:aes128cfb", "sha256", &policy_a_sha256, ATTRS_A },
+    { "rsa2048",       "rsa2048:aes128cfb", "sha256", &policy_b_sha256, ATTRS_B },
     { "rsa3072",       "rsa3072:aes256cfb", "sha384", &policy_b_sha384, ATTRS_B },
     { "rsa4096",       "rsa4096:aes256cfb", "sha384", &policy_b_sha384, ATTRS_B },
     { "ecc",           "ecc_nist_p256:aes128cfb", "sha256", &policy_a_sha256, ATTRS_A },
     { "ecc256",        "ecc_nist_p256:aes128cfb", "sha256", &policy_a_sha256, ATTRS_A },
     { "ecc384",        "ecc_nist_p384:aes256cfb", "sha384", &policy_b_sha384, ATTRS_B },
     { "ecc521",        "ecc_nist_p521:aes256cfb", "sha512", &policy_b_sha512, ATTRS_B },
-    { "ecc_nist_p256", "ecc_nist_p256:aes128cfb", "sha256", &policy_b_sha256, ATTRS_A },
+    { "ecc_nist_p256", "ecc_nist_p256:aes128cfb", "sha256", &policy_b_sha256, ATTRS_B },
     { "ecc_nist_p384", "ecc_nist_p384:aes256cfb", "sha384", &policy_b_sha384, ATTRS_B },
     { "ecc_nist_p521", "ecc_nist_p521:aes256cfb", "sha512", &policy_b_sha512, ATTRS_B },
     { "ecc_sm2",       "ecc_sm2_p256:sm4_128cfb", "sm3_256", &policy_b_sm3_256, ATTRS_B },

--- a/tools/tpm2_createek.c
+++ b/tools/tpm2_createek.c
@@ -143,7 +143,7 @@ static const alg_map alg_maps[] = {
     { "ecc256",        "ecc_nist_p256:aes128cfb", "sha256", &policy_a_sha256, ATTRS_A },
     { "ecc384",        "ecc_nist_p384:aes256cfb", "sha384", &policy_b_sha384, ATTRS_B },
     { "ecc521",        "ecc_nist_p521:aes256cfb", "sha512", &policy_b_sha512, ATTRS_B },
-    { "ecc_nist_p256", "ecc_nist_p256:aes128cfb", "sha256", &policy_a_sha256, ATTRS_A },
+    { "ecc_nist_p256", "ecc_nist_p256:aes128cfb", "sha256", &policy_b_sha256, ATTRS_A },
     { "ecc_nist_p384", "ecc_nist_p384:aes256cfb", "sha384", &policy_b_sha384, ATTRS_B },
     { "ecc_nist_p521", "ecc_nist_p521:aes256cfb", "sha512", &policy_b_sha512, ATTRS_B },
     { "ecc_sm2",       "ecc_sm2_p256:sm4_128cfb", "sm3_256", &policy_b_sm3_256, ATTRS_B },


### PR DESCRIPTION
Pretty sure this was incorrect.  All the EK templates in the High Range should use Policy B; not Policy A

See B.4.5 Template H-2: ECC NIST P256 (Storage)

for source https://trustedcomputinggroup.org/wp-content/uploads/EK-Credential-Profile-For-TPM-Family-2.0-Level-0-V2.5-R1.0_28March2022.pdf


Maybe we should come up with better names for these

e.g.   `ecc-low` and `ecc-high` ?