### PR TITLE
build: remove trailing comma

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -275,7 +275,7 @@ test_unit_test_tpm2_auth_util_LDFLAGS  = -Wl,--wrap=Esys_TR_SetAuth \
                                          -Wl,--wrap=fread \
                                          -Wl,--wrap=fseek \
                                          -Wl,--wrap=ftell \
-                                         -Wl,--wrap=feof, \
+                                         -Wl,--wrap=feof \
                                          -Wl,--wrap=fclose
 test_unit_test_tpm2_auth_util_LDADD    = $(CMOCKA_LIBS) $(LDADD)
 


### PR DESCRIPTION
With slibtool this results in a failure:
```
/usr/lib/gcc/x86_64-pc-linux-musl/14/../../../../x86_64-pc-linux-musl/bin/ld: cannot find : No such file or directory
```
While GNU libtool seems to implicitly remove it.