### PR TITLE
tpm2_util: modify tpm2_safe_read_from_stdin to read the entire line

### DIFF
--- a/lib/tpm2_util.c
+++ b/lib/tpm2_util.c
@@ -3,6 +3,7 @@
 #include <ctype.h>
 #include <dlfcn.h>
 #include <inttypes.h>
+#include <stddef.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -1010,28 +1011,16 @@ out:
 }
 
 bool tpm2_safe_read_from_stdin(int length, char *data) {
-    int rc;
 
-    char *buf = malloc(length);
-    char *read_data = malloc(length);
-
-    if (buf == fgets(buf, length, stdin)) {
-        rc = sscanf(buf, "%s", read_data);
-        if (rc != 1) {
-            free(buf);
-            free(read_data);
-            return false;
-        }
-    }
-    else {
-        free(buf);
-        free(read_data);
+    /* Read line from stdin; at most length-1 bytes + null-termination */
+    if (!fgets(data, length, stdin)) {
         return false;
     }
 
-    strcpy(data, read_data);
-    free(buf);
-    free(read_data);
+    /* Delete newline character */
+    size_t end = strcspn(data, "\r\n");
+    data[end] = '\0';
+
     return true;
 }
 


### PR DESCRIPTION
### Summary

This PR fixes an issue where `tpm2_safe_read_from_stdin` fails to correctly read file paths containing whitespaces.

Fixes #3551 
Supersedes #3548 

### Problem

The tpm2_safe_read_from_stdin function is used exclusively in `tools/fapi/tss2_template.c` to read file paths from stdin. Currently, the function uses `sscanf(buf, "%s", read_data)`, which stops reading at the first whitespace character (excluding leading whitespace). This means whitespaces are interpreted as delimiters, leading to unexpected behavior when users provide file paths containing spaces

#### Example

- Input: `/home/user/workspace/sample file.bin`
- Current result: `/home/user/workspace/sample`
- Expected result: `/home/user/workspace/sample file.bin`

### Changes

This PR modifies `tpm2_safe_read_from_stdin` to read the entire line.

- Use `fgets(data, length, stdin)` to get the entire line. This ensures null termination and prevents buffer overflows.
- Use `strcspn` to find the first newline character (`\r` or `\n`) and replace it with `\0`.

As a by-product of this change, the implementation has been significantly cleaned up:

- `malloc` and `free` calls are now completely removed, eliminating unnecessary memory management.
- An existing issue where the null check after `malloc` was missing has been resolved.

This is a breaking change because the function now captures spaces instead of treating them as delimiters. However, given its specific usage for file paths, this is the intended and correct behavior.

### Test

```c
/* test.c */
#include <stdio.h>
#include <stdlib.h>
#include <string.h>

bool tpm2_safe_read_from_stdin(int length, char *data) {

    /* Read line from stdin; at most length-1 bytes + null-termination */
    if (!fgets(data, length, stdin)) {
        return false;
    }

    /* Delete newline character */
    size_t end = strcspn(data, "\r\n");
    data[end] = '\0';

    return true;
}

int main(void) {
    char path[1024];
    if (!tpm2_safe_read_from_stdin(sizeof(path), path)) return 1;
    printf("parsed=[%s]\n", path);
    return 0;
}
```

```
gcc test.c -o test
echo "/home/ubuntu/workspace/sample folder" | ./test
echo "\"/home/ubuntu/workspace/sample folder\"" | ./test
```

```console
parsed=[/home/ubuntu/workspace/sample folder]
parsed=["/home/ubuntu/workspace/sample folder"]
```

### Note on CodeQL Alert

I noticed that CodeQL flagged "Uncontrolled data used in path expression" vulnerabilities regarding user input being passed to file operations. It is important to note that *this does not introduce a new vulnerability; the original implementation also processed user-provided paths from stdin for file access, but its previous complexity (redundant `malloc` and `sscanf`) likely obscured the data flow from the static analyzer.*

By simplifying the code to use `fgets`, the existing data flow became transparent to CodeQL. Since this is a CLI utility where the user is expected to provide file paths, this behavior is intended and consistent with the original logic.
