### PR TITLE
pcr commands: Fix session leaks

### DIFF
--- a/tools/tpm2_pcrevent.c
+++ b/tools/tpm2_pcrevent.c
@@ -453,11 +453,26 @@ static tool_rc tpm2_tool_onstop(ESYS_CONTEXT *ectx) {
     /*
      * 2. Close authorization sessions
      */
-    return tpm2_session_close(&ctx.auth.session);
+    tool_rc rc = tool_rc_success;
+    tool_rc tmp_rc = tpm2_session_close(&ctx.auth.session);
+    if (tmp_rc != tool_rc_success) {
+        rc = tmp_rc;
+    }
 
     /*
      * 3. Close auxiliary sessions
      */
+    size_t i;
+    for (i = 0; i < ctx.aux_session_cnt; i++) {
+        if (ctx.aux_session_path[i]) {
+            tmp_rc = tpm2_session_close(&ctx.aux_session[i]);
+            if (tmp_rc != tool_rc_success) {
+                rc = tmp_rc;
+            }
+        }
+    }
+
+    return rc;
 }
 
 static void tpm2_tool_onexit(void) {

--- a/tools/tpm2_pcrextend.c
+++ b/tools/tpm2_pcrextend.c
@@ -236,12 +236,26 @@ static tool_rc tpm2_tool_onstop(ESYS_CONTEXT *ectx) {
     /*
      * 2. Close authorization sessions
      */
+    tool_rc rc = tool_rc_success;
+    tool_rc tmp_rc = tpm2_session_close(&ctx.auth.session);
+    if (tmp_rc != tool_rc_success) {
+        rc = tmp_rc;
+    }
 
     /*
      * 3. Close auxiliary sessions
      */
+    size_t i;
+    for (i = 0; i < ctx.aux_session_cnt; i++) {
+        if (ctx.aux_session_path[i]) {
+            tmp_rc = tpm2_session_close(&ctx.aux_session[i]);
+            if (tmp_rc != tool_rc_success) {
+                rc = tmp_rc;
+            }
+        }
+    }
 
-    return tool_rc_success;
+    return rc;
 }
 
 static void tpm2_tool_onexit(void) {

--- a/tools/tpm2_pcrread.c
+++ b/tools/tpm2_pcrread.c
@@ -313,8 +313,19 @@ static tool_rc tpm2_tool_onstop(ESYS_CONTEXT *ectx) {
     /*
      * 3. Close auxiliary sessions
      */
+    tool_rc rc = tool_rc_success;
+    tool_rc tmp_rc = tool_rc_success;
+    size_t i;
+    for (i = 0; i < ctx.aux_session_cnt; i++) {
+        if (ctx.aux_session_path[i]) {
+            tmp_rc = tpm2_session_close(&ctx.aux_session[i]);
+            if (tmp_rc != tool_rc_success) {
+                rc = tmp_rc;
+            }
+        }
+    }
 
-    return tool_rc_success;
+    return rc;
 }
 
 // Register this tool with tpm2_tool.c


### PR DESCRIPTION
`tpm2_pcrextend`, `tpm2_pcrevent`, and `tpm2_pcrread` had session leaks in `tpm2_tool_onstop()`.
This commit adds proper session cleanup to all three tools.
This solves https://github.com/tpm2-software/tpm2-tools/issues/3533