### PR TITLE
prepare for implicit PCR session auth

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -368,6 +368,9 @@ add_c_flag([-D_GNU_SOURCE], [AC_MSG_ERROR([Cannot enable -D_GNU_SOURCE])])
 # Enable gnu99 mode, since we use some of these features.
 add_c_flag([-std=gnu99], [AC_MSG_ERROR([Cannot enable -std=gnu99])])
 
+# Detect unused macro definitions.
+add_c_flag([-Wunused-macros])
+
 # Best attempt compiler options that are on newer versions of GCC that
 # we can't widely enforce without killing other peoples builds.
 # Works with gcc only. Needs to be disabled on BSD and clang

--- a/lib/object.c
+++ b/lib/object.c
@@ -8,9 +8,6 @@
 #include "tpm2_auth_util.h"
 #include "tpm2_util.h"
 
-#define NULL_OBJECT "null"
-#define NULL_OBJECT_LEN (sizeof(NULL_OBJECT) - 1)
-
 TPM2B_PRIVATE tpm2_util_object_tsspem_priv = { 0 };
 TPM2B_PUBLIC tpm2_util_object_tsspem_pub = { 0 };
 

--- a/lib/pcr.c
+++ b/lib/pcr.c
@@ -16,8 +16,6 @@
 #include "tss2_common.h"
 #include "tss2_mu.h"
 
