### PR TITLE
man tpm2_policysigned: add parameter --raw-data

### DIFF
--- a/man/tpm2_policysigned.1.md
+++ b/man/tpm2_policysigned.1.md
@@ -58,6 +58,11 @@ The optional TPM2 parameters being cpHashA, nonceTPM, policyRef and expiration.
     The command parameter hash (cpHash), enforcing the TPM command to be
     authorized as well as its handle and parameter values.
 
+* **\--raw-data**=_FILE_:
+
+   The raw data, generated based on the selected parameters, serves as the input
+   for computing the hash that must be signed.
+
   * **\--ticket**=_FILE_:
 
     The ticket file to record the authorization ticket structure.


### PR DESCRIPTION
The parameter --raw-data which can be used to compute the hash which must be signed was not documented.