### PR TITLE
fix(attr_util): correct NV nt field decoding and show it as a friendly name

### DIFF
--- a/lib/tpm2_attr_util.c
+++ b/lib/tpm2_attr_util.c
@@ -240,9 +240,9 @@ static dispatch_table nv_attr_table[] = { // Bit Index
     dispatch_no_arg_add(authwrite),       //  2
     dispatch_no_arg_add(policywrite),     //  3
     dispatch_arg_add(nt, 4),              //  4
-    dispatch_arg_add(nt, 3),              //  5
-    dispatch_arg_add(nt, 2),              //  6
-    dispatch_arg_add(nt, 1),              //  7
+    dispatch_arg_add(nt, 4),              //  5
+    dispatch_arg_add(nt, 4),              //  6
+    dispatch_arg_add(nt, 4),              //  7
     dispatch_reserved(8),                 //  8
     dispatch_reserved(9),                 //  9
     dispatch_no_arg_add(policydelete),    // 10
@@ -581,6 +581,13 @@ static char *tpm2_attr_util_common_attrtostr(UINT32 attrs,
         const char *name = d->name;
         unsigned w = d->width;
 
+        /*
+         * A multi-bit field is naturally aligned to its width, so its base is
+         * the first set bit rounded down to a multiple of the width. For
+         * single-bit attributes (w == 1) this is just bit_index.
+         */
+        unsigned base = bit_index & ~(w - 1);
+
         /* current position and size left of the string */
         char *s = &str[string_index];
         size_t left = length - string_index;
@@ -589,13 +596,13 @@ static char *tpm2_attr_util_common_attrtostr(UINT32 attrs,
         UINT8 mask = ((UINT32) 1 << w) - 1;
 
         /* get the value in the field before clearing attrs out */
-        UINT8 field_values = (attrs & mask << bit_index) >> bit_index;
+        UINT8 field_values = (attrs & (mask << base)) >> base;
 
         /*
          * turn off the parsed bit(s) index, using width to turn off everything in a
          * field
          */
-        attrs &= ~(mask << bit_index);
+        attrs &= ~(mask << base);
 
         int n;
         /*

--- a/lib/tpm2_attr_util.c
+++ b/lib/tpm2_attr_util.c
@@ -200,6 +200,19 @@ static bool lookup_nt_friendly_name(const char *arg, uint16_t *type) {
     return true;
 }
 
+static const char *nt_to_friendly_name(UINT8 value) {
+
+    switch (value) {
+    case TPM2_NT_ORDINARY:  return "ordinary";
+    case TPM2_NT_COUNTER:   return "counter";
+    case TPM2_NT_BITS:      return "bits";
+    case TPM2_NT_EXTEND:    return "extend";
+    case TPM2_NT_PIN_FAIL:  return "pinfail";
+    case TPM2_NT_PIN_PASS:  return "pinpass";
+    default:                return NULL; /* unknown -> caller prints hex */
+    }
+}
+
 static bool nt(TPMA_NV *nv, char *arg) {
 
     uint16_t value = 0;
@@ -617,9 +630,14 @@ static char *tpm2_attr_util_common_attrtostr(UINT32 attrs,
         if (w == 1) {
             n = snprintf(s, left, attrs ? "%s|" : "%s", name);
         } else {
-            /* deal with the field */
-            n = snprintf(s, left, attrs ? "%s=0x%X|" : "%s=0x%X", name,
-                    field_values);
+            const char *fname =
+                !strcmp(name, "nt") ? nt_to_friendly_name(field_values) : NULL;
+            if (fname) {
+                n = snprintf(s, left, attrs ? "%s=%s|" : "%s=%s", name, fname);
+            } else {
+                n = snprintf(s, left, attrs ? "%s=0x%X|" : "%s=0x%X", name,
+                        field_values);
+            }
         }
 
         /* check if there was enough space left in s */

--- a/test/unit/test_tpm2_attr_util.c
+++ b/test/unit/test_tpm2_attr_util.c
@@ -182,6 +182,7 @@ test_nv_attrtostr(0x800000, "<reserved(23)>")  //bit 23- reserved
 test_nv_attrtostr(0x1000000, "<reserved(24)>") //bit 24- reserved
 
 test_nv_attrtostr(0x30, "nt=0x3") //bit 24- reserved
+test_nv_attrtostr(0x40, "nt=0x4") //bit 24- reserved
 test_nv_attrtostr(0x90, "nt=0x9") //bit 24- reserved
 
 #define NV_ALL_FIELDS \
@@ -410,6 +411,7 @@ int main(int argc, char* argv[]) {
             test_nv_attrtostr_get(0x800000),  //bit 23- reserved
             test_nv_attrtostr_get(0x1000000), //bit 24- reserved
             test_nv_attrtostr_get(0x30), //nt=0x3
+            test_nv_attrtostr_get(0x40), //nt=0x4
             test_nv_attrtostr_get(0x90), //nt=0x9
             test_nv_attrtostr_get(stclear_ppwrite),
             test_nv_attrtostr_get(stclear_ppwrite_0x30),

--- a/test/unit/test_tpm2_attr_util.c
+++ b/test/unit/test_tpm2_attr_util.c
@@ -181,9 +181,12 @@ test_nv_attrtostr(0x400000, "<reserved(22)>")  //bit 22 - reserved
 test_nv_attrtostr(0x800000, "<reserved(23)>")  //bit 23- reserved
 test_nv_attrtostr(0x1000000, "<reserved(24)>") //bit 24- reserved
 
-test_nv_attrtostr(0x30, "nt=0x3") //bit 24- reserved
-test_nv_attrtostr(0x40, "nt=0x4") //bit 24- reserved
-test_nv_attrtostr(0x90, "nt=0x9") //bit 24- reserved
+test_nv_attrtostr(0x10, "nt=counter")   // 0x1
+test_nv_attrtostr(0x20, "nt=bits")      // 0x2
+test_nv_attrtostr(0x40, "nt=extend")    // 0x4
+test_nv_attrtostr(0x80, "nt=pinfail")   // 0x8
+test_nv_attrtostr(0x90, "nt=pinpass")   // 0x9
+test_nv_attrtostr(0x30, "nt=0x3")       // unknown NT value -> stays hex
 
 #define NV_ALL_FIELDS \
         "ppwrite|ownerwrite|authwrite|policywrite|nt=0xF|<reserved(8)>"  \
@@ -214,7 +217,7 @@ test_nv_attrtostr_compound(stclear_ppwrite_0x30,
         "ppwrite|nt=0x3|write_stclear")
 test_nv_attrtostr_compound(platformcreate_ownerread_nt_0x90_0x20000,
         TPMA_NV_PLATFORMCREATE | TPMA_NV_AUTHWRITE | 0x90 | 0x200000,
-        "authwrite|nt=0x9|<reserved(21)>|platformcreate")
+        "authwrite|nt=pinpass|<reserved(21)>|platformcreate")
 
 /*
  * TPMA_OBJECT Tests
@@ -410,8 +413,11 @@ int main(int argc, char* argv[]) {
             test_nv_attrtostr_get(0x400000),  //bit 22 - reserved
             test_nv_attrtostr_get(0x800000),  //bit 23- reserved
             test_nv_attrtostr_get(0x1000000), //bit 24- reserved
+            test_nv_attrtostr_get(0x10), //nt=0x1
+            test_nv_attrtostr_get(0x20), //nt=0x2
             test_nv_attrtostr_get(0x30), //nt=0x3
             test_nv_attrtostr_get(0x40), //nt=0x4
+            test_nv_attrtostr_get(0x80), //nt=0x8
             test_nv_attrtostr_get(0x90), //nt=0x9
             test_nv_attrtostr_get(stclear_ppwrite),
             test_nv_attrtostr_get(stclear_ppwrite_0x30),


### PR DESCRIPTION
Fixes https://github.com/tpm2-software/tpm2-tools/issues/1797, decided against implementing https://github.com/tpm2-software/tpm2-tools/issues/1798.

**fix(attr_util): decode NV nt field relative to its base**

tpm2_attr_util_nv_attrtostr renders the 4-bit TPM_NT field (TPMA_NV
bits 7:4) by walking to the lowest set bit and shifting the value by
that bit index instead of by the field base (bit 4). So any nt value
whose low bit is clear was mis-rendered: bits (0x2) and extend (0x4)
both printed as "nt=0x1", and pinfail (0x8) landed on the width-1
slot and printed a bare "nt" with no value. Only values with bit 4
set (counter 0x1, pinpass 0x9, ...) came out right, which is why the
existing tests never caught it.

Anchor extraction on the field base (bit_index & ~(w - 1)) and give
all four nt table slots the full field width (4), so the whole nibble
is read as (attrs >> 4) & 0xF regardless of which bit the scanner
lands on. The same expression reduces to bit_index for single-bit
attributes (w == 1), so their behavior is unchanged.

**feat(attr_util): render NV nt field as a friendly name**

The attribute parser already accepts friendly TPM_NT names
(nt=extend, nt=counter, ...), but tpm2_attr_util_nv_attrtostr only
ever emitted the raw field value (nt=0x4), so tpm2_nvreadpublic's
"friendly" output wasn't symmetric with the input it accepts.

Map the decoded nt field value back to its name, falling back to hex for
any value that isn't a defined type. Only the human-readable "friendly:"
string changes (e.g. nt=0x9 -> nt=pinpass); the raw "value:" field is
unchanged.

Keep the nt= prefix so the string still round-trips through
tpm2_nvdefine -a, which parses this same format.

