### PR TITLE
options.md: fix typo

### DIFF
--- a/man/common/options.md
+++ b/man/common/options.md
@@ -22,7 +22,7 @@ information that many users may expect.
 
   * **-Q**, **\--quiet**:
     Silence normal tool output to stdout.
-x
+
   * **-Z**, **\--enable-errata**:
     Enable the application of errata fixups. Useful if an errata fixup needs to be
     applied to commands sent to the TPM. Defining the environment


### PR DESCRIPTION
Removal of a stray "x" in manual pages.