### PR TITLE
tpm2_getekcertificate: Improve determination of the Intel certificate.

### DIFF
--- a/tools/tpm2_getekcertificate.c
+++ b/tools/tpm2_getekcertificate.c
@@ -1167,7 +1167,22 @@ static tool_rc process_input(ESYS_CONTEXT *ectx) {
 
 static char *base64_decode(char **split, unsigned int cert_length) {
 
-    *split += strlen("certficate\" : ");
+    *split += strlen("certificate\"");
+    while (*split && **split == ' ')
+        ++*split;
+
+    if (**split != ':')
+        return NULL;
+    ++*split;
+
+    while (*split && **split == ' ')
+        ++*split;
+
+    if (**split != '"')
+        return NULL;
+
+    ++*split;
+
     char *final_string = NULL;
     int outlen;
     CURL *curl = curl_easy_init();


### PR DESCRIPTION
Improve pointer determination for the Intel certificate field, which previously worked by coincidence despite a typo. Fixes: #3559