### PR TITLE
tpm2_nvcertify: Set size if the --size parameter is not specified.

### DIFF
--- a/man/tpm2_nvcertify.1.md
+++ b/man/tpm2_nvcertify.1.md
@@ -68,7 +68,7 @@ These options control the certification:
 
   * **--attestation**=_FILE_:
 
-    The attestation data of the type TPM2_CREATION_INFO signed with signing key.
+    The attestation data of the type TPMS_ATTEST signed with signing key.
 
   * **\--cphash**=_FILE_
 

--- a/tools/tpm2_nvcertify.c
+++ b/tools/tpm2_nvcertify.c
@@ -387,6 +387,10 @@ static tool_rc check_options(ESYS_CONTEXT *ectx, tpm2_option_flags flags) {
             goto is_input_options_args_valid_out;
         }
 
+        if (ctx.size == 0) {
+            ctx.size = nv_public->nvPublic.dataSize;
+        }
+
         if (ctx.offset + ctx.size > nv_public->nvPublic.dataSize) {
             LOG_ERR("Size to read at offset is bigger than nv index size");
             rc = tool_rc_option_error;


### PR DESCRIPTION
The man page states: If not specified, the size of the data as reported by the public portion of the index will be used. But 0 was used if --size was not specified.
Also an error in the man page is fixed.
Fixes: #3538