### PR TITLE
tpm2_send: Avoid unintended stdio closing in close_file()

### DIFF
--- a/tools/tpm2_send.c
+++ b/tools/tpm2_send.c
@@ -107,7 +107,7 @@ static FILE *open_file(const char *path, const char *mode) {
 
 static void close_file(FILE *f) {
 
-    if (f && (f != stdin || f != stdout)) {
+    if (f && f != stdin && f != stdout) {
         fclose(f);
     }
 }


### PR DESCRIPTION
The `close_file()` function currently closes an input FILE `f` when `f && (f != stdin || f != stdout)` is `true`.

This condition is flawed: it is logically equivalent to `f && !(f == stdin && f == stdout)`. The clause `!(f == stdin && f == stdout)` is always `true`, the whole condition becomes `f` (`f != nullptr`). As a result, the `close_file()` function may close standard streams (`stdin`/`stdout`) unintentionally.

The intended behavior is to close only non-standard file streams. This PR fixes the condition accordingly so that `stdin` and `stdout` are never closed by `close_file()`.