### PR TITLE
tools: fix out-of-bounds write with too many aux sessions

### DIFF
--- a/tools/tpm2_activatecredential.c
+++ b/tools/tpm2_activatecredential.c
@@ -292,13 +292,12 @@ static bool on_option(char key, char *value) {
         ctx.rp_hash_path = value;
         break;
     case 'S':
-        ctx.aux_session_path[ctx.aux_session_cnt] = value;
-        if (ctx.aux_session_cnt < MAX_AUX_SESSIONS) {
-            ctx.aux_session_cnt++;
-        } else {
-            LOG_ERR("Specify a max of 3 sessions");
+        if (ctx.aux_session_cnt >= MAX_AUX_SESSIONS) {
+            LOG_ERR("Specify a max of %u auxiliary sessions", MAX_AUX_SESSIONS);
             return false;
         }
+        ctx.aux_session_path[ctx.aux_session_cnt] = value;
+        ++ctx.aux_session_cnt;
         break;
     }
 

--- a/tools/tpm2_certify.c
+++ b/tools/tpm2_certify.c
@@ -287,13 +287,12 @@ static bool on_option(char key, char *value) {
         }
         break;
     case 'S':
-        ctx.aux_session_path[ctx.aux_session_cnt] = value;
-        if (ctx.aux_session_cnt < MAX_AUX_SESSIONS) {
-            ctx.aux_session_cnt++;
-        } else {
-            LOG_ERR("Specify a max of 3 sessions");
+        if (ctx.aux_session_cnt >= MAX_AUX_SESSIONS) {
+            LOG_ERR("Specify a max of %u auxiliary sessions", MAX_AUX_SESSIONS);
             return false;
         }
+        ctx.aux_session_path[ctx.aux_session_cnt] = value;
+        ++ctx.aux_session_cnt;
         break;
     }
 

--- a/tools/tpm2_certifycreation.c
+++ b/tools/tpm2_certifycreation.c
@@ -358,13 +358,12 @@ static bool on_option(char key, char *value) {
         ctx.policy_qualifier_data = value;
         break;
     case 'S':
-        ctx.aux_session_path[ctx.aux_session_cnt] = value;
-        if (ctx.aux_session_cnt < MAX_AUX_SESSIONS) {
-            ctx.aux_session_cnt++;
-        } else {
-            LOG_ERR("Specify a max of 3 sessions");
+        if (ctx.aux_session_cnt >= MAX_AUX_SESSIONS) {
+            LOG_ERR("Specify a max of %u auxiliary sessions", MAX_AUX_SESSIONS);
             return false;
         }
+        ctx.aux_session_path[ctx.aux_session_cnt] = value;
+        ++ctx.aux_session_cnt;
         break;
         /* no default */
     }

--- a/tools/tpm2_changeauth.c
+++ b/tools/tpm2_changeauth.c
@@ -326,13 +326,12 @@ static bool on_option(char key, char *value) {
         ctx.rp_hash_path = value;
         break;
     case 'S':
-        ctx.aux_session_path[ctx.aux_session_cnt] = value;
-        if (ctx.aux_session_cnt < MAX_AUX_SESSIONS) {
-            ctx.aux_session_cnt++;
-        } else {
+        if (ctx.aux_session_cnt >= MAX_AUX_SESSIONS) {
             LOG_ERR("Specify a max of 3 sessions");
             return false;
         }
+        ctx.aux_session_path[ctx.aux_session_cnt] = value;
+        ++ctx.aux_session_cnt;
         break;
     case 'R':
         ctx.autoflush = true;

--- a/tools/tpm2_changeeps.c
+++ b/tools/tpm2_changeeps.c
@@ -164,13 +164,12 @@ static bool on_option(char key, char *value) {
         ctx.rp_hash_path = value;
         break;
     case 'S':
-        ctx.aux_session_path[ctx.aux_session_cnt] = value;
-        if (ctx.aux_session_cnt < MAX_AUX_SESSIONS) {
-            ctx.aux_session_cnt++;
-        } else {
-            LOG_ERR("Specify a max of 3 sessions");
+        if (ctx.aux_session_cnt >= MAX_AUX_SESSIONS) {
+            LOG_ERR("Specify a max of %u auxiliary sessions", MAX_AUX_SESSIONS);
             return false;
         }
+        ctx.aux_session_path[ctx.aux_session_cnt] = value;
+        ++ctx.aux_session_cnt;
         break;
     }
 

--- a/tools/tpm2_changepps.c
+++ b/tools/tpm2_changepps.c
@@ -164,13 +164,12 @@ static bool on_option(char key, char *value) {
         ctx.rp_hash_path = value;
         break;
     case 'S':
-        ctx.aux_session_path[ctx.aux_session_cnt] = value;
-        if (ctx.aux_session_cnt < MAX_AUX_SESSIONS) {
-            ctx.aux_session_cnt++;
-        } else {
-            LOG_ERR("Specify a max of 3 sessions");
+        if (ctx.aux_session_cnt >= MAX_AUX_SESSIONS) {
+            LOG_ERR("Specify a max of %u auxiliary sessions", MAX_AUX_SESSIONS);
             return false;
         }
+        ctx.aux_session_path[ctx.aux_session_cnt] = value;
+        ++ctx.aux_session_cnt;
         break;
     }
 

--- a/tools/tpm2_create.c
+++ b/tools/tpm2_create.c
@@ -540,13 +540,12 @@ static bool on_option(char key, char *value) {
         ctx.rp_hash_path = value;
         break;
     case 'S':
-        ctx.aux_session_path[ctx.aux_session_cnt] = value;
-        if (ctx.aux_session_cnt < MAX_AUX_SESSIONS) {
-            ctx.aux_session_cnt++;
-        } else {
-            LOG_ERR("Specify a max of 3 sessions");
+        if (ctx.aux_session_cnt >= MAX_AUX_SESSIONS) {
+            LOG_ERR("Specify a max of %u auxiliary sessions", MAX_AUX_SESSIONS);
             return false;
         }
+        ctx.aux_session_path[ctx.aux_session_cnt] = value;
+        ++ctx.aux_session_cnt;
         break;
     case 'f':
         ctx.format = tpm2_convert_pubkey_fmt_from_optarg(value);

--- a/tools/tpm2_getrandom.c
+++ b/tools/tpm2_getrandom.c
@@ -289,13 +289,12 @@ static bool on_option(char key, char *value) {
         ctx.rp_hash_path = value;
         break;
     case 'S':
-        ctx.aux_session_path[ctx.aux_session_cnt] = value;
-        if (ctx.aux_session_cnt < MAX_AUX_SESSIONS) {
-            ctx.aux_session_cnt++;
-        } else {
-            LOG_ERR("Specify a max of 3 sessions");
+        if (ctx.aux_session_cnt >= MAX_AUX_SESSIONS) {
+            LOG_ERR("Specify a max of %u auxiliary sessions", MAX_AUX_SESSIONS);
             return false;
         }
+        ctx.aux_session_path[ctx.aux_session_cnt] = value;
+        ++ctx.aux_session_cnt;
         break;
         /* no default */
     }

--- a/tools/tpm2_nvcertify.c
+++ b/tools/tpm2_nvcertify.c
@@ -484,13 +484,12 @@ static bool on_option(char key, char *value) {
         ctx.rp_hash_path = value;
         break;
     case 'S':
-        ctx.aux_session_path[ctx.aux_session_cnt] = value;
-        if (ctx.aux_session_cnt < MAX_AUX_SESSIONS) {
-            ctx.aux_session_cnt++;
-        } else {
-            LOG_ERR("Specify a max of 3 sessions");
+        if (ctx.aux_session_cnt >= MAX_AUX_SESSIONS) {
+            LOG_ERR("Specify a max of %u auxiliary sessions", MAX_AUX_SESSIONS);
             return false;
         }
+        ctx.aux_session_path[ctx.aux_session_cnt] = value;
+        ++ctx.aux_session_cnt;
         break;
     case 'n':
         ctx.precalc_nvname.size = BUFFER_SIZE(TPM2B_NAME, name);

--- a/tools/tpm2_nvdefine.c
+++ b/tools/tpm2_nvdefine.c
@@ -453,12 +453,12 @@ static bool on_option(char key, char *value) {
         ctx.rp_hash_path = value;
         break;
     case 'S':
-        ctx.aux_session_path[ctx.aux_session_cnt] = value;
-        if (ctx.aux_session_cnt < MAX_AUX_SESSIONS) {
-            ctx.aux_session_cnt++;
-        } else {
+        if (ctx.aux_session_cnt >= MAX_AUX_SESSIONS) {
+            LOG_ERR("Specify a max of %u auxiliary sessions", MAX_AUX_SESSIONS);
             return false;
         }
+        ctx.aux_session_path[ctx.aux_session_cnt] = value;
+        ++ctx.aux_session_cnt;
         break;
     case 'g':
         ctx.halg = tpm2_alg_util_from_optarg(value,

--- a/tools/tpm2_nvextend.c
+++ b/tools/tpm2_nvextend.c
@@ -237,12 +237,12 @@ static bool on_option(char key, char *value) {
         ctx.rp_hash_path = value;
         break;
     case 'S':
-        ctx.aux_session_path[ctx.aux_session_cnt] = value;
-        if (ctx.aux_session_cnt < MAX_AUX_SESSIONS) {
-            ctx.aux_session_cnt++;
-        } else {
+        if (ctx.aux_session_cnt >= MAX_AUX_SESSIONS) {
+            LOG_ERR("Specify a max of %u auxiliary sessions", MAX_AUX_SESSIONS);
             return false;
         }
+        ctx.aux_session_path[ctx.aux_session_cnt] = value;
+        ++ctx.aux_session_cnt;
         break;
     case 'n':
         ctx.precalc_nvname.size = BUFFER_SIZE(TPM2B_NAME, name);

--- a/tools/tpm2_nvincrement.c
+++ b/tools/tpm2_nvincrement.c
@@ -258,13 +258,12 @@ static bool on_option(char key, char *value) {
         ctx.rp_hash_path = value;
         break;
     case 'S':
-        ctx.aux_session_path[ctx.aux_session_cnt] = value;
-        if (ctx.aux_session_cnt < MAX_AUX_SESSIONS) {
-            ctx.aux_session_cnt++;
-        } else {
-            LOG_ERR("Specify a max of 3 sessions");
+        if (ctx.aux_session_cnt >= MAX_AUX_SESSIONS) {
+            LOG_ERR("Specify a max of %u auxiliary sessions", MAX_AUX_SESSIONS);
             return false;
         }
+        ctx.aux_session_path[ctx.aux_session_cnt] = value;
+        ++ctx.aux_session_cnt;
         break;
     case 'n':
         ctx.precalc_nvname.size = BUFFER_SIZE(TPM2B_NAME, name);

--- a/tools/tpm2_nvread.c
+++ b/tools/tpm2_nvread.c
@@ -336,13 +336,12 @@ static bool on_option(char key, char *value) {
         ctx.rp_hash_path = value;
         break;
     case 'S':
-        ctx.aux_session_path[ctx.aux_session_cnt] = value;
-        if (ctx.aux_session_cnt < MAX_AUX_SESSIONS) {
-            ctx.aux_session_cnt++;
-        } else {
-            LOG_ERR("Specify a max of 3 sessions");
+        if (ctx.aux_session_cnt >= MAX_AUX_SESSIONS) {
+            LOG_ERR("Specify a max of %u auxiliary sessions", MAX_AUX_SESSIONS);
             return false;
         }
+        ctx.aux_session_path[ctx.aux_session_cnt] = value;
+        ++ctx.aux_session_cnt;
         break;
     case 3:
         ctx.is_yaml = true;

--- a/tools/tpm2_nvreadlock.c
+++ b/tools/tpm2_nvreadlock.c
@@ -244,13 +244,12 @@ static bool on_option(char key, char *value) {
         ctx.rp_hash_path = value;
         break;
     case 'S':
-        ctx.aux_session_path[ctx.aux_session_cnt] = value;
-        if (ctx.aux_session_cnt < MAX_AUX_SESSIONS) {
-            ctx.aux_session_cnt++;
-        } else {
-            LOG_ERR("Specify a max of 3 sessions");
+        if (ctx.aux_session_cnt >= MAX_AUX_SESSIONS) {
+            LOG_ERR("Specify a max of %u auxiliary sessions", MAX_AUX_SESSIONS);
             return false;
         }
+        ctx.aux_session_path[ctx.aux_session_cnt] = value;
+        ++ctx.aux_session_cnt;
         break;
     case 'n':
         ctx.precalc_nvname.size = BUFFER_SIZE(TPM2B_NAME, name);

--- a/tools/tpm2_nvreadpublic.c
+++ b/tools/tpm2_nvreadpublic.c
@@ -349,13 +349,12 @@ static bool on_option(char key, char *value) {
         ctx.rp_hash_path = value;
         break;
     case 'S':
-        ctx.aux_session_path[ctx.aux_session_cnt] = value;
-        if (ctx.aux_session_cnt < MAX_AUX_SESSIONS) {
-            ctx.aux_session_cnt++;
-        } else {
-            LOG_ERR("Specify a max of 3 sessions");
+        if (ctx.aux_session_cnt >= MAX_AUX_SESSIONS) {
+            LOG_ERR("Specify a max of %u auxiliary sessions", MAX_AUX_SESSIONS);
             return false;
         }
+        ctx.aux_session_path[ctx.aux_session_cnt] = value;
+        ++ctx.aux_session_cnt;
         break;
     case 'n':
         ctx.precalc_nvname.size = BUFFER_SIZE(TPM2B_NAME, name);

--- a/tools/tpm2_nvsetbits.c
+++ b/tools/tpm2_nvsetbits.c
@@ -248,13 +248,12 @@ static bool on_option(char key, char *value) {
         ctx.rp_hash_path = value;
         break;
     case 'S':
-        ctx.aux_session_path[ctx.aux_session_cnt] = value;
-        if (ctx.aux_session_cnt < MAX_AUX_SESSIONS) {
-            ctx.aux_session_cnt++;
-        } else {
-            LOG_ERR("Specify a max of 3 sessions");
+        if (ctx.aux_session_cnt >= MAX_AUX_SESSIONS) {
+            LOG_ERR("Specify a max of %u auxiliary sessions", MAX_AUX_SESSIONS);
             return false;
         }
+        ctx.aux_session_path[ctx.aux_session_cnt] = value;
+        ++ctx.aux_session_cnt;
         break;
     case 'n':
         ctx.precalc_nvname.size = BUFFER_SIZE(TPM2B_NAME, name);

--- a/tools/tpm2_nvundefine.c
+++ b/tools/tpm2_nvundefine.c
@@ -355,13 +355,12 @@ static bool on_option(char key, char *value) {
         if (!ctx.aux_session_cnt) {
             ctx.policy_session.path = value;   
         }
-        ctx.aux_session_path[ctx.aux_session_cnt] = value;
-        if (ctx.aux_session_cnt < MAX_AUX_SESSIONS) {
-            ctx.aux_session_cnt++;
-        } else {
-            LOG_ERR("Specify a max of 3 sessions");
+        if (ctx.aux_session_cnt >= MAX_AUX_SESSIONS) {
+            LOG_ERR("Specify a max of %u auxiliary sessions", MAX_AUX_SESSIONS);
             return false;
         }
+        ctx.aux_session_path[ctx.aux_session_cnt] = value;
+        ++ctx.aux_session_cnt;
         break;
     case 0:
         ctx.cp_hash_path = value;

--- a/tools/tpm2_nvwrite.c
+++ b/tools/tpm2_nvwrite.c
@@ -396,13 +396,12 @@ static bool on_option(char key, char *value) {
         ctx.rp_hash_path = value;
         break;
     case 'S':
-        ctx.aux_session_path[ctx.aux_session_cnt] = value;
-        if (ctx.aux_session_cnt < MAX_AUX_SESSIONS) {
-            ctx.aux_session_cnt++;
-        } else {
-            LOG_ERR("Specify a max of 3 sessions");
+        if (ctx.aux_session_cnt >= MAX_AUX_SESSIONS) {
+            LOG_ERR("Specify a max of %u auxiliary sessions", MAX_AUX_SESSIONS);
             return false;
         }
+        ctx.aux_session_path[ctx.aux_session_cnt] = value;
+        ++ctx.aux_session_cnt;
         break;
     case 'n':
         ctx.precalc_nvname.size = BUFFER_SIZE(TPM2B_NAME, name);

--- a/tools/tpm2_nvwritelock.c
+++ b/tools/tpm2_nvwritelock.c
@@ -278,13 +278,12 @@ static bool on_option(char key, char *value) {
         ctx.rp_hash_path = value;
         break;
     case 'S':
-        ctx.aux_session_path[ctx.aux_session_cnt] = value;
-        if (ctx.aux_session_cnt < MAX_AUX_SESSIONS) {
-            ctx.aux_session_cnt++;
-        } else {
-            LOG_ERR("Specify a max of 3 sessions");
+        if (ctx.aux_session_cnt >= MAX_AUX_SESSIONS) {
+            LOG_ERR("Specify a max of %u auxiliary sessions", MAX_AUX_SESSIONS);
             return false;
         }
+        ctx.aux_session_path[ctx.aux_session_cnt] = value;
+        ++ctx.aux_session_cnt;
         break;
     case 'n':
         ctx.precalc_nvname.size = BUFFER_SIZE(TPM2B_NAME, name);

--- a/tools/tpm2_pcrevent.c
+++ b/tools/tpm2_pcrevent.c
@@ -375,13 +375,12 @@ static bool on_option(char key, char *value) {
         break;
         /* no default */
     case 'S':
-        ctx.aux_session_path[ctx.aux_session_cnt] = value;
-        if (ctx.aux_session_cnt < MAX_AUX_SESSIONS) {
-            ctx.aux_session_cnt++;
-        } else {
-            LOG_ERR("Specify a max of 3 sessions");
+        if (ctx.aux_session_cnt >= MAX_AUX_SESSIONS) {
+            LOG_ERR("Specify a max of %u auxiliary sessions", MAX_AUX_SESSIONS);
             return false;
         }
+        ctx.aux_session_path[ctx.aux_session_cnt] = value;
+        ++ctx.aux_session_cnt;
         break;
         /* no default */
     case 0:

--- a/tools/tpm2_pcrextend.c
+++ b/tools/tpm2_pcrextend.c
@@ -142,13 +142,12 @@ static bool on_options(char key, char *value) {
         break;
         /* no default */
     case 'S':
-        ctx.aux_session_path[ctx.aux_session_cnt] = value;
-        if (ctx.aux_session_cnt < MAX_AUX_SESSIONS) {
-            ctx.aux_session_cnt++;
-        } else {
-            LOG_ERR("Specify a max of 3 sessions");
+        if (ctx.aux_session_cnt >= MAX_AUX_SESSIONS) {
+            LOG_ERR("Specify a max of %u auxiliary sessions", MAX_AUX_SESSIONS);
             return false;
         }
+        ctx.aux_session_path[ctx.aux_session_cnt] = value;
+        ++ctx.aux_session_cnt;
         break;
         /* no default */
     }

--- a/tools/tpm2_pcrread.c
+++ b/tools/tpm2_pcrread.c
@@ -207,13 +207,12 @@ static bool on_option(char key, char *value) {
         break;
         /* no default */
     case 'S':
-        ctx.aux_session_path[ctx.aux_session_cnt] = value;
-        if (ctx.aux_session_cnt < MAX_AUX_SESSIONS) {
-            ctx.aux_session_cnt++;
-        } else {
-            LOG_ERR("Specify a max of 3 sessions");
+        if (ctx.aux_session_cnt >= MAX_AUX_SESSIONS) {
+            LOG_ERR("Specify a max of %u auxiliary sessions", MAX_AUX_SESSIONS);
             return false;
         }
+        ctx.aux_session_path[ctx.aux_session_cnt] = value;
+        ++ctx.aux_session_cnt;
         break;
         /* no default */
     case 0:


### PR DESCRIPTION
This PR fixes an out-of-bounds write in `tpm2_*` when specifying more than the supported number of auxiliary sessions via the `-S/--session` option.

### Problem

In the current implementation, the `-S` handler writes to `ctx.aux_session_path[aux_session_cnt]` before validating `ctx.aux_session_cnt < MAX_AUX_SESSIONS`, which could result in an out-of-bounds write.

### Fixes

- Validate `ctx.aux_session_cnt` before writing to `ctx.aux_session_path[]`
- Emit a clear error message when too many auxiliary sessions are specified
