### PR TITLE
ci: bump checkout v2/3 to v6 and CodeQL v2 to v4

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -24,7 +24,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v6
 
       - name: Install Packages (cpp)
         if: ${{ matrix.language == 'cpp' }}
@@ -46,15 +46,15 @@ jobs:
           export LD_LIBRARY_PATH="$RUNNER_TEMP/installdir/usr/lib:$LD_LIBRARY_PATH" && echo "LD_LIBRARY_PATH=$LD_LIBRARY_PATH" >> $GITHUB_ENV
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@v2
+        uses: github/codeql-action/init@v4
         with:
           languages: ${{ matrix.language }}
           queries: +security-and-quality
 
       - name: Autobuild
-        uses: github/codeql-action/autobuild@v2
+        uses: github/codeql-action/autobuild@v4
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@v2
+        uses: github/codeql-action/analyze@v4
         with:
           category: "/language:${{ matrix.language }}"

--- a/.github/workflows/cron.yml
+++ b/.github/workflows/cron.yml
@@ -22,7 +22,7 @@ jobs:
             sudo apt-get install qemu binfmt-support qemu-user-static
             docker run --rm --privileged multiarch/qemu-user-static --reset -p yes
       - name: Check out repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v6
       - name: Launch Action
         uses:
           tpm2-software/ci/runCI@main

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -11,7 +11,7 @@ jobs:
         compiler: [gcc, clang]
     steps:
       - name: Check out repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v6
       - name: fix-sanitizer
         run: sudo sysctl vm.mmap_rnd_bits=28
       - name: Launch Action
@@ -32,7 +32,7 @@ jobs:
         compiler: [gcc, clang]
     steps:
       - name: Check out repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v6
       - name: fix-sanitizer
         run: sudo sysctl vm.mmap_rnd_bits=28
       - name: Launch Action
@@ -52,7 +52,7 @@ jobs:
     if: "!contains(github.ref, 'coverity_scan')"
     steps:
       - name: Check out repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v6
       - name: fix-sanitizer
         run: sudo sysctl vm.mmap_rnd_bits=28
       - name: Launch Action
@@ -81,7 +81,7 @@ jobs:
     if: contains(github.ref, 'coverity_scan')
     steps:
       - name: Check out repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v6
       - name: fix-sanitizer
         run: sudo sysctl vm.mmap_rnd_bits=28
       - name: Launch Coverity Action

--- a/.github/workflows/tss2master.yml
+++ b/.github/workflows/tss2master.yml
@@ -12,7 +12,7 @@ jobs:
         compiler: [gcc, clang]
     steps:
       - name: Check out repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v6
       - name: fix-sanitizer
         run: sudo sysctl vm.mmap_rnd_bits=28
       - name: Launch Action


### PR DESCRIPTION
## Summary

This PR updates GitHub Actions to avoid deprecated CodeQL version and EoL Node.js runtimes.

- Bump `github/codeql-action` from `v2` to `v4` in `.github/workflows/codeql.yml`
- Bump `actions/checkout` from `v2`/`v3` to `v6` in:
  - `.github/workflows/codeql.yml`
  - `.github/workflows/main.yml`
  - `.github/workflows/cron.yml`
  - `.github/workflows/tss2master.yml`

No workflow logic is changed; only action versions are updated.

## Motivation

### CodeQL v2 deprecation

GitHub has deprecated `github/codeql-action` v2 and v3 and recommends migrating to v4.

### `actions/checkout` v2 and v3 depend on deprecated Node.js version

`actions/checkout` major versions are tied to specific Node.js runtimes:

- v2: Node.js 12 (EoL)
- v3: Node.js 16 (EoL)
- v4: Node.js 20 (will reach EoL at the end of April 2026)
- v5/v6: Node.js 24 (Active LTS)

Moving to `actions/checkout@v6` avoids relying on EoL or soon-to-be-EoL Node.js versions and aligns the CI with currently supported runtimes.

### References:

- https://github.blog/changelog/2025-01-10-code-scanning-codeql-action-v2-is-now-deprecated/
- https://github.blog/changelog/2025-10-28-upcoming-deprecation-of-codeql-action-v3/
- https://github.com/actions/checkout/blob/722adc63f1aa60a57ec37892e133b1d319cae598/action.yml
- https://github.com/actions/checkout/releases/tag/v3.0.0
- https://github.com/actions/checkout/releases/tag/v4.0.0
- https://github.com/actions/checkout/releases/tag/v5.0.0
- https://nodejs.org/en/about/previous-releases

## Testing

On my fork, all jobs that do not depend on upstream-only secrets or specific upstream tags are green; only the upstream-only jobs are skipped or expected to fail.