### PR TITLE
eventlog: TCG PC Client FPF renumbered its sections

### DIFF
--- a/lib/tpm2_eventlog.c
+++ b/lib/tpm2_eventlog.c
@@ -116,7 +116,7 @@ bool foreach_digest2(tpm2_eventlog_context *ctx, UINT32 eventType, unsigned pcr_
 bool parse_event2body(TCG_EVENT2 const *event, UINT32 type) {
 
     switch (type) {
-    /* TCG PC Client FPF section 9.2.6 */
+    /* TCG PC Client FPF section 10.2.6 */
     case EV_EFI_VARIABLE_DRIVER_CONFIG:
     case EV_EFI_VARIABLE_BOOT:
     case EV_EFI_VARIABLE_AUTHORITY:
@@ -135,11 +135,11 @@ bool parse_event2body(TCG_EVENT2 const *event, UINT32 type) {
             }
         }
         break;
-    /* TCG PC Client FPF section 2.3.4.1 and 9.4.1 */
+    /* TCG PC Client FPF section 3.3.4.1 and 10.4.1 */
     case EV_POST_CODE:
         // the event is a string, so there are no length requirements.
         break;
-    /* TCG PC Client FPF section 9.2.5 */
+    /* TCG PC Client FPF section 10.2.5 */
     case EV_S_CRTM_CONTENTS:
     case EV_EFI_PLATFORM_FIRMWARE_BLOB:
         {

--- a/lib/tpm2_eventlog_yaml.c
+++ b/lib/tpm2_eventlog_yaml.c
@@ -219,7 +219,7 @@ static bool yaml_uefi_var_data(UEFI_VARIABLE_DATA *data) {
     return true;
 }
 /*
- * TCG PC Client FPF section 2.3.4.1 and 9.4.1:
+ * TCG PC Client FPF section 3.3.4.1 and 10.4.1:
  * Usage of the event type EV_POST_CODE:
  * - If a combined event is measured, the event field SHOULD
  * be the string "POST CODE" in all caps. ...
@@ -473,7 +473,7 @@ static bool yaml_split_print_string(const char *indent,
 }
 
 /*
- * TCG PC Client FPF section 9.2.6
+ * TCG PC Client FPF section 10.2.6
  * The tpm2_eventlog module validates the event structure but nothing within
  * the event data buffer so we must do that here.
  */
@@ -761,7 +761,7 @@ static bool yaml_uefi_var(UEFI_VARIABLE_DATA *data, size_t size, UINT32 type,
     free(ret);
     return yaml_uefi_var_data(data);
 }
-/* TCG PC Client FPF section 9.2.5 */
+/* TCG PC Client FPF section 10.2.5 */
 bool yaml_uefi_platfwblob(UEFI_PLATFORM_FIRMWARE_BLOB *data) {
 
     tpm2_tool_output("  Event:\n"


### PR DESCRIPTION
latest revision (Level 00 Version 1.06 Revision 52 -- December 4, 2023) of the `TCG PC Client Platform Firmware Profile Specification` added a leading Scope section which shifted all the sections.

Latest spec:
<https://trustedcomputinggroup.org/wp-content/uploads/TCG-PC-Client-Platform-Firmware-Profile-Version-1.06-Revision-52_pub-2.pdf>

Previous revision:
<https://trustedcomputinggroup.org/wp-content/uploads/TCG_PCClient_PFP_r1p05_05_3feb20.pdf>