### PR TITLE
ci: Add workflow to test with tss2/master

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -12,13 +12,15 @@ task:
   install_script:
     - pkg update -f
     - pkg upgrade -y
-    - pkg install -y bash gmake coreutils libtool pkgconf autoconf autoconf-archive e2fsprogs-libuuid py311-pip expect
+    - pkg install -y ca_root_nss
+    - pkg install -y bash gmake coreutils libtool pkgconf autoconf autoconf-archive py311-pip expect
     - python3 -m pip install pyyaml
-    - pkg install -y automake glib dbus dbus-glib cmocka wget git openssl json-c vim hs-pandoc
+    - pkg install -y automake glib dbus dbus-glib cmocka uthash util-linux wget git openssl json-c vim hs-pandoc
     - pkg install -y swtpm
     - mkdir tss
     - cd tss && git clone https://github.com/tpm2-software/tpm2-tss.git
-    - cd tpm2-tss && ./bootstrap && ./configure --disable-doxygen-doc --enable-tcti-swtpm=yes  --enable-tcti-mssim=no --disable-tcti-libtpms --disable-dependency-tracking && gmake -j install
+    - cd tpm2-tss
+    - ./bootstrap && ./configure --disable-doxygen-doc --enable-tcti-swtpm=yes  --enable-tcti-mssim=no --disable-tcti-libtpms --disable-dependency-tracking && gmake -j install
     - cd ../../ && rm -rf tss
     - mkdir rm
     - cd rm && git clone https://github.com/tpm2-software/tpm2-abrmd.git && cd tpm2-abrmd

--- a/.github/workflows/tss2master.yml
+++ b/.github/workflows/tss2master.yml
@@ -1,0 +1,30 @@
+name: Tss2Master
+on:
+  schedule:
+    - cron: '0 0 * * 0'
+  workflow_dispatch:
+jobs:
+  master-tss-build-test:
+    runs-on: ubuntu-latest
+    if: "!contains(github.ref, 'coverity_scan')"
+    strategy:
+      matrix:
+        compiler: [gcc, clang]
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v2
+      - name: fix-sanitizer
+        run: sudo sysctl vm.mmap_rnd_bits=28
+      - name: Launch Action
+        uses:
+          tpm2-software/ci/runCI@main
+        with:
+          PROJECT_NAME: ${{ github.event.repository.name }}
+          DOCKER_IMAGE: ubuntu-24.04
+          CC: ${{ matrix.compiler }}
+          TPM2_TSS_VERSION: master
+          GIT_FULL_CLONE: true
+      - name: failure
+        if: ${{ failure() }}
+        run: cat build/test-suite.log || true
+


### PR DESCRIPTION
* The check whether the tools still work with the tss master will be started one time in a week.
* The test also can be started manually.