### PR TITLE
pcr commands: session support added.

### DIFF
--- a/lib/pcr.c
+++ b/lib/pcr.c
@@ -605,7 +605,9 @@ bool pcr_check_pcr_selection(TPMS_CAPABILITY_DATA *cap_data,
 
 tool_rc pcr_read_pcr_values(ESYS_CONTEXT *esys_context,
         TPML_PCR_SELECTION *pcr_select, tpm2_pcrs *pcrs, TPM2B_DIGEST *cp_hash,
-        TPMI_ALG_HASH parameter_hash_algorithm) {
+        TPMI_ALG_HASH parameter_hash_algorithm,
+        ESYS_TR session_handle_1, ESYS_TR session_handle_2,
+        ESYS_TR session_handle_3) {
 
     TPML_PCR_SELECTION pcr_selection_tmp;
     TPML_PCR_SELECTION *pcr_selection_out;
@@ -618,8 +620,8 @@ tool_rc pcr_read_pcr_values(ESYS_CONTEXT *esys_context,
     pcrs->count = 0;
     do {
         TPML_DIGEST *v;
-        tool_rc rc = tpm2_pcr_read(esys_context, ESYS_TR_NONE, ESYS_TR_NONE,
-                ESYS_TR_NONE, &pcr_selection_tmp, &pcr_update_counter,
+        tool_rc rc = tpm2_pcr_read(esys_context, session_handle_1, session_handle_2,
+                session_handle_3, &pcr_selection_tmp, &pcr_update_counter,
                 &pcr_selection_out, &v, cp_hash, parameter_hash_algorithm);
 
         if (rc != tool_rc_success || (cp_hash && cp_hash->size)) {

--- a/lib/pcr.h
+++ b/lib/pcr.h
@@ -114,6 +114,8 @@ bool pcr_check_pcr_selection(TPMS_CAPABILITY_DATA *cap_data,
 
 tool_rc pcr_read_pcr_values(ESYS_CONTEXT *esys_context,
         TPML_PCR_SELECTION *pcr_selections, tpm2_pcrs *pcrs,
-        TPM2B_DIGEST *cp_hash, TPMI_ALG_HASH parameter_hash_algorithm);
+        TPM2B_DIGEST *cp_hash, TPMI_ALG_HASH parameter_hash_algorithm,
+        ESYS_TR session_handle_1, ESYS_TR session_handle_2,
+        ESYS_TR session_handle_3);
 
 #endif /* SRC_PCR_H_ */

--- a/lib/tpm2.h
+++ b/lib/tpm2.h
@@ -430,11 +430,14 @@ tool_rc tpm2_loadexternal(ESYS_CONTEXT *ectx, const TPM2B_SENSITIVE *private,
     TPMI_ALG_HASH parameter_hash_algorithm);
 
 tool_rc tpm2_pcr_extend(ESYS_CONTEXT *ectx, TPMI_DH_PCR pcr_index,
-    TPML_DIGEST_VALUES *digests);
+    tpm2_session *session,
+    TPML_DIGEST_VALUES *digests,
+    ESYS_TR session_handle_2, ESYS_TR session_handle_3);
 
 tool_rc tpm2_pcr_event(ESYS_CONTEXT *ectx, ESYS_TR pcr, tpm2_session *session,
         const TPM2B_EVENT *event_data, TPML_DIGEST_VALUES **digests,
-        TPM2B_DIGEST *cp_hash, TPMI_ALG_HASH parameter_hash_algorithm);
+        TPM2B_DIGEST *cp_hash, TPMI_ALG_HASH parameter_hash_algorithm,
+        ESYS_TR session_handle_2, ESYS_TR session_handle_3);
 
 tool_rc tpm2_getrandom(ESYS_CONTEXT *ectx, UINT16 count,
         TPM2B_DIGEST **random, TPM2B_DIGEST *cp_hash, TPM2B_DIGEST *rp_hash,

--- a/lib/tpm2_policy.c
+++ b/lib/tpm2_policy.c
@@ -212,7 +212,8 @@ tool_rc tpm2_policy_build_pcr(ESYS_CONTEXT *ectx, tpm2_session *policy_session,
     } else {
         // Read PCRs
         tool_rc rc = pcr_read_pcr_values(ectx, pcr_selections, &pcrs,
-                                         NULL, TPM2_ALG_ERROR);
+                                         NULL, TPM2_ALG_ERROR, ESYS_TR_NONE,
+                                         ESYS_TR_NONE, ESYS_TR_NONE);
         if (rc != tool_rc_success) {
             return rc;
         }

--- a/man/tpm2_pcrevent.1.md
+++ b/man/tpm2_pcrevent.1.md
@@ -36,15 +36,23 @@ These options control extending the pcr:
 
     Specifies the authorization value for PCR.
 
+  * **-S**, **\--session**=_FILE_:
+
+    Specifies the auxiliary sessions for the command.
+
   * **\--cphash**=_FILE_
 
     File path to record the hash of the command parameters. This is commonly
     termed as cpHash. NOTE: When this option is selected, The tool will not
     actually execute the command, it simply returns a cpHash.
 
-[common options](common/options.md)
+## References
 
-[common tcti options](common/tcti.md)
+[common options](common/options.md) collection of common options that provide
+information many users may expect.
+
+[common tcti options](common/tcti.md) collection of options used to configure
+the various known TCTI modules.
 
 [authorization formatting](common/authorizations.md)
 

--- a/man/tpm2_pcrextend.1.md
+++ b/man/tpm2_pcrextend.1.md
@@ -36,7 +36,13 @@ supported. This is to keep the parser simple.
 
 # OPTIONS
 
-This tool accepts no tool specific options.
+* **-P**, **\--auth**=_AUTH_:
+
+The authorization value of the used PCR register.
+
+* **-S**, **\--session**=_FILE_:
+
+Specifies the auxiliary sessions for the command.
 
 [common options](common/options.md)
 

--- a/man/tpm2_pcrread.1.md
+++ b/man/tpm2_pcrread.1.md
@@ -48,6 +48,10 @@ sha256 :
     termed as cpHash. NOTE: When this option is selected, The tool will not
     actually execute the command, it simply returns a cpHash.
 
+  * **-S**, **\--session**=_FILE_:
+
+    Specifies the auxiliary sessions for the command.
+
 [PCR output file format specifiers](common/pcrs_format.md)
     Default is 'values'.
 

--- a/test/integration/tests/pcrevent.sh
+++ b/test/integration/tests/pcrevent.sh
@@ -10,7 +10,7 @@ yaml_out_file=pcr_list.yaml
 
 cleanup() {
   rm -f $hash_in_file $hash_out_file $yaml_out_file
-
+  rm -f audit_session.ctx hmac_session.ctx eventfile
   shut_down
 }
 trap cleanup EXIT
@@ -82,5 +82,10 @@ if [ $? -eq 0 ]; then
   echo "Expected $cmd to fail, passed."
   exit 1;
 fi
+
+echo event > eventfile
+tpm2 startauthsession -Q --session hmac_session.ctx --hmac 
+tpm2 startauthsession -Q --session audit_session.ctx --audit
+tpm2 pcrevent -S audit_session.ctx -P session:hmac_session.ctx 10 eventfile
 
 exit 0

--- a/test/integration/tests/pcrextend.sh
+++ b/test/integration/tests/pcrextend.sh
@@ -2,6 +2,12 @@
 
 source helpers.sh
 
+cleanup() {
+  rm -f audit_session.ctx hmac_session.ctx
+  shut_down
+}
+trap cleanup EXIT
+
 start_up
 
 declare -A alg_hashes=(
@@ -45,5 +51,10 @@ if tpm2 pcrextend 8:$digests,sha1=${alg_hashes["sha256"]}; then
 else
     true
 fi
+
+tpm2 startauthsession -Q --session hmac_session.ctx --hmac 
+tpm2 startauthsession -Q --session audit_session.ctx --audit
+tpm2 pcrextend -S audit_session.ctx -P session:hmac_session.ctx \
+               16:sha256=b5bb9d8014a0f9b1d61e21e796d78dccdf1352f23cd32812f4850b878ae4944c
 
 exit 0

--- a/tools/tpm2_quote.c
+++ b/tools/tpm2_quote.c
@@ -159,7 +159,8 @@ static tool_rc process_output(ESYS_CONTEXT *ectx) {
 
         // Gather PCR values from the TPM (the quote doesn't have them!)
         rc = pcr_read_pcr_values(ectx, &ctx.pcr_selections, &ctx.pcrs,
-            NULL, TPM2_ALG_ERROR);
+             NULL, TPM2_ALG_ERROR, ESYS_TR_NONE,
+             ESYS_TR_NONE, ESYS_TR_NONE);
         if (rc != tool_rc_success) {
             LOG_ERR("Failed to retrieve PCR values related to quote!");
             return rc;


### PR DESCRIPTION
Session support is added for the following commands: tpm2_pcrextend, tpm2_event, and tpm2_pcrread.
Examples for usage:
```
tpm2_startauthsession -Q --session audit_session.ctx --audit
tpm2_pcrread sha256:0 -o pcr0  -S audit_session.ctx

tpm2_startauthsession -Q --session hmac_session.ctx --hmac 
tpm2_startauthsession -Q --session audit_session.ctx --audit
tpm2_pcrextend -S audit_session.ctx -P session:hmac_session.ctx \
               16:sha256=b5bb9d8014a0f9b1d61e21e796d78dccdf1352f23cd32812f4850b878ae4944c

tpm2_startauthsession -Q --session hmac_session.ctx --hmac 
tpm2_startauthsession -Q   --session audit_session.ctx --audit
echo event |tpm2_pcrevent -S audit_session.ctx -Psession:hmac_session.ctx 10

``