### PR TITLE
tpm2_nvundefine: Provide usage of password for undefine special.

### DIFF
--- a/lib/tpm2.c
+++ b/lib/tpm2.c
@@ -4217,8 +4217,14 @@ tpm2_nvundefinespecial_free_name1:
         return rc;
     }
 
-    ESYS_TR policy_session_handle = tpm2_session_get_handle(policy_session);
-
+    ESYS_TR policy_session_handle = ESYS_TR_NONE;
+    rc = tpm2_auth_util_get_shandle(esys_context,
+            esys_tr_nv_handle, policy_session,
+            &policy_session_handle);
+    if (rc != tool_rc_success) {
+        LOG_ERR("Couldn't get shandle");
+        return rc;
+    }
     rval = Esys_NV_UndefineSpaceSpecial(esys_context,
             esys_tr_nv_handle,
             auth_hierarchy_obj->tr_handle,

--- a/man/tpm2_nvundefine.1.md
+++ b/man/tpm2_nvundefine.1.md
@@ -44,7 +44,8 @@ default value for `-C` is the "owner" hierarchy when `TPMA_NV_POLICY_DELETE` is 
        aux session can be specified. The order of how sessions are specified
        also matters. First specification of `-S` is interpreted as the session
        for satisfying the ADMIN role required for
-       TPM2_CC_NV_UndefineSpaceSpecial.
+       TPM2_CC_NV_UndefineSpaceSpecial. If a password is used for the NV object
+       the password has to be added to the the session path: "path+passwdord".
 
     2. If TPM2_CC_NV_Undefine is invoked then only two additional aux sessions
        can be specified.
@@ -119,6 +120,11 @@ tpm2_policyauthvalue -S s.ctx
 tpm2_policycommandcode -S s.ctx TPM2_CC_NV_UndefineSpaceSpecial
 
 tpm2_nvundefine -S s.ctx 1
+```
+If a password is used for the nv object. The nv undefine command has to be executed
+as follows:
+```
+tpm2_nvundefine -S s.ctx+mypassword  1
 ```
 
 [returns](common/returns.md)

--- a/test/integration/tests/abrmd_nvundefinespecial.sh
+++ b/test/integration/tests/abrmd_nvundefinespecial.sh
@@ -43,4 +43,20 @@ tpm2 policycommandcode -S session.ctx TPM2_CC_NV_UndefineSpaceSpecial
 
 tpm2 nvundefine -S session.ctx 1
 
+tpm2 flushcontext session.ctx
+
+# Test with password for nv object
+tpm2 startauthsession -S session.ctx
+tpm2 policyauthvalue -S session.ctx
+tpm2 policycommandcode -S session.ctx -L policy.dat TPM2_CC_NV_UndefineSpaceSpecial
+tpm2 nvdefine -C p -s 32 -a "platformcreate|policydelete|ownerread|ownerwrite|authwrite|authread" -L policy.dat -p "mypassword" 1
+
+tpm2 flushcontext session.ctx
+tpm2 startauthsession --policy-session -S session.ctx
+tpm2 policyauthvalue -S session.ctx
+tpm2 policycommandcode -S session.ctx TPM2_CC_NV_UndefineSpaceSpecial
+
+tpm2 nvundefine -C p -S session.ctx+mypassword 1
+
+
 exit 0

--- a/tools/tpm2_nvundefine.c
+++ b/tools/tpm2_nvundefine.c
@@ -7,6 +7,7 @@
 #include "tpm2_tool.h"
 #include "tpm2_nv_util.h"
 #include "tpm2_options.h"
+#include "tpm2_auth_util.h"
 
 #define MAX_SESSIONS 3
 #define MAX_AUX_SESSIONS 2
@@ -111,6 +112,58 @@ static tool_rc process_output(ESYS_CONTEXT *ectx) {
     return rc;
 }
 
+/*
+ * Get the handle for the policy session which is used for
+ * undefine special and set the needed out value passed with the session
+ * pathname (+passwd).
+ */ 
+static tool_rc get_policy_session(ESYS_CONTEXT *ectx, const char *path,
+       tpm2_session **session) {
+
+    TPM2B_AUTH auth = { 0 };
+
+    /* Make a local copy for manipulation */
+    char tmp[PATH_MAX];
+    size_t len = snprintf(tmp, sizeof(tmp), "%s", path);
+    if (len >= sizeof(tmp)) {
+        LOG_ERR("Path truncated");
+        return tool_rc_general_error;
+    }
+    /*
+     * Sessions can have an associated password/auth value denoted after
+     * a + sign, ie session.ctx+foo, deal with it by
+     * finding a +, splitting the string on it, and if
+     * not a NULL byte after the +, use that as a password.
+     */
+    char *password = strchr(tmp, '+');
+    if (password) {
+        *password = '\0';
+        password++;
+        if (*password) {
+            bool result = handle_password(password, &auth);
+            if (!result) {
+                return tool_rc_general_error;
+            }
+        }
+    }
+
+    tool_rc rc = tpm2_session_restore(ectx, tmp, false, session);
+    if (rc != tool_rc_success) {
+        return rc;
+    }
+
+    tpm2_session_set_auth_value(*session, &auth);
+
+    bool is_trial = tpm2_session_is_trial(*session);
+    if (is_trial) {
+        LOG_ERR("A trial session cannot be used to authenticate, "
+                "Please use an hmac or policy session");
+        tpm2_session_close(session);
+        return tool_rc_general_error;
+    }
+
+    return tool_rc_success;
+}
 
 static tool_rc process_inputs(ESYS_CONTEXT *ectx, tpm2_option_flags flags) {
 
@@ -155,8 +208,7 @@ static tool_rc process_inputs(ESYS_CONTEXT *ectx, tpm2_option_flags flags) {
      * TPM2_CC_NV_UndefineSpaceSpecial
      */
     if (ctx.has_policy_delete_set && !ctx.is_tcti_none) {
-        rc = tpm2_session_restore(ectx, ctx.policy_session.path, false,
-                &ctx.policy_session.session);
+        rc = get_policy_session(ectx, ctx.policy_session.path, &ctx.policy_session.session);
         if (rc != tool_rc_success) {
             return rc;
         }


### PR DESCRIPTION
The usage of the password of an NV object for undefine special was not supported. The password can now be added to the needed policy session e.g.: tpm2_nvundefine -C p -S "s.ctx+mypassword"
The integration test abrmd_nvundefinespecial.sh is extended. Fixes #3400