### PR TITLE
tpm2_getekcertificate: Fix curl_easy_setopt type warnings

### DIFF
--- a/tools/tpm2_getekcertificate.c
+++ b/tools/tpm2_getekcertificate.c
@@ -520,7 +520,7 @@ static bool retrieve_web_endorsement_certificate(char *uri) {
      * should not be used - Used only on platforms with older CA certificates.
      */
     if (ctx.SSL_NO_VERIFY) {
-        rc = curl_easy_setopt(curl, CURLOPT_SSL_VERIFYPEER, 0);
+        rc = curl_easy_setopt(curl, CURLOPT_SSL_VERIFYPEER, 0L);
         if (rc != CURLE_OK) {
             LOG_ERR("curl_easy_setopt for CURLOPT_SSL_VERIFYPEER failed: %s",
                     curl_easy_strerror(rc));
@@ -565,7 +565,7 @@ static bool retrieve_web_endorsement_certificate(char *uri) {
         goto out_easy_cleanup;
     }
 
-    rc = curl_easy_setopt(curl, CURLOPT_FAILONERROR, true);
+    rc = curl_easy_setopt(curl, CURLOPT_FAILONERROR, 1L);
     if (rc != CURLE_OK) {
         LOG_ERR("curl_easy_setopt for CURLOPT_FAILONERROR failed: %s",
                 curl_easy_strerror(rc));


### PR DESCRIPTION
curl_easy_setopt expects long arguments for CURLOPT_SSL_VERIFYPEER and CURLOPT_FAILONERROR options. Using int (0) or bool (true) causes compiler warnings with modern curl versions that enforce type safety.

Changed to use long literals (0L and 1L) to match the expected type.

Fixes compiler warnings:
- call to 'Wcurl_easy_setopt_err_long' declared with attribute warning: curl_easy_setopt expects a long argument