### PR TITLE
tpm2_loadexternal: Add option rsa_exponent_zero

### DIFF
--- a/man/tpm2_loadexternal.1.md
+++ b/man/tpm2_loadexternal.1.md
@@ -112,6 +112,11 @@ It also saves a context file for future interactions with the object.
     It mirrors the -passin option of OSSL and is known to support the pass,
     file, env, fd and plain password formats of openssl.
     (see *man(1) openssl*) for more.
+    
+ * **-e**, **\--rsa_exponent_zero**:
+    Set the exponent of a public RSA key to zero, to enable compatibility
+    in the computation of the key name if the TPM key is generated with
+    exponent zero.
 
 ## References
 


### PR DESCRIPTION
If TPM RSA keys are exported to PEM the exponent is set to 0x10001. The option --rsa_exponent_zero is added to enable compatibility in the computation of the key name if the TPM key is generated with exponent zero.
Fixes: #3508