-#define MAX(a,b) ((a>b)?a:b)
-
 static inline void set_pcr_select_size(TPMS_PCR_SELECTION *pcr_selection,
         UINT8 size) {
 

--- a/lib/tpm2_auth_util.c
+++ b/lib/tpm2_auth_util.c
@@ -18,21 +18,6 @@
 #include "tpm2_alg_util.h"
 #include "tpm2_capability.h"
 
-#define HEX_PREFIX "hex:"
-#define HEX_PREFIX_LEN sizeof(HEX_PREFIX) - 1
-
-#define STR_PREFIX "str:"
-#define STR_PREFIX_LEN sizeof(STR_PREFIX) - 1
-
-#define SESSION_PREFIX "session:"
-#define SESSION_PREFIX_LEN sizeof(SESSION_PREFIX) - 1
-
-#define FILE_PREFIX "file:"
-#define FILE_PREFIX_LEN sizeof(FILE_PREFIX) - 1
-
-#define PCR_PREFIX "pcr:"
-#define PCR_PREFIX_LEN sizeof(PCR_PREFIX) - 1
-
 static struct termios old;
 
 /* When the program is interrupted during callbacks,
@@ -42,10 +27,6 @@ static void signal_termio_restore(__attribute__((unused)) int signumber) {
 }
 
 static bool handle_hex_password(const char *password, TPM2B_AUTH *auth) {
-
-    /* if it is hex, then skip the prefix */
-    password += HEX_PREFIX_LEN;
-
     auth->size = BUFFER_SIZE(typeof(*auth), buffer);
     int rc = tpm2_util_hex_to_byte_structure(password, &auth->size,
             auth->buffer);
@@ -61,8 +42,9 @@ bool handle_password(const char *password, TPM2B_AUTH *auth);
 
 static tool_rc get_auth_for_file_param(const char* password, TPM2B_AUTH *auth) {
     const char* path = password;
-    size_t size = (sizeof(auth->buffer) * 2) + HEX_PREFIX_LEN + 2;
+    size_t size = strlen("hex:") + 2 * sizeof(auth->buffer) + strlen("\r\n");
     bool is_a_tty = isatty(STDIN_FILENO);
+    bool is_stdin = strcmp("-", path) == 0;
 
     /* Allocating one extra byte for \0 termination safety */
     UINT8 *buffer = calloc(1, size + 1);
@@ -70,15 +52,11 @@ static tool_rc get_auth_for_file_param(const char* password, TPM2B_AUTH *auth) {
         LOG_ERR("oom");
         return tool_rc_general_error;
     }
-    buffer[size] = '\0';
 
-    if (path) {
-        path = strcmp("-", path) ? path : NULL;
-    }
-    if (!is_a_tty || path) {
-        UINT16 fsize = size - 1;
-        bool ret = files_load_bytes_from_buffer_or_file_or_stdin(NULL, path,
-                                                                 &fsize, buffer);
+    if (!is_a_tty || !is_stdin) {
+        UINT16 fsize = size;
+        bool ret = files_load_bytes_from_buffer_or_file_or_stdin(NULL,
+                is_stdin ? NULL : path, &fsize, buffer);
         if (!ret) {
             free(buffer);
             return tool_rc_general_error;
@@ -142,9 +120,9 @@ static tool_rc get_auth_for_file_param(const char* password, TPM2B_AUTH *auth) {
 bool handle_str_password(const char *password, TPM2B_AUTH *auth) {
 
     /* str may or may not have the str: prefix */
-    bool is_str_prefix = !strncmp(password, STR_PREFIX, STR_PREFIX_LEN);
+    bool is_str_prefix = !strncmp(password, "str:", 4);
     if (is_str_prefix) {
-        password += STR_PREFIX_LEN;
+        password += 4;
     }
 
     /*
@@ -165,10 +143,10 @@ bool handle_str_password(const char *password, TPM2B_AUTH *auth) {
 
 bool handle_password(const char *password, TPM2B_AUTH *auth) {
 
-    bool is_file = !strncmp(password, FILE_PREFIX, FILE_PREFIX_LEN);
+    bool is_file = !strncmp(password, "file:", 5);
 
     if (is_file) {
-        tool_rc rc = get_auth_for_file_param(password + FILE_PREFIX_LEN, auth);
+        tool_rc rc = get_auth_for_file_param(password + 5, auth);
         if (rc != tool_rc_success) {
             LOG_ERR("get password");
             return false;
@@ -176,8 +154,9 @@ bool handle_password(const char *password, TPM2B_AUTH *auth) {
         return true;
     }
 
-    bool is_hex = !strncmp(password, HEX_PREFIX, HEX_PREFIX_LEN);
+    bool is_hex = !strncmp(password, "hex:", 4);
     if (is_hex) {
+        password += 4;
         return handle_hex_password(password, auth);
     }
 
@@ -255,9 +234,6 @@ static tool_rc handle_session(ESYS_CONTEXT *ectx, const char *path,
 
     TPM2B_AUTH auth = { 0 };
 
-    /* if it is session, then skip the prefix */
-    path += SESSION_PREFIX_LEN;
-
     /* Make a local copy for manipulation */
     char tmp[PATH_MAX];
     size_t len = snprintf(tmp, sizeof(tmp), "%s", path);
@@ -304,8 +280,6 @@ static tool_rc handle_session(ESYS_CONTEXT *ectx, const char *path,
 
 static bool parse_pcr(const char *policy, char **pcr_str, char **raw_path) {
     char *split;
-
-    policy += PCR_PREFIX_LEN;
 
     *pcr_str = NULL;
     *raw_path = NULL;
@@ -420,8 +394,6 @@ out:
 static tool_rc handle_file(ESYS_CONTEXT *ectx, const char *path,
         tpm2_session **session) {
 
-    path += FILE_PREFIX_LEN;
-    path = strcmp("-", path) ? path : NULL;
     TPM2B_AUTH auth = { 0 };
 
     tool_rc rc = get_auth_for_file_param(path, &auth);
@@ -439,8 +411,10 @@ tool_rc tpm2_auth_util_from_optarg(ESYS_CONTEXT *ectx, const char *password,
     password = password ? password : "";
 
     /* starts with session: */
-    bool is_session = !strncmp(password, SESSION_PREFIX, SESSION_PREFIX_LEN);
+    bool is_session = !strncmp(password, "session:", 8);
     if (is_session) {
+        /* if it is session, then skip the prefix */
+        password += 8;
 
         if (is_restricted) {
             LOG_ERR("Cannot specify password type \"session:\"");
@@ -451,18 +425,20 @@ tool_rc tpm2_auth_util_from_optarg(ESYS_CONTEXT *ectx, const char *password,
     }
 
     /* starts with "file:" */
-    bool is_file = !strncmp(password, FILE_PREFIX, FILE_PREFIX_LEN);
+    bool is_file = !strncmp(password, "file:", 5);
     if (is_file) {
+        password += 5;
         return handle_file(ectx, password, session);
     }
 
     /* starts with pcr: */
-    bool is_pcr = !strncmp(password, PCR_PREFIX, PCR_PREFIX_LEN);
+    bool is_pcr = !strncmp(password, "pcr:", 4);
     if (is_pcr) {
         if (is_restricted) {
             LOG_ERR("Cannot specify password type \"pcr:\"");
             return tool_rc_general_error;
         }
+        password += 4;
         return handle_pcr(ectx, password, session);
     }
 

--- a/lib/tpm2_auth_util.c
+++ b/lib/tpm2_auth_util.c
@@ -38,9 +38,11 @@ static bool handle_hex_password(const char *password, TPM2B_AUTH *auth) {
     return true;
 }
 
-bool handle_password(const char *password, TPM2B_AUTH *auth);
+static bool handle_password_rec(const char *password, TPM2B_AUTH *auth,
+        unsigned int depth);
 
-static tool_rc get_auth_for_file_param(const char* password, TPM2B_AUTH *auth) {
+static tool_rc get_auth_for_file_param(const char* password, TPM2B_AUTH *auth,
+        unsigned int depth) {
     const char* path = password;
     size_t size = strlen("hex:") + 2 * sizeof(auth->buffer) + strlen("\r\n");
     bool is_a_tty = isatty(STDIN_FILENO);
@@ -108,7 +110,7 @@ static tool_rc get_auth_for_file_param(const char* password, TPM2B_AUTH *auth) {
         }
     }
     /* from here the buffer has been populated with the password */
-    bool ret = handle_password((char *) buffer, auth);
+    bool ret = handle_password_rec((char *) buffer, auth, depth);
     if (!ret) {
         free(buffer);
         return tool_rc_general_error;
@@ -141,14 +143,21 @@ bool handle_str_password(const char *password, TPM2B_AUTH *auth) {
     return true;
 }
 
-bool handle_password(const char *password, TPM2B_AUTH *auth) {
+#define MAX_PASSWORD_FILE_NESTING 16
+static bool handle_password_rec(const char *password, TPM2B_AUTH *auth,
+        unsigned int depth) {
+
+    if (depth >= MAX_PASSWORD_FILE_NESTING) {
+        LOG_ERR("Maximum password file redirection depth reached");
+        return false;
+    }
 
     bool is_file = !strncmp(password, "file:", 5);
 
     if (is_file) {
-        tool_rc rc = get_auth_for_file_param(password + 5, auth);
+        tool_rc rc = get_auth_for_file_param(password + 5, auth, depth + 1);
         if (rc != tool_rc_success) {
-            LOG_ERR("get password");
+            LOG_ERR("get password for redirected file");
             return false;
         }
         return true;
@@ -162,6 +171,10 @@ bool handle_password(const char *password, TPM2B_AUTH *auth) {
 
     /* must be string, handle it */
     return handle_str_password(password, auth);
+}
+
+bool handle_password(const char *password, TPM2B_AUTH *auth) {
+    return handle_password_rec(password, auth, 0);
 }
 
 static tool_rc start_hmac_session(ESYS_CONTEXT *ectx, TPM2B_AUTH *auth,
@@ -396,7 +409,7 @@ static tool_rc handle_file(ESYS_CONTEXT *ectx, const char *path,
 
     TPM2B_AUTH auth = { 0 };
 
-    tool_rc rc = get_auth_for_file_param(path, &auth);
+    tool_rc rc = get_auth_for_file_param(path, &auth, 1);
 
     if (rc != tool_rc_success) {
         LOG_ERR("get password");

--- a/test/unit/test_tpm2_auth_util.c
+++ b/test/unit/test_tpm2_auth_util.c
@@ -147,13 +147,31 @@ static void test_tpm2_auth_util_from_optarg_file(void **state) {
     unlink(path);
 }
 
+static void test_handle_password_file_redirection_depth(void **state) {
+    UNUSED(state);
+
+    char file_path[] = "file:/tmp/test_tpm2_auth_util_nesting-XXXXXXXXXX";
+    char *path = &file_path[strlen("file:")];
+
+    int fd = mkstemp(path);
+    assert_true(fd >= 0);
+    ssize_t n = write(fd, file_path, strlen(file_path));
+    assert_int_equal(n, strlen(file_path));
+    close(fd);
+
+    TPM2B_AUTH auth = { 0 };
+    assert_false(handle_password(file_path, &auth));
+
+    unlink(path);
+}
+
 #define PCR_SPECIFICATION "sha256:0,1,2,3+sha1:0,1,2,3"
 #define PCR_FILE "raw-pcr-file"
 
 static void test_parse_pcr_no_raw_file(void **state) {
     UNUSED(state);
 
-    const char *policy = "pcr:" PCR_SPECIFICATION;
+    const char *policy = PCR_SPECIFICATION;
 
     char *pcr_str, *raw_file;
 
@@ -168,7 +186,7 @@ static void test_parse_pcr_no_raw_file(void **state) {
 static void test_parse_pcr_with_raw_file(void **state) {
     UNUSED(state);
 
-    const char *policy = "pcr:" PCR_SPECIFICATION "=" PCR_FILE;
+    const char *policy = PCR_SPECIFICATION "=" PCR_FILE;
 
     char *pcr_str, *raw_file;
 
@@ -254,7 +272,7 @@ static void test_tpm2_auth_util_from_optarg_empty_str_hex_prefix(
 static void test_parse_pcr_empty(void **state) {
     UNUSED(state);
 
-    const char *policy = "pcr:";
+    const char *policy = "";
 
     char *pcr_str, *raw_file;
 
@@ -265,7 +283,7 @@ static void test_parse_pcr_empty(void **state) {
 static void test_parse_pcr_empty_pcr_specification(void **state) {
     UNUSED(state);
 
-    const char *policy = "pcr:=" PCR_FILE;
+    const char *policy = "=" PCR_FILE;
 
     char *pcr_str, *raw_file;
 
@@ -364,6 +382,7 @@ int main(int argc, char* argv[]) {
             cmocka_unit_test_setup_teardown(test_tpm2_auth_util_get_pw_shandle,
                                             setup, teardown),
             cmocka_unit_test(test_tpm2_auth_util_from_optarg_file),
+            cmocka_unit_test(test_handle_password_file_redirection_depth),
 
             cmocka_unit_test(test_parse_pcr_no_raw_file),
             cmocka_unit_test(test_parse_pcr_with_raw_file),

--- a/tools/tpm2_getekcertificate.c
+++ b/tools/tpm2_getekcertificate.c
@@ -18,6 +18,7 @@
 #include "tpm2_alg_util.h"
 #include "tpm2_auth_util.h"
 #include "tpm2_capability.h"
+#include "tpm2_openssl.h"
 #include "tpm2_nv_util.h"
 #include "tpm2_tool.h"
 #if OPENSSL_VERSION_NUMBER >= 0x30000000L
@@ -798,9 +799,6 @@ cleanup:
 #endif
     return rc;
 }
-
-#define EC_POINT_get_affine_coordinates_tss(group, tpm_pub_key, bn_x, bn_y, dmy) \
-        EC_POINT_get_affine_coordinates(group, tpm_pub_key, bn_x, bn_y, dmy)
 
 tool_rc get_ecc_tpm2b_public_from_evp(
     EVP_PKEY *publicKey,

--- a/tools/tpm2_pcrextend.c
+++ b/tools/tpm2_pcrextend.c
@@ -11,7 +11,6 @@
 
 typedef struct tpm_pcr_extend_ctx tpm_pcr_extend_ctx;
 #define MAX_AUX_SESSIONS 2
-#define MAX_SESSIONS 3
 struct tpm_pcr_extend_ctx {
     /*
      * Inputs


### PR DESCRIPTION
Minor things I came up with trying to improve #3597

I am still not convinced that changing `XXX_PREFIX_LEN` to a number is better. Maybe `strlen(...)` everywhere is more descriptive.