### PR TITLE
Add Wformat-security to Wformat check

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -314,8 +314,7 @@ AS_IF([test x"$enable_hardening" != x"no"], [
   add_hardened_c_flag([-Wextra])
   AS_IF([test "x$ax_is_release" = "xno"], [add_hardened_c_flag([-Werror])])
 
-  add_hardened_c_flag([-Wformat])
-  add_hardened_c_flag([-Wformat-security])
+  add_hardened_c_flag([-Wformat -Wformat-security])
   add_hardened_c_flag([-Wstack-protector])
   add_hardened_c_flag([-fstack-protector-all])
   add_hardened_c_flag([-Wstrict-overflow=5])


### PR DESCRIPTION
Wformat is included only for Wformat-security and Wformat-security can't be checked without Wformat so they both might as well be checked together and doing the checks separately fails as described below. 

Keeping configure.ac the way it is fails to complete ./configure with GCC 14.2 on kernel 6.12.21-4-MANJARO