### PR TITLE
tools: Fix several clang-tidy errors

### DIFF
--- a/lib/pcr.c
+++ b/lib/pcr.c
@@ -74,22 +74,25 @@ static bool pcr_parse_list(const char *str, size_t len,
         current_string = str;
         str = memchr(current_string, ',', len);
         if (str) {
-            current_length = str - current_string;
+            ptrdiff_t diff = str - current_string;
+            if (diff > INT_MAX)
+                return false;
+            current_length = (int)diff;
             str++;
             len -= current_length + 1;
         } else {
-            current_length = len;
+            current_length = (int)len;
             len = 0;
         }
 
         dgst = memchr(current_string, '=', current_length);
         if (dgst && ((str == NULL) || (str && dgst < str))) {
-            pcr_len = dgst - current_string;
+            pcr_len = (int)(dgst - current_string);
             dgst++;
             if (str) {
-                dgst_len = str - dgst - 1;
+                dgst_len = (int)(str - dgst - 1);
             } else {
-                dgst_len = current_length - pcr_len - 1;
+                dgst_len = (int)(current_length - pcr_len - 1);
             }
         } else {
             dgst = NULL;

--- a/lib/tpm2_convert.c
+++ b/lib/tpm2_convert.c
@@ -806,7 +806,7 @@ bool tpm2_base64_encode(BYTE *buffer, size_t buffer_length, char *base64) {
     EVP_ENCODE_CTX *ctx = EVP_ENCODE_CTX_new();
     EVP_EncodeInit(ctx);
 
-    int rc = EVP_EncodeUpdate(ctx, out, &outl, buffer, buffer_length);
+    int rc = EVP_EncodeUpdate(ctx, out, &outl, buffer, (int)buffer_length);
     if(rc < 0) {
         LOG_ERR("EVP_DecodeUpdate failed with %d\n", rc);
         EVP_ENCODE_CTX_free(ctx);
@@ -824,19 +824,20 @@ bool tpm2_base64_encode(BYTE *buffer, size_t buffer_length, char *base64) {
 
 bool tpm2_base64_decode(char *base64, BYTE *buffer, size_t *buffer_length) {
 
-    bool is_base64_bufferlen_valid = strlen(base64) > 1024 ? false : true;
+    size_t len = strlen(base64);
+    bool is_base64_bufferlen_valid = len > 1024 ? false : true;
     if (!is_base64_bufferlen_valid) {
         return false;
     }
 
     unsigned char base64u[1024];
-    memcpy(base64u, base64, strlen(base64));
+    memcpy(base64u, base64, len);
 
     EVP_ENCODE_CTX *ctx = EVP_ENCODE_CTX_new();
     EVP_DecodeInit(ctx);
     unsigned char out[1024];
     int outl;
-    int rc = EVP_DecodeUpdate(ctx, out, &outl, base64u, strlen(base64));
+    int rc = EVP_DecodeUpdate(ctx, out, &outl, base64u, (int)len);
     if(rc < 0) {
         LOG_ERR("EVP_DecodeUpdate failed with %d\n", rc);
         EVP_ENCODE_CTX_free(ctx);

--- a/lib/tpm2_identity_util.c
+++ b/lib/tpm2_identity_util.c
@@ -1,6 +1,7 @@
 /* SPDX-License-Identifier: BSD-3-Clause */
 
 #include <stdbool.h>
+#include <stdint.h>
 #include <stdlib.h>
 #include <string.h>
 
@@ -249,8 +250,13 @@ static bool aes_encrypt_buffers(TPMT_SYM_DEF_OBJECT *sym,
         if (!b) {
             continue;
         }
+        size_t diff = total_len - offset;
+        if (diff > INT_MAX || l > INT_MAX) {
+            LOG_ERR("Size can't be converted to int");
+            return false;
+        }
 
-        int output_len = total_len - offset;
+        int output_len = (int)diff;
 
         rc = EVP_EncryptUpdate(ctx, &cipher_text->buffer[offset], &output_len,
                 b, l);

--- a/lib/tpm2_util.c
+++ b/lib/tpm2_util.c
@@ -188,7 +188,7 @@ int tpm2_util_hex_to_byte_structure(const char *input_string, UINT16 *byte_lengt
     int i = 0;
     if (input_string == NULL || byte_length == NULL || byte_buffer == NULL)
         return -1;
-    str_length = strlen(input_string);
+    str_length = (int)strlen(input_string);
     if (str_length % 2)
         return -2;
     for (i = 0; i < str_length; i++) {

--- a/tools/fapi/tss2_gettpm2object.c
+++ b/tools/fapi/tss2_gettpm2object.c
@@ -81,7 +81,7 @@ static int tss2_tool_onrun (FAPI_CONTEXT *fctx) {
         return 1;
     }
 
-    if (strcmp(ctx.data, "-")) {
+    if (strcmp(ctx.data, "-") != 0) {
         if (!ctx.overwrite) {
             FILE *fp = fopen(ctx.data, "rb");
             if (fp) {

--- a/tools/fapi/tss2_quote.c
+++ b/tools/fapi/tss2_quote.c
@@ -141,7 +141,7 @@ static int tss2_tool_onrun (FAPI_CONTEXT *fctx) {
 
     /* Read qualifyingData file */
     TSS2_RC r;
-    uint8_t *qualifyingData = NULL;
+    void *qualifyingData = NULL;
     size_t qualifyingDataSize = 0;
     if (ctx.qualifyingData) {
         r = open_read_and_close (ctx.qualifyingData,

--- a/tools/fapi/tss2_template.c
+++ b/tools/fapi/tss2_template.c
@@ -142,7 +142,7 @@ static tpm2_option_code tss2_handle_options (
         case '?':
             goto out;
         default:
-            if (!(*tool_opts)->callbacks.on_opt(c, optarg))
+            if (!(*tool_opts)->callbacks.on_opt((char)c, optarg))
                 goto out;
         }
     }
@@ -293,8 +293,8 @@ TSS2_RC sign_callback(
         int cpy_size = 0;
         if (strlen(publicKeyHint) > 0) {
             const char* tmp = "the key corresponding to the key hint \"%s\" and";
-            cpy_size = strlen(tmp) - 2 /* remove replaced %s */ +
-                strlen(publicKeyHint);
+            cpy_size = (int)(strlen(tmp) - 2 /* remove replaced %s */ +
+                             strlen(publicKeyHint));
             rc = snprintf(publicKeyHintStr, cpy_size+1 /* add \0 */, tmp,
                 publicKeyHint);
             if (rc != cpy_size){
@@ -311,8 +311,8 @@ TSS2_RC sign_callback(
                     "PEM-encoded public key\n");
                 return TSS2_FAPI_RC_GENERAL_FAILURE;
             }
-            cpy_size = strlen(tmp) - 2 /* remove replaced %s */ +
-                strlen(publicKeyHintTmp);
+            cpy_size = (int)(strlen(tmp) - 2 /* remove replaced %s */ +
+                             strlen(publicKeyHintTmp));
             rc = snprintf(publicKeyHintStr, cpy_size+1 /* add \0 */, tmp,
                 publicKeyHintTmp);
             if (rc != cpy_size){

--- a/tools/misc/tpm2_print.c
+++ b/tools/misc/tpm2_print.c
@@ -4,6 +4,7 @@
 #include <stdbool.h>
 #include <stdio.h>
 #include <string.h>
+#include <errno.h>
 
 #include <tss2/tss2_esys.h>
 #include <tss2/tss2_rc.h>
@@ -304,7 +305,10 @@ static bool print_TPMS_CONTEXT(FILE *fstream) {
     if (!result) {
         LOG_WARN("The loaded tpm context does not appear to be in the proper "
                  "format, assuming old format.");
-        rewind(fstream);
+        if (fseek(fstream, 0, SEEK_SET) != 0) {
+            LOG_ERR("Could not rewind stream: %s", strerror(errno));
+            return false;
+        }
         result = files_read_bytes(fstream, (UINT8 *) &context, sizeof(context));
         if (!result) {
             LOG_ERR("Could not load tpm context file");

--- a/tools/tpm2_getekcertificate.c
+++ b/tools/tpm2_getekcertificate.c
@@ -671,9 +671,9 @@ static tool_rc nv_read(ESYS_CONTEXT *ectx, TPMI_RH_NV_INDEX nv_index) {
             ESYS_TR_NONE, ESYS_TR_NONE, NULL);
 
     if(ctx.need_x509_trunc) {
-        int len = is_rsa ? 
+        int len = (int)(is_rsa ? 
                   x509_get_len(ctx.rsa_cert_buffer, nv_buf_size) :
-                  x509_get_len(ctx.ecc_cert_buffer, nv_buf_size);
+                  x509_get_len(ctx.ecc_cert_buffer, nv_buf_size));
         if(len > 0){
             nv_buf_size = len;
         }
@@ -1044,7 +1044,7 @@ tool_rc get_tpm_properties(ESYS_CONTEXT *ectx) {
                 continue;
             }
             cert_buffer_ossl = cert_buffer;
-            cert = d2i_X509(NULL, (const unsigned char **)&cert_buffer_ossl, cert_buffer_size);
+            cert = d2i_X509(NULL, (const unsigned char **)&cert_buffer_ossl, (int)cert_buffer_size);
             if (!cert) {
                 free(cert_buffer);
                 LOG_WARN("Invalid certificate found at %x", index);


### PR DESCRIPTION
Several clang-tidy error related to conversion from uint to int, rewind, and realloc were fixed.