### PR TITLE
tpm2_alg_util: avoid mutating input scheme in handle_scheme_sign

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -27,10 +27,6 @@ LDADD = \
 
 AM_DISTCHECK_CONFIGURE_FLAGS = --with-bashcompdir='$$(datarootdir)/bash-completion/completions'
 
-AM_CFLAGS += -DCMOCKA_ENABLE_DEPRECATED=1
-AM_CFLAGS += -Wno-error=deprecated-declarations
-AM_CFLAGS += -Wno-error=discarded-qualifiers
-
 # keep me sorted
 bin_PROGRAMS =
 FAPI_CFLAGS = $(EXTRA_CFLAGS) $(TSS2_FAPI_CFLAGS) $(CODE_COVERAGE_CFLAGS) $(CRYPTO_CFLAGS)


### PR DESCRIPTION
This PR fixes the bug in the `handle_scheme_sign()` function, which was likely introduced in commit 9b4d03a.

### Problem

In the current implementation, the `handle_scheme_sign()` function copies the input argument `const char *scheme` to a local buffer `buf[256]` using `snprintf`, then accidentally parses the original `scheme` without using the buffer. During parsing, the function may replace the `-` separator character of `scheme` with the null character `'\0'`. This is an invalid write operation on a *const-referenced* string.

### Changes

This PR changes the parsing/splitting operation to be performed on the local buffer, thereby preventing invalid writes to (const) string arguments. It also makes the following fixes:

- Rename the functional macro `do_scheme_halg` to an UPPER_CAMEL_CASE identifier `DO_SCHEME_HALG` to follow macro naming conventions
- Rename the macro parameter `scheme` to `scheme_` to avoid accidental substitution into member names of `s->scheme.scheme`
