### PR TITLE
tpm2_util: Fix error message in tpm2_pem_encoded_key_to_fingerprint

### DIFF
--- a/lib/tpm2_util.c
+++ b/lib/tpm2_util.c
@@ -1079,7 +1079,7 @@ bool tpm2_pem_encoded_key_to_fingerprint(const char *pem_encoded_key,
 
     rc = tpm2_base64_encode(buffer, buffer_length, base64);
     if(!rc){
-        LOG_ERR("%s", "tpm2_base64_decode");
+        LOG_ERR("%s", "tpm2_base64_encode");
         return false;
     }
     strcpy(fingerprint, "SHA256:");


### PR DESCRIPTION
This PR fixes a minor typo in the error logging within the `tpm2_pem_encoded_key_to_fingerprint` function. Specifically, when `tpm2_base64_encode` fails, the current error message incorrectly referred to `tpm2_base64_decode`. This has been corrected to accurately reflect the failing function.