### PR TITLE
fapi test: fix fapi-verify-sign.sh

### DIFF
--- a/.ci/docker.run
+++ b/.ci/docker.run
@@ -7,6 +7,11 @@ git config --global --add safe.directory "$DOCKER_BUILD_DIR"
 
 source $DOCKER_BUILD_DIR/.ci/docker-prelude.sh
 
+# Prefer pkg-config metadata installed under /usr/local by extending
+# PKG_CONFIG_PATH. This ensures that CI uses the freshly built tpm2-tss
+# libraries instead of an older distribution-provided installation.
+export PKG_CONFIG_PATH="/usr/local/lib/pkgconfig:/usr/local/share/pkgconfig${PKG_CONFIG_PATH:+:$PKG_CONFIG_PATH}"
+
 if [ -d build ]; then
   rm -rf build
 fi
@@ -86,7 +91,7 @@ fi
 
 ../configure --enable-unit $config_flags
 make -j$(nproc)
-make -j check
+make -j check 
 
 popd
 

--- a/configure.ac
+++ b/configure.ac
@@ -82,10 +82,24 @@ AC_CHECK_LIB(crypto, [EVP_sm3], [
 AC_CHECK_LIB(crypto, [EVP_sm4_cfb128], [
         AC_DEFINE([HAVE_EVP_SM4_CFB], [1], [Support EVP_sm4_cfb in openssl])],
         [])
-AC_CHECK_LIB(tss2-fapi, [Fapi_DigestAndSign], [
-        AC_DEFINE([HAVE_FAPI_DIGEST_AND_SIGN], [1], [Support signing with restricted keys])],
-        [])
-LIBS="${LIBS_save}"
+save_CPPFLAGS="$CPPFLAGS"
+save_LIBS="$LIBS"
+
+save_LIBS="$LIBS"
+
+LIBS="$TSS2_FAPI_LIBS $LIBS"
+
+AC_CHECK_FUNC(
+    [Fapi_DigestAndSign],
+    [AC_DEFINE(
+        [HAVE_FAPI_DIGEST_AND_SIGN],
+        [1],
+        [Define if Fapi_DigestAndSign is available]
+    )]
+)
+
+LIBS="$save_LIBS"
+
 PKG_CHECK_MODULES([CURL], [libcurl])
 
 # pretty print of devicepath if efivar library is present

--- a/test/integration/fapi/fapi-sign-verify.sh
+++ b/test/integration/fapi/fapi-sign-verify.sh
@@ -337,19 +337,23 @@ dd if=/dev/zero of=$DATA_FILE bs=1 count=1024
 if [ "$CRYPTO_PROFILE" = "RSA" ]; then
     PADDING="--padding=RSA_PSS"
 fi
-if nm -D $(ldconfig -p | grep "libtss2-fapi" | head -n1 | awk '{print $NF}') | \
-        grep "Fapi_DigestAndSign";
+
+if printf '%s\n' \
+    'extern void Fapi_DigestAndSign(void);' \
+    'int main(void) { Fapi_DigestAndSign(); return 0; }' |
+   "${CC:-cc}" -x c - -L/usr/local/lib -ltss2-fapi -o /tmp/check-fapi
 then
     tss2 sign --data=$DATA_FILE --keyPath=$KEY_PATH $PADDING \
          --signature=$SIGNATURE_FILE --publicKey=$PUBLIC_KEY_FILE -f
-
-    shasum -a 256 $DATA_FILE | awk '{ $1 }' | xxd -r -p > $DIGEST_FILE
+    shasum -a 256 $DATA_FILE | awk '{ print $1 }' | xxd -r -p > $DIGEST_FILE
     tss2 verifysignature --keyPath=$PUB_KEY_DIR/$IMPORTED_KEY_NAME \
          --digest=$DIGEST_FILE --signature=$SIGNATURE_FILE
 else
     # The sign should fail because Fapi_DigestAndSign is not available
-    ! tss2 sign --data=$DATA_FILE --keyPath=$KEY_PATH $PADDING \
-      --signature=$SIGNATURE_FILE --publicKey=$PUBLIC_KEY_FILE
+    if tss2 sign --data=$DATA_FILE --keyPath=$KEY_PATH $PADDING \
+            --signature=$SIGNATURE_FILE --publicKey=$PUBLIC_KEY_FILE ; then
+        echo "ERROR: tss2_sign unexpectedly succeeded"
+        exit 1;
+    fi
 fi
-
 exit 0


### PR DESCRIPTION
The test for Fapi_DigestAndSign incorrectly reported that the function was unavailable because ldconfig was not run after installing tpm2-tss.

Now pkg_config is used to determine whether Fapi_DigestAndSign is available.

This issue also masked an error in an awk command that is executed when Fapi_DigestAndSign is available. The awk statement is fixed.

Fixes: #3606