### PR TITLE
Update OpenSSL API compatibility

### DIFF
--- a/lib/object.c
+++ b/lib/object.c
@@ -1,4 +1,3 @@
-
 #include <stdio.h>
 
 #include "files.h"
@@ -251,21 +250,21 @@ tool_rc tpm2_util_object_fetch_priv_pub_from_tpk(const char *objectstr,
         goto ret;
     }
 
-    int pub_len = tpk->pubkey->length;
-    int priv_len = tpk->privkey->length;
+    int pub_len = ASN1_STRING_length(tpk->pubkey);
+    int priv_len = ASN1_STRING_length(tpk->privkey);
     if (pub_len < 1 || priv_len < 1) {
         LOG_ERR("Error deserializing TSS Privkey Object");
         goto ret;
     }
 
-    rc = Tss2_MU_TPM2B_PUBLIC_Unmarshal(tpk->pubkey->data, pub_len,
+    rc = Tss2_MU_TPM2B_PUBLIC_Unmarshal(ASN1_STRING_get0_data(tpk->pubkey), pub_len,
         NULL, pub);
     if (rc != tool_rc_success) {
         LOG_ERR("Error deserializing public portion of object");
         goto ret;
     }
 
-    rc = Tss2_MU_TPM2B_PRIVATE_Unmarshal(tpk->privkey->data, priv_len,
+    rc = Tss2_MU_TPM2B_PRIVATE_Unmarshal(ASN1_STRING_get0_data(tpk->privkey), priv_len,
         NULL, priv);
     if (rc != tool_rc_success) {
         LOG_ERR("Error deserializing private portion of object");

--- a/lib/tpm2_convert.c
+++ b/lib/tpm2_convert.c
@@ -501,8 +501,8 @@ static bool pop_ecdsa(const char *path, TPMS_SIGNATURE_ECDSA *ecdsa) {
         LOG_ERR("oom");
         return false;
     }
-    memcpy(R->buffer, r->data, r->length);
-    R->size = r->length;
+    memcpy(R->buffer, ASN1_STRING_get0_data(r), ASN1_STRING_length(r));
+    R->size = ASN1_STRING_length(r);
     ASN1_INTEGER_free(r);
 
     /*
@@ -514,8 +514,8 @@ static bool pop_ecdsa(const char *path, TPMS_SIGNATURE_ECDSA *ecdsa) {
         LOG_ERR("oom");
         return false;
     }
-    memcpy(S->buffer, s->data, s->length);
-    S->size = s->length;
+    memcpy(S->buffer, ASN1_STRING_get0_data(s), ASN1_STRING_length(s));
+    S->size = ASN1_STRING_length(s);
     ASN1_INTEGER_free(s);
 
     return true;


### PR DESCRIPTION
This change allows the code to be compiled against OpenSSL 4.

This updates the code to interact correctly with modern OpenSSL versions (4.0+) where these structures are opaque, ensuring API compatibility and preventing build errors.