### PR TITLE
ci: remove stray space.

### DIFF
--- a/.ci/docker.run
+++ b/.ci/docker.run
@@ -91,7 +91,7 @@ fi
 
 ../configure --enable-unit $config_flags
 make -j$(nproc)
-make -j check 
+make -j check
 
 popd
 


### PR DESCRIPTION
A stray space is removed in docker.run