### PR TITLE
tpm2_certify: Add parameter qualifying-data.

### DIFF
--- a/man/tpm2_certify.1.md
+++ b/man/tpm2_certify.1.md
@@ -58,6 +58,13 @@ These options control the certification:
 
     Output file name for the attestation data.
 
+  * **-q**, **\--qualifying-data**=_HEX\_STRING\_OR\_PATH_:
+
+    Data given as a Hex string or binary file to qualify the certification, optional.
+    This is typically used to add a nonce against replay attacks.
+    The default is:  0x00, 0xff, 0x55, 0xaa
+
+
   * **-s**, **\--signature**=_FILE_:
 
     Output file name for the signature data.

--- a/test/integration/tests/certify.sh
+++ b/test/integration/tests/certify.sh
@@ -53,4 +53,16 @@ tpm2 certify \
 
 verify_signature_with_ssl
 
+# Test with changed qualified data.
+
+tpm2 certify \
+    -c primary.ctx -P signedpass \
+    -C certify.ctx -p certifypass \
+    -q "0f0f0f0f" \
+    -g sha256 -o attest.out -f plain -s sig.out
+
+tpm2 print -t TPMS_ATTEST attest.out| grep 0f0f0f0f > /dev/null
+
+verify_signature_with_ssl
+
 exit 0


### PR DESCRIPTION
The default for qualifying data is still 0x00, 0xff, 0x55, 0xaa. But the value now can be adjusted with the parameter --qualifying-data. Addresses: #3489