### PR TITLE
tpm2_create: Fix creation of ctx file without TPM2_CreateLoaded 

### DIFF
--- a/lib/tpm2.h
+++ b/lib/tpm2.h
@@ -64,8 +64,11 @@ tool_rc tpm2_sess_get_noncetpm(ESYS_CONTEXT *esys_context,
     ESYS_TR session_handle, TPM2B_NONCE **nonce_tpm);
 
 tool_rc tpm2_policy_restart(ESYS_CONTEXT *esys_context, ESYS_TR session_handle,
-        ESYS_TR shandle1, ESYS_TR shandle2, ESYS_TR shandle3,
-        TPM2B_DIGEST *cp_hash, TPMI_ALG_HASH parameter_hash_algorithm);
+                            ESYS_TR shandle1, ESYS_TR shandle2,
+                            ESYS_TR shandle3, TPM2B_DIGEST *cp_hash,
+                            TPMI_ALG_HASH parameter_hash_algorithm);
+
+tool_rc tpm2_check_cc(ESYS_CONTEXT *ectx, uint32_t cc, bool *exists);
 
 tool_rc tpm2_get_capability(ESYS_CONTEXT *esys_context, ESYS_TR shandle1,
         ESYS_TR shandle2, ESYS_TR shandle3, TPM2_CAP capability,
@@ -212,7 +215,7 @@ tool_rc tpm2_create(ESYS_CONTEXT *esys_context, tpm2_loaded_object *parent_obj,
 tool_rc tpm2_create_loaded(ESYS_CONTEXT *esys_context,
         tpm2_loaded_object *parent_obj,
         const TPM2B_SENSITIVE_CREATE *in_sensitive,
-        const TPM2B_TEMPLATE *in_public, ESYS_TR *object_handle,
+        const TPM2B_PUBLIC *in_public, ESYS_TR *object_handle,
         TPM2B_PRIVATE **out_private, TPM2B_PUBLIC **out_public,
         TPM2B_DIGEST *cp_hash, TPM2B_DIGEST *rp_hash,
         TPMI_ALG_HASH parameter_hash_algorithm, ESYS_TR shandle2,

--- a/tools/tpm2_create.c
+++ b/tools/tpm2_create.c
@@ -134,19 +134,9 @@ static tool_rc create(ESYS_CONTEXT *ectx) {
 
     /* TPM2_CC_CreateLoaded */
     if (ctx.is_createloaded) {
-        size_t offset = 0;
-        TPM2B_TEMPLATE template = { .size = 0 };
-        tool_rc tmp_rc = tpm2_mu_tpmt_public_marshal(
-                &ctx.object.in_public.publicArea, &template.buffer[0],
-                sizeof(TPMT_PUBLIC), &offset);
-        if (tmp_rc != tool_rc_success) {
-            return tmp_rc;
-        }
-
-        template.size = offset;
-
+        tool_rc tmp_rc;
         tmp_rc = tpm2_create_loaded(ectx, &ctx.parent.object,
-            &ctx.object.sensitive, &template, &ctx.object.object_handle,
+            &ctx.object.sensitive, &ctx.object.in_public, &ctx.object.object_handle,
             &ctx.object.out_private, &ctx.object.out_public, &ctx.cp_hash,
             &ctx.rp_hash, ctx.parameter_hash_algorithm,
             ctx.aux_session_handle[0], ctx.aux_session_handle[1]);


### PR DESCRIPTION
…ilable.

If the TPM2 command CreateLoaded is not available the creation of a ctx file with tpm2_create was not possible. Now a TPM2_Create and TPM2_Load is used to create a ctx file if CreateLoaded is not available.