### PR TITLE
Use password based sessions if no other session types specified

### DIFF
--- a/lib/object.c
+++ b/lib/object.c
@@ -1,4 +1,5 @@
 #include <stdio.h>
+#include <string.h>
 
 #include "files.h"
 #include "log.h"
@@ -10,6 +11,15 @@
 
 #define NULL_OBJECT "null"
 #define NULL_OBJECT_LEN (sizeof(NULL_OBJECT) - 1)
+
+#define SESSION_PREFIX "session:"
+#define SESSION_PREFIX_LEN sizeof(SESSION_PREFIX) - 1
+
+#define FILE_PREFIX "file:"
+#define FILE_PREFIX_LEN sizeof(FILE_PREFIX) - 1
+
+#define PCR_PREFIX "pcr:"
+#define PCR_PREFIX_LEN sizeof(PCR_PREFIX) - 1
 
 TPM2B_PRIVATE tpm2_util_object_tsspem_priv = { 0 };
 TPM2B_PUBLIC tpm2_util_object_tsspem_pub = { 0 };
@@ -411,6 +421,12 @@ tool_rc tpm2_util_object_load_auth(ESYS_CONTEXT *ctx, const char *objectstr,
         const char *auth, tpm2_loaded_object *outobject,
         bool is_restricted_pswd_session, tpm2_handle_flags flags) {
 
+    bool is_session = auth && !strncmp(auth, SESSION_PREFIX, SESSION_PREFIX_LEN);
+    bool is_file = auth && !strncmp(auth, FILE_PREFIX, FILE_PREFIX_LEN);
+    bool is_pcr = auth && !strncmp(auth, PCR_PREFIX, PCR_PREFIX_LEN);
+    bool use_restricted_pswd_session = is_restricted_pswd_session &&
+        !is_session && !is_file && !is_pcr;
+
     return tpm2_util_object_load2(ctx, objectstr, auth, true, outobject,
-            is_restricted_pswd_session, flags);
+        use_restricted_pswd_session, flags);
 }


### PR DESCRIPTION
This PR fixes the problem where you currently can't specify authentication with ESYS_TR_PASSWORD by the --pwd-session (-z) parameter, and session / file / pcr based auth at the same time.

This is especially useful when --pwd-session is enabled by default in FIPS based environments for all tpm2-tools commands, but we want to disable it when users specify --auth=session: etc.

This lets combinations like the following work:

Before:

$ sudo tpm2_nvread --pwd-session --auth=session:session.ctx 0x1500016 
WARN: Reading full size of the NV index
ERROR: Cannot specify password type "session:"

After:

$ sudo tpm2_nvread --pwd-session --auth=session:session.ctx 0x1500016 
WARN: Reading full size of the NV index
ERROR: Could not open path "session.ctx", due to error: "No such file or directory"

This fixes issue #3521.

I know the code duplicates SESSION_PREFIX, FILE_PREFIX, PCR_PREFIX from lib/tpm2_auth_util.c, but I wanted to get your feedback on the idea before we start moving these definitions into common header files.