### PR TITLE
tpm2_send: Validate command_size before computing data_size

### DIFF
--- a/tools/tpm2_send.c
+++ b/tools/tpm2_send.c
@@ -47,14 +47,18 @@ static int read_command_from_file(FILE *f, tpm2_command_header **c,
     const tpm2_command_header *header = tpm2_command_header_from_bytes(buffer);
 
     UINT32 command_size = tpm2_command_header_get_size(header, true);
-    UINT32 data_size = tpm2_command_header_get_size(header, false);
-
-    if (command_size > TPM2_MAX_SIZE || command_size < data_size) {
-        LOG_ERR("Command buffer %"PRIu32" bytes cannot be smaller then the "
-                "encapsulated data %"PRIu32" bytes, and can not be bigger than"
-                " the maximum buffer size", command_size, data_size);
+    if (command_size < TPM2_COMMAND_HEADER_SIZE) {
+        LOG_ERR("Command buffer size %"PRIu32" is smaller than command header "
+                "size %zu", command_size, TPM2_COMMAND_HEADER_SIZE);
         return -1;
     }
+    if (command_size > TPM2_MAX_SIZE) {
+        LOG_ERR("Command buffer size %"PRIu32" exceeds maximum buffer size %u",
+                command_size, TPM2_MAX_SIZE);
+        return -1;
+    }
+
+    UINT32 data_size = tpm2_command_header_get_size(header, false);
 
     tpm2_command_header *command = (tpm2_command_header *) malloc(command_size);
     if (!command) {


### PR DESCRIPTION
### Background

In `lib/tpm2_header.h`, TPM command buffers are represented by the `tpm2_command_header` union, which exposes both a raw byte view and a structured header view (`tag`, `size`, `command_code`, `data[]`).

https://github.com/tpm2-software/tpm2-tools/blob/14b9445ba5894341083051bd3f2759418a7dd751/lib/tpm2_header.h#L18-L26

 `TPM2_COMMAND_HEADER_SIZE` is defined as `sizeof(tpm2_command_header)`, i.e., the fixed-size header portion (excluding the variable-length `data[]`). The helper `tpm2_command_header_get_size()` returns either the full command size (`include_header=true`) or payload size (`include_header=false`, computed as `size - TPM2_COMMAND_HEADER_SIZE`).

https://github.com/tpm2-software/tpm2-tools/blob/14b9445ba5894341083051bd3f2759418a7dd751/lib/tpm2_header.h#L82-L87

In `tools/tpm2_send.c`, the code currently derives both `command_size` and `data_size` from the input header, and then validates size relationships before allocating/parsing the command body.​

https://github.com/tpm2-software/tpm2-tools/blob/14b9445ba5894341083051bd3f2759418a7dd751/tools/tpm2_send.c#L47-L57

### Problem

If malformed input sets `tpm2_command_header.size` to a value smaller than `TPM2_COMMAND_HEADER_SIZE`, computing `data_size` (`size - TPM2_COMMAND_HEADER_SIZE`) causes unsigned overflow.

As a result, later checks may report a confusing error path/message based on overflowed values rather than the actual root cause (invalid header-size field).

For example:

```bash
# malformed header:
#   tag: 00 in TPMI_ST_COMMAND_TAG (uint16)
#   size: 00 00 00 09 in UINT32
#   command_code: 00 00 00 00 in TPM2_CC (UINT32)
#   data: {} in uint8[]
printf "00000000000900000000" | xxd -r -p > malformed_command.bin
tpm2_send < malformed_command.bin
```

Current behavior can produce an error like:

```console
ERROR: Command buffer 9 bytes cannot be smaller then the encapsulated data 4294967295 bytes, and can not be bigger than the maximum buffer size
ERROR: failed to read TPM2 command buffer from file
ERROR: Unable to run tpm2_send
```

This message is misleading when the real issue is that the encoded command size is smaller than the required header size.

### Fix

This PR changes validation order in `tpm2_send`:
- Read `command_size`.
- Validate `command_size >= TPM2_COMMAND_HEADER_SIZE`.
- Validate `command_size <= TPM2_MAX_SIZE`.
- Only then derive `data_size`.

With this order, overflow during `data_size` derivation is avoided for malformed short-size headers. Since `data_size` is then derived from a validated `command_size`, the `command_size < data_size` check becomes unnecessary and is removed.

After those changes, the command

```bash
printf "00000000000900000000" | xxd -r -p > malformed_command.bin
tpm2_send < malformed_command.bin
```

yields a relevant error message:

```console
ERROR: Command buffer size 9 is smaller than command header size 10
ERROR: failed to read TPM2 command buffer from file
ERROR: Unable to run tpm2_send
```
