### PR TITLE
tpm2_getekcertificate: add option --x509-trunc

### DIFF
--- a/man/tpm2_getekcertificate.1.md
+++ b/man/tpm2_getekcertificate.1.md
@@ -89,6 +89,12 @@ conditions dictating the certificate location lookup.
     Specifies the encoding format to use explicitly. Normally, the default
     method is the one used by Intel unless an AMD fTPM is detected, in which
     case the AMD-specific encoding is used. Use 'a' for AMD and 'i' for Intel.
+    
+  * **-t**, **\--x509-trunc**:
+
+    This flags the tool to parse certificates, with a X509 parser, read from TPM
+    NV indices, and truncate the trailing data before output. Useful when dealing
+    with TPMs that output certificates with trailing data padded to a fixed size.
 
   * **ARGUMENT** the command line argument specifies the URL address for the EK
     certificate portal. This forces the tool to not look for the EK certificates


### PR DESCRIPTION
New option to handle x509 DER with trailing data

ST micro's ST33HTPHF2ENIST TPM creates NIST P-256 ECC and RSA EK certificates with 0xff data padded to a fixed 1600 bytes length. The option "--x509-trunc" or "-t" parses the output of "nv_read" with a X509 parser and truncates the trailing data. This makes the output formate more accessable to GOLANG's X509.ParseCertificate(). Details about this issue can be found at: tpm2-software#3474

Signed-off-by: Samuel Cheng <samuelogre@gmail.com>