### PR TITLE
tpm2_makecredential: Fix usage of name parameter.

### DIFF
--- a/man/tpm2_makecredential.1.md
+++ b/man/tpm2_makecredential.1.md
@@ -55,9 +55,10 @@ TCTI option.
 
     The secret which will be protected by the key derived from the random seed. It can be specified as a file or passed from stdin.
 
-  * **-n**, **\--name**=_FILE_:
+  * **-n**, **\--name**=_FILE\_OR\_HEX_:
 
-    The name of the key for which certificate is to be created.
+    The name of the key for which certificate is to be created. Can either be
+    a path or hex string.
 
   * **-o**, **\--credential-blob**=_FILE_:
 

--- a/test/integration/tests/makecredential.sh
+++ b/test/integration/tests/makecredential.sh
@@ -14,6 +14,7 @@ output_ek_pub=ek_pub.out
 output_ak_pub=ak_pub.out
 output_ak_pub_name=ak_name_pub.out
 output_mkcredential=mkcredential.out
+output_mkcredential2=mkcredentiali2.out
 
 cleanup() {
     rm -f $output_ek_pub $output_ak_pub $output_ak_pub_name \
@@ -44,6 +45,10 @@ Loadkeyname=`cat $output_ak_pub_name | xxd -p -c $file_size`
 
 tpm2 makecredential -Q -u $output_ek_pub -s $file_input_data -n $Loadkeyname \
 -o $output_mkcredential
+
+# Check usage of name file instead of hex string
+tpm2 makecredential -Q -u $output_ek_pub -s $file_input_data -n $output_ak_pub_name \
+-o $output_mkcredential2
 
 # use no tpm backend
 tpm2 makecredential -T none -Q -u $output_ek_pub -s $file_input_data \

--- a/tools/tpm2_makecredential.c
+++ b/tools/tpm2_makecredential.c
@@ -203,6 +203,7 @@ static tool_rc make_credential_and_save(ESYS_CONTEXT *ectx) {
 
 static bool on_option(char key, char *value) {
 
+    tool_rc rc;
     switch (key) {
     case 'u':
         if (ctx.flags.e) {
@@ -226,12 +227,15 @@ static bool on_option(char key, char *value) {
         break;
     case 'n':
         ctx.object_name.size = BUFFER_SIZE(TPM2B_NAME, name);
-        int q;
-        if ((q = tpm2_util_hex_to_byte_structure(value, &ctx.object_name.size,
-                ctx.object_name.name)) != 0) {
-            LOG_ERR("FAILED: %d", q);
+        rc = tpm2_util_bin_from_hex_or_file(value,
+               &ctx.object_name.size, ctx.object_name.name) ?
+               tool_rc_success : tool_rc_general_error;
+
+        if (rc != tool_rc_success) {
+            LOG_ERR("Could not load name data");
             return false;
         }
+ 
         ctx.flags.n = 1;
         break;
     case 'o':


### PR DESCRIPTION
The man page for tpm2_makecredential states that the -name parameter can be a file. However, a hex string of the name is expected. Similar to the procedure used with tpm2_certifycreation, a file with the name or a hex string can now be passed.
Fixes: #3274