### PR TITLE
docs: remove broken FreeBSD badge

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1,5 +1,4 @@
 [![Build Status](https://github.com/tpm2-software/tpm2-tools/workflows/CI/badge.svg)](https://github.com/tpm2-software/tpm2-tools/actions)
-[![FreeBSD Build Status](https://api.cirrus-ci.com/github/tpm2-software/tpm2-tools.svg?branch=master)](https://cirrus-ci.com/github/tpm2-software/tpm2-tools)
 [![codecov](https://codecov.io/gh/tpm2-software/tpm2-tools/branch/master/graph/badge.svg)](https://codecov.io/gh/tpm2-software/tpm2-tools)
 [![Coverity Scan](https://img.shields.io/coverity/scan/3997.svg)](https://scan.coverity.com/projects/01org-tpm2-0-tools)
 [![Language grade: C/C++](https://img.shields.io/lgtm/grade/cpp/g/tpm2-software/tpm2-tools.svg?logo=lgtm&logoWidth=18)](https://lgtm.com/projects/g/tpm2-software/tpm2-tools/context:cpp)


### PR DESCRIPTION
Cirrus CI no longer works and the badge no longer resolves.

Closes #3623 