### PR TITLE
ci: update cirrus to free bsd 14.3

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -8,7 +8,7 @@ task:
     ibmtpm_name: ibmtpm1637
     TSS2_LOG: "all+ERROR;tcti+TRACE"
   freebsd_instance:
-    image_family: freebsd-14-2
+    image_family: freebsd-14-3
   install_script:
     - pkg update -f
     - pkg upgrade -y


### PR DESCRIPTION
A version mismatch has to be fixed.