### PR TITLE
ci: switch to freebsd 14.4

### DIFF
--- a/.github/workflows/ci-freebsd.yaml
+++ b/.github/workflows/ci-freebsd.yaml
@@ -14,21 +14,22 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Run FreeBSD 14.3 build and tests
+      - name: Run FreeBSD 14.4 build and tests
         uses: vmactions/freebsd-vm@v1
         with:
-          release: "14.3"
+          release: "14.4"
           usesh: true
 
           prepare: |
             set -eux
-
+            export ASSUME_ALWAYS_YES=yes
             export PKG_CONFIG_PATH="/usr/local/lib/pkgconfig"
             export CFLAGS="-I/usr/local/include -I/usr/local/openssl/include"
             export LDFLAGS="-L/usr/local/lib"
             export libusb_version="v1.0.26"
             export PKG_CONFIG_PATH="/usr/local/lib/pkgconfig"
-
+            rm -rf /var/db/pkg/repo-* /var/db/pkg/FreeBSD.meta /var/cache/pkg/*
+            pkg bootstrap -f
             pkg update -f
             pkg upgrade -y
 
@@ -41,7 +42,7 @@ jobs:
               pkgconf \
               autoconf \
               autoconf-archive \
-              py311-pip \
+              py312-pip \
               expect \
               python3
 


### PR DESCRIPTION
With freebsd 14.3 the error:
pkg: repository FreeBSD contains packages for wrong OS version: FreeBSD:14:amd64 did occur.