### PR TITLE
tss2-tools: flush stdout before reading input

### DIFF
--- a/tools/fapi/tss2_template.c
+++ b/tools/fapi/tss2_template.c
@@ -221,6 +221,7 @@ TSS2_RC auth_callback(
     } else {
         printf ("Authorize %s \"%s\": ", objectPath, description);
     }
+    fflush(stdout);
     tcsetattr (STDIN_FILENO, TCSANOW, &new);
 
     size_t input_size = 0;
@@ -333,6 +334,7 @@ TSS2_RC sign_callback(
 
     }
     printf("Filename for nonce output: ");
+    fflush(stdout);
     rc = tpm2_safe_read_from_stdin(READ_SIZE, path);
     if (rc != true){
         fprintf (stderr, "Please enter a valid file path\n");
@@ -347,6 +349,7 @@ TSS2_RC sign_callback(
     }
 
     printf("Filename for signature input: ");
+    fflush(stdout);
     rc = tpm2_safe_read_from_stdin(READ_SIZE, path);
     if (rc != true){
         fprintf (stderr, "Please enter a valid file path\n");
@@ -390,6 +393,7 @@ TSS2_RC branch_callback(
 
     while (1) {
         printf ("Your choice: ");
+        fflush(stdout);
         if (scanf ("%zu", selectedBranch) != EOF) {
             while (getchar () != '\n'); /* Consume all remaining input */
             if (*selectedBranch > numBranches || *selectedBranch < 1) {


### PR DESCRIPTION
After asking the user for input (i.e., printf("[...]: "), flush stdout. Otherwise, this could fail in testing with expect. We observed the following error related to this in CI:
```
FAIL: test/integration/fapi/fapi-policy_signed
==============================================

creating simulator working dir: /tmp/tpm2_test_KbVbhl /tmp/tpm2_test_KbVbhl /workspace/tpm2-tools/build
Switched to CWD: /tmp/tpm2_test_KbVbhl
Starting the simulator
Attempting to start simulator on port: 47145
LISTEN 0      1          127.0.0.1:47145      0.0.0.0:*    users:(("swtpm",pid=40459,fd=4))
LISTEN 0      1          127.0.0.1:47146      0.0.0.0:*    users:(("swtpm",pid=40459,fd=3))
Started simulator on port 47145 in dir "/tmp/tpm2_test_KbVbhl"
tpm2tools_tcti="swtpm:host=localhost,port=47145"
Started the simulator
Starting tpm2-abrmd
TPM2ABRMD_TCTI is empty, configuring
TPM2ABRMD_TCTI="--session --dbus-name=com.intel.tss2.Tabrmd47145 --tcti=swtpm:port=47145"
tpm2-abrmd command: tpm2-abrmd --allow-root --session --dbus-name=com.intel.tss2.Tabrmd47145 --tcti=swtpm:port=47145 --session --dbus-name=com.intel.tss2.Tabrmd47145 --tcti=swtpm:port=47145
tpm2tools_tcti="tabrmd:bus_type=session,bus_name=com.intel.tss2.Tabrmd47145"
TPM2TOOLS_TEST_TCTI=
TPM2TOOLS_TEST_TCTI not set, attempting to figure out default
export TPM2TOOLS_TCTI="tabrmd:bus_type=session,bus_name=com.intel.tss2.Tabrmd47145"

--- To recreate this test run the following: ---
\#!/usr/bin/env bash
export TPM2_ABRMD="tpm2-abrmd"
export TPM2_SIM="swtpm"
export TPM2ABRMD_TCTI="--session --dbus-name=com.intel.tss2.Tabrmd47145 --tcti=swtpm:port=47145" export TPM2_SIMPORT="47145"
export TPM2TOOLS_TEST_TCTI="tabrmd:bus_type=session,bus_name=com.intel.tss2.Tabrmd47145" export TPM2TOOLS_TEST_PERSISTENT=""
export PATH="/workspace/tpm2-tools/build/tools:/workspace/tpm2-tools/build/tools/misc:/workspace/tpm2-tools/build/../test/integration:/workspace/tpm2-tools/build/tools/fapi:/root/.local/bin/:/ibmtpm974/src:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin" export srcdir=".."
export abs_srcdir="/workspace/tpm2-tools/build/.." export abs_builddir="/workspace/tpm2-tools/build"

dbus-run-session /workspace/tpm2-tools/test/integration/fapi/fapi-policy_signed.sh --- EOF ---

run_startup: false
10+0 records in
10+0 records out
10485760 bytes (10 MB, 10 MiB) copied, 0.0789787 s, 133 MB/s spawn sh -c tss2 sign --keyPath=HS/SRK/mySignKey1 --digest=digest.file --signature=test_signature.file --force 2> /tmp/tpm2_test_KbVbhl/tss2_fapi.8dE028/log.file PolicySigned: Authorize usage of P_RSA2048SHA256/HS/SRK/mySignKey1 by signing the nonce with the key corresponding to the fingerprint "SHA256:Gf8QGWT2MOy8tOfpe6m+6MUUm2GUijGPkvCTjtJPOJz//XMom+k+7OaWmA==" and the hash algorithm "sha1".Please enter a valid file path ERROR:fapi:src/tss2-fapi/ifapi_policy_callbacks.c:837:ifapi_sign_buffer() ErrorCode (0x00060001) Execute policy signature callback. ERROR:fapi:src/tss2-fapi/ifapi_policy_execute.c:446:execute_policy_signed() ErrorCode (0x00060001) Execute policy signature callback. ERROR:fapi:src/tss2-fapi/ifapi_policy_execute.c:1528:execute_policy_element() ErrorCode (0x00060001) Execute policy signed

** (tpm2-abrmd:43302): WARNING **: 09:54:56.529: read_data: read on istream produced error: Error receiving data: Connection reset by peer Shutting down
/workspace/tpm2-tools/build
Removing sim dir: /tmp/tpm2_test_KbVbhl
/workspace/tpm2-tools/build/../test/integration/helpers.sh: line 443: 40459 Killed                  "$TPM2_SIM" socket --tpm2 --server port="$tpm2_sim_port" --ctrl type=tcp,port="$tpm2_sim_cmd_port" --flags not-need-init --tpmstate dir="$PWD"  (wd: /tmp/tpm2_test_KbVbhl)
/workspace/tpm2-tools/build/../test/integration/helpers.sh: line 443: 43302 Killed                  $TPM2_ABRMD $tpm2_tabrmd_opts $TPM2ABRMD_TCTI  (wd: /tmp/tpm2_test_KbVbhl)
FAIL test/integration/fapi/fapi-policy_signed.sh (exit status: 1)
```


Addresses #3619