### PR TITLE
Add FIPS mode detection and set pwd session by default

### DIFF
--- a/lib/tpm2_options.c
+++ b/lib/tpm2_options.c
@@ -17,6 +17,9 @@
 #include <sys/wait.h>
 #include <sys/stat.h>
 
+#include <openssl/evp.h>
+#include <openssl/provider.h>
+
 #include "config.h"
 #include "log.h"
 #include "tpm2_options.h"
@@ -274,6 +277,24 @@ static TSS2_RC tcti_fake_transmit (TSS2_TCTI_CONTEXT *tcti_ctx, size_t size,
 	return TSS2_TCTI_RC_NOT_IMPLEMENTED;
 }
 
+static bool is_fips_mode_enabled(void)
+{
+    /* FIPS mode cannot change at runtime, so cache the result. */
+    static int fips_mode = -1;
+
+    if (fips_mode < 0) {
+#if OPENSSL_VERSION_NUMBER >= 0x30000000L
+        /* Both conditions must hold: the default properties must request FIPS
+         * and the FIPS provider must actually be loaded and available. */
+        fips_mode = (EVP_default_properties_is_fips_enabled(NULL)
+                     && OSSL_PROVIDER_available(NULL, "fips")) ? 1 : 0;
+#else
+        fips_mode = 0;
+#endif /* OPENSSL_VERSION_NUMBER >= 0x30000000L */
+    }
+    return fips_mode == 1;
+}
+
 tpm2_option_code tpm2_handle_options(int argc, char **argv,
     tpm2_options *tool_opts, tpm2_option_flags *flags,
     TSS2_TCTI_CONTEXT **tcti) {
@@ -290,6 +311,7 @@ tpm2_option_code tpm2_handle_options(int argc, char **argv,
         { "version",       no_argument,       NULL, 'v' },
         { "enable-errata", no_argument,       NULL, 'Z' },
         { "pwd-session",   no_argument,       NULL, 'z' },
+        { "disable-pwd-session",   no_argument,       NULL, 'D' },
     };
 
     const char *tcti_conf_option = NULL;
@@ -299,8 +321,13 @@ tpm2_option_code tpm2_handle_options(int argc, char **argv,
     bool show_help = false;
     bool result = false;
 
+    /* set --pwd-session by default when fips mode is enabled */
+    if (is_fips_mode_enabled()) {
+        flags->restricted_pwd_session = 1;
+    }
+
     /* handle any options */
-    const char* common_short_opts = "T:h::vVQZz";
+    const char* common_short_opts = "T:h::vVQZzD";
     tpm2_options *opts = tpm2_options_new(common_short_opts,
             ARRAY_LEN(long_options), long_options, NULL, NULL, 0);
     if (!opts) {
@@ -377,6 +404,9 @@ tpm2_option_code tpm2_handle_options(int argc, char **argv,
             break;
         case 'z':
             flags->restricted_pwd_session = 1;
+            break;
+        case 'D':
+            flags->restricted_pwd_session = 0;
             break;
         case 'Q':
             flags->quiet = 1;

--- a/man/common/options.md
+++ b/man/common/options.md
@@ -32,6 +32,13 @@ information that many users may expect.
     is passed to the TPM to authorize the action. This option can be used to avoid problems
     when unsalted sessions are used in OpenSSL FIPS mode. If auth values are used
     a salted session should be used for authentication.
+
+    Enabled by default in FIPS mode.
+
+  * **-D**, **\--disable-pwd-session**:
+    Disables password session and returns to using a HMAC session for authentication.
+    Use this option if you find something not working under FIPS mode.
+
   * **-R**, **\--autoflush**:
     Enable autoflush for transient objects created by the command. If a parent
     object is loaded from a context file also the transient parent object will


### PR DESCRIPTION
This is a vendor patch carried in Ubuntu FIPS 140-3 packages.

This is the actual patch we went with, and it is a refactor of the older version I posted in https://github.com/tpm2-software/tpm2-tools/pull/3587#issuecomment-4748721716

This patch has a nice function that asks openssl if the system has FIPS mode enabled, and it returns the result.

The patch uses the FIPS detection logic to set the --pwd-session flag by default for FIPS users.

It still needs the changes from #3587 to really work seamlessly for FIPS users.

I am providing this in the chance it happens to be helpful, but you don't have to merge it. This would be very useful for distros needing to support FIPS SP800-131A.