### PR TITLE
man tpm2_getrandom: add missing --hex parameter in example

### DIFF
--- a/man/tpm2_getrandom.1.md
+++ b/man/tpm2_getrandom.1.md
@@ -76,7 +76,7 @@ tpm2_getrandom -o random.out 20
 
 ## Generate a random 8 bytes and output the hex formatted data to stdout
 ```bash
-tpm2_getrandom 8
+tpm2_getrandom 8 --hex
 ```
 
 [returns](common/returns.md)


### PR DESCRIPTION
The example demonstrating hex output was missing the --hex flag, which would cause the command to output binary data instead of the intended hexadecimal format.
This solves https://github.com/tpm2-software/tpm2-tools/issues/3472 